### PR TITLE
Replace references to staging branch with master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ before_install:
 branches:
   only:
   - master
-  - staging
 cache: yarn
 language: node_js
 node_js:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,19 +68,9 @@ If you have multiple directories inside of `packages/themes`, you can specify wh
 
 Here are a few guidelines to follow when submitting a pull request:
 
-- Branch off of `staging`: `git checkout -b username/branch-name`
+- Branch off of `master`: `git checkout -b username/branch-name`
 - Commit your changes
-- Make a pull request against the `staging` branch
-
-## Merging pull requests
-
-#### Staging
-
-Use the "**Squash and merge**" option when merging pull requests into the `staging` branch. This keeps our history clean and makes it easier on us when it comes time to create a new release.
-
-#### Master
-
-Use the "**Create a merge commit**" option when merging `staging` into `master`. If the pull request includes a version bump, set the commit title to the version number and include the PR # in the commit description.
+- Make a pull request against the `master` branch
 
 ## Licenses and attribution
 

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -6,11 +6,11 @@ GREEN='\033[0;32m'
 NC='\033[0m' # No color
 
 echo "${GREEN}Pulling latest from GitHub...${NC}"
-git checkout staging
+git checkout master
 git pull
 
 echo "${GREEN}Bumping version...${NC}"
-./node_modules/.bin/lerna publish --skip-git --skip-npm --allow-branch staging --scope "@cmsgov/design-system-*"
+./node_modules/.bin/lerna publish --skip-git --skip-npm --allow-branch master --scope "@cmsgov/design-system-*"
 
 echo "${GREEN}Building...${NC}"
 npm run build


### PR DESCRIPTION
### Internal

Rather than merging feature branches into `staging` first, then merging `staging` into `master`, we'll now squash merge directly into `master`. 

Previously, `master` reflected whatever the public release was, and historically this was because we used to use GitHub Pages as our documentation hosting. That's no longer the case, and this change should simplify things, as well as make it easier to consistently use squash merging and keep our history clean.