### PR TITLE
Fix: Use Open Sans in input fields

### DIFF
--- a/packages/core/src/components/TextField/TextField.scss
+++ b/packages/core/src/components/TextField/TextField.scss
@@ -45,6 +45,7 @@ Style guide: components.text-field
   box-sizing: border-box; // ensure padding doesn't affect width
   color: $color-base;
   display: block;
+  font-family: $font-sans;
   font-size: $base-font-size;
   line-height: $input-line-height;
   margin: $spacer-half 0;


### PR DESCRIPTION
### Fixed

- Use Open Sans on `ds-c-field` inputs, rather than the system font 🙈 