### PR TITLE
Internal: Run prettier on Sass files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "design-system",
   "private": true,
-  "description":
-    "A shared set of design and code elements for creating accessible and consistent websites",
+  "description": "A shared set of design and code elements for creating accessible and consistent websites",
   "repository": "CMSgov/design-system",
   "scripts": {
     "build": "NODE_ENV=production gulp build --env=production",
@@ -18,14 +17,11 @@
     "start:theme": "npm run start -- --theme",
     "test": "jest",
     "test:watch": "NODE_ENV=test jest --watch",
-    "lint":
-      "eslint tools/ examples/**/src/ packages/**/src/ --ext .js --ext .jsx -f table && gulp lint --env=test --theme"
+    "lint": "eslint tools/ examples/**/src/ packages/**/src/ --ext .js --ext .jsx -f table && gulp lint --env=test --theme"
   },
   "devDependencies": {
-    "@cmsgov/eslint-config-design-system":
-      "file:./packages/eslint-config-design-system",
-    "@cmsgov/stylelint-config-design-system":
-      "file:./packages/stylelint-config-design-system",
+    "@cmsgov/eslint-config-design-system": "file:./packages/eslint-config-design-system",
+    "@cmsgov/stylelint-config-design-system": "file:./packages/stylelint-config-design-system",
     "autoprefixer": "^7.1.6",
     "babel-core": "^6.26.0",
     "babel-jest": "^21.0.2",
@@ -86,6 +82,7 @@
     "recast": "^0.12.7",
     "run-sequence": "^2.2.0",
     "stylelint": "^8.2.0",
+    "stylelint-config-prettier": "^1.0.2",
     "through2": "^2.0.3",
     "tota11y": "^0.1.6",
     "vinyl-source-stream": "^1.1.0",
@@ -112,7 +109,11 @@
     ]
   },
   "lint-staged": {
-    "*.{js,jsx}": ["prettier --write", "eslint --fix", "git add"]
+    "*.{js,jsx}": [
+      "prettier --write",
+      "eslint --fix",
+      "git add"
+    ]
   },
   "resolutions": {
     "gulp-sass/node-sass": ">=4.5.3"

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -164,7 +164,7 @@ Style guide: components.choice.inversed
 }
 
 // Display a circular radio button
-.ds-c-choice[type=radio] + label::before {
+.ds-c-choice[type='radio'] + label::before {
   border-radius: 100%;
 }
 

--- a/packages/core/src/components/Spinner/Spinner.scss
+++ b/packages/core/src/components/Spinner/Spinner.scss
@@ -93,8 +93,12 @@ Style guide: components.spinner
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 /*

--- a/packages/core/src/generics/_fonts.scss
+++ b/packages/core/src/generics/_fonts.scss
@@ -6,8 +6,8 @@
   font-style: normal;
   font-weight: normal;
   src: url('#{$font-path}/Bitter-Regular.eot');
-  src:
-    url('#{$font-path}/Bitter-Regular.eot?#iefix') format('embedded-opentype'),
+  src: url('#{$font-path}/Bitter-Regular.eot?#iefix')
+      format('embedded-opentype'),
     url('#{$font-path}/Bitter-Regular.woff2') format('woff2'),
     url('#{$font-path}/Bitter-Regular.woff') format('woff'),
     url('#{$font-path}/Bitter-Regular.ttf') format('truetype');
@@ -18,8 +18,7 @@
   font-style: normal;
   font-weight: bold;
   src: url('#{$font-path}/Bitter-Bold.eot');
-  src:
-    url('#{$font-path}/Bitter-Bold.eot?#iefix') format('embedded-opentype'),
+  src: url('#{$font-path}/Bitter-Bold.eot?#iefix') format('embedded-opentype'),
     url('#{$font-path}/Bitter-Bold.woff2') format('woff2'),
     url('#{$font-path}/Bitter-Bold.woff') format('woff'),
     url('#{$font-path}/Bitter-Bold.ttf') format('truetype');
@@ -30,8 +29,7 @@
   font-style: italic;
   font-weight: normal;
   src: url('#{$font-path}/Bitter-Italic.eot');
-  src:
-    url('#{$font-path}/Bitter-Italic.eot?#iefix') format('embedded-opentype'),
+  src: url('#{$font-path}/Bitter-Italic.eot?#iefix') format('embedded-opentype'),
     url('#{$font-path}/Bitter-Italic.woff2') format('woff2'),
     url('#{$font-path}/Bitter-Italic.woff') format('woff'),
     url('#{$font-path}/Bitter-Italic.ttf') format('truetype');
@@ -42,8 +40,8 @@
   font-style: normal;
   font-weight: normal;
   src: url('#{$font-path}/OpenSans-Regular-webfont.eot');
-  src:
-    url('#{$font-path}/OpenSans-Regular-webfont.eot?#iefix') format('embedded-opentype'),
+  src: url('#{$font-path}/OpenSans-Regular-webfont.eot?#iefix')
+      format('embedded-opentype'),
     url('#{$font-path}/OpenSans-Regular-webfont.woff2') format('woff2'),
     url('#{$font-path}/OpenSans-Regular-webfont.woff') format('woff'),
     url('#{$font-path}/OpenSans-Regular-webfont.ttf') format('truetype');
@@ -54,8 +52,8 @@
   font-style: italic;
   font-weight: normal;
   src: url('#{$font-path}/OpenSans-Italic-webfont.eot');
-  src:
-    url('#{$font-path}/OpenSans-Italic-webfont.eot?#iefix') format('embedded-opentype'),
+  src: url('#{$font-path}/OpenSans-Italic-webfont.eot?#iefix')
+      format('embedded-opentype'),
     url('#{$font-path}/OpenSans-Italic-webfont.woff2') format('woff2'),
     url('#{$font-path}/OpenSans-Italic-webfont.woff') format('woff'),
     url('#{$font-path}/OpenSans-Italic-webfont.ttf') format('truetype');
@@ -66,8 +64,8 @@
   font-style: normal;
   font-weight: 600;
   src: url('#{$font-path}/OpenSans-Semibold-webfont.eot');
-  src:
-    url('#{$font-path}/OpenSans-Semibold-webfont.eot?#iefix') format('embedded-opentype'),
+  src: url('#{$font-path}/OpenSans-Semibold-webfont.eot?#iefix')
+      format('embedded-opentype'),
     url('#{$font-path}/OpenSans-Semibold-webfont.woff2') format('woff2'),
     url('#{$font-path}/OpenSans-Semibold-webfont.woff') format('woff'),
     url('#{$font-path}/OpenSans-Semibold-webfont.ttf') format('truetype');
@@ -78,8 +76,8 @@
   font-style: normal;
   font-weight: 700;
   src: url('#{$font-path}/OpenSans-Bold-webfont.eot');
-  src:
-    url('#{$font-path}/OpenSans-Bold-webfont.eot?#iefix') format('embedded-opentype'),
+  src: url('#{$font-path}/OpenSans-Bold-webfont.eot?#iefix')
+      format('embedded-opentype'),
     url('#{$font-path}/OpenSans-Bold-webfont.woff2') format('woff2'),
     url('#{$font-path}/OpenSans-Bold-webfont.woff') format('woff'),
     url('#{$font-path}/OpenSans-Bold-webfont.ttf') format('truetype');

--- a/packages/core/src/utilities/flexbox.scss
+++ b/packages/core/src/utilities/flexbox.scss
@@ -162,11 +162,7 @@ Markup:
 
 Style guide: utilities.flexbox.flex-wrap
 */
-$_flex-wrap-values: (
-  nowrap: nowrap,
-  wrap: wrap,
-  reverse: wrap-reverse
-);
+$_flex-wrap-values: (nowrap: nowrap, wrap: wrap, reverse: wrap-reverse);
 
 @each $name in map-keys($_flex-wrap-values) {
   $value: map-get($_flex-wrap-values, $name);

--- a/packages/docs/src/styles/base/_details.scss
+++ b/packages/docs/src/styles/base/_details.scss
@@ -12,6 +12,7 @@ summary::before {
   padding-right: 0.5em;
 }
 
-details[open] > summary::before { // stylelint-disable-line selector-no-qualifying-type
+// stylelint-disable-next-line selector-no-qualifying-type
+details[open] > summary::before {
   content: '\25BC';
 }

--- a/packages/docs/src/styles/base/_syntax-highlighting.scss
+++ b/packages/docs/src/styles/base/_syntax-highlighting.scss
@@ -4,8 +4,8 @@
  * Inspired by Github syntax coloring
  */
 
-code[class*="language-"],
-pre[class*="language-"] {
+code[class*='language-'],
+pre[class*='language-'] {
   direction: ltr;
   text-align: left;
   white-space: pre;
@@ -16,7 +16,7 @@ pre[class*="language-"] {
 }
 
 /* Code blocks */
-pre[class*="language-"] {
+pre[class*='language-'] {
   overflow: auto;
 }
 
@@ -39,7 +39,7 @@ pre[class*="language-"] {
 
 .token.punctuation,
 .token.operator {
-  color: #393A34; /* no highlight */
+  color: #393a34; /* no highlight */
 }
 
 .token.entity,

--- a/packages/docs/src/styles/components/_Docs.scss
+++ b/packages/docs/src/styles/components/_Docs.scss
@@ -8,8 +8,12 @@
 }
 
 @keyframes lock {
-  from { position: static; }
-  to { position: fixed; }
+  from {
+    position: static;
+  }
+  to {
+    position: fixed;
+  }
 }
 
 .docs__toggle {

--- a/packages/docs/src/styles/settings/_typography.scss
+++ b/packages/docs/src/styles/settings/_typography.scss
@@ -1,3 +1,4 @@
-$font-monospace: 'Roboto Mono', 'Consolas', 'Bitstream Vera Sans Mono', 'Courier New';
+$font-monospace: 'Roboto Mono', 'Consolas', 'Bitstream Vera Sans Mono',
+  'Courier New';
 
 $xs-font-size: 12px;

--- a/packages/generator-cmsgov/generators/app/templates/index.scss
+++ b/packages/generator-cmsgov/generators/app/templates/index.scss
@@ -13,7 +13,7 @@ Markup:
 Style guide: components.<%= slug %>
 */
 
-.ds-c-<%= slug %> {
+.ds-c-<%= slug % >  {
   // TODO: Enter your ruleset here
 }
 

--- a/packages/stylelint-config-design-system/index.js
+++ b/packages/stylelint-config-design-system/index.js
@@ -24,7 +24,6 @@ module.exports = {
     ],
     'comment-whitespace-inside': 'always',
     'declaration-bang-space-after': 'never',
-    'declaration-bang-space-before': 'always',
     'declaration-block-no-duplicate-properties': [
       true,
       {

--- a/packages/support/src/settings/_override.uswds.scss
+++ b/packages/support/src/settings/_override.uswds.scss
@@ -8,28 +8,27 @@
 // the root element (typically <html>) to have its font size set to
 // 10px. Since styling a root element goes against the guiding principles
 // of this design system, we use px units instead.
-$base-font-size:      16px !default;
-$small-font-size:     14px !default;
-$lead-font-size:      18px !default;
+$base-font-size: 16px !default;
+$small-font-size: 14px !default;
+$lead-font-size: 18px !default;
 
-$h1-font-size:        36px !default;
-$h2-font-size:        24px !default;
-$h3-font-size:        21px !default;
-$h4-font-size:        18px !default;
-$h5-font-size:        $base-font-size !default;
-$h6-font-size:        $small-font-size !default;
+$h1-font-size: 36px !default;
+$h2-font-size: 24px !default;
+$h3-font-size: 21px !default;
+$h4-font-size: 18px !default;
+$h5-font-size: $base-font-size !default;
+$h6-font-size: $small-font-size !default;
 
-$title-font-size:     48px !default;
-$display-font-size:   60px !default;
+$title-font-size: 48px !default;
+$display-font-size: 60px !default;
 
 // Replace US WDS font stacks with HealthCare.gov font stacks
-$font-sans:           'Open Sans', Helvetica, sans-serif !default;
-$font-serif:          Bitter, Georgia, serif !default;
+$font-sans: 'Open Sans', Helvetica, sans-serif !default;
+$font-serif: Bitter, Georgia, serif !default;
 
 // Inputs
-$input-max-width:     460px !default; // rem -> px
+$input-max-width: 460px !default; // rem -> px
 
 // Paths
-$font-path:   '../fonts' !default;
-$image-path:  '../images' !default;
-
+$font-path: '../fonts' !default;
+$image-path: '../images' !default;

--- a/packages/support/src/settings/_variables.color.scss
+++ b/packages/support/src/settings/_variables.color.scss
@@ -130,7 +130,8 @@ Style guide: style.color.status
 // Generic
 // USWDS doesn't include a "lighter" variant for red, so we create one
 // in order to be consistent with the other "state" colors.
-$color-secondary-lighter: mix($color-secondary-light, $color-secondary-lightest) !default;
+$color-secondary-lighter: mix($color-secondary-light, $color-secondary-lightest)
+  !default;
 
 $color-error: $color-secondary !default;
 $color-error-dark: $color-secondary-dark !default;
@@ -160,7 +161,8 @@ $color-muted-inverse: #bac5cf !default;
 // USWDS has a default focus color, but we want one that can be applied to
 // fields that are displayed on top of an inverted background
 $color-focus-inverse: #59bcff !default;
-$focus-shadow-inverse: 0 0 3px $color-focus-inverse, 0 0 7px $color-focus-inverse !default;
+$focus-shadow-inverse: 0 0 3px $color-focus-inverse,
+  0 0 7px $color-focus-inverse !default;
 
 // Background
 $color-background: $color-white !default;

--- a/packages/support/src/settings/_variables.layout.scss
+++ b/packages/support/src/settings/_variables.layout.scss
@@ -17,15 +17,16 @@ Style guide: layout.spacing
 $multiple: 8px !default;
 
 $spacers: (
-  0,
-  $multiple,
-  $multiple * 2,
-  $multiple * 3,
-  $multiple * 4,
-  $multiple * 5,
-  $multiple * 6,
-  $multiple * 7
-) !default;
+    0,
+    $multiple,
+    $multiple * 2,
+    $multiple * 3,
+    $multiple * 4,
+    $multiple * 5,
+    $multiple * 6,
+    $multiple * 7
+  )
+  !default;
 
 $spacer-1: nth($spacers, 2) !default; // 8px
 $spacer-2: nth($spacers, 3) !default; // 16px
@@ -34,7 +35,7 @@ $spacer-4: nth($spacers, 5) !default; // 32px
 $spacer-5: nth($spacers, 6) !default; // 40px
 $spacer-6: nth($spacers, 7) !default; // 48px
 $spacer-7: nth($spacers, 8) !default; // 56px
-$spacer-half: $spacer-1 / 2;          // 4px
+$spacer-half: $spacer-1 / 2; // 4px
 
 // Breakpoint widths
 // INTERNAL: If these values change, the values used for the responsive previews
@@ -46,16 +47,8 @@ $width-lg: 1024px !default;
 $width-xl: 1280px !default;
 
 // Breakpoints
-$breakpoints: (
-  // Small screen / landscape phone
-  sm: $width-sm,
-  // Medium screen / tablet
-  md: $width-md,
-  // Large screen / desktop
-  lg: $width-lg,
-  // Extra large screen / wide desktop
-  xl: $width-xl
-) !default;
+$breakpoints: (sm: $width-sm, md: $width-md, lg: $width-lg, xl: $width-xl)
+  !default;
 
 // Borders
 $border-radius-circle: 100%;

--- a/packages/support/src/vendor/uswds/core/_variables.scss
+++ b/packages/support/src/vendor/uswds/core/_variables.scss
@@ -10,83 +10,83 @@
 // Typography
 // Removing the !default from $em-base so we are not inheriting that
 // value from Bourbon.
-$em-base:             10px;
-$base-font-size:      1.7rem !default;
-$small-font-size:     1.4rem !default;
-$lead-font-size:      2rem !default;
-$title-font-size:     5.2rem !default;
-$h1-font-size:        4rem !default;
-$h2-font-size:        3rem !default;
-$h3-font-size:        2rem !default;
-$h4-font-size:        1.7rem !default;
-$h5-font-size:        1.5rem !default;
-$h6-font-size:        1.3rem !default;
-$base-line-height:    1.5 !default;
+$em-base: 10px;
+$base-font-size: 1.7rem !default;
+$small-font-size: 1.4rem !default;
+$lead-font-size: 2rem !default;
+$title-font-size: 5.2rem !default;
+$h1-font-size: 4rem !default;
+$h2-font-size: 3rem !default;
+$h3-font-size: 2rem !default;
+$h4-font-size: 1.7rem !default;
+$h5-font-size: 1.5rem !default;
+$h6-font-size: 1.3rem !default;
+$base-line-height: 1.5 !default;
 $heading-line-height: 1.3 !default;
-$lead-line-height:    1.7 !default;
+$lead-line-height: 1.7 !default;
 
-$font-sans:           'Source Sans Pro', $helvetica !default;
-$font-serif:          'Merriweather', $georgia !default;
+$font-sans: 'Source Sans Pro', $helvetica !default;
+$font-serif: 'Merriweather', $georgia !default;
 
-$font-normal:         400 !default;
-$font-bold:           700 !default;
+$font-normal: 400 !default;
+$font-bold: 700 !default;
 
 // Color
-$color-primary:              #0071bc !default;
-$color-primary-darker:       #205493 !default;
-$color-primary-darkest:      #112e51 !default;
+$color-primary: #0071bc !default;
+$color-primary-darker: #205493 !default;
+$color-primary-darkest: #112e51 !default;
 
-$color-primary-alt:          #02bfe7 !default;
-$color-primary-alt-dark:     #00a6d2 !default;
-$color-primary-alt-darkest:  #046b99 !default;
-$color-primary-alt-light:    #9bdaf1 !default; // lighten($color-primary-alt, 60%)
+$color-primary-alt: #02bfe7 !default;
+$color-primary-alt-dark: #00a6d2 !default;
+$color-primary-alt-darkest: #046b99 !default;
+$color-primary-alt-light: #9bdaf1 !default; // lighten($color-primary-alt, 60%)
 $color-primary-alt-lightest: #e1f3f8 !default; // lighten($color-primary-alt, 90%)
 
-$color-secondary:            #e31c3d !default;
-$color-secondary-dark:       #cd2026 !default;
-$color-secondary-darkest:    #981b1e !default;
-$color-secondary-light:      #e59393 !default; // lighten($color-secondary, 60%)
-$color-secondary-lightest:   #f9dede !default; // lighten($color-secondary, 90%)
+$color-secondary: #e31c3d !default;
+$color-secondary-dark: #cd2026 !default;
+$color-secondary-darkest: #981b1e !default;
+$color-secondary-light: #e59393 !default; // lighten($color-secondary, 60%)
+$color-secondary-lightest: #f9dede !default; // lighten($color-secondary, 90%)
 
-$color-white:                #ffffff !default;
-$color-base:                 #212121 !default;
-$color-black:                #000000 !default;
+$color-white: #ffffff !default;
+$color-base: #212121 !default;
+$color-black: #000000 !default;
 
-$color-gray-dark:            #323a45 !default;
-$color-gray:                 #5b616b !default; // lighten($color-gray-dark, 20%)
-$color-gray-medium:          #757575 !default; // lightest gray that passes color contrast
-$color-gray-light:           #aeb0b5 !default; // lighten($color-gray-dark, 60%)
-$color-gray-lighter:         #d6d7d9 !default; // lighten($color-gray-dark, 80%)
-$color-gray-lightest:        #f1f1f1 !default; // lighten($color-gray-dark, 91%)
+$color-gray-dark: #323a45 !default;
+$color-gray: #5b616b !default; // lighten($color-gray-dark, 20%)
+$color-gray-medium: #757575 !default; // lightest gray that passes color contrast
+$color-gray-light: #aeb0b5 !default; // lighten($color-gray-dark, 60%)
+$color-gray-lighter: #d6d7d9 !default; // lighten($color-gray-dark, 80%)
+$color-gray-lightest: #f1f1f1 !default; // lighten($color-gray-dark, 91%)
 
-$color-gray-warm-dark:       #494440 !default;
-$color-gray-warm-light:      #e4e2e0 !default; // lighten($color-gray-warm-dark, 90%)
-$color-gray-cool-light:      #dce4ef !default; // lighten($color-primary, 90%)
+$color-gray-warm-dark: #494440 !default;
+$color-gray-warm-light: #e4e2e0 !default; // lighten($color-gray-warm-dark, 90%)
+$color-gray-cool-light: #dce4ef !default; // lighten($color-primary, 90%)
 
-$color-gold:                 #fdb81e !default;
-$color-gold-light:           #f9c642 !default; //  lighten($color-gold, 20%)
-$color-gold-lighter:         #fad980 !default; //  lighten($color-gold, 60%)
-$color-gold-lightest:        #fff1d2 !default; //  lighten($color-gold, 83%)
+$color-gold: #fdb81e !default;
+$color-gold-light: #f9c642 !default; //  lighten($color-gold, 20%)
+$color-gold-lighter: #fad980 !default; //  lighten($color-gold, 60%)
+$color-gold-lightest: #fff1d2 !default; //  lighten($color-gold, 83%)
 
-$color-green:                #2e8540 !default;
-$color-green-light:          #4aa564 !default; // lighten($color-green, 20%)
-$color-green-lighter:        #94bfa2 !default; // lighten($color-green, 60%)
-$color-green-lightest:       #e7f4e4 !default; // lighten($color-green, 60%)
+$color-green: #2e8540 !default;
+$color-green-light: #4aa564 !default; // lighten($color-green, 20%)
+$color-green-lighter: #94bfa2 !default; // lighten($color-green, 60%)
+$color-green-lightest: #e7f4e4 !default; // lighten($color-green, 60%)
 
-$color-cool-blue:            #205493 !default;
-$color-cool-blue-light:      #4773aa !default; // lighten($color-cool-blue, 20%)
-$color-cool-blue-lighter:    #8ba6ca !default; // lighten($color-cool-blue, 60%)
-$color-cool-blue-lightest:   #dce4ef !default; // lighten($color-cool-blue, 90%)
+$color-cool-blue: #205493 !default;
+$color-cool-blue-light: #4773aa !default; // lighten($color-cool-blue, 20%)
+$color-cool-blue-lighter: #8ba6ca !default; // lighten($color-cool-blue, 60%)
+$color-cool-blue-lightest: #dce4ef !default; // lighten($color-cool-blue, 90%)
 
-$color-focus:                #3e94cf !default;
-$color-visited:              #4c2c92 !default;
+$color-focus: #3e94cf !default;
+$color-visited: #4c2c92 !default;
 
-$color-shadow:               rgba(#000, 0.3) !default;
+$color-shadow: rgba(#000, 0.3) !default;
 
 // Mobile First Breakpoints
-$small-screen:  481px !default;
+$small-screen: 481px !default;
 $medium-screen: 600px !default;
-$large-screen:  1201px !default;
+$large-screen: 1201px !default;
 
 // Grid column counts by screen size
 $grid-columns-small: 1 !default;
@@ -99,24 +99,24 @@ $medium: new-breakpoint(min-width $medium-screen $grid-columns-medium) !default;
 $large: new-breakpoint(min-width $large-screen $grid-columns-large) !default;
 
 // Relative font and image file paths
-$font-path:   '../fonts' !default;
-$image-path:  '../img' !default;
+$font-path: '../fonts' !default;
+$image-path: '../img' !default;
 
 // Set $asset-pipeline to true if you're using the Rails Asset Pipeline
-$asset-pipeline:      false !default;
+$asset-pipeline: false !default;
 
 // Magic Numbers
-$text-max-width:      53rem !default;
-$lead-max-width:      77rem !default;
-$site-max-width:      1040px !default;
-$site-margins:        3rem !default;
+$text-max-width: 53rem !default;
+$lead-max-width: 77rem !default;
+$site-max-width: 1040px !default;
+$site-margins: 3rem !default;
 $site-margins-mobile: 1.5rem !default;
-$article-max-width:   600px !default;
-$input-max-width:     46rem !default;
-$border-radius:       3px !default;
-$box-shadow:          0 0 2px $color-shadow !default;
-$focus-shadow:        0 0 3px $color-focus, 0 0 7px $color-focus !default;
-$nav-width:           951px !default;
+$article-max-width: 600px !default;
+$input-max-width: 46rem !default;
+$border-radius: 3px !default;
+$box-shadow: 0 0 2px $color-shadow !default;
+$focus-shadow: 0 0 3px $color-focus, 0 0 7px $color-focus !default;
+$nav-width: 951px !default;
 
 // 44 x 44 pixels hit target following Apple iOS Human Interface
 // Guidelines

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,5 +1,8 @@
 module.exports = {
-  extends: ['./packages/stylelint-config-design-system'],
+  extends: [
+    './packages/stylelint-config-design-system',
+    'stylelint-config-prettier'
+  ],
   ignoreFiles: [
     'packages/generator-cmsgov/*',
     'packages/support/src/vendor/**/*.scss'

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -6,5 +6,9 @@ module.exports = {
   ignoreFiles: [
     'packages/generator-cmsgov/*',
     'packages/support/src/vendor/**/*.scss'
-  ]
+  ],
+  rules: {
+    // Prettier sometimes wraps !default to a new line
+    'declaration-bang-space-before': null
+  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8987,6 +8987,10 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
+stylelint-config-prettier@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-1.0.2.tgz#46adcb685bc5baf797ab1d251e4a8e86573d91bc"
+
 stylelint-order@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-0.7.0.tgz#ceab5cbe24aa33fa63590024995395f6edfc9ab7"


### PR DESCRIPTION
### Internal

When I added prettier, I only ran it on `js` and `jsx` files, but not `scss` files. This does that, and also adds `stylelint-config-prettier` to disable any conflicting Stylelint rules.