### PR TITLE
[HDSG-197] Change default input width from 1px to 2px

### DIFF
--- a/packages/support/src/settings/_variables.forms.scss
+++ b/packages/support/src/settings/_variables.forms.scss
@@ -17,5 +17,5 @@ $button-primary-bg--active: $color-primary-darkest !default;
 // USWDS overrides...
 // These variables apply to form fields (input, select, textarea, button)
 $input-line-height: 1.3 !default;
-$input-border-width: 1px !default;
+$input-border-width: 2px !default;
 $input-padding: $spacer-1 !default;


### PR DESCRIPTION
### Changed
Changed the `$input-border-width` variable from 1px to 2px.

Before:
![image](https://user-images.githubusercontent.com/3903208/36693134-4f4749ae-1b08-11e8-8213-be2791f20d5a.png)
![image](https://user-images.githubusercontent.com/3903208/36693143-51ba8f5c-1b08-11e8-99ba-9f494fe995be.png)

After:
![image](https://user-images.githubusercontent.com/3903208/36693079-211f590e-1b08-11e8-90db-7439b552a225.png)
![image](https://user-images.githubusercontent.com/3903208/36693085-2685bac8-1b08-11e8-8f92-0dd73f7a22b8.png)