### PR TITLE
Internal: Compile JS components in watch task

### DIFF
--- a/tools/gulp/build.js
+++ b/tools/gulp/build.js
@@ -72,6 +72,13 @@ module.exports = (gulp, shared) => {
     dutil.logMessage('✅ ', 'Build succeeded');
   });
 
+  /**
+   * Tasks ran before starting a local dev environment
+   */
+  gulp.task('build:dev', done => {
+    runSequence(jsonTasks, babelTasks, 'docs:build', 'sass:process:docs', done);
+  });
+
   gulp.task('build', done => {
     dutil.logIntroduction();
 

--- a/tools/gulp/docs/generatePage.js
+++ b/tools/gulp/docs/generatePage.js
@@ -3,9 +3,9 @@ require('babel-register')({
   only: /(packages\/([a-z-_]+|themes\/[a-z_-]+)\/src|generateDocPage)/
 });
 
-const generateDocPage = require('./generateDocPage');
 const generateHtmlExample = require('./generateHtmlExample');
 const generateReactExample = require('./generateReactExample');
+let generateDocPage;
 
 /**
  * Create an HTML page
@@ -18,6 +18,14 @@ const generateReactExample = require('./generateReactExample');
  * @return {Promise<Boolean>}
  */
 function generatePage(routes, page, docsPath, rootPath, isExample) {
+  if (!generateDocPage) {
+    // We need to require this module inside of the method because
+    // it depends on compiled React files. Those files are compiled
+    // in a preceding Gulp task, and requiring this outside of the
+    // method will break things.
+    generateDocPage = require('./generateDocPage');
+  }
+
   if (isExample) {
     return generateExamples(page, docsPath, rootPath);
   } else if (typeof page.referenceURI === 'string') {

--- a/tools/gulp/watch.js
+++ b/tools/gulp/watch.js
@@ -47,10 +47,6 @@ module.exports = (gulp, shared) => {
   gulp.task('watch', () => {
     dutil.logMessage('👀 ', 'Transpiling + watching files for future changes');
 
-    runSequence('docs:build', 'sass:process:docs', [
-      'server',
-      'watch:packages',
-      'watch:docs'
-    ]);
+    runSequence('build:dev', ['server', 'watch:packages', 'watch:docs']);
   });
 };


### PR DESCRIPTION
### Internal

This will create the `dist/` folder for all packages as the first task in the `yarn start` script. This handles a scenario where the `dist/` folder doesn't yet exist but another dependency is relying on a compiled component.