### PR TITLE
Lock uswds package version

### DIFF
--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -8,6 +8,6 @@
   "repository": "CMSgov/design-system",
   "license": "SEE LICENSE IN LICENSE.md",
   "dependencies": {
-    "uswds": "^1.3.1"
+    "uswds": "1.3.1"
   }
 }

--- a/packages/support/yarn.lock
+++ b/packages/support/yarn.lock
@@ -876,7 +876,7 @@ url@~0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-uswds@^1.3.1:
+uswds@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/uswds/-/uswds-1.3.1.tgz#1687b2a8f844e328013465a09c78d32c75d096da"
   dependencies:


### PR DESCRIPTION
### Fixed

- Locked `uswds` package at `1.3.x`. `1.4` renamed some variables that we depend on, so upgrading will require additional changes on our end in order to not break things. 