### PR TITLE
 Update example text of DateField

### DIFF
--- a/packages/core/src/components/DateField/DateField.jsx
+++ b/packages/core/src/components/DateField/DateField.jsx
@@ -133,7 +133,7 @@ export class DateField extends React.PureComponent {
 
 DateField.defaultProps = {
   label: 'Date',
-  hint: 'For example: 4/25/1986',
+  hint: 'For example: 4 28 1986',
   dayLabel: 'Day',
   dayName: 'day',
   monthLabel: 'Month',

--- a/packages/core/src/components/DateField/DateField.scss
+++ b/packages/core/src/components/DateField/DateField.scss
@@ -11,7 +11,7 @@ Markup:
 <fieldset class="ds-c-fieldset">
   <legend class="ds-c-label">
     <span class="ds-u-font-weight--bold">Date of birth</span>
-    <span class="ds-c-field__hint">For example: 4 25 1986</span>
+    <span class="ds-c-field__hint">For example: 4 28 1986</span>
   </legend>
   <div class="ds-l-form-row">
     <div class="ds-l-col--auto">

--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4/25/1986
+      For example: 4 28 1986
     </span>
   </legend>
   <div
@@ -138,7 +138,7 @@ exports[`DateField has errorMessage 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4/25/1986
+      For example: 4 28 1986
     </span>
   </legend>
   <div
@@ -249,7 +249,7 @@ exports[`DateField has invalid day 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4/25/1986
+      For example: 4 28 1986
     </span>
   </legend>
   <div
@@ -360,7 +360,7 @@ exports[`DateField has invalid month 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4/25/1986
+      For example: 4 28 1986
     </span>
   </legend>
   <div
@@ -471,7 +471,7 @@ exports[`DateField has invalid year 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4/25/1986
+      For example: 4 28 1986
     </span>
   </legend>
   <div
@@ -583,7 +583,7 @@ exports[`DateField has requirementLabel 1`] = `
       className="ds-c-field__hint"
     >
       Optional.
-       For example: 4/25/1986
+       For example: 4 28 1986
     </span>
   </legend>
   <div
@@ -694,7 +694,7 @@ exports[`DateField is inversed 1`] = `
     <span
       className="ds-c-field__hint ds-c-field__hint--inverse"
     >
-      For example: 4/25/1986
+      For example: 4 28 1986
     </span>
   </legend>
   <div
@@ -805,7 +805,7 @@ exports[`DateField renders with all defaultProps 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4/25/1986
+      For example: 4 28 1986
     </span>
   </legend>
   <div


### PR DESCRIPTION
### Changed

- Removed slashes from the date field's example based on guidance from content team. This reverts things back to how they were, and is consistent with the USWDS.