### PR TITLE
[HOTFIX] steplist-flexbox IE11 layout issue

### DIFF
--- a/packages/core/src/components/Dialog/__snapshots__/Dialog.test.jsx.snap
+++ b/packages/core/src/components/Dialog/__snapshots__/Dialog.test.jsx.snap
@@ -4,30 +4,18 @@ exports[`Dialog renders react-aria-modal 1`] = `
 <Dialog
   ariaCloseLabel="Close modal dialog"
   escapeExitDisabled={false}
-  getApplicationNode={
-    [MockFunction] {
-      "calls": Array [
-        Array [],
-      ],
-    }
-  }
-  onExit={[MockFunction]}
+  getApplicationNode={[Function]}
+  onExit={[Function]}
   title="Foo"
   underlayClickExits={false}
 >
   <Displaced
     dialogClass="ds-c-dialog"
     escapeExits={true}
-    getApplicationNode={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-      }
-    }
+    getApplicationNode={[Function]}
     includeDefaultStyles={false}
     mounted={true}
-    onExit={[MockFunction]}
+    onExit={[Function]}
     titleId="dialog-title"
     underlayClass="ds-c-dialog-wrap"
     underlayClickExits={false}
@@ -37,16 +25,10 @@ exports[`Dialog renders react-aria-modal 1`] = `
       dialogId="react-aria-modal-dialog"
       escapeExits={true}
       focusTrapPaused={false}
-      getApplicationNode={
-        [MockFunction] {
-          "calls": Array [
-            Array [],
-          ],
-        }
-      }
+      getApplicationNode={[Function]}
       includeDefaultStyles={false}
       mounted={true}
-      onExit={[MockFunction]}
+      onExit={[Function]}
       scrollDisabled={true}
       titleId="dialog-title"
       underlayClass="ds-c-dialog-wrap"
@@ -94,7 +76,7 @@ exports[`Dialog renders react-aria-modal 1`] = `
                   <button
                     aria-label="Close modal dialog"
                     className="ds-c-button ds-c-button--transparent ds-c-dialog__close"
-                    onClick={[MockFunction]}
+                    onClick={[Function]}
                   >
                     Close
                   </button>

--- a/packages/core/src/components/Dialog/__snapshots__/Dialog.test.jsx.snap
+++ b/packages/core/src/components/Dialog/__snapshots__/Dialog.test.jsx.snap
@@ -4,18 +4,30 @@ exports[`Dialog renders react-aria-modal 1`] = `
 <Dialog
   ariaCloseLabel="Close modal dialog"
   escapeExitDisabled={false}
-  getApplicationNode={[Function]}
-  onExit={[Function]}
+  getApplicationNode={
+    [MockFunction] {
+      "calls": Array [
+        Array [],
+      ],
+    }
+  }
+  onExit={[MockFunction]}
   title="Foo"
   underlayClickExits={false}
 >
   <Displaced
     dialogClass="ds-c-dialog"
     escapeExits={true}
-    getApplicationNode={[Function]}
+    getApplicationNode={
+      [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+      }
+    }
     includeDefaultStyles={false}
     mounted={true}
-    onExit={[Function]}
+    onExit={[MockFunction]}
     titleId="dialog-title"
     underlayClass="ds-c-dialog-wrap"
     underlayClickExits={false}
@@ -25,10 +37,16 @@ exports[`Dialog renders react-aria-modal 1`] = `
       dialogId="react-aria-modal-dialog"
       escapeExits={true}
       focusTrapPaused={false}
-      getApplicationNode={[Function]}
+      getApplicationNode={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+        }
+      }
       includeDefaultStyles={false}
       mounted={true}
-      onExit={[Function]}
+      onExit={[MockFunction]}
       scrollDisabled={true}
       titleId="dialog-title"
       underlayClass="ds-c-dialog-wrap"
@@ -76,7 +94,7 @@ exports[`Dialog renders react-aria-modal 1`] = `
                   <button
                     aria-label="Close modal dialog"
                     className="ds-c-button ds-c-button--transparent ds-c-dialog__close"
-                    onClick={[Function]}
+                    onClick={[MockFunction]}
                   >
                     Close
                   </button>

--- a/packages/core/src/components/StepList/StepList.scss
+++ b/packages/core/src/components/StepList/StepList.scss
@@ -107,7 +107,8 @@ $step-list-number-font-size-mobile: $small-font-size !default;
 $step-list-number-border-size: 2px !default;
 $step-list-number-margin: 10px !default;
 $step-list-padding-h: 0 !default;
-$step-list-padding-left: $step-list-padding-h + $step-list-number-margin + $step-list-number-size;
+$step-list-padding-left: $step-list-padding-h + $step-list-number-margin +
+  $step-list-number-size;
 $step-list-breakpoint: $width-md !default;
 $step-margin: $spacer-2 !default;
 $step-border-width: 1px !default;
@@ -138,7 +139,8 @@ $current-step-color: $color-primary !default;
     font-size: $step-list-number-font-size-mobile;
     height: $step-list-number-size-mobile;
     left: -($step-list-number-margin + $step-list-number-size-mobile);
-    line-height: $step-list-number-size-mobile - $step-list-number-border-size * 2;
+    line-height: $step-list-number-size-mobile - $step-list-number-border-size *
+      2;
     position: absolute;
     text-align: center;
     top: ($step-button-height - $step-list-number-size-mobile) / 2;
@@ -229,6 +231,7 @@ $current-step-color: $color-primary !default;
 
 .ds-c-step__actions {
   font-size: $small-font-size;
+  margin-left: auto;
 
   .ds-c-step__content--with-content + & {
     margin-top: $spacer-2;


### PR DESCRIPTION
### Summary
IE11 doesn't automatically fill the entire horizontal space for child elements set to space-between. By adding a `margin-left: auto` to the step actions, the layout issue is resolved. Screenshots attached.

![screen shot 2018-01-17 at 11 58 29 am](https://user-images.githubusercontent.com/934879/35058956-40413602-fb7f-11e7-899b-4beaf0c67b96.png)

![screen shot 2018-01-17 at 11 58 55 am](https://user-images.githubusercontent.com/934879/35058964-4417c8e0-fb7f-11e7-854d-9f2063edabbd.png)

### Added
* `.ds-c-step__actions` has had a margin-left: auto added to force full width in all browsers