### PR TITLE
Internal: Add margin to React examples

### DIFF
--- a/packages/docs/src/scripts/components/ReactExample.jsx
+++ b/packages/docs/src/scripts/components/ReactExample.jsx
@@ -34,7 +34,7 @@ class ReactExample extends React.PureComponent {
 
   render() {
     return (
-      <div className="markup markup--react">
+      <div className="ds-u-margin-top--3 markup markup--react">
         <div className="ds-u-border--1 ds-u-padding--1">
           {this.renderComponent()}
         </div>


### PR DESCRIPTION
### Internal

Quick fix for weird spacing when there isn't a React example heading or description:

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/371943/32032545-c432980c-b9d5-11e7-88d3-d063e1c0d5dc.png) | ![image](https://user-images.githubusercontent.com/371943/32032526-b27c704c-b9d5-11e7-8db8-64badae67de3.png) |
