### PR TITLE
Small PropTypes refactor; Fix inconsistent PropTypes

### DIFF
--- a/packages/core/src/components/ChoiceList/Choice.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.jsx
@@ -140,11 +140,11 @@ Choice.propTypes = {
   /**
    * Content to be shown when the choice is checked
    */
-  checkedChildren: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  checkedChildren: PropTypes.node,
   /**
    * Content to be shown when the choice is not checked
    */
-  uncheckedChildren: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  uncheckedChildren: PropTypes.node,
   /**
    * Additional classes to be added to the root `div` element.
    */
@@ -166,7 +166,7 @@ Choice.propTypes = {
   /**
    * Text showing the requirement ("Required", "Optional", etc.). See [Required and Optional Fields]({{root}}/guidelines/forms/#required-and-optional-fields).
    */
-  requirementLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  requirementLabel: PropTypes.node,
   /**
    * Applies the "inverse" UI theme
    */

--- a/packages/core/src/components/ChoiceList/ChoiceList.jsx
+++ b/packages/core/src/components/ChoiceList/ChoiceList.jsx
@@ -170,7 +170,7 @@ ChoiceList.propTypes = {
    * Disables the entire field.
    */
   disabled: PropTypes.bool,
-  errorMessage: PropTypes.string,
+  errorMessage: PropTypes.node,
   /**
    * Additional hint text to display
    */

--- a/packages/core/src/components/ChoiceList/ChoiceList.jsx
+++ b/packages/core/src/components/ChoiceList/ChoiceList.jsx
@@ -159,7 +159,7 @@ ChoiceList.propTypes = {
       disabled: Choice.propTypes.disabled,
       label: Choice.propTypes.children,
       value: Choice.propTypes.value,
-      requirementLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+      requirementLabel: PropTypes.node
     })
   ).isRequired,
   /**
@@ -178,7 +178,7 @@ ChoiceList.propTypes = {
   /**
    * Text showing the requirement ("Required", "Optional", etc.). See [Required and Optional Fields]({{root}}/guidelines/forms/#required-and-optional-fields).
    */
-  requirementLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  requirementLabel: PropTypes.node,
   /**
    * Applies the "inverse" UI theme
    */

--- a/packages/core/src/components/DateField/DateField.jsx
+++ b/packages/core/src/components/DateField/DateField.jsx
@@ -103,7 +103,7 @@ export class DateField extends React.PureComponent {
 
 DateField.defaultProps = {
   label: 'Date',
-  hint: 'For example: 4 25 1986',
+  hint: 'For example: 4/25/1986',
   dayLabel: 'Day',
   dayName: 'day',
   monthLabel: 'Month',

--- a/packages/core/src/components/DateField/DateField.jsx
+++ b/packages/core/src/components/DateField/DateField.jsx
@@ -121,11 +121,11 @@ DateField.propTypes = {
    * its only argument, in the shape of: `{ day, month, year }`
    */
   dateFormatter: PropTypes.func,
-  errorMessage: PropTypes.string,
+  errorMessage: PropTypes.node,
   /**
    * Additional hint text to display above the individual month/day/year fields
    */
-  hint: PropTypes.string,
+  hint: PropTypes.node,
   /**
    * Applies the "inverse" UI theme
    */
@@ -133,7 +133,7 @@ DateField.propTypes = {
   /**
    * The primary label, rendered above the individual month/day/year fields
    */
-  label: PropTypes.string,
+  label: PropTypes.node,
   /**
    * Text showing the requirement ("Required", "Optional", etc.). See [Required and Optional Fields]({{root}}/guidelines/forms/#required-and-optional-fields).
    */
@@ -149,7 +149,7 @@ DateField.propTypes = {
   /**
    * Label for the day field
    */
-  dayLabel: PropTypes.string,
+  dayLabel: PropTypes.node,
   /**
    * `name` for the day `input` field
    */
@@ -171,7 +171,7 @@ DateField.propTypes = {
   /**
    * Label for the month field
    */
-  monthLabel: PropTypes.string,
+  monthLabel: PropTypes.node,
   /**
    * `name` for the month `input` field
    */
@@ -202,7 +202,7 @@ DateField.propTypes = {
   /**
    * Label for the year `input` field
    */
-  yearLabel: PropTypes.string,
+  yearLabel: PropTypes.node,
   /**
    * Max value for the year `input` field
    */

--- a/packages/core/src/components/DateField/DateField.jsx
+++ b/packages/core/src/components/DateField/DateField.jsx
@@ -137,7 +137,7 @@ DateField.propTypes = {
   /**
    * Text showing the requirement ("Required", "Optional", etc.). See [Required and Optional Fields]({{root}}/guidelines/forms/#required-and-optional-fields).
    */
-  requirementLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  requirementLabel: PropTypes.node,
   /**
    * Called anytime any date input is blurred
    */

--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 25 1986
+      For example: 4/25/1986
     </span>
   </legend>
   <div
@@ -138,7 +138,7 @@ exports[`DateField has errorMessage 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 25 1986
+      For example: 4/25/1986
     </span>
   </legend>
   <div
@@ -255,7 +255,7 @@ exports[`DateField has requirementLabel 1`] = `
         Optional
       </span>
        
-      For example: 4 25 1986
+      For example: 4/25/1986
     </span>
   </legend>
   <div
@@ -366,7 +366,7 @@ exports[`DateField is inversed 1`] = `
     <span
       className="ds-c-field__hint ds-c-field__hint--inverse"
     >
-      For example: 4 25 1986
+      For example: 4/25/1986
     </span>
   </legend>
   <div
@@ -477,7 +477,7 @@ exports[`DateField renders with all defaultProps 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 25 1986
+      For example: 4/25/1986
     </span>
   </legend>
   <div

--- a/packages/core/src/components/FormLabel/FormLabel.jsx
+++ b/packages/core/src/components/FormLabel/FormLabel.jsx
@@ -81,7 +81,7 @@ FormLabel.propTypes = {
   /** The root HTML element used to render the label */
   component: PropTypes.oneOf(['label', 'legend']),
   /** Enable the error state by providing an error message. */
-  errorMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  errorMessage: PropTypes.node,
   /**
    * The ID of the field this label is for. This is used for the label's `for`
    * attribute and any related ARIA attributes, such as for the error message.
@@ -90,11 +90,11 @@ FormLabel.propTypes = {
   /**
    * Additional hint text to display
    */
-  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  hint: PropTypes.node,
   /**
    * Text showing the requirement ("Required", "Optional", etc.). See [Required and Optional Fields]({{root}}/guidelines/forms/#required-and-optional-fields).
    */
-  requirementLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  requirementLabel: PropTypes.node,
   /**
    * Set to `true` to apply the "inverse" theme
    */

--- a/packages/core/src/components/MonthPicker/MonthPicker.jsx
+++ b/packages/core/src/components/MonthPicker/MonthPicker.jsx
@@ -223,7 +223,7 @@ MonthPicker.propTypes = {
   /**
    * Text showing the requirement ("Required", "Optional", etc.). See [Required and Optional Fields]({{root}}/guidelines/forms/#required-and-optional-fields).
    */
-  requirementLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  requirementLabel: PropTypes.node,
   /**
    * Array of month numbers, where `1` is January, and any month included
    * is disabled for selection.

--- a/packages/core/src/components/MonthPicker/MonthPicker.jsx
+++ b/packages/core/src/components/MonthPicker/MonthPicker.jsx
@@ -215,7 +215,7 @@ MonthPicker.propTypes = {
    * Additional classes to be added to the `FormLabel`.
    */
   labelClassName: PropTypes.string,
-  errorMessage: PropTypes.string,
+  errorMessage: PropTypes.node,
   /**
    * Additional hint text to display
    */

--- a/packages/core/src/components/TextField/TextField.jsx
+++ b/packages/core/src/components/TextField/TextField.jsx
@@ -86,7 +86,7 @@ TextField.propTypes = {
    * Sets the initial value. Use this for an uncontrolled component; otherwise,
    * use the `value` property.
    */
-  defaultValue: PropTypes.string,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   disabled: PropTypes.bool,
   errorMessage: PropTypes.node,
   /**
@@ -149,7 +149,7 @@ TextField.propTypes = {
    * Sets the input's `value`. Use this in combination with `onChange`
    * for a controlled component; otherwise, set `defaultValue`.
    */
-  value: PropTypes.string
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 
 export default TextField;

--- a/packages/core/src/components/TextField/TextField.jsx
+++ b/packages/core/src/components/TextField/TextField.jsx
@@ -108,7 +108,7 @@ TextField.propTypes = {
   /**
    * Text showing the requirement ("Required", "Optional", etc.). See [Required and Optional Fields]({{root}}/guidelines/forms/#required-and-optional-fields).
    */
-  requirementLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  requirementLabel: PropTypes.node,
   /**
    * Applies the "inverse" UI theme
    */

--- a/packages/core/src/components/TextField/TextField.jsx
+++ b/packages/core/src/components/TextField/TextField.jsx
@@ -88,7 +88,7 @@ TextField.propTypes = {
    */
   defaultValue: PropTypes.string,
   disabled: PropTypes.bool,
-  errorMessage: PropTypes.string,
+  errorMessage: PropTypes.node,
   /**
    * Additional classes to be added to the field element
    */

--- a/packages/docs/src/scripts/components/ReactPropDoc.jsx
+++ b/packages/docs/src/scripts/components/ReactPropDoc.jsx
@@ -52,6 +52,8 @@ class ReactPropDoc extends React.PureComponent {
       }
 
       return `${propType}[${valueType}]`;
+    } else if (propType === 'node') {
+      return 'string, number, element, or array';
     } else if (validValues) {
       return validValues;
     }


### PR DESCRIPTION
### Changed

- Props which were set to `PropTypes.oneOfType([PropTypes.string, PropTypes.node])` were changed to `PropTypes.node`, since `node` includes `string`.
- Updated the `DateField` `hint` to include slashes, based on feedback from the CMS content team. It's now `For example: 4/25/1986`.
- In the docs, use a verbose description of `PropTypes.node` since it could be confused with "DOM node".

### Fixed

- Some props that were passed through to a child component were stricter than the original PropType. These were loosened in most cases from `string` to `node`.
- Added `number` as a valid PropType to `TextField`'s `defaultValue` and `value`.
