### PR TITLE
Autocomplete items prop to be optional

### DIFF
--- a/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
@@ -95,6 +95,14 @@ ReactDOM.render(
         name="Downshift_autocomplete"
       />
     </Autocomplete>
+
+    <Autocomplete>
+      <TextField
+        hint="No list should be shown if no item array is provided and it's not loading. This could be the case if a user has not yet entered the minimum number of characters required for a search."
+        label="Nothing shown"
+        name="Downshift_autocomplete"
+      />
+    </Autocomplete>
   </div>,
   document.getElementById('js-example')
 );

--- a/packages/core/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.jsx
@@ -110,7 +110,7 @@ export class Autocomplete extends React.PureComponent {
           <div className="ds-u-clearfix ds-c-autocomplete">
             {this.renderChildren(getInputProps)}
 
-            {isOpen ? (
+            {isOpen && (loading || items) ? (
               <div className="ds-u-border--1 ds-u-padding--1 ds-c-autocomplete__list">
                 {label &&
                   !loading && (
@@ -188,7 +188,7 @@ Autocomplete.propTypes = {
       id: PropTypes.string,
       name: PropTypes.string
     })
-  ).isRequired,
+  ),
   /**
    * Adds a heading to the top of the autocomplete list. This can be used to convey to the user that they're required to select an option from the autocomplete list.
    */

--- a/packages/core/src/components/Autocomplete/Autocomplete.test.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.test.jsx
@@ -27,6 +27,22 @@ describe('Autocomplete', () => {
     expect(inst).toBeInstanceOf(Autocomplete);
   });
 
+  it('renders items', () => {
+    const { wrapper } = render({ isOpen: true }, true);
+
+    const list = wrapper.find('ul');
+    expect(list.exists()).toBe(true);
+
+    const items = list.find('li');
+    expect(items.length).toEqual(1);
+    expect(items.text()).toEqual('Cook County, IL');
+  });
+
+  it('renders Autocomplete component without items', () => {
+    const { wrapper } = render({ items: undefined, isOpen: true }, true);
+    expect(wrapper.find('ul').exists()).toBe(false);
+  });
+
   it('returns correct default props', () => {
     const data = render({}, true);
     const wrapper = data.wrapper;


### PR DESCRIPTION
Allows items prop to be optional and doesn't render the list if it doesn't exist and it's not loading. Also added a unit test for the item rendering

### Added
- Unit test for `<Autocomplete>` to make sure it renders items

### Changed
- `<Autocomplete>`'s `items` prop is now optional