### PR TITLE
Visual bug fixes

### DIFF
--- a/packages/core/src/base/typography.scss
+++ b/packages/core/src/base/typography.scss
@@ -137,7 +137,12 @@ Style guide: style.typography
 }
 
 .ds-h1 {
-  font-size: $h1-font-size;
+  font-size: $h1-mobile-font-size;
+  font-weight: $font-normal;
+
+  @media (min-width: $width-md) {
+    font-size: $h1-font-size;
+  }
 }
 
 .ds-h2 {
@@ -196,19 +201,19 @@ Style guide: style.typography
 /*
 Responsive typography
 
-The `ds-display` and `ds-title` classes are responsive by default. To apply responsive typography elsewhere, use the [font size utility class](/utilites/font-size#responsive). Since the base typography margins and line height is measured in `em` units, they'll automatically adjust as you change the font size.
+The `ds-display`, `ds-title`, and `ds-h1` classes are responsive by default.
+To apply responsive typography elsewhere, use the [font size utility class](/utilites/font-size#responsive).
+Since the base typography margins and line height is measured in `em` units,
+they'll automatically adjust as you change the font size.
 
 _Resize your browser to see each breakpoint in action:_
 
 Markup:
 <article class="ds-base--inverse ds-u-padding--2">
-  <h1 class="ds-display">Responsive heading</h1>
-  <p class="ds-text ds-u-font-size--small ds-u-md-font-size--base ds-u-lg-font-size--lead ds-u-measure--wide">
-    <strong>Responsive body text.</strong>
-    {{ lorem-l }}
-  </p>
-  <h2 class="ds-h2 ds-u-font-size--h4 ds-u-md-font-size--h3 ds-u-lg-font-size--h2">Responsive subheading</h2>
-  <p class="ds-text ds-u-measure--wide ds-u-color--muted-inverse">{{ lorem-l }}</p>
+  <h1 class="ds-display ds-u-margin-y--1">Display</h1>
+  <h2 class="ds-title ds-u-margin-y--1">Title</h1>
+  <h3 class="ds-h1 ds-u-margin-y--1">Heading 1</h1>
+  <h4 class="ds-h2 ds-u-margin-y--1 ds-u-font-size--h4 ds-u-md-font-size--h3 ds-u-lg-font-size--h2">Responsive utility classes</h4>
 </div>
 
 Style guide: style.typography.responsive
@@ -228,6 +233,7 @@ The following Sass variables can be overridden to change the type sizes:
 - `$h3-font-size`
 - `$h2-font-size`
 - `$h1-font-size`
+- `$h1-mobile-font-size`
 - `$title-font-size`
 - `$display-font-size`
 

--- a/packages/core/src/components/ChoiceList/Select.scss
+++ b/packages/core/src/components/ChoiceList/Select.scss
@@ -39,13 +39,14 @@ Style guide: components.select
 
 // stylelint-disable selector-no-qualifying-type
 select.ds-c-field {
+  $select-icon-size: 10px;
   appearance: none;
   background-color: $color-white;
   background-image: url('#{$image-path}/arrow-both.svg');
-  background-position: right $small-font-size center;
+  background-position: right $spacer-1 center;
   background-repeat: no-repeat;
-  background-size: $small-font-size;
-  padding-right: ($small-font-size * 2) + $spacer-1;
+  background-size: $select-icon-size;
+  padding-right: ($select-icon-size * 2) + $spacer-1;
 
   &[multiple] {
     background-image: none;

--- a/packages/core/src/components/DateField/DateField.jsx
+++ b/packages/core/src/components/DateField/DateField.jsx
@@ -56,7 +56,7 @@ export class DateField extends React.PureComponent {
   render() {
     const sharedDateFieldProps = {
       className: 'ds-l-col--auto',
-      labelClassName: 'ds-u-margin-top--1',
+      labelClassName: 'ds-u-font-weight--normal ds-u-margin-top--1',
       inversed: this.props.inversed,
       onBlur:
         (this.props.onBlur || this.props.onComponentBlur) && this.handleBlur,

--- a/packages/core/src/components/DateField/DateField.scss
+++ b/packages/core/src/components/DateField/DateField.scss
@@ -15,15 +15,15 @@ Markup:
   </legend>
   <div class="ds-l-form-row">
     <div class="ds-l-col--auto">
-      <label class="ds-c-label ds-u-margin-top--1" for="month">Month</label>
+      <label class="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1" for="month">Month</label>
       <input class="ds-c-field ds-c-field--month" type="number" min="1" max="12" id="month" name="birthdate[month]">
     </div>
     <div class="ds-l-col--auto">
-      <label class="ds-c-label ds-u-margin-top--1" for="day">Day</label>
+      <label class="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1" for="day">Day</label>
       <input class="ds-c-field ds-c-field--day" type="number" min="1" max="31" id="day" name="birthdate[day]">
     </div>
     <div class="ds-l-col--auto">
-      <label class="ds-c-label ds-u-margin-top--1" for="year">Year</label>
+      <label class="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1" for="year">Year</label>
       <input class="ds-c-field ds-c-field--year" type="number" min="1900" max="2000" id="year" name="birthdate[year]">
     </div>
   </div>

--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -54,7 +54,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -82,7 +82,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -143,7 +143,7 @@ exports[`DateField has errorMessage 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -171,7 +171,7 @@ exports[`DateField has errorMessage 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -199,7 +199,7 @@ exports[`DateField has errorMessage 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -253,7 +253,7 @@ exports[`DateField has invalid day 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -281,7 +281,7 @@ exports[`DateField has invalid day 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -309,7 +309,7 @@ exports[`DateField has invalid day 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -363,7 +363,7 @@ exports[`DateField has invalid month 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -391,7 +391,7 @@ exports[`DateField has invalid month 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -419,7 +419,7 @@ exports[`DateField has invalid month 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -473,7 +473,7 @@ exports[`DateField has invalid year 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -501,7 +501,7 @@ exports[`DateField has invalid year 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -529,7 +529,7 @@ exports[`DateField has invalid year 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -584,7 +584,7 @@ exports[`DateField has requirementLabel 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -612,7 +612,7 @@ exports[`DateField has requirementLabel 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -640,7 +640,7 @@ exports[`DateField has requirementLabel 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -694,7 +694,7 @@ exports[`DateField is inversed 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -722,7 +722,7 @@ exports[`DateField is inversed 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -750,7 +750,7 @@ exports[`DateField is inversed 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -804,7 +804,7 @@ exports[`DateField renders with all defaultProps 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -832,7 +832,7 @@ exports[`DateField renders with all defaultProps 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span
@@ -860,7 +860,7 @@ exports[`DateField renders with all defaultProps 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
       >
         <span

--- a/packages/support/src/settings/_override.uswds.scss
+++ b/packages/support/src/settings/_override.uswds.scss
@@ -13,6 +13,7 @@ $small-font-size: 14px !default;
 $lead-font-size: 18px !default;
 
 $h1-font-size: 36px !default;
+$h1-mobile-font-size: 30px !default;
 $h2-font-size: 24px !default;
 $h3-font-size: 21px !default;
 $h4-font-size: 18px !default;


### PR DESCRIPTION
### Fixed

- Fixed responsive styling of `ds-h1` so page titles scale down on small screens
   ![image](https://user-images.githubusercontent.com/371943/37485852-09851c12-2863-11e8-9af6-ec3122629e8c.png)

- Fixed obnoxious size of dropdown arrow to be consistent with USWDS styling
   ![image](https://user-images.githubusercontent.com/371943/37485820-e7f8b4c8-2862-11e8-9166-174f19890963.png)

- Fixed weight of the date fields labels
   ![image](https://user-images.githubusercontent.com/371943/37485837-f861987a-2862-11e8-9191-6f4b8628c22d.png)
