### PR TITLE
Change: Dynamically add punctuation after requirementLabel

### DIFF
--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -583,8 +583,7 @@ exports[`DateField has requirementLabel 1`] = `
       className="ds-c-field__hint"
     >
       Optional.
-       
-      For example: 4/25/1986
+       For example: 4/25/1986
     </span>
   </legend>
   <div

--- a/packages/core/src/components/FormLabel/FormLabel.example.jsx
+++ b/packages/core/src/components/FormLabel/FormLabel.example.jsx
@@ -7,7 +7,7 @@ ReactDOM.render(
     errorMessage="Please enter a valid phone number."
     hint="We'll use this number as a backup if we need to contact you about your application."
     fieldId="number-field-id"
-    requirementLabel="Optional."
+    requirementLabel="Optional"
   >
     Phone number
   </FormLabel>,

--- a/packages/core/src/components/FormLabel/FormLabel.jsx
+++ b/packages/core/src/components/FormLabel/FormLabel.jsx
@@ -22,17 +22,28 @@ export class FormLabel extends React.PureComponent {
   }
 
   hint() {
-    const { hint, requirementLabel } = this.props;
+    let { hint, requirementLabel } = this.props;
     if (!hint && !requirementLabel) return;
 
     const classes = classNames('ds-c-field__hint', {
       'ds-c-field__hint--inverse': this.props.inversed
     });
 
+    if (requirementLabel && hint) {
+      if (typeof requirementLabel === 'string') {
+        // Remove any existing spacing and punctuation
+        requirementLabel = requirementLabel.trim().replace(/\.$/, '');
+        // Add punctuation after the requirementLabel so it doesn't run into the hint
+        requirementLabel = requirementLabel + '.';
+      }
+
+      // Add space between hint and preceding requirementLabel
+      hint = ' ' + hint;
+    }
+
     return (
       <span className={classes}>
         {requirementLabel}
-        {requirementLabel && hint && ' '}
         {hint}
       </span>
     );

--- a/packages/core/src/components/FormLabel/FormLabel.test.jsx
+++ b/packages/core/src/components/FormLabel/FormLabel.test.jsx
@@ -61,6 +61,20 @@ describe('FormLabel', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('adds punctuation to requirementLabel when hint is also present', () => {
+    const props = { hint: 'Hint', requirementLabel: 'Optional' };
+    const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('avoids duplicate punctuation after requirementLabel', () => {
+    const props = { hint: 'Hint', requirementLabel: 'Optional.' };
+    const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('renders as a legend element', () => {
     const props = { component: 'legend' };
     const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);

--- a/packages/core/src/components/FormLabel/FormLabel.test.jsx
+++ b/packages/core/src/components/FormLabel/FormLabel.test.jsx
@@ -12,6 +12,7 @@ describe('FormLabel', () => {
     expect(wrapper.text()).toBe(labelText);
     expect(wrapper.is('label')).toBe(true);
     expect(wrapper.prop('htmlFor')).toBe(props.fieldId);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('renders error state', () => {
@@ -20,21 +21,17 @@ describe('FormLabel', () => {
       fieldId: 'name'
     };
     const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
-    const $error = wrapper.render().find('.ds-u-color--error');
 
-    expect($error.text()).toBe(props.errorMessage);
-    expect($error.attr('id')).toBe(`${props.fieldId}-message`);
     // Label becomes bold when there's an error
     expect(wrapper.find('.ds-u-font-weight--bold').length).toBe(1);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('renders hint string', () => {
     const props = { hint: 'President #44' };
     const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
-    const hint = wrapper.find('.ds-c-field__hint');
 
-    expect(hint.text()).toBe(props.hint);
-    expect(hint.hasClass('ds-c-field__hint--inverse')).toBe(false);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('renders hint node', () => {
@@ -42,19 +39,17 @@ describe('FormLabel', () => {
       hint: <strong>President #44</strong>
     };
     const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
-    const hint = wrapper.find('.ds-c-field__hint');
 
-    expect(hint.html()).toMatch(/<strong>/);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('renders requirementLabel string', () => {
     const props = {
-      requirementLabel: 'Optional.'
+      requirementLabel: 'Optional'
     };
     const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
-    const hint = wrapper.find('.ds-c-field__hint');
 
-    expect(hint.text()).toEqual('Optional.');
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('renders requirementLabel node', () => {
@@ -62,10 +57,8 @@ describe('FormLabel', () => {
       requirementLabel: <em>It is really optional</em>
     };
     const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
-    const hint = wrapper.find('.ds-c-field__hint');
 
-    expect(hint.html()).toMatch(/<em>/);
-    expect(hint.text()).toEqual('It is really optional');
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('renders as a legend element', () => {
@@ -88,24 +81,13 @@ describe('FormLabel', () => {
         .first()
         .hasClass('ds-c-field__hint--inverse')
     ).toBe(true);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('supports additional classNames', () => {
-    const props = { className: 'ds-u-foo' };
+    const props = { className: 'ds-u-foo', labelClassName: 'ds-u-bar' };
     const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
 
-    expect(wrapper.hasClass('ds-u-foo')).toBe(true);
-  });
-
-  it('supports additional label classNames', () => {
-    const props = { labelClassName: 'ds-u-foo' };
-    const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
-
-    expect(
-      wrapper
-        .children()
-        .first()
-        .hasClass('ds-u-foo')
-    ).toBe(true);
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/core/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
+++ b/packages/core/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FormLabel adds punctuation to requirementLabel when hint is also present 1`] = `
+<label
+  className="ds-c-label"
+>
+  <span
+    className=""
+  >
+    Hello world
+  </span>
+  <span
+    className="ds-c-field__hint"
+  >
+    Optional.
+     Hint
+  </span>
+</label>
+`;
+
+exports[`FormLabel avoids duplicate punctuation after requirementLabel 1`] = `
+<label
+  className="ds-c-label"
+>
+  <span
+    className=""
+  >
+    Hello world
+  </span>
+  <span
+    className="ds-c-field__hint"
+  >
+    Optional.
+     Hint
+  </span>
+</label>
+`;
+
 exports[`FormLabel is inversed 1`] = `
 <label
   className="ds-c-label"

--- a/packages/core/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
+++ b/packages/core/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
@@ -1,0 +1,135 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormLabel is inversed 1`] = `
+<label
+  className="ds-c-label"
+>
+  <span
+    className=""
+  >
+    Hello world
+  </span>
+  <span
+    className="ds-c-field__hint ds-c-field__hint--inverse"
+  >
+    Foo
+  </span>
+</label>
+`;
+
+exports[`FormLabel renders error state 1`] = `
+<label
+  className="ds-c-label"
+  htmlFor="name"
+>
+  <span
+    className="ds-u-font-weight--bold"
+  >
+    Hello world
+  </span>
+  <span
+    className="ds-c-field__hint ds-u-color--error"
+    id="name-message"
+    role="alert"
+  >
+    Nah, try again.
+  </span>
+</label>
+`;
+
+exports[`FormLabel renders hint node 1`] = `
+<label
+  className="ds-c-label"
+>
+  <span
+    className=""
+  >
+    Hello world
+  </span>
+  <span
+    className="ds-c-field__hint"
+  >
+    <strong>
+      President #44
+    </strong>
+  </span>
+</label>
+`;
+
+exports[`FormLabel renders hint string 1`] = `
+<label
+  className="ds-c-label"
+>
+  <span
+    className=""
+  >
+    Hello world
+  </span>
+  <span
+    className="ds-c-field__hint"
+  >
+    President #44
+  </span>
+</label>
+`;
+
+exports[`FormLabel renders label text 1`] = `
+<label
+  className="ds-c-label"
+  htmlFor="name"
+>
+  <span
+    className=""
+  >
+    Hello world
+  </span>
+</label>
+`;
+
+exports[`FormLabel renders requirementLabel node 1`] = `
+<label
+  className="ds-c-label"
+>
+  <span
+    className=""
+  >
+    Hello world
+  </span>
+  <span
+    className="ds-c-field__hint"
+  >
+    <em>
+      It is really optional
+    </em>
+  </span>
+</label>
+`;
+
+exports[`FormLabel renders requirementLabel string 1`] = `
+<label
+  className="ds-c-label"
+>
+  <span
+    className=""
+  >
+    Hello world
+  </span>
+  <span
+    className="ds-c-field__hint"
+  >
+    Optional
+  </span>
+</label>
+`;
+
+exports[`FormLabel supports additional classNames 1`] = `
+<label
+  className="ds-c-label ds-u-foo"
+>
+  <span
+    className="ds-u-bar"
+  >
+    Hello world
+  </span>
+</label>
+`;

--- a/packages/core/src/components/TextField/TextField.example.jsx
+++ b/packages/core/src/components/TextField/TextField.example.jsx
@@ -9,6 +9,7 @@ ReactDOM.render(
       label="Single line"
       labelClassName="ds-u-margin-top--0"
       name="single_example"
+      requirementLabel="Optional"
     />
     <TextField
       errorMessage="Error message example"


### PR DESCRIPTION
### Changed

- Removed the need for adding punctuation to `requirementLabel` on the label and field components. This avoids adopters accidentally having a field description that says stuff like _"Optional Enter the ID from your card"_, and should be more future-proof if we ever to decide to place the requirement label elsewhere.