### PR TITLE
fix: Pass-through properties for TextField component

### DIFF
--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -42,7 +42,6 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       <input
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max="12"
         min="1"
@@ -70,7 +69,6 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       <input
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max="31"
         min="1"
@@ -98,7 +96,6 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       <input
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max={2000}
         min="1990"
@@ -163,7 +160,6 @@ exports[`DateField has errorMessage 1`] = `
       <input
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max="12"
         min="1"
@@ -191,7 +187,6 @@ exports[`DateField has errorMessage 1`] = `
       <input
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max="31"
         min="1"
@@ -219,7 +214,6 @@ exports[`DateField has errorMessage 1`] = `
       <input
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max={undefined}
         min={1900}
@@ -283,7 +277,6 @@ exports[`DateField has requirementLabel 1`] = `
       <input
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max="12"
         min="1"
@@ -311,7 +304,6 @@ exports[`DateField has requirementLabel 1`] = `
       <input
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max="31"
         min="1"
@@ -339,7 +331,6 @@ exports[`DateField has requirementLabel 1`] = `
       <input
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max={undefined}
         min={1900}
@@ -397,7 +388,6 @@ exports[`DateField is inversed 1`] = `
       <input
         className="ds-c-field ds-c-field--inverse ds-c-field--month"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max="12"
         min="1"
@@ -425,7 +415,6 @@ exports[`DateField is inversed 1`] = `
       <input
         className="ds-c-field ds-c-field--inverse ds-c-field--day"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max="31"
         min="1"
@@ -453,7 +442,6 @@ exports[`DateField is inversed 1`] = `
       <input
         className="ds-c-field ds-c-field--inverse ds-c-field--year"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max={undefined}
         min={1900}
@@ -511,7 +499,6 @@ exports[`DateField renders with all defaultProps 1`] = `
       <input
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max="12"
         min="1"
@@ -539,7 +526,6 @@ exports[`DateField renders with all defaultProps 1`] = `
       <input
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max="31"
         min="1"
@@ -567,7 +553,6 @@ exports[`DateField renders with all defaultProps 1`] = `
       <input
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
-        disabled={undefined}
         id="textfield_snapshot"
         max={undefined}
         min={1900}

--- a/packages/core/src/components/TextField/TextField.jsx
+++ b/packages/core/src/components/TextField/TextField.jsx
@@ -15,49 +15,73 @@ export class TextField extends React.PureComponent {
   }
 
   render() {
-    const FieldComponent = this.props.multiline ? 'textarea' : 'input';
-    const rows =
-      this.props.multiline && this.props.rows ? this.props.rows : undefined;
+    const {
+      hint,
+      labelClassName,
+      fieldClassName,
+      errorMessage,
+      inversed,
+      rows,
+      max,
+      min,
+      name,
+      onChange,
+      onBlur,
+      fieldRef,
+      multiline,
+      type,
+      value,
+      className,
+      requirementLabel,
+      label,
+      defaultValue,
+      disabled,
+      ...props
+    } = this.props;
+
+    const FieldComponent = multiline ? 'textarea' : 'input';
+    const _rows = multiline && rows ? rows : undefined;
 
     const classes = classNames(
       'ds-u-clearfix', // fixes issue where the label's margin is collapsed
-      this.props.className
+      className
     );
     const fieldClasses = classNames(
       'ds-c-field',
       {
-        'ds-c-field--error': typeof this.props.errorMessage === 'string',
-        'ds-c-field--inverse': this.props.inversed
+        'ds-c-field--error': typeof errorMessage === 'string',
+        'ds-c-field--inverse': inversed
       },
-      this.props.fieldClassName
+      fieldClassName
     );
 
     return (
       <div className={classes}>
         <FormLabel
-          className={this.props.labelClassName}
-          errorMessage={this.props.errorMessage}
+          className={labelClassName}
+          errorMessage={errorMessage}
           fieldId={this.id}
-          hint={this.props.hint}
-          requirementLabel={this.props.requirementLabel}
-          inversed={this.props.inversed}
+          hint={hint}
+          requirementLabel={requirementLabel}
+          inversed={inversed}
         >
-          {this.props.label}
+          {label}
         </FormLabel>
         <FieldComponent
           className={fieldClasses}
-          defaultValue={this.props.defaultValue}
-          disabled={this.props.disabled}
+          defaultValue={defaultValue}
+          disabled={disabled}
           id={this.id}
-          max={this.props.max}
-          min={this.props.min}
-          name={this.props.name}
-          onChange={this.props.onChange}
-          onBlur={this.props.onBlur}
-          ref={this.props.fieldRef}
-          rows={rows}
-          type={this.props.multiline ? undefined : this.props.type}
-          value={this.props.value}
+          max={max}
+          min={min}
+          name={name}
+          onChange={onChange}
+          onBlur={onBlur}
+          ref={fieldRef}
+          rows={_rows}
+          type={multiline ? undefined : type}
+          value={value}
+          {...props}
         />
       </div>
     );

--- a/packages/core/src/components/TextField/TextField.jsx
+++ b/packages/core/src/components/TextField/TextField.jsx
@@ -7,7 +7,7 @@ import uniqueId from 'lodash.uniqueid';
 /**
  * A `TextField` component renders an input field as well as supporting UI
  * elements like a label, error message, and hint text.
-*/
+ */
 export class TextField extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -16,27 +16,19 @@ export class TextField extends React.PureComponent {
 
   render() {
     const {
-      hint,
+      className,
       labelClassName,
       fieldClassName,
       errorMessage,
+      hint,
+      requirementLabel,
       inversed,
       rows,
-      max,
-      min,
-      name,
-      onChange,
-      onBlur,
-      fieldRef,
       multiline,
-      type,
-      value,
-      className,
-      requirementLabel,
       label,
-      defaultValue,
-      disabled,
-      ...props
+      fieldRef,
+      type,
+      ...fieldProps
     } = this.props;
 
     const FieldComponent = multiline ? 'textarea' : 'input';
@@ -69,19 +61,11 @@ export class TextField extends React.PureComponent {
         </FormLabel>
         <FieldComponent
           className={fieldClasses}
-          defaultValue={defaultValue}
-          disabled={disabled}
           id={this.id}
-          max={max}
-          min={min}
-          name={name}
-          onChange={onChange}
-          onBlur={onBlur}
           ref={fieldRef}
           rows={_rows}
           type={multiline ? undefined : type}
-          value={value}
-          {...props}
+          {...fieldProps}
         />
       </div>
     );
@@ -109,8 +93,8 @@ TextField.propTypes = {
    */
   fieldClassName: PropTypes.string,
   /**
-    * Access a reference to the `input` or `textarea` element
-    */
+   * Access a reference to the `input` or `textarea` element
+   */
   fieldRef: PropTypes.func,
   /**
    * Additional hint text to display

--- a/packages/core/src/components/TextField/TextField.test.jsx
+++ b/packages/core/src/components/TextField/TextField.test.jsx
@@ -135,6 +135,15 @@ describe('TextField', function() {
     expect(field.prop('min')).toBe(data.props.min);
   });
 
+  it('adds undocumented prop to input field', () => {
+    const data = render({
+      'data-foo': 'bar'
+    });
+    const field = data.wrapper.find('.ds-c-field').first();
+
+    expect(field.prop('data-foo')).toBe(data.props['data-foo']);
+  });
+
   it('returns reference to input field', () => {
     let ref;
     const data = render(


### PR DESCRIPTION
### Fixed
- The `TextField` component was not passing through certain DOM properties so I created a fix to let it pass additional DOM attributes to the `input` or `textarea` DOM components.