### PR TITLE
[HDSG-203] Fix hint+requirementLabel bug in FormLabel component

### DIFF
--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -610,7 +610,8 @@ exports[`DateField has requirementLabel 1`] = `
       className="ds-c-field__hint"
     >
       Optional.
-       For example: 4 28 1986
+       
+      For example: 4 28 1986
     </span>
   </legend>
   <div

--- a/packages/core/src/components/FormLabel/FormLabel.jsx
+++ b/packages/core/src/components/FormLabel/FormLabel.jsx
@@ -22,12 +22,15 @@ export class FormLabel extends React.PureComponent {
   }
 
   hint() {
-    let { hint, requirementLabel } = this.props;
+    const { hint } = this.props;
+    let { requirementLabel } = this.props;
     if (!hint && !requirementLabel) return;
 
     const classes = classNames('ds-c-field__hint', {
       'ds-c-field__hint--inverse': this.props.inversed
     });
+
+    let hintPadding = null;
 
     if (requirementLabel && hint) {
       if (typeof requirementLabel === 'string') {
@@ -38,12 +41,13 @@ export class FormLabel extends React.PureComponent {
       }
 
       // Add space between hint and preceding requirementLabel
-      hint = ' ' + hint;
+      hintPadding = ' ';
     }
 
     return (
       <span className={classes}>
         {requirementLabel}
+        {hintPadding}
         {hint}
       </span>
     );

--- a/packages/core/src/components/FormLabel/FormLabel.test.jsx
+++ b/packages/core/src/components/FormLabel/FormLabel.test.jsx
@@ -60,8 +60,16 @@ describe('FormLabel', () => {
   });
 
   it('adds punctuation to requirementLabel when hint is also present', () => {
-    const props = { hint: 'Hint', requirementLabel: 'Optional' };
-    const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
+    let props = { hint: 'Hint', requirementLabel: 'Optional' };
+    let wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
+
+    expect(wrapper).toMatchSnapshot();
+
+    props = {
+      hint: <span>Hint</span>,
+      requirementLabel: <span>Optional</span>
+    };
+    wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/packages/core/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
+++ b/packages/core/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
@@ -13,7 +13,31 @@ exports[`FormLabel adds punctuation to requirementLabel when hint is also presen
     className="ds-c-field__hint"
   >
     Optional.
-     Hint
+     
+    Hint
+  </span>
+</label>
+`;
+
+exports[`FormLabel adds punctuation to requirementLabel when hint is also present 2`] = `
+<label
+  className="ds-c-label"
+>
+  <span
+    className=""
+  >
+    Hello world
+  </span>
+  <span
+    className="ds-c-field__hint"
+  >
+    <span>
+      Optional
+    </span>
+     
+    <span>
+      Hint
+    </span>
   </span>
 </label>
 `;
@@ -31,7 +55,8 @@ exports[`FormLabel avoids duplicate punctuation after requirementLabel 1`] = `
     className="ds-c-field__hint"
   >
     Optional.
-     Hint
+     
+    Hint
   </span>
 </label>
 `;


### PR DESCRIPTION
Fixed bug in FormLabel where the hint text would render incorrectly if it is a node and there is a `requirementLabel`. Updated snapshots may look like they're wrong, but it renders correctly when it goes into the DOM.

### Added
- Added to the FormLabel test to make sure we handle the case when those props are nodes.

### Changed
- Had to separate out the hint destructuring to a const because of the linter even though it doesn't look as good

### Fixed
- HDSG-203