### PR TITLE
Feature/a11y tabs

### DIFF
--- a/packages/core/src/components/Tabs/Tab.jsx
+++ b/packages/core/src/components/Tabs/Tab.jsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 export class Tab extends React.PureComponent {
   constructor(props) {
     super(props);
+    this.focus = this.focus.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.href = this.props.href || `#${this.props.panelId}`;
@@ -32,6 +33,10 @@ export class Tab extends React.PureComponent {
     }
   }
 
+  focus() {
+    this.tab.focus();
+  }
+
   render() {
     const classes = classnames('ds-c-tabs__item', this.props.className);
 
@@ -45,6 +50,7 @@ export class Tab extends React.PureComponent {
         onClick={this.handleClick}
         onKeyDown={this.handleKeyDown}
         role='tab'
+        ref={(tab) => { this.tab = tab; }}
       >
         {this.props.children}
       </a>

--- a/packages/core/src/components/Tabs/Tab.jsx
+++ b/packages/core/src/components/Tabs/Tab.jsx
@@ -6,12 +6,24 @@ export class Tab extends React.PureComponent {
   constructor(props) {
     super(props);
     this.handleClick = this.handleClick.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
     this.href = this.props.href || `#${this.props.panelId}`;
   }
 
   handleClick(evt) {
     if (this.props.onClick) {
       this.props.onClick(
+        evt,
+        this.props.panelId,
+        this.props.id,
+        this.href
+      );
+    }
+  }
+
+  handleKeyDown(evt) {
+    if (this.props.onKeyDown) {
+      this.props.onKeyDown(
         evt,
         this.props.panelId,
         this.props.id,
@@ -31,6 +43,7 @@ export class Tab extends React.PureComponent {
         href={this.href}
         id={this.props.id}
         onClick={this.handleClick}
+        onKeyDown={this.handleKeyDown}
         role='tab'
       >
         {this.props.children}
@@ -64,6 +77,12 @@ Tab.propTypes = {
    * `id`, `panelId`
    */
   onClick: PropTypes.func,
+  /**
+   * Called when the tab is clicked, with the following arguments:
+   * [`SyntheticEvent`](https://facebook.github.io/react/docs/events.html),
+   * `id`, `panelId`
+   */
+  onKeyDown: PropTypes.func,
   /**
    * The `id` of the associated `TabPanel`. Used for the `aria-controls` attribute.
    */

--- a/packages/core/src/components/Tabs/Tabs.example.jsx
+++ b/packages/core/src/components/Tabs/Tabs.example.jsx
@@ -9,6 +9,9 @@ export default function() {
       <TabPanel id='summary' tab='Summary'>
         The Bill of Rights is the first ten amendments to the United States Constitution.
       </TabPanel>
+      <TabPanel id='preamble' tab='Preamble'>
+        We the People of the United States, in Order to form a more perfect Union, establish Justice, insure domestic Tranquility, provide for the common defence, promote the general Welfare, and secure the Blessings of Liberty to ourselves and our Posterity, do ordain and establish this Constitution for the United States of America.
+      </TabPanel>
       <TabPanel id='amendments' tab='Amendments'>
         <h2 className='ds-h4'>Bill of Rights</h2>
 

--- a/packages/core/src/components/Tabs/Tabs.jsx
+++ b/packages/core/src/components/Tabs/Tabs.jsx
@@ -4,6 +4,14 @@ import Tab from './Tab';
 import TabPanel from './TabPanel';
 import classnames from 'classnames';
 
+/** CONSTANTS
+ * Adding in the constant values for keycodes
+ * to handle onKeyDown events
+ */
+const LEFT_ARROW = 'ArrowLeft';
+const RIGHT_ARROW = 'ArrowRight';
+const TAB = 'Tab';
+
 /**
  * Get the id of the first TabPanel child
  * @param {Object} props
@@ -33,6 +41,15 @@ function panelTabId(panel) {
 }
 
 /**
+ * Determine if a React component is a Tab
+ * @param {React.Node} child - a React component
+ * @return {Boolean} Is this a TabPanel component?
+ */
+function isTab(child) {
+  return child != null && child.props.tab != null;
+}
+
+/**
  * Determine if a React component is a TabPanel
  * @param {React.Node} child - a React component
  * @return {Boolean} Is this a TabPanel component?
@@ -58,6 +75,7 @@ export class Tabs extends React.PureComponent {
     }
 
     this.handleTabClick = this.handleTabClick.bind(this);
+    this.handleTabKeyPress = this.handleTabKeyPress.bind(this);
     this.state = { selectedId };
   }
 
@@ -72,6 +90,21 @@ export class Tabs extends React.PureComponent {
     evt.preventDefault();
     this.setState({ selectedId: panelId });
     this.replaceState(href);
+  }
+
+  handleTabKeyPress(evt, panelId) {
+    switch (evt.key) {
+      case LEFT_ARROW:
+        this.tabSwitchLeft(evt, panelId);
+        break;
+      case RIGHT_ARROW:
+        this.tabSwitchRight(evt, panelId);
+        break;
+      case TAB:
+        break;
+      default:
+        break;
+    }
   }
 
   // Filter children and return only TabPanel components
@@ -113,6 +146,7 @@ export class Tabs extends React.PureComponent {
           id={panelTabId(panel)}
           key={panel.key}
           onClick={this.handleTabClick}
+          onKeyDown={this.handleTabKeyPress}
           panelId={panel.props.id}
           selected={this.state.selectedId === panel.props.id}
         >
@@ -131,6 +165,59 @@ export class Tabs extends React.PureComponent {
   replaceState(url) {
     if (window.history) {
       window.history.replaceState({}, document.title, url);
+    }
+  }
+
+  /**
+   * Build tabs array to handle arrow keypress events accurately
+   */
+  tabsArrayLen() {
+    return React.Children.toArray(this.props.children)
+      .filter(isTab);
+  }
+
+  /**
+   * Find the current tab index on left or right arrow keypress
+   */
+  tabFindIndex(tabsArr, findId) {
+    const index = tabsArr.findIndex(elem => elem.props.id === findId);
+
+    return index;
+  }
+
+  /**
+   * Handle the left arrow keydown events
+   */
+  tabSwitchLeft(evt, curId) {
+    const tabs = this.tabsArrayLen();
+    const index = this.tabFindIndex(tabs, curId);
+
+    if (index === 0) {
+      const target = tabs[tabs.length - 1].props.id;
+      this.setState({ selectedId: target });
+      this.replaceState(`#${target}`);
+    } else {
+      const target = tabs[index - 1].props.id;
+      this.setState({ selectedId: target });
+      this.replaceState(`#${target}`);
+    }
+  }
+
+  /**
+   * Handle the right arrow keydown events
+   */
+  tabSwitchRight(evt, curId) {
+    const tabs = this.tabsArrayLen();
+    const index = this.tabFindIndex(tabs, curId);
+
+    if (index === tabs.length - 1) {
+      const target = tabs[0].props.id;
+      this.setState({ selectedId: target });
+      this.replaceState(`#${target}`);
+    } else {
+      const target = tabs[index + 1].props.id;
+      this.setState({ selectedId: target });
+      this.replaceState(`#${target}`);
     }
   }
 

--- a/packages/core/src/components/Tabs/Tabs.jsx
+++ b/packages/core/src/components/Tabs/Tabs.jsx
@@ -80,9 +80,11 @@ export class Tabs extends React.PureComponent {
   }
 
   componentDidUpdate(_, prevState) {
-    if (typeof this.props.onChange === 'function' &&
-        this.state.selectedId !== prevState.selectedId) {
-      this.props.onChange(this.state.selectedId, prevState.selectedId);
+    if (this.state.selectedId !== prevState.selectedId) {
+      if (typeof this.props.onChange === 'function') {
+        this.props.onChange(this.state.selectedId, prevState.selectedId);
+      }
+      this.tabs[this.state.selectedId].focus();
     }
   }
 
@@ -107,7 +109,9 @@ export class Tabs extends React.PureComponent {
     }
   }
 
-  // Filter children and return only TabPanel components
+  /**
+   * Filter children and return only TabPanel components
+   */
   panelChildren() {
     return React.Children.toArray(this.props.children)
       .filter(isTabPanel);
@@ -138,6 +142,8 @@ export class Tabs extends React.PureComponent {
     const panels = this.panelChildren();
     const listClasses = classnames('ds-c-tabs', this.props.tablistClassName);
 
+    this.tabs = {};
+
     const tabs = panels.map(panel => {
       return (
         <Tab
@@ -148,6 +154,7 @@ export class Tabs extends React.PureComponent {
           onClick={this.handleTabClick}
           onKeyDown={this.handleTabKeyPress}
           panelId={panel.props.id}
+          ref={(tab) => { this.tabs[panel.props.id] = tab; }}
           selected={this.state.selectedId === panel.props.id}
         >
           {panel.props.tab}
@@ -178,6 +185,9 @@ export class Tabs extends React.PureComponent {
 
   /**
    * Find the current tab index on left or right arrow keypress
+   * @param {Array} React Tab components
+   * @param {String} ID prop of currently selected Tab
+   * @return {Number} Returns index of currently selected array item
    */
   tabFindIndex(tabsArr, findId) {
     const index = tabsArr.findIndex(elem => elem.props.id === findId);
@@ -187,6 +197,15 @@ export class Tabs extends React.PureComponent {
 
   /**
    * Handle the left arrow keydown events
+   * @param {Object} Native event object, used to listen for left arrow keycode
+   * @param {String} ID prop of currently selected Tab
+   * 
+   * The index returned from tabFindIndex is used in a reduce by 1 logic
+   * tree to ensure the right tab[index] ID is targeted for updated state.
+   * 
+   * The replaceState function did not like the href argument passed into 
+   * handleTabClick, so passing an interpolated hashbang plus selected Tab
+   * string instead. 
    */
   tabSwitchLeft(evt, curId) {
     const tabs = this.tabsArrayLen();
@@ -205,6 +224,10 @@ export class Tabs extends React.PureComponent {
 
   /**
    * Handle the right arrow keydown events
+   * @param {Object} Native event object, used to listen for right arrow keycode
+   * @param {String} ID prop of currently selected Tab
+   * 
+   * See logic decisions above in tabSwitchLeft method
    */
   tabSwitchRight(evt, curId) {
     const tabs = this.tabsArrayLen();

--- a/packages/core/src/components/Tabs/Tabs.test.jsx
+++ b/packages/core/src/components/Tabs/Tabs.test.jsx
@@ -1,7 +1,7 @@
+import { mount, shallow } from 'enzyme';
 import React from 'react';
 import TabPanel from './TabPanel';
 import Tabs from './Tabs';
-import {shallow} from 'enzyme';
 
 const defaultPanelChildren = 'Foo';
 const defaultPanelProps = {
@@ -19,6 +19,19 @@ function shallowRender(customProps = {}, children) {
   return {
     props: props,
     wrapper: shallow(<Tabs {...props}>{children}</Tabs>)
+  };
+}
+
+function deepMount(customProps = {}, children) {
+  const props = Object.assign({}, customProps);
+
+  if (!children) {
+    children = <TabPanel {...defaultPanelProps}>{defaultPanelChildren}</TabPanel>;
+  }
+
+  return {
+    props: props,
+    wrapper: mount(<Tabs {...props}>{children}</Tabs>)
   };
 }
 
@@ -109,7 +122,7 @@ describe('Tabs', function() {
 
     it('calls onChange', () => {
       const onChangeMock = jest.fn();
-      const data = shallowRender(
+      const data = deepMount(
         {
           onChange: onChangeMock,
           selectedId: 'panel-1'

--- a/packages/docs/src/scripts/helpers/polyfills.js
+++ b/packages/docs/src/scripts/helpers/polyfills.js
@@ -5,6 +5,7 @@
 // - github.com/facebook/react/issues/8379#issuecomment-264867090
 require('core-js/fn/array/includes');
 require('core-js/fn/array/fill');
+require('core-js/fn/array/find-index');
 require('core-js/fn/function/name');
-require('core-js/fn/object/get-own-property-symbols');
+require('core-js/fn/object/get-own-property-names');
 require('core-js/fn/string/includes');


### PR DESCRIPTION
### Added
Added the ability for Tabs component to change tab focus by pressing left and right arrows. This is in line with the latest [WAI-ARIA Authoring Practices 1.1 for Tabs.](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel)

### Changed
* Updated Tabs.jsx to include a keydown method that listens for left and right arrow presses, without interfering with Tab or Enter keypresses
* Updated Tabs.jsx to include a ref prop for handling focus
* Updated Tab.jsx to include a ref prop for handling focus
* Updated Tabs.test.jsx to include a deepMount function that passes custom props and renders a full component using Enzyme's mount method
* Updated the Webpack.config.js file to add CoreJS method for Array.prototype.findIndex
* Updated the Webpack.config.js file to add CoreJS method for Object.getOwnPropertyNames

### Tested for a11y
* Verified proper keyboard handling in following browsers:
** Windows 10 - IE11, Edge, Chrome, Firefox
** OSX - Safari, Chrome, Firefox
* Verified tab usability in following screenreader combinations:
** Windows 10 - IE11 - JAWS
** Windows 10 - Firefox - NVDA
** OSX - Safari - VoiceOver