### PR TITLE
Change muted color

### DIFF
--- a/packages/core/src/utilities/color.scss
+++ b/packages/core/src/utilities/color.scss
@@ -16,13 +16,16 @@ Markup:
 <% var groups = {
   'white': [
     'base',
-    'muted',
     'black',
-    'primary', 'primary-darker', 'primary-darkest',
+    'muted',
     'gray',
+    'primary', 'primary-darker', 'primary-darkest',
     'error', 'error-dark',
     'success'
   ],
+  'gray-lightest': ['muted', 'primary', 'error-dark'],
+  'gray-lighter': ['base', 'primary-darker'],
+  'gray-light': ['base', 'primary-darkest'],
   'background-inverse': ['base-inverse', 'muted-inverse', 'error-light'],
   'base': ['white'],
   'gray-dark': ['white'],
@@ -47,8 +50,6 @@ Markup:
   'error-dark': ['white'],
   'secondary': ['white'],
   'error': ['white'],
-  'gray-light': ['base'],
-  'gray-lighter': ['base'],
   'primary-alt-lightest': ['base'],
   'green-lighter': ['base'],
   'success-lighter': ['base'],

--- a/packages/support/src/settings/_variables.color.scss
+++ b/packages/support/src/settings/_variables.color.scss
@@ -153,7 +153,7 @@ $color-success-lighter: $color-green-lighter !default;
 $color-success-lightest: $color-green-lightest !default;
 
 // Text
-$color-muted: $color-gray-medium !default;
+$color-muted: $color-gray !default;
 $color-base-inverse: $color-white !default;
 $color-muted-inverse: #bac5cf !default;
 


### PR DESCRIPTION
### Changed

- Change `$color-muted` to reference `$color-gray`, rather than `$color-gray-medium`. This means the muted color becomes darker and can now be combined with a background that is `$color-gray-lightest` while still being accessible. This also brings the color inline with what we've been using in the latest HealthCare.gov design updates.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/371943/35924049-f274fbda-0bef-11e8-8f26-d6d7636013e1.png) | ![image](https://user-images.githubusercontent.com/371943/35923991-c8a82570-0bef-11e8-97cc-d08b163a618a.png) | 
| ![image](https://user-images.githubusercontent.com/371943/35924105-1c574b1a-0bf0-11e8-8bb7-8aa5ddaf2406.png) | ![image](https://user-images.githubusercontent.com/371943/35924124-2bf65732-0bf0-11e8-851b-c5382680568c.png) |
| ![image](https://user-images.githubusercontent.com/371943/35924181-4d8fdd46-0bf0-11e8-9bc2-7e3e44a4edfb.png) | ![image](https://user-images.githubusercontent.com/371943/35924153-3c1d1fb0-0bf0-11e8-814b-1f22f5f1dcd4.png) |

#### TODO:

- [ ] Update Sketch file


