### PR TITLE
[AUTOCOMPLETE] Hotfix to add onInputValueChange prop to component

### DIFF
--- a/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
@@ -42,8 +42,10 @@ ReactDOM.render(
       ]}
       label="Select from the options below:"
       onChange={selectedItem => console.log(selectedItem)}
+      onInputValueChange={inputVal => console.log('[INPUT_VALUE]: ' + inputVal)}
     >
       <TextField
+        aria-controls="owned_listbox"
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Labeled list"
         name="Downshift_autocomplete"
@@ -68,6 +70,7 @@ ReactDOM.render(
       onChange={selectedItem => console.log(selectedItem)}
     >
       <TextField
+        aria-controls="owned_listbox"
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Simple list"
         name="Downshift_autocomplete"
@@ -81,6 +84,7 @@ ReactDOM.render(
       onChange={selectedItem => console.log(selectedItem)}
     >
       <TextField
+        aria-controls="owned_listbox"
         hint="List should return string Loading to simulate async data call."
         label="Loading message"
         name="Downshift_autocomplete"
@@ -89,6 +93,7 @@ ReactDOM.render(
 
     <Autocomplete items={[]}>
       <TextField
+        aria-controls="owned_listbox"
         hint="List should return string No results found."
         label="No results message"
         name="Downshift_autocomplete"

--- a/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
@@ -42,12 +42,17 @@ ReactDOM.render(
       ]}
       label="Select from the options below:"
       onChange={selectedItem => console.log(selectedItem)}
-      onInputValueChange={inputVal => console.log('[INPUT_VALUE]: ' + inputVal)}
+      onInputValueChange={inputVal =>
+        console.log('[AUTOCOMPLETE_VALUE]: ' + inputVal)
+      }
     >
       <TextField
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Labeled list"
         name="Downshift_autocomplete"
+        onBlur={() => console.log('Blur event')}
+        onChange={e => console.log(e)}
+        onKeyDown={() => console.log('Keydown event')}
       />
     </Autocomplete>
 
@@ -72,6 +77,9 @@ ReactDOM.render(
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Simple list"
         name="Downshift_autocomplete"
+        onBlur={() => console.log('Blur event')}
+        onChange={e => console.log(e)}
+        onKeyDown={() => console.log('Keydown event')}
       />
     </Autocomplete>
 

--- a/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
@@ -45,7 +45,6 @@ ReactDOM.render(
       onInputValueChange={inputVal => console.log('[INPUT_VALUE]: ' + inputVal)}
     >
       <TextField
-        aria-controls="owned_listbox"
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Labeled list"
         name="Downshift_autocomplete"
@@ -70,7 +69,6 @@ ReactDOM.render(
       onChange={selectedItem => console.log(selectedItem)}
     >
       <TextField
-        aria-controls="owned_listbox"
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Simple list"
         name="Downshift_autocomplete"
@@ -84,7 +82,6 @@ ReactDOM.render(
       onChange={selectedItem => console.log(selectedItem)}
     >
       <TextField
-        aria-controls="owned_listbox"
         hint="List should return string Loading to simulate async data call."
         label="Loading message"
         name="Downshift_autocomplete"
@@ -93,7 +90,6 @@ ReactDOM.render(
 
     <Autocomplete items={[]}>
       <TextField
-        aria-controls="owned_listbox"
         hint="List should return string No results found."
         label="No results message"
         name="Downshift_autocomplete"

--- a/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
@@ -43,16 +43,16 @@ ReactDOM.render(
       label="Select from the options below:"
       onChange={selectedItem => console.log(selectedItem)}
       onInputValueChange={inputVal =>
-        console.log('[AUTOCOMPLETE_VALUE]: ' + inputVal)
+        console.log('[Autocomplete]: ' + inputVal)
       }
     >
       <TextField
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Labeled list"
         name="Downshift_autocomplete"
-        onBlur={() => console.log('Blur event')}
+        onBlur={() => console.log('[TextField]: Blur event')}
         onChange={e => console.log(e)}
-        onKeyDown={() => console.log('Keydown event')}
+        onKeyDown={() => console.log('[TextField]: Keydown event')}
       />
     </Autocomplete>
 
@@ -77,9 +77,9 @@ ReactDOM.render(
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Simple list"
         name="Downshift_autocomplete"
-        onBlur={() => console.log('Blur event')}
+        onBlur={() => console.log('[TextField]: Blur event')}
         onChange={e => console.log(e)}
-        onKeyDown={() => console.log('Keydown event')}
+        onKeyDown={() => console.log('[TextField]: Keydown event')}
       />
     </Autocomplete>
 

--- a/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
@@ -50,9 +50,6 @@ ReactDOM.render(
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Labeled list"
         name="Downshift_autocomplete"
-        onBlur={() => console.log('[TextField]: Blur event')}
-        onChange={e => console.log(e)}
-        onKeyDown={() => console.log('[TextField]: Keydown event')}
       />
     </Autocomplete>
 
@@ -72,23 +69,18 @@ ReactDOM.render(
         }
       ]}
       onChange={selectedItem => console.log(selectedItem)}
+      onInputValueChange={inputVal =>
+        console.log('[Autocomplete]: ' + inputVal)
+      }
     >
       <TextField
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Simple list"
         name="Downshift_autocomplete"
-        onBlur={() => console.log('[TextField]: Blur event')}
-        onChange={e => console.log(e)}
-        onKeyDown={() => console.log('[TextField]: Keydown event')}
       />
     </Autocomplete>
 
-    <Autocomplete
-      items={[]}
-      label="Select from the options below:"
-      loading
-      onChange={selectedItem => console.log(selectedItem)}
-    >
+    <Autocomplete items={[]} loading>
       <TextField
         hint="List should return string Loading to simulate async data call."
         label="Loading message"

--- a/packages/core/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.jsx
@@ -23,6 +23,7 @@ export class Autocomplete extends React.PureComponent {
 
     this.id = uniqueId('autocomplete_');
     this.labelId = uniqueId('autocomplete_header_');
+    this.listboxId = uniqueId('autocomplete_owned_listbox_');
   }
 
   filterItems(
@@ -73,6 +74,7 @@ export class Autocomplete extends React.PureComponent {
         return React.cloneElement(
           child,
           getInputProps({
+            'aria-controls': this.listboxId,
             id: this.id
           })
         );
@@ -125,7 +127,7 @@ export class Autocomplete extends React.PureComponent {
                 <ul
                   aria-labelledby={label ? this.labelId : null}
                   className="ds-c-list--bare"
-                  id="owned_listbox"
+                  id={this.listboxId}
                   role="listbox"
                 >
                   {this.filterItems(

--- a/packages/core/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.jsx
@@ -71,13 +71,15 @@ export class Autocomplete extends React.PureComponent {
     // Downshift's `getInputProps` method
     return React.Children.map(this.props.children, child => {
       if (isTextField(child)) {
-        return React.cloneElement(
-          child,
-          getInputProps({
-            'aria-controls': this.listboxId,
-            id: this.id
-          })
-        );
+        const propOverrides = {
+          'aria-controls': this.listboxId,
+          id: this.id,
+          onBlur: child.props.onBlur,
+          onChange: child.props.onChange,
+          onKeyDown: child.props.onKeyDown
+        };
+
+        return React.cloneElement(child, getInputProps(propOverrides));
       }
 
       return child;
@@ -93,7 +95,9 @@ export class Autocomplete extends React.PureComponent {
       label,
       loading,
       onChange,
-      onInputValueChange
+      onInputValueChange,
+      children,
+      ...autocompleteProps
     } = this.props;
 
     return (
@@ -152,6 +156,7 @@ export class Autocomplete extends React.PureComponent {
             </Button>
           </div>
         )}
+        {...autocompleteProps}
       />
     );
   }

--- a/packages/core/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.jsx
@@ -91,20 +91,14 @@ export class Autocomplete extends React.PureComponent {
       ariaClearLabel,
       clearInputText,
       items,
-      itemToString,
       label,
       loading,
-      onChange,
-      onInputValueChange,
       children,
       ...autocompleteProps
     } = this.props;
 
     return (
       <Downshift
-        itemToString={itemToString}
-        onChange={onChange}
-        onInputValueChange={onInputValueChange}
         render={({
           clearSelection,
           getInputProps,
@@ -204,7 +198,7 @@ Autocomplete.propTypes = {
    */
   loading: PropTypes.bool,
   /**
-   * Message users will see when the `loading` prop is passed to `Autcomplete`.
+   * Message users will see when the `loading` prop is passed to `Autocomplete`.
    */
   loadingMessage: PropTypes.node,
   /**
@@ -212,13 +206,13 @@ Autocomplete.propTypes = {
    */
   noResultsMessage: PropTypes.node,
   /**
-   * Called when the user selects an item and the selected item has changed. Called with the item that was selected and the new state of `Downshift`.
+   * Called when the user selects an item and the selected item has changed. Called with the item that was selected and the new state.
    *
    * Also see: https://github.com/paypal/downshift#onchange
    */
   onChange: PropTypes.func,
   /**
-   * Called whenever the child `TextField` value changes. Returns a String `inputValue`.
+   * Called when the child `TextField` value changes. Returns a String `inputValue`.
    *
    * Also see: https://github.com/paypal/downshift#oninputvaluechange
    */

--- a/packages/core/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.jsx
@@ -90,13 +90,15 @@ export class Autocomplete extends React.PureComponent {
       itemToString,
       label,
       loading,
-      onChange
+      onChange,
+      onInputValueChange
     } = this.props;
 
     return (
       <Downshift
         itemToString={itemToString}
         onChange={onChange}
+        onInputValueChange={onInputValueChange}
         render={({
           clearSelection,
           getInputProps,
@@ -123,6 +125,7 @@ export class Autocomplete extends React.PureComponent {
                 <ul
                   aria-labelledby={label ? this.labelId : null}
                   className="ds-c-list--bare"
+                  id="owned_listbox"
                   role="listbox"
                 >
                   {this.filterItems(
@@ -162,12 +165,12 @@ Autocomplete.defaultProps = {
 
 Autocomplete.propTypes = {
   /**
-   * Screenreader-specific label for the Clear input link. Intended to provide a longer, more descriptive explanation of the link's behavior.
+   * Screenreader-specific label for the Clear search `<button>`. Intended to provide a longer, more descriptive explanation of the button's behavior.
    */
   ariaClearLabel: PropTypes.string,
   children: PropTypes.node,
   /**
-   * Clear link text that will appear on the page as part of the rendered component
+   * Clear search text that will appear on the page as part of the rendered `<button>` component
    */
   clearInputText: PropTypes.node,
   /**
@@ -194,7 +197,7 @@ Autocomplete.propTypes = {
    */
   loading: PropTypes.bool,
   /**
-   * Message users will see when the `loading` prop is passed to `<Autcomplete />`.
+   * Message users will see when the `loading` prop is passed to `Autcomplete`.
    */
   loadingMessage: PropTypes.node,
   /**
@@ -202,11 +205,17 @@ Autocomplete.propTypes = {
    */
   noResultsMessage: PropTypes.node,
   /**
-   * Called when the user selects an item and the selected item has changed. Called with the item that was selected and the new state of `downshift`.
+   * Called when the user selects an item and the selected item has changed. Called with the item that was selected and the new state of `Downshift`.
    *
    * Also see: https://github.com/paypal/downshift#onchange
    */
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  /**
+   * Called whenever the child `TextField` value changes. Returns a String `inputValue`.
+   *
+   * Also see: https://github.com/paypal/downshift#oninputvaluechange
+   */
+  onInputValueChange: PropTypes.func
 };
 
 export default Autocomplete;

--- a/packages/core/src/components/Autocomplete/Autocomplete.test.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.test.jsx
@@ -38,6 +38,7 @@ describe('Autocomplete', () => {
     expect(wrapper.prop('label')).toBe(undefined);
     expect(wrapper.prop('loading')).toBe(undefined);
     expect(wrapper.prop('onChange')).toBe(undefined);
+    expect(wrapper.prop('onInputValueChange')).toBe(undefined);
   });
 
   it('only renders expected elements', () => {


### PR DESCRIPTION
### Added
* `onInputValueChange` prop was added to `Autocomplete` for gathering child input value
* documentation for new method
* `listboxId` class attribute
* `aria-controls=this.listboxId` to the `getInputProps` method for building out TextField
* child cloned `onBlur, onChange, onKeyDown` events
* undocumented Autocomplete props can be passed to Downshift

### Removed
* hard-coded `aria-controls` attribute in examples