### PR TITLE
Internal: Add support for theme's including design system Sass imports + Theme React files

### DIFF
--- a/packages/docs/src/styles/example.scss
+++ b/packages/docs/src/styles/example.scss
@@ -1,7 +1,7 @@
 // Loaded within the markup example iframes
-@import '~theme/index';
 @import '@cmsgov/design-system-core/src/index';
 @import '@cmsgov/design-system-layout/src/index';
+@import '~theme/index';
 @import 'settings/index';
 
 body {

--- a/tools/gulp/sass/index.js
+++ b/tools/gulp/sass/index.js
@@ -52,7 +52,10 @@ module.exports = (gulp, shared) => {
       // inline/base64 images
       postcssPlugins.push(
         postcssInliner({
-          assetPaths: [path.resolve(__dirname, `../../../${cwd}/src/`)],
+          assetPaths: [
+            path.resolve(__dirname, '../../../', cwd, 'images'),
+            path.resolve(__dirname, '../../../', 'packages/core/images')
+          ],
           strict: true
         })
       );


### PR DESCRIPTION
### Internal

- Fixed `postcss-image-inliner` configuration
- Added support for previewing themes which `@import` the design system's files directly within the theme's Sass file. This doesn't introduce duplicate declarations thanks to [cssnano](http://cssnano.co/optimisations/discardduplicates/).
- Added support for compiling a theme's JS files