### PR TITLE
Moved react and react-dom to peerDependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
     "downshift": "^1.28.2",
     "ev-emitter": "^1.1.1",
     "lodash.uniqueid": "^4.0.1",
-    "react-aria-modal": "^2.11.1",
+    "react-aria-modal": "^2.11.1"
   },
   "peerDependencies": {
     "prop-types": "^15.0.0 || ^16.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,9 +15,11 @@
     "downshift": "^1.28.2",
     "ev-emitter": "^1.1.1",
     "lodash.uniqueid": "^4.0.1",
+    "react-aria-modal": "^2.11.1",
+  },
+  "peerDependencies": {
     "prop-types": "^15.0.0 || ^16.0.0",
     "react": "^15.0.0 || ^16.0.0",
-    "react-aria-modal": "^2.11.1",
     "react-dom": "^15.0.0 || ^16.0.0"
   }
 }


### PR DESCRIPTION
### Changed
- Moved `react` and `react-dom` to `peerDependencies` for our core package so webpack can automatically deduplicate in target applications