### PR TITLE
Docs: Helpful links in header

### DIFF
--- a/packages/docs/src/scripts/Docs.jsx
+++ b/packages/docs/src/scripts/Docs.jsx
@@ -1,10 +1,10 @@
 /**
  * This is main template file for the documentation site.
  */
+import GitHubLinks from './components/GitHubLinks';
 import Header from './components/Header';
 import Nav from './components/Nav';
 import Page from './components/Page';
-import GitHubLinks from './components/GitHubLinks';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -37,7 +37,7 @@ class Docs extends React.PureComponent {
         <div className='ds-l-row ds-u-margin--0'>
           <nav className='ds-l-md-col--3 ds-u-padding--2 ds-u-fill--white docs__sidebar'>
             <Nav items={routes} selectedId={page.referenceURI} />
-            <GitHubLinks className='ds-u-md-display--none ds-u-margin-top--2' vertical={true} />
+            <GitHubLinks className='ds-u-md-display--none ds-u-margin-top--2' vertical />
           </nav>
           <main className='ds-l-md-col ds-u-padding--0 docs__main'>
             <Page {...page} />

--- a/packages/docs/src/scripts/components/GitHubLinks.jsx
+++ b/packages/docs/src/scripts/components/GitHubLinks.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import packageInfo from '../../../package.json';
@@ -20,6 +21,11 @@ const GitHubLinks = (props) => {
       <a href={githubUrl} className={githubBtnClassName}>View on Github</a>
     </div>
   );
+};
+
+GitHubLinks.propTypes = {
+  inverse: PropTypes.bool,
+  vertical: PropTypes.bool
 };
 
 export default GitHubLinks;

--- a/packages/docs/src/scripts/components/Header.jsx
+++ b/packages/docs/src/scripts/components/Header.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
 import GitHubLinks from './GitHubLinks';
+import React from 'react';
 
 const Header = () => {
   return (
     <header className='ds-base--inverse ds-u-padding--3 ds-u-display--flex ds-u-justify-content--between ds-u-align-items--center'>
       <h1 className='ds-h3 ds-u-margin-bottom--0'>CMS.gov Design System</h1>
-      <GitHubLinks className='ds-u-display--none ds-u-md-display--block' inverse={true} />
+      <GitHubLinks className='ds-u-display--none ds-u-md-display--block' inverse />
     </header>
   );
 };


### PR DESCRIPTION
https://jira.cms.gov/browse/HDSG-48

### Added
Added links to current release and github repository landing page in the header. Uses version from `lerna.json` to build the zip-download url.