### PR TITLE
Add ds-u-border--dark utility class

### DIFF
--- a/packages/core/src/utilities/border.scss
+++ b/packages/core/src/utilities/border.scss
@@ -96,7 +96,8 @@ Border color
 @hide-markup
 
 Markup:
-<% ['inverse',
+<% ['dark',
+    'inverse',
     'error', 'error-light', 'error-lighter',
     'warn', 'warn-light', 'warn-lighter',
     'success', 'success-light', 'success-lighter'].forEach(color => { -%>
@@ -109,6 +110,10 @@ Markup:
 
 Style guide: utilities.border.color
 */
+.ds-u-border--dark {
+  border-color: $border-color-dark !important;
+}
+
 .ds-u-border--inverse {
   border-color: $border-color-inverse !important;
 }
@@ -157,6 +162,7 @@ Style guide: utilities.border.color
 The following Sass variables can be overridden to theme the border utility:
 
 - `$border-color`
+- `$border-color-dark`
 - `$border-color-inverse`
 
 Style guide: utilities.border.guidance

--- a/packages/support/src/settings/_variables.color.scss
+++ b/packages/support/src/settings/_variables.color.scss
@@ -172,4 +172,5 @@ $color-background-dialog: $color-white !default;
 
 // Border
 $border-color: $color-gray-lighter !default;
+$border-color-dark: $color-gray-dark !default;
 $border-color-inverse: $color-white !default;


### PR DESCRIPTION
### Added

- New `ds-u-border--dark` utility class to set the border to a dark gray.
- New `$border-color-dark` Sass variable

These are useful for situations where the background isn't white, and you need a darker neutral border color.