### PR TITLE
Fix behavior of grid columns resizing

### DIFF
--- a/packages/layout/src/_col.scss
+++ b/packages/layout/src/_col.scss
@@ -5,6 +5,7 @@
 %grid-column {
   box-sizing: border-box;
   min-height: 1px; // Prevent columns from collapsing when empty
+  min-width: 0; // Resize columns as expected (https://css-tricks.com/flexbox-truncated-text/)
   padding-left: ($grid-gutter-width / 2);
   padding-right: ($grid-gutter-width / 2);
   position: relative;


### PR DESCRIPTION
### Fixed

- This addresses some, what I think is weird, flexbox behavior caused by the default `min-width` value of flexbox items being set to `auto`. This could result in a grid column overflowing the viewport on the x-axis, rather than resizing to fit within the viewport as you'd expect. For more context, [check out this article](https://css-tricks.com/flexbox-truncated-text/).