### PR TITLE
Add styling to base <a> HTML element

### DIFF
--- a/packages/core/src/base/typography.scss
+++ b/packages/core/src/base/typography.scss
@@ -4,7 +4,7 @@
 /*
 Typography
 
-The design system does not style base HTML text elements (like `h1`, `h2`, `p`, etc) and you should instead use one of the base class names to apply type styling. The base typography classes are:
+The design system doesn't style base HTML typography elements (like `h1`, `h2`, `p`, etc) and you should instead use one of the base class names to apply type styling. The base typography classes are:
 
 - `ds-display`
 - `ds-title`
@@ -14,6 +14,8 @@ The design system does not style base HTML text elements (like `h1`, `h2`, `p`, 
 See the examples below to see how each of these can be used.
 
 Utility classes can also be used to change type features like [font size]({{root}}/utilities/font-size), [color]({{root}}/utilities/color), [weight]({{root}}/utilities/font-weight), and [style]({{root}}/utilities/font-style).
+
+Note: The only base HTML element the design system applies styling to is the `<a>` element. To prevent this, you can override the `$ds-include-base-html-rulesets` Sass variable and set it to `false`.
 
 Markup:
 <p class="ds-text--lead"><strong>Lead paragraph.</strong>  {{lorem-l}}</p>
@@ -37,6 +39,27 @@ Markup:
 
 Style guide: style.typography
 */
+
+@if $ds-include-base-html-rulesets {
+  // <a> is the only base HTML element in the design system that
+  // has a style declaration. In all other cases, styles are applied using a
+  // namespaced class name. This selector isn't scoped under .ds-base, since that
+  // would cause the selector's specificity to be higher than most other component
+  // selectors (i.e. ds-c-button), necessitating overly specific selectors anytime
+  // a developer wanted to change an anchor's color property.
+  a {
+    color: $color-primary;
+
+    &:hover,
+    &:focus {
+      color: $color-primary-darker;
+    }
+
+    &:active {
+      color: $color-primary-darkest;
+    }
+  }
+}
 
 // Titles and headings
 .ds-display,

--- a/packages/docs/src/styles/base/_typography.scss
+++ b/packages/docs/src/styles/base/_typography.scss
@@ -1,16 +1,3 @@
-a {
-  color: $color-primary;
-
-  &:hover,
-  &:focus {
-    color: $color-primary-darker;
-  }
-
-  &:active {
-    color: $color-primary-darkest;
-  }
-}
-
 blockquote {
   background: $color-primary-alt-lightest;
   border-left: 2px solid $color-primary-alt-light;

--- a/packages/support/src/settings/_index.scss
+++ b/packages/support/src/settings/_index.scss
@@ -14,6 +14,7 @@ $helvetica: 'Helvetica Neue', 'Helvetica', 'Roboto', 'Arial', sans-serif;
 // Design system variables
 // Defined after vendor variables so we can use them as values here
 @import 'variables.animation';
+@import 'variables.build';
 @import 'variables.color';
 @import 'variables.forms';
 @import 'variables.layout';

--- a/packages/support/src/settings/_variables.build.scss
+++ b/packages/support/src/settings/_variables.build.scss
@@ -1,0 +1,3 @@
+// Override these variables to change what CSS rulesets get outputted when
+// the Sass is transpiled to CSS
+$ds-include-base-html-rulesets: true !default;


### PR DESCRIPTION
### Added

- Added a `$ds-include-base-html-rulesets: true` Sass variable which, when set to `false`, will disable the base HTML selectors. (Only `a {...}` right now — see below)
- **Added styling to `<a>` elements.**
  The design system doesn't currently apply styling to anchor tags, so without writing custom CSS, links render in the default browser blue. This didn't seem ideal for someone implementing the design system, so this sets a default `color` property for them. 

  Here's the dilemma though! In order to best support this, we're styling the base HTML tag, rather than using a namespaced class name like we originally set out to do. So far this is the only exception to that rule. I went this route because if this ruleset was scoped under something like `.ds-base a`, that would cause the selector's specificity to be higher than most other component selectors (ie. `.ds-c-button`), necessitating overly specific selectors anytime a developer wanted to change an anchor's color property (ie. `a.ds-c-button`, `.page a`, etc)

  @allypalanzi @keithk @pwolfert I'd like to hear any thoughts and get a 👍 from y'all first before I merge this.

  🚨 This could be considered a breaking change since it's not namespaced.