### PR TITLE
RTL Choice components

### DIFF
--- a/packages/core/src/components/ChoiceList/Choice.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.jsx
@@ -17,16 +17,18 @@ export const Choice = function(props) {
     className,
     id,
     inversed,
-    right,
+    inputPlacement,
+    inputClassName,
     ...inputProps
   } = props;
   /* eslint-enable prefer-const */
 
   const inputClasses = classNames(
+    inputClassName,
     'ds-c-choice',
     {
       'ds-c-choice--inverse': inversed,
-      'ds-c-choice--right': right
+      'ds-c-choice--right': inputPlacement === 'right'
     }
   );
 
@@ -65,6 +67,10 @@ Choice.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * Additional classes to be added to the `input` element.
+   */
+  inputClassName: PropTypes.string,
+  /**
    * Sets the initial checked state. Use this for an uncontrolled component;
    * otherwise, use the `checked` property.
    */
@@ -79,9 +85,9 @@ Choice.propTypes = {
    */
   inversed: PropTypes.bool,
   /**
-   * Displays the checkbox on the right side of the label
+   * Placement of the input relative to the text label (`left` or `right`)
    */
-  right: PropTypes.bool,
+  inputPlacement: PropTypes.oneOf(['left', 'right'])
   /**
    * The `input` field's `name` attribute
    */

--- a/packages/core/src/components/ChoiceList/Choice.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.jsx
@@ -49,7 +49,8 @@ export const Choice = function(props) {
 };
 
 Choice.defaultProps = {
-  type: 'checkbox'
+  type: 'checkbox',
+  inputPlacement: 'left'
 };
 
 Choice.propTypes = {
@@ -85,7 +86,7 @@ Choice.propTypes = {
    */
   inversed: PropTypes.bool,
   /**
-   * Placement of the input relative to the text label (`left` or `right`)
+   * Placement of the input relative to the text label
    */
   inputPlacement: PropTypes.oneOf(['left', 'right']),
   /**

--- a/packages/core/src/components/ChoiceList/Choice.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.jsx
@@ -17,7 +17,7 @@ export const Choice = function(props) {
     className,
     id,
     inversed,
-    labelOnLeft,
+    right,
     ...inputProps
   } = props;
   /* eslint-enable prefer-const */
@@ -26,7 +26,7 @@ export const Choice = function(props) {
     'ds-c-choice',
     {
       'ds-c-choice--inverse': inversed,
-      'ds-c-choice--left-label': labelOnLeft
+      'ds-c-choice--right': right
     }
   );
 
@@ -79,9 +79,9 @@ Choice.propTypes = {
    */
   inversed: PropTypes.bool,
   /**
-   * Displays the label on the left side of the check
+   * Displays the checkbox on the right side of the label
    */
-  labelOnLeft: PropTypes.bool,
+  right: PropTypes.bool,
   /**
    * The `input` field's `name` attribute
    */

--- a/packages/core/src/components/ChoiceList/Choice.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.jsx
@@ -17,13 +17,17 @@ export const Choice = function(props) {
     className,
     id,
     inversed,
+    labelOnLeft,
     ...inputProps
   } = props;
   /* eslint-enable prefer-const */
 
   const inputClasses = classNames(
     'ds-c-choice',
-    {'ds-c-choice--inverse': inversed}
+    {
+      'ds-c-choice--inverse': inversed,
+      'ds-c-choice--left-label': labelOnLeft
+    }
   );
 
   if (!id) {
@@ -74,6 +78,10 @@ Choice.propTypes = {
    * Applies the "inverse" UI theme
    */
   inversed: PropTypes.bool,
+  /**
+   * Displays the label on the left side of the check
+   */
+  labelOnLeft: PropTypes.bool,
   /**
    * The `input` field's `name` attribute
    */

--- a/packages/core/src/components/ChoiceList/Choice.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.jsx
@@ -87,7 +87,7 @@ Choice.propTypes = {
   /**
    * Placement of the input relative to the text label (`left` or `right`)
    */
-  inputPlacement: PropTypes.oneOf(['left', 'right'])
+  inputPlacement: PropTypes.oneOf(['left', 'right']),
   /**
    * The `input` field's `name` attribute
    */

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -189,7 +189,6 @@ Style guide: components.choice
 
 // Display label on the left side of the checkbox
 .ds-c-choice--left-label + label {
-  margin: 0;
   padding-left: 0;
   padding-right: $spacer-5;
 

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -67,6 +67,32 @@ Markup:
     <label for="washington-4">Booker T. Washington</label>
   </fieldset>
 </div>
+<div class="ds-u-margin-top--2 ds-u-padding--2 ds-u-text-align--right ds-u-border--2" style="width: 160px">
+  <fieldset class="ds-c-fieldset ds-u-margin-top--0">
+    <legend class="ds-c-label">Right to left</legend>
+    <span class="ds-c-field__hint ds-u-margin-bottom--1">Select desired fruits</span>
+    <input class="ds-c-choice ds-c-choice--left-label" id="apple-1" type="checkbox" name="fruit-1" value="apple" checked>
+    <label for="apple-1">Apple</label>
+    <input class="ds-c-choice ds-c-choice--left-label" id="banana-1" type="checkbox" name="fruit-1" value="banana">
+    <label for="banana-1">Banana</label>
+    <input class="ds-c-choice ds-c-choice--left-label" id="fig-1" type="checkbox" name="fruit-1" value="fig">
+    <label for="fig-1">Fig</label>
+    <input class="ds-c-choice ds-c-choice--left-label" id="plum-1" type="checkbox" name="fruit-1" disabled>
+    <label for="plum-1">Plum</label>
+  </fieldset>
+</div>
+<div class="ds-u-margin-top--2 ds-u-padding--2 ds-u-text-align--right ds-u-border--2 ds-base--inverse ds-u-border--success-lighter" style="width: 160px">
+  <fieldset class="ds-c-fieldset ds-u-margin-top--0">
+    <legend class="ds-c-label">Right to left</legend>
+    <span class="ds-c-field__hint ds-c-field__hint--inverse ds-u-margin-bottom--1">Select desired fruits</span>
+    <input class="ds-c-choice ds-c-choice--left-label ds-c-choice--inverse" id="apple-2" type="radio" name="fruit-2" value="apple" checked>
+    <label for="apple-2">Apple</label>
+    <input class="ds-c-choice ds-c-choice--left-label ds-c-choice--inverse" id="banana-2" type="radio" name="fruit-2" value="banana">
+    <label for="banana-2">Banana</label>
+    <input class="ds-c-choice ds-c-choice--left-label ds-c-choice--inverse" id="fig-2" type="radio" name="fruit-2" value="fig">
+    <label for="fig-2">Fig</label>
+  </fieldset>
+</div>
 
 Style guide: components.choice
 */
@@ -159,6 +185,18 @@ Style guide: components.choice
 // Display a circular radio button
 .ds-c-choice[type=radio] + label::before {
   border-radius: 100%;
+}
+
+// Display label on the left side of the checkbox
+.ds-c-choice--left-label + label {
+  margin: 0;
+  padding-left: 0;
+  padding-right: $spacer-5;
+
+  &::before {
+    left: auto;
+    right: 0;
+  }
 }
 
 /*

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -44,6 +44,14 @@ Markup:
   <input class="ds-c-choice" id="washington-3" type="radio" name="historical-figures-3" value="washington">
   <label for="washington-3">Booker T. Washington</label>
 </fieldset>
+
+Style guide: components.choice
+*/
+
+/*
+Inverse theme
+
+Markup:
 <div class="ds-base ds-base--inverse ds-u-padding--2 ds-u-margin-top--2">
   <fieldset class="ds-c-fieldset ds-u-margin-top--0">
     <legend class="ds-c-label">Historical figures</legend>
@@ -67,34 +75,44 @@ Markup:
     <label for="washington-4">Booker T. Washington</label>
   </fieldset>
 </div>
-<div class="ds-u-margin-top--2 ds-u-padding--2 ds-u-text-align--right ds-u-border--2" style="width: 160px">
-  <fieldset class="ds-c-fieldset ds-u-margin-top--0">
-    <legend class="ds-c-label">Right to left</legend>
-    <span class="ds-c-field__hint ds-u-margin-bottom--1">Select desired fruits</span>
-    <input class="ds-c-choice ds-c-choice--left-label" id="apple-1" type="checkbox" name="fruit-1" value="apple" checked>
-    <label for="apple-1">Apple</label>
-    <input class="ds-c-choice ds-c-choice--left-label" id="banana-1" type="checkbox" name="fruit-1" value="banana">
-    <label for="banana-1">Banana</label>
-    <input class="ds-c-choice ds-c-choice--left-label" id="fig-1" type="checkbox" name="fruit-1" value="fig">
-    <label for="fig-1">Fig</label>
-    <input class="ds-c-choice ds-c-choice--left-label" id="plum-1" type="checkbox" name="fruit-1" disabled>
-    <label for="plum-1">Plum</label>
-  </fieldset>
-</div>
-<div class="ds-u-margin-top--2 ds-u-padding--2 ds-u-text-align--right ds-u-border--2 ds-base--inverse ds-u-border--success-lighter" style="width: 160px">
-  <fieldset class="ds-c-fieldset ds-u-margin-top--0">
-    <legend class="ds-c-label">Right to left</legend>
-    <span class="ds-c-field__hint ds-c-field__hint--inverse ds-u-margin-bottom--1">Select desired fruits</span>
-    <input class="ds-c-choice ds-c-choice--left-label ds-c-choice--inverse" id="apple-2" type="radio" name="fruit-2" value="apple" checked>
-    <label for="apple-2">Apple</label>
-    <input class="ds-c-choice ds-c-choice--left-label ds-c-choice--inverse" id="banana-2" type="radio" name="fruit-2" value="banana">
-    <label for="banana-2">Banana</label>
-    <input class="ds-c-choice ds-c-choice--left-label ds-c-choice--inverse" id="fig-2" type="radio" name="fruit-2" value="fig">
-    <label for="fig-2">Fig</label>
-  </fieldset>
+
+Style guide: components.choice.inversed
+*/
+
+/*
+Right-to-Left
+
+Markup:
+<div class="ds-u-clearfix">
+  <div class="ds-u-padding--2 ds-u-text-align--right ds-u-border--2 ds-u-float--left">
+    <fieldset class="ds-c-fieldset ds-u-margin-top--0">
+      <legend class="ds-c-label">Right to left</legend>
+      <span class="ds-c-field__hint ds-u-margin-bottom--1">Select desired fruits</span>
+      <input class="ds-c-choice ds-c-choice--right" id="apple-1" type="checkbox" name="fruit-1" value="apple" checked>
+      <label for="apple-1">Apple</label>
+      <input class="ds-c-choice ds-c-choice--right" id="banana-1" type="checkbox" name="fruit-1" value="banana">
+      <label for="banana-1">Banana</label>
+      <input class="ds-c-choice ds-c-choice--right" id="fig-1" type="checkbox" name="fruit-1" value="fig">
+      <label for="fig-1">Fig</label>
+      <input class="ds-c-choice ds-c-choice--right" id="plum-1" type="checkbox" name="fruit-1" disabled>
+      <label for="plum-1">Plum</label>
+    </fieldset>
+  </div>
+  <div class="ds-u-padding--2 ds-u-text-align--right ds-u-float--left ds-u-margin-left--2 ds-base--inverse">
+    <fieldset class="ds-c-fieldset ds-u-margin-top--0">
+      <legend class="ds-c-label">Right to left</legend>
+      <span class="ds-c-field__hint ds-c-field__hint--inverse ds-u-margin-bottom--1">Select desired fruits</span>
+      <input class="ds-c-choice ds-c-choice--right ds-c-choice--inverse" id="apple-2" type="radio" name="fruit-2" value="apple" checked>
+      <label for="apple-2">Apple</label>
+      <input class="ds-c-choice ds-c-choice--right ds-c-choice--inverse" id="banana-2" type="radio" name="fruit-2" value="banana">
+      <label for="banana-2">Banana</label>
+      <input class="ds-c-choice ds-c-choice--right ds-c-choice--inverse" id="fig-2" type="radio" name="fruit-2" value="fig">
+      <label for="fig-2">Fig</label>
+    </fieldset>
+  </div>
 </div>
 
-Style guide: components.choice
+Style guide: components.choice.rtl
 */
 
 // Hide the default browser checkbox/radio button since we'll
@@ -188,9 +206,9 @@ Style guide: components.choice
 }
 
 // Display label on the left side of the checkbox
-.ds-c-choice--left-label + label {
+.ds-c-choice--right + label {
   padding-left: 0;
-  padding-right: $spacer-5;
+  padding-right: $choice-size + $spacer-1;
 
   &::before {
     left: auto;

--- a/packages/core/src/components/ChoiceList/Choice.test.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.test.jsx
@@ -115,6 +115,31 @@ describe('Choice', () => {
     expect(input.hasClass('ds-c-choice--inverse')).toBe(true);
   });
 
+  it('places input on left by default', () => {
+    const props = {
+      name: 'presidents',
+      value: label
+    };
+    const wrapper = shallow(<Choice {...props}>{label}</Choice>);
+    const input = wrapper.find('input');
+
+    expect(input.hasClass('ds-c-choice')).toBe(true);
+    expect(input.hasClass('ds-c-choice--right')).toBe(false);
+  });
+
+  it('places input on right', () => {
+    const props = {
+      inputPlacement: 'right',
+      name: 'presidents',
+      value: label
+    };
+    const wrapper = shallow(<Choice {...props}>{label}</Choice>);
+    const input = wrapper.find('input');
+
+    expect(input.hasClass('ds-c-choice')).toBe(true);
+    expect(input.hasClass('ds-c-choice--right')).toBe(true);
+  });
+
   it('applies additional classNames to root element', () => {
     const props = {
       className: 'foo',
@@ -124,6 +149,18 @@ describe('Choice', () => {
     const wrapper = shallow(<Choice {...props}>{label}</Choice>);
 
     expect(wrapper.hasClass('foo')).toBe(true);
+  });
+
+  it('applies additional classNames to input element', () => {
+    const props = {
+      inputClassName: 'foo',
+      name: 'presidents',
+      value: label
+    };
+    const wrapper = shallow(<Choice {...props}>{label}</Choice>);
+    const input = wrapper.find('input');
+
+    expect(input.hasClass('foo')).toBe(true);
   });
 
   it('accepts a string value', () => {


### PR DESCRIPTION
There is now an option to put the label for a checkbox or radio button on the left side instead of the right.

### Added
- `ds-c-choice--left-label` puts the label on the left side of the checkbox/radio button


![rtl-choice](https://user-images.githubusercontent.com/7595652/30505560-476efcd6-9a2a-11e7-83ca-17e760d0ae66.jpg)
