### PR TITLE
Fix:  Remove Chrome's default border-radius

### DIFF
--- a/packages/core/src/components/Tabs/Tabs.scss
+++ b/packages/core/src/components/Tabs/Tabs.scss
@@ -88,9 +88,11 @@ Style guide: components.tabs.react-tabpanel
 Style guide: components.tabs.react-tab
 */
 .ds-c-tabs__item {
+  appearance: none;
   background-color: $color-background;
   border-bottom: 1px solid $border-color;
   border-left: 1px solid $border-color;
+  border-radius: 0;
   border-top: 1px solid $border-color;
   color: $color-base;
   cursor: pointer;
@@ -131,7 +133,8 @@ Style guide: components.tabs.react-tab
     right: -1px;
     top: -1px;
     transform: scale3d(0, 1, 1);
-    transition: opacity $animation-speed-2 $ease-in-out-expo, transform $animation-speed-2 $ease-in-out-expo;
+    transition: opacity $animation-speed-2 $ease-in-out-expo,
+      transform $animation-speed-2 $ease-in-out-expo;
   }
 
   // States

--- a/packages/core/src/components/VerticalNav/VerticalNav.scss
+++ b/packages/core/src/components/VerticalNav/VerticalNav.scss
@@ -86,6 +86,7 @@ Style guide: components.vertical-nav
   background-repeat: no-repeat;
   background-size: $small-font-size;
   border-bottom: 0; // Clear <button> borders (border-left is already set)
+  border-radius: 0; // Remove default browser radius in Chrome
   border-right: 0;
   border-top: 0;
   cursor: pointer;


### PR DESCRIPTION
### Fixed

🤔 Seems like Chrome introduced a default `4px` `border-radius` on `button` elements. This removes that radius on the tabs and vertical nav items, which may be used on a `button` element.

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/371943/32031070-026486fc-b9cd-11e7-84aa-9d426035eb06.png) | ![image](https://user-images.githubusercontent.com/371943/32031073-0492cf7e-b9cd-11e7-8fbd-62f001eb3b28.png) |

