### PR TITLE
Use each package's version in compiled index.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "gulp-postcss": "^7.0.0",
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^2.6.0",
-    "gulp-string-replace": "^0.4.0",
     "gulp-stylelint": "^4.0.0",
     "gulp-util": "^3.0.8",
     "jest": "^20.0.4",

--- a/tools/gulp/common/packageVersions.js
+++ b/tools/gulp/common/packageVersions.js
@@ -1,0 +1,36 @@
+const fs = require('mz/fs');
+const path = require('path');
+
+/**
+ * Get the version number of each of the packages
+ * @param {Array} names - Names of the packages we want versions for
+ * @return {Promise<Object>} Resolves with object resembling: {package name: version}
+ */
+function packageVersions(names) {
+  return Promise.all(names.map(packageVersion))
+    .then(packages => {
+      const data = {};
+
+      packages.forEach(pkg => {
+        data[pkg.name] = pkg.version;
+      });
+
+      return data;
+    });
+}
+
+/**
+ * @param {String} name - Package directory name
+ * @return {Promise}
+ */
+function packageVersion(name) {
+  const filePath = path.resolve(__dirname, '../../../packages', name, 'package.json');
+
+  return fs.readFile(filePath, 'utf8')
+    .then(JSON.parse)
+    .then(data => {
+      return { name: name, version: data.version };
+    });
+}
+
+module.exports = packageVersions;

--- a/tools/gulp/index.js
+++ b/tools/gulp/index.js
@@ -5,7 +5,6 @@
  */
 'use strict';
 const argv = require('yargs').argv;
-const pkg = require('../../packages/core/package.json');
 
 module.exports = (gulp) => {
   const rootPath = ''; // pkg.version
@@ -17,7 +16,6 @@ module.exports = (gulp) => {
     // TODO: Replace the line below once we move to publishing the docs on S3
     // rather than GitHub pages.
     rootPath: rootPath,
-    version: pkg.version,
     webpackConfig: require('../../packages/docs/webpack.config')(rootPath)
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2749,7 +2749,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -3963,15 +3963,6 @@ gulp-sourcemaps@^2.6.0:
     through2 "2.X"
     vinyl "1.X"
 
-gulp-string-replace@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/gulp-string-replace/-/gulp-string-replace-0.4.0.tgz#e0af8b37e2d4c50f915d6d36d6d972fef644f716"
-  dependencies:
-    extend "^3.0.0"
-    gulp-util "^3.0.7"
-    replacestream "^4.0.0"
-    through2 "^2.0.1"
-
 gulp-stylelint@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/gulp-stylelint/-/gulp-stylelint-4.0.0.tgz#440fa7e6c447e92644700e1e2a06a73e6e457750"
@@ -3985,7 +3976,7 @@ gulp-stylelint@^4.0.0:
     stylelint "^8.0.0"
     through2 "^2.0.3"
 
-gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.7, gulp-util@^3.0.8, gulp-util@~3.0.0:
+gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.8, gulp-util@~3.0.0:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -7453,14 +7444,6 @@ replace-ext@0.0.1:
 replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
-
-replacestream@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/replacestream/-/replacestream-4.0.2.tgz#0c4140707e4f0323f50de044851708cf58bc37bd"
-  dependencies:
-    escape-string-regexp "^1.0.3"
-    object-assign "^4.0.1"
-    readable-stream "^2.0.2"
 
 request@2, request@2.79.0, request@^2.61.0, request@^2.74.0, request@^2.79.0:
   version "2.79.0"


### PR DESCRIPTION
### Internal

- This fixes an issue where the wrong version number might be included in a package's compiled top-level `index.css` file