### PR TITLE
Docs: Add trailing slash to React example iframe paths

### DIFF
--- a/packages/docs/src/scripts/components/ReactExample.jsx
+++ b/packages/docs/src/scripts/components/ReactExample.jsx
@@ -16,7 +16,8 @@ class ReactExample extends React.PureComponent {
 
   render() {
     const rootPath = process.env.root ? `/${process.env.root}` : '';
-    const iframeURL = `${rootPath}/example/${this.props.reference}`;
+    // GitHub Pages wants a trailing slash, otherwise it redirects to a blocked http page
+    const iframeURL = `${rootPath}/example/${this.props.reference}/`;
 
     return (
       <div className="ds-u-margin-top--3 markup markup--react">


### PR DESCRIPTION
### Internal

- Fixes an issue related to GitHub Pages redirecting paths not ending in a trailing slash to an `http` page, which breaks iframe examples.