### PR TITLE
Change buttons to be same height as text fields

### DIFF
--- a/packages/core/src/components/Button/Button.scss
+++ b/packages/core/src/components/Button/Button.scss
@@ -32,8 +32,8 @@ Style guide: components.button
   font-family: $font-sans;
   font-size: $base-font-size;
   font-weight: $font-bold;
-  line-height: $reset-line-height;
-  padding: $spacer-2;
+  line-height: $input-line-height;
+  padding: $input-padding;
   text-align: center;
   text-decoration: none;
 
@@ -236,6 +236,18 @@ Style guide: components.button.icons
 .ds-c-button > svg {
   @include inline-icon;
 }
+
+/*
+Button inline with field
+
+The button is the same height as a single-line text field.
+
+Markup:
+<input type="text" class="ds-c-field ds-u-display--inline-block" />
+<button class="ds-c-button">Submit</button>
+
+Style guide: components.button.inline-field
+*/
 
 /*
 React

--- a/packages/core/src/settings/_variables.forms.scss
+++ b/packages/core/src/settings/_variables.forms.scss
@@ -8,7 +8,7 @@ $choice-border-color-inverse: $color-white !default;
 $choice-border-width: 2px !default;
 
 // USWDS overrides...
-// These variables apply to form fields (input, select, textarea)
+// These variables apply to form fields (input, select, textarea, button)
 $input-line-height: 1.3 !default;
 $input-border-width: 1px !default;
 $input-padding: $multiple * 1.5 !default;


### PR DESCRIPTION
Resolves https://jira.cms.gov/browse/HDSG-67

### Changed

- Sizing of Button component changed to match height of text fields
  ![image](https://cloud.githubusercontent.com/assets/371943/26599716/8d439a6a-4547-11e7-9916-e5b570ede86e.png)
