### PR TITLE
Use image-path variable rather than relative link

### DIFF
--- a/packages/core/src/components/Dialog/Dialog.scss
+++ b/packages/core/src/components/Dialog/Dialog.scss
@@ -71,7 +71,7 @@ $dialog-spacer: $spacer-4;
 }
 
 .ds-c-dialog__close {
-  background: url('../images/close.svg') center left no-repeat;
+  background: url('#{$image-path}/close.svg') center left no-repeat;
   background-size: 12px 12px;
   margin-left: auto;
   padding: 0 0 0 (12px + $spacer-1);


### PR DESCRIPTION
### Fixed

- Replaces relative image link with customizable `$image-path` variable.