### PR TITLE
Fix wrapping completed text in <Step> component

### DIFF
--- a/packages/core/src/components/StepList/StepList.scss
+++ b/packages/core/src/components/StepList/StepList.scss
@@ -268,6 +268,7 @@ $current-step-color: $color-primary !default;
     display: block;
     margin-right: 0;
     padding-top: 6px;
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
Fixes a CSS bug wherein a `<Step>`'s the completed text can drop down to the line below its check mark depending on the size of the description and substep content.

### Fixed
- Added `white-space: nowrap;` to `.ds-c-step__completed-text`

<img width="323" alt="screen shot 2017-12-15 at 2 08 32 pm" src="https://user-images.githubusercontent.com/7595652/34062575-1ab160ca-e1a2-11e7-9286-bbdcb5e3d73c.png">

Fixed to

<img width="325" alt="screen shot 2017-12-15 at 2 08 20 pm" src="https://user-images.githubusercontent.com/7595652/34062582-21c79190-e1a2-11e7-9bff-b92c55cb8e78.png">

