### PR TITLE
Added an onClick prop to SkipNav component

### DIFF
--- a/packages/core/src/components/SkipNav/SkipNav.jsx
+++ b/packages/core/src/components/SkipNav/SkipNav.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export function SkipNav(props) {
+export function SkipNav({ children, href, onClick }) {
   return (
-    <a className="ds-c-skip-nav" href={props.href}>
-      {props.children}
+    <a className="ds-c-skip-nav" href={href} onClick={onClick}>
+      {children}
     </a>
   );
 }
@@ -18,7 +18,13 @@ SkipNav.propTypes = {
   /**
    * The anchor or target for the link (where the link will jump the user to)
    */
-  href: PropTypes.string.isRequired
+  href: PropTypes.string.isRequired,
+  /**
+   * An onClick handler used for manually setting focus on the content.
+   * Sometimes it's necessary to manually set focus, like when an app uses hash
+   * routing and element-id links will be mistaken for routes.
+   */
+  onClick: PropTypes.func
 };
 
 export default SkipNav;

--- a/packages/core/src/components/SkipNav/SkipNav.test.jsx
+++ b/packages/core/src/components/SkipNav/SkipNav.test.jsx
@@ -20,4 +20,15 @@ describe('SkipNav', function() {
 
     expect(wrapper.text()).toBe('Skip to main content');
   });
+
+  it('calls onClick when clicked', () => {
+    const spy = jest.fn();
+    const href = 'javascript:void(0)';
+    const wrapper = shallow(<SkipNav href={href} onClick={spy} />);
+
+    const fakeEvent = { anEventProperty: 'hey' };
+    wrapper.simulate('click', fakeEvent);
+
+    expect(spy).toHaveBeenCalledWith(fakeEvent);
+  });
 });


### PR DESCRIPTION
For apps that use hash routing, the existing skipNavHref will not work (unless we inject JavaScript in the href, but that's icky). Adds the ability to provide an onClick handler so we can manually set the focus to the main element in those scenarios.

### Added
- Added an onClick prop to SkipNav component

### JIRA tickets
https://jira.cms.gov/browse/HDSG-192