### PR TITLE
Use negative ems instead of negative percentage on Choice margin

### DIFF
--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -74,7 +74,7 @@ Style guide: components.choice
 // Hide the default browser checkbox/radio button since we'll
 // create our own custom version
 .ds-c-choice {
-  margin-left: -999em;
+  left: -999em;
   opacity: 0;
   position: absolute;
 }

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -74,7 +74,7 @@ Style guide: components.choice
 // Hide the default browser checkbox/radio button since we'll
 // create our own custom version
 .ds-c-choice {
-  margin-left: -100%;
+  margin-left: -999em;
   opacity: 0;
   position: absolute;
 }
@@ -117,7 +117,8 @@ Style guide: components.choice
 }
 
 .ds-c-choice--inverse:focus + label::before {
-  box-shadow: 0 0 0 2px $color-background-inverse, 0 0 2px 4px $color-focus-inverse;
+  box-shadow: 0 0 0 2px $color-background-inverse,
+    0 0 2px 4px $color-focus-inverse;
 }
 
 // Display a checkmark


### PR DESCRIPTION
### Changed
Changed the way the Choice input is hidden via its left margin property by using `-999em` instead of negative percent to allow Choice inputs to be side-by-side without unexpected behavior.