### PR TITLE
Add dayInvalid, monthInvalid, yearInvalid props to DateField

### DIFF
--- a/packages/core/src/components/DateField/DateField.example.jsx
+++ b/packages/core/src/components/DateField/DateField.example.jsx
@@ -3,10 +3,20 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 ReactDOM.render(
-  <DateField
-    monthDefaultValue={10}
-    dayDefaultValue="31"
-    yearDefaultValue="2020"
-  />,
+  <React.Fragment>
+    <DateField
+      monthDefaultValue={10}
+      dayDefaultValue="31"
+      yearDefaultValue="2020"
+    />
+
+    <DateField
+      errorMessage="Please enter a year in the past"
+      monthDefaultValue={10}
+      dayDefaultValue="31"
+      yearDefaultValue="2020"
+      yearInvalid
+    />
+  </React.Fragment>,
   document.getElementById('js-example')
 );

--- a/packages/core/src/components/DateField/DateField.jsx
+++ b/packages/core/src/components/DateField/DateField.jsx
@@ -2,6 +2,7 @@ import FormLabel from '../FormLabel/FormLabel';
 import PropTypes from 'prop-types';
 import React from 'react';
 import TextField from '../TextField/TextField';
+import classNames from 'classnames';
 
 export class DateField extends React.PureComponent {
   constructor(props) {
@@ -55,7 +56,9 @@ export class DateField extends React.PureComponent {
         <div className="ds-l-form-row">
           <TextField
             {...sharedDateFieldProps}
-            fieldClassName="ds-c-field--month"
+            fieldClassName={classNames('ds-c-field--month', {
+              'ds-c-field--error': this.props.monthInvalid
+            })}
             fieldRef={el => {
               this.monthInput = el;
               if (this.props.monthFieldRef) this.props.monthFieldRef(el);
@@ -69,7 +72,9 @@ export class DateField extends React.PureComponent {
           />
           <TextField
             {...sharedDateFieldProps}
-            fieldClassName="ds-c-field--day"
+            fieldClassName={classNames('ds-c-field--day', {
+              'ds-c-field--error': this.props.dayInvalid
+            })}
             fieldRef={el => {
               this.dayInput = el;
               if (this.props.dayFieldRef) this.props.dayFieldRef(el);
@@ -83,7 +88,9 @@ export class DateField extends React.PureComponent {
           />
           <TextField
             {...sharedDateFieldProps}
-            fieldClassName="ds-c-field--year"
+            fieldClassName={classNames('ds-c-field--year', {
+              'ds-c-field--error': this.props.yearInvalid
+            })}
             fieldRef={el => {
               this.yearInput = el;
               if (this.props.yearFieldRef) this.props.yearFieldRef(el);
@@ -160,9 +167,13 @@ DateField.propTypes = {
    */
   dayDefaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /**
-   * Access a reference to the day `input` element
+   * Access a reference to the day `input`
    */
   dayFieldRef: PropTypes.func,
+  /**
+   * Apply error styling to the day `input`
+   */
+  dayInvalid: PropTypes.bool,
   /**
    * Sets the day input's `value`. Use this in combination with `onChange`
    * for a controlled component; otherwise, set `dayDefaultValue`.
@@ -182,9 +193,13 @@ DateField.propTypes = {
    */
   monthDefaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /**
-   * Access a reference to the month `input` element
+   * Access a reference to the month `input`
    */
   monthFieldRef: PropTypes.func,
+  /**
+   * Apply error styling to the month `input`
+   */
+  monthInvalid: PropTypes.bool,
   /**
    * Sets the month input's `value`. Use this in combination with `onChange`
    * for a controlled component; otherwise, set `monthDefaultValue`.
@@ -196,9 +211,13 @@ DateField.propTypes = {
    */
   yearDefaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /**
-   * Access a reference to the year `input` element
+   * Access a reference to the year `input`
    */
   yearFieldRef: PropTypes.func,
+  /**
+   * Apply error styling to the year `input`
+   */
+  yearInvalid: PropTypes.bool,
   /**
    * Label for the year `input` field
    */

--- a/packages/core/src/components/DateField/DateField.test.jsx
+++ b/packages/core/src/components/DateField/DateField.test.jsx
@@ -26,6 +26,18 @@ describe('DateField', () => {
     expect(renderer.create(<DateField inversed />)).toMatchSnapshot();
   });
 
+  it('has invalid month', () => {
+    expect(renderer.create(<DateField monthInvalid />)).toMatchSnapshot();
+  });
+
+  it('has invalid day', () => {
+    expect(renderer.create(<DateField dayInvalid />)).toMatchSnapshot();
+  });
+
+  it('has invalid year', () => {
+    expect(renderer.create(<DateField yearInvalid />)).toMatchSnapshot();
+  });
+
   it('has custom yearMax and yearMin', () => {
     expect(
       renderer.create(<DateField yearMax={2000} yearMin="1990" />)

--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -249,7 +249,7 @@ exports[`DateField has invalid day 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 25 1986
+      For example: 4/25/1986
     </span>
   </legend>
   <div
@@ -360,7 +360,7 @@ exports[`DateField has invalid month 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 25 1986
+      For example: 4/25/1986
     </span>
   </legend>
   <div
@@ -471,7 +471,7 @@ exports[`DateField has invalid year 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 25 1986
+      For example: 4/25/1986
     </span>
   </legend>
   <div

--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -229,6 +229,339 @@ exports[`DateField has errorMessage 1`] = `
 </fieldset>
 `;
 
+exports[`DateField has invalid day 1`] = `
+<fieldset
+  className="ds-c-fieldset"
+>
+  <legend
+    className="ds-c-label"
+    htmlFor={undefined}
+  >
+    <span
+      className=""
+    >
+      <span
+        className="ds-u-font-weight--bold"
+      >
+        Date
+      </span>
+    </span>
+    <span
+      className="ds-c-field__hint"
+    >
+      For example: 4 25 1986
+    </span>
+  </legend>
+  <div
+    className="ds-l-form-row"
+  >
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+      >
+        <span
+          className=""
+        >
+          Month
+        </span>
+      </label>
+      <input
+        className="ds-c-field ds-c-field--month"
+        defaultValue={undefined}
+        id="textfield_snapshot"
+        max="12"
+        min="1"
+        name="month"
+        onBlur={undefined}
+        onChange={undefined}
+        rows={undefined}
+        type="number"
+        value={undefined}
+      />
+    </div>
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+      >
+        <span
+          className=""
+        >
+          Day
+        </span>
+      </label>
+      <input
+        className="ds-c-field ds-c-field--day ds-c-field--error"
+        defaultValue={undefined}
+        id="textfield_snapshot"
+        max="31"
+        min="1"
+        name="day"
+        onBlur={undefined}
+        onChange={undefined}
+        rows={undefined}
+        type="number"
+        value={undefined}
+      />
+    </div>
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+      >
+        <span
+          className=""
+        >
+          Year
+        </span>
+      </label>
+      <input
+        className="ds-c-field ds-c-field--year"
+        defaultValue={undefined}
+        id="textfield_snapshot"
+        max={undefined}
+        min={1900}
+        name="year"
+        onBlur={undefined}
+        onChange={undefined}
+        rows={undefined}
+        type="number"
+        value={undefined}
+      />
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`DateField has invalid month 1`] = `
+<fieldset
+  className="ds-c-fieldset"
+>
+  <legend
+    className="ds-c-label"
+    htmlFor={undefined}
+  >
+    <span
+      className=""
+    >
+      <span
+        className="ds-u-font-weight--bold"
+      >
+        Date
+      </span>
+    </span>
+    <span
+      className="ds-c-field__hint"
+    >
+      For example: 4 25 1986
+    </span>
+  </legend>
+  <div
+    className="ds-l-form-row"
+  >
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+      >
+        <span
+          className=""
+        >
+          Month
+        </span>
+      </label>
+      <input
+        className="ds-c-field ds-c-field--month ds-c-field--error"
+        defaultValue={undefined}
+        id="textfield_snapshot"
+        max="12"
+        min="1"
+        name="month"
+        onBlur={undefined}
+        onChange={undefined}
+        rows={undefined}
+        type="number"
+        value={undefined}
+      />
+    </div>
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+      >
+        <span
+          className=""
+        >
+          Day
+        </span>
+      </label>
+      <input
+        className="ds-c-field ds-c-field--day"
+        defaultValue={undefined}
+        id="textfield_snapshot"
+        max="31"
+        min="1"
+        name="day"
+        onBlur={undefined}
+        onChange={undefined}
+        rows={undefined}
+        type="number"
+        value={undefined}
+      />
+    </div>
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+      >
+        <span
+          className=""
+        >
+          Year
+        </span>
+      </label>
+      <input
+        className="ds-c-field ds-c-field--year"
+        defaultValue={undefined}
+        id="textfield_snapshot"
+        max={undefined}
+        min={1900}
+        name="year"
+        onBlur={undefined}
+        onChange={undefined}
+        rows={undefined}
+        type="number"
+        value={undefined}
+      />
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`DateField has invalid year 1`] = `
+<fieldset
+  className="ds-c-fieldset"
+>
+  <legend
+    className="ds-c-label"
+    htmlFor={undefined}
+  >
+    <span
+      className=""
+    >
+      <span
+        className="ds-u-font-weight--bold"
+      >
+        Date
+      </span>
+    </span>
+    <span
+      className="ds-c-field__hint"
+    >
+      For example: 4 25 1986
+    </span>
+  </legend>
+  <div
+    className="ds-l-form-row"
+  >
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+      >
+        <span
+          className=""
+        >
+          Month
+        </span>
+      </label>
+      <input
+        className="ds-c-field ds-c-field--month"
+        defaultValue={undefined}
+        id="textfield_snapshot"
+        max="12"
+        min="1"
+        name="month"
+        onBlur={undefined}
+        onChange={undefined}
+        rows={undefined}
+        type="number"
+        value={undefined}
+      />
+    </div>
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+      >
+        <span
+          className=""
+        >
+          Day
+        </span>
+      </label>
+      <input
+        className="ds-c-field ds-c-field--day"
+        defaultValue={undefined}
+        id="textfield_snapshot"
+        max="31"
+        min="1"
+        name="day"
+        onBlur={undefined}
+        onChange={undefined}
+        rows={undefined}
+        type="number"
+        value={undefined}
+      />
+    </div>
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+      >
+        <span
+          className=""
+        >
+          Year
+        </span>
+      </label>
+      <input
+        className="ds-c-field ds-c-field--year ds-c-field--error"
+        defaultValue={undefined}
+        id="textfield_snapshot"
+        max={undefined}
+        min={1900}
+        name="year"
+        onBlur={undefined}
+        onChange={undefined}
+        rows={undefined}
+        type="number"
+        value={undefined}
+      />
+    </div>
+  </div>
+</fieldset>
+`;
+
 exports[`DateField has requirementLabel 1`] = `
 <fieldset
   className="ds-c-fieldset"


### PR DESCRIPTION
### Added

- `dayInvalid`, `monthInvalid`, `yearInvalid` boolean props added to `DateField` to support error styling on the individual `input` elements
