### PR TITLE
eslint-config: Ignore i18next HOC t prop

### DIFF
--- a/packages/eslint-config-design-system/index.js
+++ b/packages/eslint-config-design-system/index.js
@@ -47,7 +47,7 @@ module.exports = {
     'react/no-multi-comp': 'error',
     'react/prefer-es6-class': 'error',
     'react/prefer-stateless-function': 'error',
-    'react/prop-types': ['error', { ignore: ['className'] }],
+    'react/prop-types': ['error', { ignore: ['className', 't'] }],
     'react/sort-comp': 'error',
     'standard/computed-property-even-spacing': 'off'
   }

--- a/packages/eslint-config-design-system/package.json
+++ b/packages/eslint-config-design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/eslint-config-design-system",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### Changed

- Ignore the `t` prop passed into components via react-i18next