### PR TITLE
Docs: Sort nested sections by line number

### DIFF
--- a/packages/docs/src/scripts/components/Page.jsx
+++ b/packages/docs/src/scripts/components/Page.jsx
@@ -13,12 +13,6 @@ function isGuidanceSection(section) {
   return Boolean(section.reference.match(/\.guidance([a-z-_]+)?$/i));
 }
 
-//  Sort nested sections by their position in the file
-function sortSections(sections) {
-  return sections.concat([])
-    .sort((a, b) => a.source.line - b.source.line);
-}
-
 class Page extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -35,7 +29,7 @@ class Page extends React.PureComponent {
 
   renderChildPageBlocks(sections) {
     if (sections.length) {
-      return sortSections(sections).map(section => (
+      return sections.map(section => (
         <PageBlock key={section.referenceURI} {...section} />
       ));
     }

--- a/packages/docs/src/scripts/components/__tests__/Page.test.js
+++ b/packages/docs/src/scripts/components/__tests__/Page.test.js
@@ -78,15 +78,5 @@ describe('Page', () => {
 
       expect(panels.length).toBe(2);
     });
-
-    it('should sort nested sections by line number', () => {
-      const wrapper = shallow(<Page {...page} />);
-      const panels = wrapper.find('TabPanel');
-      const usageBlocks = panels.first().find('PageBlock');
-
-      expect(usageBlocks.length).toEqual(3);
-      expect(usageBlocks.get(0).props.header).toEqual(page.header);
-      expect(usageBlocks.get(2).props.header).toEqual('React');
-    });
   });
 });

--- a/tools/gulp/docs/__tests__/nestSections.test.js
+++ b/tools/gulp/docs/__tests__/nestSections.test.js
@@ -1,40 +1,103 @@
 const _ = require('lodash');
 const nestSections = require('../nestSections');
 
-const sections = [
-  {
-    reference: 'components',
-    sections: []
-  }, {
-    reference: 'components.buttons',
-    sections: []
-  }, {
-    reference: 'components.buttons.primary',
-    sections: []
-  }, {
-    reference: 'utilities',
-    sections: []
-  }, {
-    reference: 'utilities.colors',
-    sections: []
-  }, {
-    reference: 'home',
-    sections: []
-  }
-];
-
 describe('nestSections', () => {
+  let sections;
+
+  beforeEach(() => {
+    sections = [
+      {
+        reference: 'components',
+        sections: [],
+        source: {
+          line: 1
+        }
+      }, {
+        reference: 'components.buttons',
+        sections: [],
+        source: {
+          line: 1
+        }
+      }, {
+        reference: 'components.buttons.secondary',
+        sections: [],
+        source: {
+          line: 2
+        }
+      }, {
+        reference: 'components.buttons.primary',
+        sections: [],
+        source: {
+          line: 1
+        }
+      }, {
+        reference: 'components.buttons.tertiary',
+        sections: [],
+        source: {
+          line: 3
+        }
+      }, {
+        reference: 'utilities',
+        sections: [],
+        source: {
+          line: 1
+        }
+      }, {
+        reference: 'utilities.colors',
+        sections: [],
+        source: {
+          line: 1
+        }
+      }, {
+        reference: 'home',
+        sections: [],
+        source: {
+          line: 1
+        }
+      }
+    ];
+  });
+
   it('nests children within parent section', () => {
-    let nestedSections = nestSections(sections);
-    let components = _.find(nestedSections, {
+    const nestedSections = nestSections(sections);
+    const components = _.find(nestedSections, {
       reference: 'components'
     });
 
     expect(components.sections[0].reference)
-      .toEqual('components.buttons');
+      .toBe('components.buttons');
     expect(components.sections[0].sections[0].reference)
-      .toEqual('components.buttons.primary');
+      .toBe('components.buttons.primary');
     expect(nestedSections.length)
-      .toEqual(3);
+      .toBe(3);
+  });
+
+  it('sorts third-level sections by their line number', () => {
+    const nestedSections = nestSections(sections);
+    const components = _.find(nestedSections, {
+      reference: 'components'
+    });
+    const buttonSection = _.find(components.sections, {
+      reference: 'components.buttons'
+    });
+
+    expect(buttonSection.sections.length)
+      .toBe(3);
+    expect(buttonSection.sections[0].reference)
+      .toBe('components.buttons.primary');
+    expect(buttonSection.sections[1].reference)
+      .toBe('components.buttons.secondary');
+    expect(buttonSection.sections[2].reference)
+      .toBe('components.buttons.tertiary');
+  });
+
+  it('removes line number prop', () => {
+    const nestedSections = nestSections(sections);
+    const components = _.find(nestedSections, {
+      reference: 'components'
+    });
+
+    expect(components.source.line).toBeUndefined();
+    expect(components.sections[0].source.line).toBeUndefined();
   });
 });

--- a/tools/gulp/docs/processSection.js
+++ b/tools/gulp/docs/processSection.js
@@ -26,7 +26,6 @@ function processSection(kssSection, rootPath) {
   delete data.deprecated;
   delete data.experimental;
   delete data.parameters;
-  delete data.source.line;
 
   data = Object.assign({}, data, {
     sections: []


### PR DESCRIPTION
Fixes a bug caused by removing the section's line number prematurely.