### PR TITLE
Linting documentation update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,22 +33,24 @@ The `bootstrap:yarn` command runs [Lerna](https://lernajs.io/) which allows us t
 
 These scripts can all be run from the root level of the repo:
 
-- `yarn run start`
+- `yarn start`
   - Starts local server running the documentation site
   - Regenerates documentation when files change
-- `yarn run build`
+- `yarn build`
   - Compile/transpile/uglify everything and makes things release-ready.
-- `yarn run bump`
+- `yarn bump`
   - Increments package versions. Read "[Versioning](https://github.com/CMSgov/design-system/wiki/Versioning)" for more info.
-- `yarn run generate`
+- `yarn generate`
   - Generates the necessary files for a new core component
-  - Alias: `yarn run g`
+  - Alias: `yarn g`
 - `yarn test`
   - Runs JS unit tests
   - Lints JS using ESLint
   - Lints Sass using stylelint
-- `yarn run test:watch`
+- `yarn test:watch`
   - Runs JS unit tests and will continue to run tests as files change
+- `yarn lint`
+  - Runs just the linting portion of the tests
 
 ## Submitting a pull request
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "g": "yarn generate",
     "start": "NODE_ENV=development gulp watch --env=development",
     "test": "NODE_ENV=test gulp docs:react && jest && gulp lint --env=test",
-    "test:watch": "NODE_ENV=test jest --watch"
+    "test:watch": "NODE_ENV=test jest --watch",
+    "lint": "yarn run gulp lint"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",


### PR DESCRIPTION
Please follow the format below. Feel free to remove any sections that aren't relevant.

### Added
- New package script `lint` with documentation in `CONTRIBUTING.md`

### Changed
- Changed commands found in `CONTRIBUTING.md` to change `yarn run <SCRIPT>` to `yarn <SCRIPT>`