### PR TITLE
Docs: Retain console.log in React examples

### DIFF
--- a/packages/docs/webpack.config.js
+++ b/packages/docs/webpack.config.js
@@ -56,10 +56,8 @@ function createConfig(rootPath = '', packages, hotReload = true) {
   if (process.env.NODE_ENV === 'production') {
     const uglifyPlugin = new webpack.optimize.UglifyJsPlugin({
       compress: {
-        drop_console: true,
-        warnings: false
-      },
-      mangle: false // Mangle messes up React code snippets
+        drop_console: true
+      }
     });
 
     config.plugins.push(uglifyPlugin);

--- a/tools/gulp/docs/generateReactExample.js
+++ b/tools/gulp/docs/generateReactExample.js
@@ -82,10 +82,7 @@ function createWebpackCompiler(examplePath) {
 
   if (process.env.NODE_ENV === 'production') {
     const uglifyPlugin = new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        drop_console: true,
-        warnings: false
-      }
+      mangle: false // Mangle messes up React code snippets
     });
 
     webpackConfig.plugins.push(uglifyPlugin);


### PR DESCRIPTION
### Internal

- Update our UglifyJS configs so that `console.log` is preserved in the React examples since we use these for demo purposes.
- Re-enable mangling on the docs JS now that React examples are compiled using a separate process.