### PR TITLE
Fix: Ensure masked field re-render when TextField receives new props

### DIFF
--- a/packages/core/src/components/TextField/TextField.test.jsx
+++ b/packages/core/src/components/TextField/TextField.test.jsx
@@ -286,5 +286,15 @@ describe('TextField', function() {
 
       expect(data.wrapper).toMatchSnapshot();
     });
+
+    it('updates input classes when props are updated', () => {
+      const wrapper = render({ mask: 'currency' }, true).wrapper;
+
+      expect(wrapper.find('input').hasClass('ds-c-field--error')).toBe(false);
+
+      wrapper.setProps({ errorMessage: 'Oh no' });
+
+      expect(wrapper.find('input').hasClass('ds-c-field--error')).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
### Fixed

Masked fields weren't being re-rendered when the child `TextField` received new props (like `errorMessage`).

#### Before

![update-error](https://user-images.githubusercontent.com/371943/38374799-9c056b22-38c2-11e8-905b-2a71b05dc1f4.gif)

#### After

![update-working](https://user-images.githubusercontent.com/371943/38374803-9f1af462-38c2-11e8-929a-cfee49fe80ff.gif)
