### PR TITLE
Add modifier to hide alert icon

### DIFF
--- a/packages/core/src/components/Alert/Alert.scss
+++ b/packages/core/src/components/Alert/Alert.scss
@@ -69,7 +69,7 @@ $alert-icon-size: $spacer-5;
 }
 
 .ds-c-alert--hide-icon .ds-c-alert__body {
-  padding-left: $alert-padding;
+  padding-left: 0;
 }
 
 .ds-c-alert__heading {

--- a/packages/core/src/components/Alert/Alert.scss
+++ b/packages/core/src/components/Alert/Alert.scss
@@ -10,6 +10,7 @@ Alerts keep users informed of important and sometimes time-sensitive changes.
 .ds-c-alert--error - Error message
 .ds-c-alert--warn - Warning message
 .ds-c-alert--success - Success message
+.ds-c-alert--hide-icon - Hide icon
 
 Markup:
 <div class="ds-c-alert {{modifier}}">
@@ -39,6 +40,10 @@ $alert-icon-size: $spacer-5;
   padding: $alert-padding;
   position: relative;
 
+  &.ds-c-alert--hide-icon {
+    background-image: none;
+  }
+
   a {
     color: $color-primary-darker;
 
@@ -61,6 +66,10 @@ $alert-icon-size: $spacer-5;
 
 .ds-c-alert__body {
   padding-left: $alert-icon-size + $alert-bar-size;
+}
+
+.ds-c-alert--hide-icon .ds-c-alert__body {
+  padding-left: $alert-padding;
 }
 
 .ds-c-alert__heading {


### PR DESCRIPTION
### Added
Added a modifier class for the alert component, `.ds-c-alert--hide-icon`, to hide the icon and adjust the left padding.

![image](https://user-images.githubusercontent.com/3903208/32137048-c976d7ca-bbe6-11e7-8d82-dc152662f538.png)
