### PR TITLE
Button component allows all strings for variation prop

### DIFF
--- a/packages/core/src/components/Button/Button.jsx
+++ b/packages/core/src/components/Button/Button.jsx
@@ -122,7 +122,10 @@ Button.propTypes = {
    * Button [`type`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) attribute
    */
   type: PropTypes.oneOf(['button', 'submit']),
-  variation: PropTypes.oneOf(['primary', 'danger', 'success', 'transparent'])
+  /**
+   * A string corresponding to the button-component variation classes (`primary`, `danger`, `success`, `transparent`)
+   */
+  variation: PropTypes.string
 };
 
 export default Button;


### PR DESCRIPTION
Opens up the `variation` prop on the `<Button>` component so we can have arbitrary variation classes in site packages and themes.

### Changed
- `variation` prop on `<Button>` now accepts all strings