### PR TITLE
removes tree/master/ from examples link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A [Yeoman](http://yeoman.io/) generator used in the development process. Again, 
 
 ## Examples
 
-Examples of the design system in use can be found in the [`examples` directory](tree/master/examples).
+Examples of the design system in use can be found in the [`examples` directory](examples/).
 
 ## Contributing
 


### PR DESCRIPTION
### Fixed
The link to the examples directory was 404'ing - I've removed `tree/master/` from the path, which means the default relative link (`blob/master/examples/`) works as intended.