### PR TITLE
Docs: Add footer

### DIFF
--- a/packages/docs/src/scripts/Docs.jsx
+++ b/packages/docs/src/scripts/Docs.jsx
@@ -1,6 +1,7 @@
 /**
  * This is main template file for the documentation site.
  */
+import Footer from './components/Footer';
 import GitHubLinks from './components/GitHubLinks';
 import Header from './components/Header';
 import Nav from './components/Nav';
@@ -41,7 +42,7 @@ class Docs extends React.PureComponent {
             <Nav items={routes} selectedId={page.referenceURI} />
             <GitHubLinks className='ds-u-md-display--none ds-u-margin-top--2' vertical />
           </nav>
-          <main id='main' className='ds-l-md-col docs__main'>
+          <main id='main' className='ds-l-md-col ds-u-padding--0 ds-u-padding-bottom--4'>
             <Page {...page} />
           </main>
         </div>
@@ -51,6 +52,7 @@ class Docs extends React.PureComponent {
         >
           {menuOpen ? 'Close' : 'Menu'}
         </button>
+        <Footer />
       </div>
     );
   }

--- a/packages/docs/src/scripts/components/Footer.jsx
+++ b/packages/docs/src/scripts/components/Footer.jsx
@@ -1,5 +1,5 @@
-import githubUrl from '../shared/githubUrl';
 import React from 'react';
+import githubUrl from '../shared/githubUrl';
 
 const helpfulLinks = {
   'https://standards.usa.gov/': 'U.S. Web Design Standards',

--- a/packages/docs/src/scripts/components/Footer.jsx
+++ b/packages/docs/src/scripts/components/Footer.jsx
@@ -1,0 +1,65 @@
+import githubUrl from '../shared/githubUrl';
+import React from 'react';
+
+const helpfulLinks = {
+  'https://standards.usa.gov/': 'U.S. Web Design Standards',
+  'http://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/FOIA.html': 'Freedom of Information Act',
+  'https://oig.hhs.gov/': 'Inspector General',
+  'http://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/NoFearAct.html': 'No Fear Act',
+  'http://www.medicare.gov/about-us/plain-writing/plain-writing.html': 'Plain Writing',
+  'http://www.usa.gov': 'USA.gov'
+};
+
+const cmsLinks = {
+  'http://www.cms.gov': 'CMS.gov',
+  'http://www.medicare.gov': 'Medicare.gov',
+  'http://www.mymedicare.gov': 'MyMedicare.gov',
+  'http://www.stopmedicarefraud.gov': 'StopMedicareFraud.gov',
+  'http://www.medicaid.gov': 'Medicaid.gov',
+  'http://www.healthcare.gov': 'HealthCare.gov',
+  'http://www.HHS.gov/open': 'HHS.gov'
+};
+
+/**
+ * @param {Array[Object]} links
+ * @return {Array[<li>]}
+ */
+function renderLinks(links) {
+  const urls = Object.getOwnPropertyNames(links);
+
+  return urls.map(function(url) {
+    return (
+      <li key={url}>
+        <a href={url} target='_blank'>{links[url]}</a>
+      </li>
+    );
+  });
+}
+
+const Footer = () => {
+  return (
+    <footer className='ds-u-fill--primary-alt-lightest ds-u-padding-y--6 ds-u-md-padding-bottom--3'>
+      <div className='ds-l-container ds-u-padding-x--3 ds-u-margin-x--0'>
+        <div className='ds-l-row'>
+          <article className='ds-l-col--12 ds-l-lg-col--4 ds-u-margin-bottom--4'>
+            <h2 className='ds-h4'>Find an issue or have a feature request?</h2>
+            <a className='ds-c-button ds-c-button--primary' href={githubUrl('issues')} target='_blank'>Ask questions on GitHub</a>
+            <p className='ds-text ds-u-font-size--small ds-u-margin-top--2 ds-u-measure--wide'>
+              A federal government website managed by the Centers for Medicare & Medicaid Services 7500 Security Boulevard, Baltimore, MD 21124
+            </p>
+          </article>
+          <article className='ds-l-col--12 ds-l-sm-col--6 ds-l-lg-col--4 ds-u-margin-bottom--4'>
+            <h2 className='ds-h4'>CMS & HHS Websites</h2>
+            <ul className='ds-c-list ds-c-list--bare ds-u-font-size--small'>{renderLinks(cmsLinks)}</ul>
+          </article>
+          <article className='ds-l-col--12 ds-l-sm-col--6 ds-l-lg-col--4 ds-u-margin-bottom--4'>
+            <h2 className='ds-h4'>Additional resources</h2>
+            <ul className='ds-c-list ds-c-list--bare ds-u-font-size--small'>{renderLinks(helpfulLinks)}</ul>
+          </article>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/packages/docs/src/scripts/components/Footer.jsx
+++ b/packages/docs/src/scripts/components/Footer.jsx
@@ -39,17 +39,17 @@ function renderLinks(links) {
 const Footer = () => {
   return (
     <footer className='ds-u-fill--primary-alt-lightest ds-u-padding-y--6 ds-u-md-padding-bottom--3'>
-      <div className='ds-l-container ds-u-padding-x--3 ds-u-margin-x--0'>
+      <div className='ds-u-padding-x--3 ds-u-margin-x--0'>
         <div className='ds-l-row'>
           <article className='ds-l-col--12 ds-l-lg-col--4 ds-u-margin-bottom--4'>
             <h2 className='ds-h4'>Find an issue or have a feature request?</h2>
             <a className='ds-c-button ds-c-button--primary' href={githubUrl('issues')} target='_blank'>Ask questions on GitHub</a>
-            <p className='ds-text ds-u-font-size--small ds-u-margin-top--2 ds-u-measure--wide'>
+            <p className='ds-text ds-u-color--primary-darkest ds-u-font-size--small ds-u-margin-top--3 ds-u-measure--base'>
               A federal government website managed by the Centers for Medicare & Medicaid Services 7500 Security Boulevard, Baltimore, MD 21124
             </p>
           </article>
           <article className='ds-l-col--12 ds-l-sm-col--6 ds-l-lg-col--4 ds-u-margin-bottom--4'>
-            <h2 className='ds-h4'>CMS & HHS Websites</h2>
+            <h2 className='ds-h4'>CMS &amp; HHS Websites</h2>
             <ul className='ds-c-list ds-c-list--bare ds-u-font-size--small'>{renderLinks(cmsLinks)}</ul>
           </article>
           <article className='ds-l-col--12 ds-l-sm-col--6 ds-l-lg-col--4 ds-u-margin-bottom--4'>

--- a/packages/docs/src/scripts/components/GitHubLinks.jsx
+++ b/packages/docs/src/scripts/components/GitHubLinks.jsx
@@ -24,6 +24,7 @@ const GitHubLinks = (props) => {
 };
 
 GitHubLinks.propTypes = {
+  className: PropTypes.string,
   inverse: PropTypes.bool,
   vertical: PropTypes.bool
 };

--- a/packages/docs/src/styles/components/_Docs.scss
+++ b/packages/docs/src/styles/components/_Docs.scss
@@ -12,16 +12,6 @@
   to { position: fixed; }
 }
 
-.docs__main {
-  // Setting left + right padding to 0 clears the padding applied to the element
-  // by the grid column class
-  padding: 0 0 ($spacer-4 + $menu-toggle-height);
-
-  @media (min-width: $breakpoint-mobile-nav) {
-    padding-bottom: $spacer-4;
-  }
-}
-
 .docs__toggle {
   border-radius: 0;
   bottom: 0;


### PR DESCRIPTION
### Internal

- Added footer to docs site with required links

@shashashasha @allypalanzi @cindyphan Does anyone have a strong preference for either of these? The light blue is what USWDS uses for footers, so that's what I currently have implemented:

![localhost-3000-design-system-](https://user-images.githubusercontent.com/371943/29619740-d8e4e32c-87e9-11e7-8f99-8d81204cf9a8.png)

![localhost-3000-design-system- 1](https://user-images.githubusercontent.com/371943/29619737-d6f6bbbc-87e9-11e7-9849-9598443759d5.png)
