### PR TITLE
Removing unneeded shim for webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "enzyme-to-json": "^3.3.0",
     "eslint": "^4.13.1",
     "eslint-config-nava": "^2.1.0",
-    "event-source-polyfill": "^0.0.12",
     "front-matter": "^2.3.0",
     "generator-cmsgov": "file:./packages/generator-cmsgov",
     "github": "^13.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3531,10 +3531,6 @@ event-emitter@^0.3.5, event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-event-source-polyfill@^0.0.12:
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-0.0.12.tgz#e539cd67fdef2760a16aa5262fa98134df52e3af"
-
 eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"


### PR DESCRIPTION
### Removed
* event-source-polyfill was not needed for IE11, so it has been removed