### PR TITLE
Remove ds-c-field--select + Fix overlapping select icon

### DIFF
--- a/packages/core/src/components/ChoiceList/Select.jsx
+++ b/packages/core/src/components/ChoiceList/Select.jsx
@@ -22,7 +22,7 @@ export const Select = function(props) {
   /* eslint-enable prefer-const */
 
   const classes = classNames(
-    'ds-c-field ds-c-field--select',
+    'ds-c-field',
     { 'ds-c-field--inverse': inversed },
     className
   );

--- a/packages/core/src/components/ChoiceList/Select.scss
+++ b/packages/core/src/components/ChoiceList/Select.scss
@@ -9,7 +9,7 @@ A select field allows users to select one option from a list.
 
 Markup:
 <label class="ds-c-label ds-u-margin-top--0" for="options">Field label</label>
-<select class="ds-c-field ds-c-field--select" name="options" id="options">
+<select class="ds-c-field" name="options" id="options">
   <option value="1">Option 1</option>
   <option value="2">Option 2</option>
   <option value="3">Option 3</option>
@@ -23,7 +23,7 @@ Markup:
     Field label
     <span class="ds-c-field__hint ds-c-field__hint--inverse">Helpful hint text</span>
   </label>
-  <select class="ds-c-field ds-c-field--select ds-c-field--inverse" name="options-inverse" id="options-inverse">
+  <select class="ds-c-field ds-c-field--inverse" name="options-inverse" id="options-inverse">
     <option value="1">Option 1</option>
     <option value="2">Option 2</option>
     <option value="3">Option 3</option>
@@ -37,18 +37,21 @@ Markup:
 Style guide: components.select
 */
 
-.ds-c-field--select {
+// stylelint-disable selector-no-qualifying-type
+select.ds-c-field {
   appearance: none;
   background-color: $color-white;
   background-image: url('#{$image-path}/arrow-both.svg');
   background-position: right $small-font-size center;
   background-repeat: no-repeat;
   background-size: $small-font-size;
+  padding-right: ($small-font-size * 2) + $spacer-1;
 
   &[multiple] {
     background-image: none;
   }
 }
+// stylelint-enable selector-no-qualifying-type
 
 /*
 `<ChoiceList>`

--- a/packages/core/src/components/ChoiceList/Select.test.jsx
+++ b/packages/core/src/components/ChoiceList/Select.test.jsx
@@ -55,7 +55,6 @@ describe('Select', () => {
     const data = shallowRender();
 
     expect(data.wrapper.hasClass('ds-c-field')).toBe(true);
-    expect(data.wrapper.hasClass('ds-c-field--select')).toBe(true);
   });
 
   it("renders <option>'s as children", () => {


### PR DESCRIPTION
### Removed

- Removed `.ds-c-field--select`. This seems unnecessary, and we can look at whether `ds-c-field` is added to a `select` element instead. I can't think of any use cases where it would be added to some other form element. (This is not a breaking change).

### Fixed

- Added padding to the select element so that text doesn't overlap with the icon when the field's width is set to `auto`:
   ![image](https://user-images.githubusercontent.com/371943/32111515-b9ab1d12-bb08-11e7-951c-ef2345fca3ee.png)
