### PR TITLE
Add currency field component/text field mask prop

### DIFF
--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -36,6 +36,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -63,6 +64,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -90,6 +92,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -150,6 +153,7 @@ exports[`DateField has errorMessage 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -177,6 +181,7 @@ exports[`DateField has errorMessage 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -204,6 +209,7 @@ exports[`DateField has errorMessage 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -257,6 +263,7 @@ exports[`DateField has invalid day 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -284,6 +291,7 @@ exports[`DateField has invalid day 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--day ds-c-field--error"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -311,6 +319,7 @@ exports[`DateField has invalid day 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -364,6 +373,7 @@ exports[`DateField has invalid month 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--month ds-c-field--error"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -391,6 +401,7 @@ exports[`DateField has invalid month 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -418,6 +429,7 @@ exports[`DateField has invalid month 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -471,6 +483,7 @@ exports[`DateField has invalid year 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -498,6 +511,7 @@ exports[`DateField has invalid year 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -525,6 +539,7 @@ exports[`DateField has invalid year 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--year ds-c-field--error"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -579,6 +594,7 @@ exports[`DateField has requirementLabel 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -606,6 +622,7 @@ exports[`DateField has requirementLabel 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -633,6 +650,7 @@ exports[`DateField has requirementLabel 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -686,6 +704,7 @@ exports[`DateField is inversed 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--inverse ds-c-field--month"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -713,6 +732,7 @@ exports[`DateField is inversed 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--inverse ds-c-field--day"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -740,6 +760,7 @@ exports[`DateField is inversed 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--inverse ds-c-field--year"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -793,6 +814,7 @@ exports[`DateField renders with all defaultProps 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -820,6 +842,7 @@ exports[`DateField renders with all defaultProps 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
         id="textfield_snapshot"
@@ -847,6 +870,7 @@ exports[`DateField renders with all defaultProps 1`] = `
         </span>
       </label>
       <input
+        aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
         id="textfield_snapshot"

--- a/packages/core/src/components/TextField/CurrencyField.example.jsx
+++ b/packages/core/src/components/TextField/CurrencyField.example.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TextField from './TextField';
+
+ReactDOM.render(
+  <TextField
+    ariaLabel="Enter amount in dollars"
+    label="Monthly income"
+    mask="currency"
+    name="currency_example"
+  />,
+  document.getElementById('js-example')
+);

--- a/packages/core/src/components/TextField/CurrencyField.example.jsx
+++ b/packages/core/src/components/TextField/CurrencyField.example.jsx
@@ -4,7 +4,7 @@ import TextField from './TextField';
 
 ReactDOM.render(
   <TextField
-    ariaLabel="Enter amount in dollars"
+    ariaLabel="Enter monthly income amount in dollars."
     label="Monthly income"
     mask="currency"
     name="currency_example"

--- a/packages/core/src/components/TextField/CurrencyField.scss
+++ b/packages/core/src/components/TextField/CurrencyField.scss
@@ -38,7 +38,7 @@ Style guide: components.currency-field.react
 
 .ds-c-field--currency {
   // Normal padding + space for the icon + normal padding
-  padding-left: $input-padding + 6px + $input-padding;
+  padding-left: $input-padding + 4px + $input-padding;
 }
 
 /*

--- a/packages/core/src/components/TextField/CurrencyField.scss
+++ b/packages/core/src/components/TextField/CurrencyField.scss
@@ -1,0 +1,67 @@
+@import '@cmsgov/design-system-support/src/settings/index';
+
+/*
+Currency field
+
+A currency field is an enhanced input field that provides visual and non-visual
+cues to a user to enter an amount of money in a specified currency.
+
+Markup:
+<label class="ds-c-label" for="currency_field">
+  Monthly income
+</label>
+<div class="ds-c-field-mask ds-c-field-mask--currency">
+  <div class="ds-c-field__before ds-c-field__before--currency">$</div>
+  <input type="text" aria-label="Enter amount in dollars" class="ds-c-field ds-c-field--currency" id="currency_field" name="currency_example">
+</div>
+
+Style guide: components.currency-field
+*/
+
+/*
+`<TextField mask="currency">`
+
+@react-component TextField
+
+@react-example CurrencyField
+
+Style guide: components.currency-field.react
+*/
+.ds-c-field__before--currency {
+  // Increase currency size so it serves more as an icon and
+  // better aligns with the input value text
+  font-size: $base-font-size + 2;
+  font-weight: $font-bold;
+  // Adjust to better align icon with value's baseline
+  padding-top: 1px;
+}
+
+.ds-c-field--currency {
+  // Normal padding + space for the icon + normal padding
+  padding-left: $input-padding + 6px + $input-padding;
+}
+
+/*
+---
+
+## When to use
+
+- Use the Currency input component anytime users should enter an amount of money in a particular currency, like dollars.
+
+**[View the "Text field" guidance for additional guidance and best practices.]({{root}}/patterns/text-field#guidance)**
+
+## Accessibility
+
+- Ensure the field includes an `aria-label` describing the expected currency for users using assistive devices.
+
+## Related patterns
+
+- [Text field]({{root}}/components/text-field/)
+
+## Learn more
+
+- [Form Guidelines]({{root}}/guidelines/forms/)
+- [GOV.UK - Currency input testing and research](https://github.com/alphagov/govuk-design-system/wiki/Currency-input-testing-and-research)
+
+Style guide: components.currency-field.guidance
+*/

--- a/packages/core/src/components/TextField/TextField.example.jsx
+++ b/packages/core/src/components/TextField/TextField.example.jsx
@@ -12,12 +12,6 @@ ReactDOM.render(
       requirementLabel="Optional"
     />
     <TextField
-      ariaLabel="Enter amount in dollars"
-      label="Currency input"
-      mask="dollar"
-      name="currency_example"
-    />
-    <TextField
       errorMessage="Error message example"
       hint="Example of a multiline field with an error"
       label="Multiline"

--- a/packages/core/src/components/TextField/TextField.example.jsx
+++ b/packages/core/src/components/TextField/TextField.example.jsx
@@ -18,7 +18,12 @@ ReactDOM.render(
       multiline
       name="multiline_example"
     />
-
+    <TextField
+      label="Disabled field"
+      disabled
+      name="disabled_example"
+      value="Example value"
+    />
     <TextField label="Password field" name="disabled_example" type="password" />
   </div>,
   document.getElementById('js-example')

--- a/packages/core/src/components/TextField/TextField.example.jsx
+++ b/packages/core/src/components/TextField/TextField.example.jsx
@@ -12,18 +12,19 @@ ReactDOM.render(
       requirementLabel="Optional"
     />
     <TextField
+      ariaLabel="Enter amount in dollars"
+      label="Currency input"
+      mask="dollar"
+      name="currency_example"
+    />
+    <TextField
       errorMessage="Error message example"
       hint="Example of a multiline field with an error"
       label="Multiline"
       multiline
       name="multiline_example"
     />
-    <TextField
-      label="Disabled field"
-      disabled
-      name="disabled_example"
-      value="Example value"
-    />
+
     <TextField label="Password field" name="disabled_example" type="password" />
   </div>,
   document.getElementById('js-example')

--- a/packages/core/src/components/TextField/TextField.jsx
+++ b/packages/core/src/components/TextField/TextField.jsx
@@ -14,8 +14,56 @@ export class TextField extends React.PureComponent {
     this.id = props.id || uniqueId('textfield_');
   }
 
+  ariaLabel() {
+    if (this.props.ariaLabel) {
+      return this.props.ariaLabel;
+    } else if (this.props.mask === 'dollar') {
+      return 'Enter amount in dollars';
+    }
+  }
+
+  /**
+   * @param {React.Component} field
+   * @returns {React.Component} The input field, optionally including mask
+   *  markup if a mask is present
+   */
+  renderFieldAndMask(field) {
+    const maskName = this.props.mask;
+
+    return maskName ? (
+      <div className={`ds-c-field-mask ds-c-field-mask--${maskName}`}>
+        {this.renderMask()}
+        {field}
+      </div>
+    ) : (
+      field
+    );
+  }
+
+  /**
+   * UI overlayed on top of a field to support certain masks
+   */
+  renderMask() {
+    if (this.props.mask) {
+      const content = {
+        dollar: '$'
+      };
+
+      return (
+        <div
+          className={`ds-c-field__before ds-c-field__before--${
+            this.props.mask
+          }`}
+        >
+          {content[this.props.mask]}
+        </div>
+      );
+    }
+  }
+
   render() {
     const {
+      ariaLabel,
       className,
       labelClassName,
       fieldClassName,
@@ -25,6 +73,7 @@ export class TextField extends React.PureComponent {
       requirementLabel,
       inversed,
       rows,
+      mask,
       multiline,
       label,
       fieldRef,
@@ -39,13 +88,27 @@ export class TextField extends React.PureComponent {
       'ds-u-clearfix', // fixes issue where the label's margin is collapsed
       className
     );
+
     const fieldClasses = classNames(
       'ds-c-field',
+      mask && `ds-c-field--${mask}`,
       {
         'ds-c-field--error': typeof errorMessage === 'string',
         'ds-c-field--inverse': inversed
       },
       fieldClassName
+    );
+
+    const field = (
+      <FieldComponent
+        aria-label={this.ariaLabel()}
+        className={fieldClasses}
+        id={this.id}
+        ref={fieldRef}
+        rows={_rows}
+        type={multiline ? undefined : type}
+        {...fieldProps}
+      />
     );
 
     return (
@@ -60,14 +123,8 @@ export class TextField extends React.PureComponent {
         >
           {label}
         </FormLabel>
-        <FieldComponent
-          className={fieldClasses}
-          id={this.id}
-          ref={fieldRef}
-          rows={_rows}
-          type={multiline ? undefined : type}
-          {...fieldProps}
-        />
+
+        {this.renderFieldAndMask(field, mask)}
       </div>
     );
   }
@@ -78,6 +135,11 @@ TextField.defaultProps = {
 };
 
 TextField.propTypes = {
+  /**
+   * Apply an `aria-label` to the text field to provide additional
+   * context to assistive devices.
+   */
+  ariaLabel: PropTypes.string,
   /**
    * Additional classes to be added to the root `div` element
    */
@@ -122,6 +184,12 @@ TextField.propTypes = {
    */
   labelClassName: PropTypes.string,
   /**
+   * Apply formatting to the field that's unique to the value
+   * you expect to be entered. Depending on the mask, the
+   * field's appearance and functionality may be affected.
+   */
+  mask: PropTypes.oneOf(['dollar']),
+  /**
    * `max` HTML input attribute
    */
   max: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -130,7 +198,7 @@ TextField.propTypes = {
    */
   min: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
-   * Whether or not the textfield is a multiline textfield
+   * Whether or not the text field is a multiline text field
    */
   multiline: PropTypes.bool,
   name: PropTypes.string.isRequired,

--- a/packages/core/src/components/TextField/TextField.jsx
+++ b/packages/core/src/components/TextField/TextField.jsx
@@ -18,7 +18,7 @@ export class TextField extends React.PureComponent {
     if (this.props.ariaLabel) {
       return this.props.ariaLabel;
     } else if (this.props.mask === 'currency') {
-      return 'Enter amount in dollars';
+      return `${this.props.label}. Enter amount in dollars.`;
     }
   }
 

--- a/packages/core/src/components/TextField/TextField.jsx
+++ b/packages/core/src/components/TextField/TextField.jsx
@@ -17,7 +17,7 @@ export class TextField extends React.PureComponent {
   ariaLabel() {
     if (this.props.ariaLabel) {
       return this.props.ariaLabel;
-    } else if (this.props.mask === 'dollar') {
+    } else if (this.props.mask === 'currency') {
       return 'Enter amount in dollars';
     }
   }
@@ -46,7 +46,7 @@ export class TextField extends React.PureComponent {
   renderMask() {
     if (this.props.mask) {
       const content = {
-        dollar: '$'
+        currency: '$'
       };
 
       return (
@@ -188,7 +188,7 @@ TextField.propTypes = {
    * you expect to be entered. Depending on the mask, the
    * field's appearance and functionality may be affected.
    */
-  mask: PropTypes.oneOf(['dollar']),
+  mask: PropTypes.oneOf(['currency']),
   /**
    * `max` HTML input attribute
    */

--- a/packages/core/src/components/TextField/TextField.scss
+++ b/packages/core/src/components/TextField/TextField.scss
@@ -45,9 +45,6 @@ Style guide: components.text-field
   box-sizing: border-box; // ensure padding doesn't affect width
   color: $color-base;
   display: block;
-  font-family: $font-sans;
-  font-size: $base-font-size;
-  line-height: $input-line-height;
   margin: $spacer-half 0;
   max-width: $input-max-width;
   outline: none;
@@ -62,6 +59,13 @@ Style guide: components.text-field
   &:focus {
     box-shadow: $focus-shadow;
   }
+}
+
+.ds-c-field,
+.ds-c-field-mask {
+  font-family: $font-sans;
+  font-size: $base-font-size;
+  line-height: $input-line-height;
 }
 
 /*
@@ -102,12 +106,41 @@ Style guide: components.text-field.inverse
 }
 
 // State modifiers and message
+// ==============================
 .ds-c-field--error {
   border: 3px solid $color-error;
 }
 
 .ds-c-field--success {
   border: 3px solid $color-success-light;
+}
+
+// Masks
+// ==============================
+.ds-c-field-mask {
+  position: relative;
+}
+
+.ds-c-field__before {
+  bottom: $input-padding;
+  left: $input-padding;
+  position: absolute;
+  top: $input-padding;
+}
+
+// Dollar mask
+.ds-c-field__before--dollar {
+  // Increase dollar size so it serves more as an icon and
+  // better aligns with the input value text
+  font-size: $base-font-size + 2;
+  font-weight: $font-bold;
+  // Adjust to better align icon with value's baseline
+  padding-top: 1px;
+}
+
+.ds-c-field--dollar {
+  // Normal padding + space for the icon + normal padding
+  padding-left: $input-padding + 6px + $input-padding;
 }
 
 /*

--- a/packages/core/src/components/TextField/TextField.scss
+++ b/packages/core/src/components/TextField/TextField.scss
@@ -128,21 +128,6 @@ Style guide: components.text-field.inverse
   top: $input-padding;
 }
 
-// Dollar mask
-.ds-c-field__before--dollar {
-  // Increase dollar size so it serves more as an icon and
-  // better aligns with the input value text
-  font-size: $base-font-size + 2;
-  font-weight: $font-bold;
-  // Adjust to better align icon with value's baseline
-  padding-top: 1px;
-}
-
-.ds-c-field--dollar {
-  // Normal padding + space for the icon + normal padding
-  padding-left: $input-padding + 6px + $input-padding;
-}
-
 /*
 `<TextField>`
 
@@ -195,7 +180,8 @@ The following Sass variables can be overridden to theme a field:
 
 ## Related patterns
 
-- [Date field]({{root}}/patterns/date-field/)
+- [Currency field]({{root}}/components/currency-field/)
+- [Date field]({{root}}/components/date-field/)
 
 ## Learn more
 

--- a/packages/core/src/components/TextField/TextField.test.jsx
+++ b/packages/core/src/components/TextField/TextField.test.jsx
@@ -144,9 +144,9 @@ describe('TextField', function() {
     expect(field.prop('aria-label')).toBe(data.props.ariaLabel);
   });
 
-  it('adds default aria-label for dollar mask', () => {
+  it('adds default aria-label for currency mask', () => {
     const data = render({
-      mask: 'dollar'
+      mask: 'currency'
     });
     const field = data.wrapper.find('.ds-c-field').first();
 
@@ -156,7 +156,7 @@ describe('TextField', function() {
   it('adds overrides default aria-label with defined prop', () => {
     const data = render({
       ariaLabel: 'Foo',
-      mask: 'dollar'
+      mask: 'currency'
     });
     const field = data.wrapper.find('.ds-c-field').first();
 
@@ -263,9 +263,9 @@ describe('TextField', function() {
   });
 
   describe('masked', () => {
-    it('renders dollar mask', () => {
+    it('renders currency mask', () => {
       const data = render({
-        mask: 'dollar'
+        mask: 'currency'
       });
 
       expect(data.wrapper).toMatchSnapshot();

--- a/packages/core/src/components/TextField/TextField.test.jsx
+++ b/packages/core/src/components/TextField/TextField.test.jsx
@@ -150,7 +150,9 @@ describe('TextField', function() {
     });
     const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.prop('aria-label')).toBe('Enter amount in dollars');
+    expect(field.prop('aria-label')).toBe(
+      `${data.props.label}. Enter amount in dollars.`
+    );
   });
 
   it('adds overrides default aria-label with defined prop', () => {

--- a/packages/core/src/components/TextField/TextField.test.jsx
+++ b/packages/core/src/components/TextField/TextField.test.jsx
@@ -135,6 +135,34 @@ describe('TextField', function() {
     expect(field.prop('min')).toBe(data.props.min);
   });
 
+  it('adds aria-label attribute', () => {
+    const data = render({
+      ariaLabel: 'Foo'
+    });
+    const field = data.wrapper.find('.ds-c-field').first();
+
+    expect(field.prop('aria-label')).toBe(data.props.ariaLabel);
+  });
+
+  it('adds default aria-label for dollar mask', () => {
+    const data = render({
+      mask: 'dollar'
+    });
+    const field = data.wrapper.find('.ds-c-field').first();
+
+    expect(field.prop('aria-label')).toBe('Enter amount in dollars');
+  });
+
+  it('adds overrides default aria-label with defined prop', () => {
+    const data = render({
+      ariaLabel: 'Foo',
+      mask: 'dollar'
+    });
+    const field = data.wrapper.find('.ds-c-field').first();
+
+    expect(field.prop('aria-label')).toBe(data.props.ariaLabel);
+  });
+
   it('adds undocumented prop to input field', () => {
     const data = render({
       'data-foo': 'bar'
@@ -231,6 +259,16 @@ describe('TextField', function() {
         .simulate('change');
 
       expect(data.props.onChange.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe('masked', () => {
+    it('renders dollar mask', () => {
+      const data = render({
+        mask: 'dollar'
+      });
+
+      expect(data.wrapper).toMatchSnapshot();
     });
   });
 });

--- a/packages/core/src/components/TextField/__snapshots__/TextField.test.jsx.snap
+++ b/packages/core/src/components/TextField/__snapshots__/TextField.test.jsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextField masked renders dollar mask 1`] = `
+<div
+  className="ds-u-clearfix"
+>
+  <FormLabel
+    component="label"
+    fieldId="textfield_27"
+  >
+    Foo
+  </FormLabel>
+  <div
+    className="ds-c-field-mask ds-c-field-mask--dollar"
+  >
+    <div
+      className="ds-c-field__before ds-c-field__before--dollar"
+    >
+      $
+    </div>
+    <input
+      aria-label="Enter amount in dollars"
+      className="ds-c-field ds-c-field--dollar"
+      id="textfield_27"
+      name="spec-field"
+      type="text"
+    />
+  </div>
+</div>
+`;

--- a/packages/core/src/components/TextField/__snapshots__/TextField.test.jsx.snap
+++ b/packages/core/src/components/TextField/__snapshots__/TextField.test.jsx.snap
@@ -19,7 +19,7 @@ exports[`TextField masked renders currency mask 1`] = `
       $
     </div>
     <input
-      aria-label="Enter amount in dollars"
+      aria-label="Foo. Enter amount in dollars."
       className="ds-c-field ds-c-field--currency"
       id="textfield_27"
       name="spec-field"

--- a/packages/core/src/components/TextField/__snapshots__/TextField.test.jsx.snap
+++ b/packages/core/src/components/TextField/__snapshots__/TextField.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TextField masked renders dollar mask 1`] = `
+exports[`TextField masked renders currency mask 1`] = `
 <div
   className="ds-u-clearfix"
 >
@@ -11,16 +11,16 @@ exports[`TextField masked renders dollar mask 1`] = `
     Foo
   </FormLabel>
   <div
-    className="ds-c-field-mask ds-c-field-mask--dollar"
+    className="ds-c-field-mask ds-c-field-mask--currency"
   >
     <div
-      className="ds-c-field__before ds-c-field__before--dollar"
+      className="ds-c-field__before ds-c-field__before--currency"
     >
       $
     </div>
     <input
       aria-label="Enter amount in dollars"
-      className="ds-c-field ds-c-field--dollar"
+      className="ds-c-field ds-c-field--currency"
       id="textfield_27"
       name="spec-field"
       type="text"

--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -15,5 +15,8 @@
 @import 'Table/Table';
 @import 'Tabs/Tabs';
 @import 'TextField/TextField';
-@import 'DateField/DateField'; // needs imported after TextField since it modifies it
+// Currency and Date field styles need imported
+// after TextField since they modify it
+@import 'CurrencyField/CurrencyField';
+@import 'DateField/DateField';
 @import 'VerticalNav/VerticalNav';

--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -17,6 +17,6 @@
 @import 'TextField/TextField';
 // Currency and Date field styles need imported
 // after TextField since they modify it
-@import 'CurrencyField/CurrencyField';
+@import 'TextField/CurrencyField';
 @import 'DateField/DateField';
 @import 'VerticalNav/VerticalNav';

--- a/tools/gulp/docs/processKssSection.js
+++ b/tools/gulp/docs/processKssSection.js
@@ -76,6 +76,9 @@ function processFlags(section) {
             // Include the React component's documentation
             section.reactComponent = value;
             break;
+          case 'react-example':
+            section.reactExample = value;
+            break;
           case 'responsive':
             // Render breakpoint toggles on markup example
             section.responsive = true;


### PR DESCRIPTION
### Added

- Added a "Currency field" component. This extends the default text field component and applies additional styling to indicate the expected value (by default: a dollar amount). To use in React, add a `mask="currency"` prop to the `TextField` component.

   Note: this only includes styling at the moment, and additional masking/validation functionality may come later.
   
   ![image](https://user-images.githubusercontent.com/371943/36983035-58113214-205f-11e8-9c3e-cc897fb21cce.png)
