### PR TITLE
Aria-describedby attributes for the DateField fields

### DIFF
--- a/packages/core/src/components/DateField/DateField.jsx
+++ b/packages/core/src/components/DateField/DateField.jsx
@@ -3,12 +3,22 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import TextField from '../TextField/TextField';
 import classNames from 'classnames';
+import uniqueId from 'lodash.uniqueid';
 
 export class DateField extends React.PureComponent {
   constructor(props) {
     super(props);
     this.handleBlur = this.handleBlur.bind(this);
     this.handleChange = this.handleChange.bind(this);
+  }
+
+  labelId() {
+    if (!this._labelId) {
+      // Cache the ID so we're not regenerating it on each method call
+      this._labelId = uniqueId('datefield_label_');
+    }
+
+    return this._labelId;
   }
 
   formatDate() {
@@ -63,6 +73,7 @@ export class DateField extends React.PureComponent {
       onChange: this.props.onChange && this.handleChange,
       type: 'number'
     };
+    const labelId = this.labelId();
 
     return (
       <fieldset className="ds-c-fieldset">
@@ -72,6 +83,7 @@ export class DateField extends React.PureComponent {
           hint={this.props.hint}
           inversed={this.props.inversed}
           requirementLabel={this.props.requirementLabel}
+          id={labelId}
         >
           {this.props.label}
         </FormLabel>
@@ -92,6 +104,7 @@ export class DateField extends React.PureComponent {
             label={this.props.monthLabel}
             name={this.props.monthName}
             value={this.props.monthValue}
+            aria-describedby={labelId}
           />
           <TextField
             {...sharedDateFieldProps}
@@ -108,6 +121,7 @@ export class DateField extends React.PureComponent {
             label={this.props.dayLabel}
             name={this.props.dayName}
             value={this.props.dayValue}
+            aria-describedby={labelId}
           />
           <TextField
             {...sharedDateFieldProps}
@@ -124,6 +138,7 @@ export class DateField extends React.PureComponent {
             max={this.props.yearMax}
             name={this.props.yearName}
             value={this.props.yearValue}
+            aria-describedby={labelId}
           />
         </div>
       </fieldset>

--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
   <legend
     className="ds-c-label"
     htmlFor={undefined}
+    id="datefield_label_snapshot"
   >
     <span
       className=""
@@ -28,6 +29,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -36,6 +38,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
@@ -56,6 +59,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -64,6 +68,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
@@ -84,6 +89,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -92,6 +98,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
@@ -117,6 +124,7 @@ exports[`DateField has errorMessage 1`] = `
   <legend
     className="ds-c-label"
     htmlFor={undefined}
+    id="datefield_label_snapshot"
   >
     <span
       className=""
@@ -145,6 +153,7 @@ exports[`DateField has errorMessage 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -153,6 +162,7 @@ exports[`DateField has errorMessage 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
@@ -173,6 +183,7 @@ exports[`DateField has errorMessage 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -181,6 +192,7 @@ exports[`DateField has errorMessage 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
@@ -201,6 +213,7 @@ exports[`DateField has errorMessage 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -209,6 +222,7 @@ exports[`DateField has errorMessage 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
@@ -234,6 +248,7 @@ exports[`DateField has invalid day 1`] = `
   <legend
     className="ds-c-label"
     htmlFor={undefined}
+    id="datefield_label_snapshot"
   >
     <span
       className=""
@@ -255,6 +270,7 @@ exports[`DateField has invalid day 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -263,6 +279,7 @@ exports[`DateField has invalid day 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
@@ -283,6 +300,7 @@ exports[`DateField has invalid day 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -291,6 +309,7 @@ exports[`DateField has invalid day 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--day ds-c-field--error"
         defaultValue={undefined}
@@ -311,6 +330,7 @@ exports[`DateField has invalid day 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -319,6 +339,7 @@ exports[`DateField has invalid day 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
@@ -344,6 +365,7 @@ exports[`DateField has invalid month 1`] = `
   <legend
     className="ds-c-label"
     htmlFor={undefined}
+    id="datefield_label_snapshot"
   >
     <span
       className=""
@@ -365,6 +387,7 @@ exports[`DateField has invalid month 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -373,6 +396,7 @@ exports[`DateField has invalid month 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--month ds-c-field--error"
         defaultValue={undefined}
@@ -393,6 +417,7 @@ exports[`DateField has invalid month 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -401,6 +426,7 @@ exports[`DateField has invalid month 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
@@ -421,6 +447,7 @@ exports[`DateField has invalid month 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -429,6 +456,7 @@ exports[`DateField has invalid month 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
@@ -454,6 +482,7 @@ exports[`DateField has invalid year 1`] = `
   <legend
     className="ds-c-label"
     htmlFor={undefined}
+    id="datefield_label_snapshot"
   >
     <span
       className=""
@@ -475,6 +504,7 @@ exports[`DateField has invalid year 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -483,6 +513,7 @@ exports[`DateField has invalid year 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
@@ -503,6 +534,7 @@ exports[`DateField has invalid year 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -511,6 +543,7 @@ exports[`DateField has invalid year 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
@@ -531,6 +564,7 @@ exports[`DateField has invalid year 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -539,6 +573,7 @@ exports[`DateField has invalid year 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--year ds-c-field--error"
         defaultValue={undefined}
@@ -564,6 +599,7 @@ exports[`DateField has requirementLabel 1`] = `
   <legend
     className="ds-c-label"
     htmlFor={undefined}
+    id="datefield_label_snapshot"
   >
     <span
       className=""
@@ -586,6 +622,7 @@ exports[`DateField has requirementLabel 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -594,6 +631,7 @@ exports[`DateField has requirementLabel 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
@@ -614,6 +652,7 @@ exports[`DateField has requirementLabel 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -622,6 +661,7 @@ exports[`DateField has requirementLabel 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
@@ -642,6 +682,7 @@ exports[`DateField has requirementLabel 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -650,6 +691,7 @@ exports[`DateField has requirementLabel 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}
@@ -675,6 +717,7 @@ exports[`DateField is inversed 1`] = `
   <legend
     className="ds-c-label"
     htmlFor={undefined}
+    id="datefield_label_snapshot"
   >
     <span
       className=""
@@ -696,6 +739,7 @@ exports[`DateField is inversed 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -704,6 +748,7 @@ exports[`DateField is inversed 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--inverse ds-c-field--month"
         defaultValue={undefined}
@@ -724,6 +769,7 @@ exports[`DateField is inversed 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -732,6 +778,7 @@ exports[`DateField is inversed 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--inverse ds-c-field--day"
         defaultValue={undefined}
@@ -752,6 +799,7 @@ exports[`DateField is inversed 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -760,6 +808,7 @@ exports[`DateField is inversed 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--inverse ds-c-field--year"
         defaultValue={undefined}
@@ -785,6 +834,7 @@ exports[`DateField renders with all defaultProps 1`] = `
   <legend
     className="ds-c-label"
     htmlFor={undefined}
+    id="datefield_label_snapshot"
   >
     <span
       className=""
@@ -806,6 +856,7 @@ exports[`DateField renders with all defaultProps 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -814,6 +865,7 @@ exports[`DateField renders with all defaultProps 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--month"
         defaultValue={undefined}
@@ -834,6 +886,7 @@ exports[`DateField renders with all defaultProps 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -842,6 +895,7 @@ exports[`DateField renders with all defaultProps 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--day"
         defaultValue={undefined}
@@ -862,6 +916,7 @@ exports[`DateField renders with all defaultProps 1`] = `
       <label
         className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
         htmlFor="textfield_snapshot"
+        id={undefined}
       >
         <span
           className=""
@@ -870,6 +925,7 @@ exports[`DateField renders with all defaultProps 1`] = `
         </span>
       </label>
       <input
+        aria-describedby="datefield_label_snapshot"
         aria-label={undefined}
         className="ds-c-field ds-c-field--year"
         defaultValue={undefined}

--- a/packages/core/src/components/FormLabel/FormLabel.jsx
+++ b/packages/core/src/components/FormLabel/FormLabel.jsx
@@ -50,13 +50,14 @@ export class FormLabel extends React.PureComponent {
   }
 
   render() {
+    const { fieldId, id, children } = this.props;
     const ComponentType = this.props.component;
     const labelTextClasses = classNames(this.props.labelClassName);
     const classes = classNames('ds-c-label', this.props.className);
 
     return (
-      <ComponentType className={classes} htmlFor={this.props.fieldId}>
-        <span className={labelTextClasses}>{this.props.children}</span>
+      <ComponentType className={classes} htmlFor={fieldId} id={id}>
+        <span className={labelTextClasses}>{children}</span>
         {this.errorMessage()}
         {this.hint()}
       </ComponentType>
@@ -67,6 +68,11 @@ export class FormLabel extends React.PureComponent {
 FormLabel.defaultProps = { component: 'label' };
 FormLabel.propTypes = {
   children: PropTypes.node.isRequired,
+  /**
+   * A unique `id` for the label element. Useful for referencing the label from
+   * other components with aria-describedby.
+   */
+  id: PropTypes.string,
   /**
    * Additional classes to be added to the root element.
    */

--- a/packages/core/src/components/FormLabel/FormLabel.jsx
+++ b/packages/core/src/components/FormLabel/FormLabel.jsx
@@ -70,7 +70,7 @@ FormLabel.propTypes = {
   children: PropTypes.node.isRequired,
   /**
    * A unique `id` for the label element. Useful for referencing the label from
-   * other components with aria-describedby.
+   * other components with `aria-describedby`.
    */
   id: PropTypes.string,
   /**

--- a/packages/core/src/components/MonthPicker/__snapshots__/MonthPicker.test.jsx.snap
+++ b/packages/core/src/components/MonthPicker/__snapshots__/MonthPicker.test.jsx.snap
@@ -42,6 +42,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
     <legend
       className="ds-c-label ds-u-visibility--screen-reader"
       htmlFor={undefined}
+      id={undefined}
     >
       <span
         className="ds-u-font-weight--bold"
@@ -74,6 +75,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_33"
+              id={undefined}
             >
               <span
                 className=""
@@ -102,6 +104,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_34"
+              id={undefined}
             >
               <span
                 className=""
@@ -130,6 +133,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_35"
+              id={undefined}
             >
               <span
                 className=""
@@ -158,6 +162,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_36"
+              id={undefined}
             >
               <span
                 className=""
@@ -186,6 +191,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_37"
+              id={undefined}
             >
               <span
                 className=""
@@ -214,6 +220,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_38"
+              id={undefined}
             >
               <span
                 className=""
@@ -242,6 +249,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_39"
+              id={undefined}
             >
               <span
                 className=""
@@ -270,6 +278,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_40"
+              id={undefined}
             >
               <span
                 className=""
@@ -298,6 +307,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_41"
+              id={undefined}
             >
               <span
                 className=""
@@ -326,6 +336,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_42"
+              id={undefined}
             >
               <span
                 className=""
@@ -354,6 +365,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_43"
+              id={undefined}
             >
               <span
                 className=""
@@ -382,6 +394,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             <label
               className="ds-c-label"
               htmlFor="checkbox_months_44"
+              id={undefined}
             >
               <span
                 className=""


### PR DESCRIPTION
Fulfills HSDG-199 by adding the id and aria-describedby attributes to `<DateField>`.

### Added
- Added the id and aria-describedby fields to `<DateField>`
- Added an optional `id` prop to `<FormLabel>`

### Changed
- 9 snapshots
    - I could have avoided changing all these snapshots but figured it was better to change those than add extra code to the component

Tested with VoiceOver