### PR TITLE
HSDG-213: Allow for masked, partially obfuscated SSNs

### DIFF
--- a/packages/core/src/components/TextField/Mask.jsx
+++ b/packages/core/src/components/TextField/Mask.jsx
@@ -12,7 +12,7 @@ import React from 'react';
 // Deliminate chunks of integers
 const deliminatedMaskRegex = {
   phone: /(\d{3})(\d{1,3})?(\d+)?/,
-  ssn: /(\d{3})(\d{1,2})?(\d+)?/,
+  ssn: /([*\d]{3})([*\d]{1,2})?([*\d]+)?/,
   zip: /(\d{5})(\d+)/
 };
 
@@ -23,7 +23,7 @@ const deliminatedMaskRegex = {
  * @returns {String}
  */
 function deliminateRegexGroups(value, rx) {
-  const matches = toInt(value).match(rx);
+  const matches = toDigitsAndAsterisks(value).match(rx);
 
   if (matches && matches.length > 1) {
     value = matches
@@ -64,8 +64,8 @@ function stringWithFixedDigits(value, digits = 2) {
  * @param {String} value
  * @returns {String}
  */
-function toInt(value) {
-  return value.replace(/\D+/g, '');
+function toDigitsAndAsterisks(value) {
+  return value.replace(/[^\d*]/g, '');
 }
 
 /**
@@ -238,7 +238,7 @@ export function unmask(value, mask) {
     value = value.match(/^-|[\d.]/g).join('');
   } else if (Object.keys(deliminatedMaskRegex).includes(mask)) {
     // Remove the deliminators and revert to single ungrouped string
-    value = toInt(value);
+    value = toDigitsAndAsterisks(value);
   } else {
     return rawValue;
   }

--- a/packages/core/src/components/TextField/Mask.test.jsx
+++ b/packages/core/src/components/TextField/Mask.test.jsx
@@ -309,6 +309,7 @@ describe('unmask', () => {
     expect(unmask('', name)).toBe('');
     expect(unmask(' 123-45-6789 ', name)).toBe('123456789');
     expect(unmask('123456789', name)).toBe('123456789');
+    expect(unmask('***-**-6789', name)).toBe('*****6789');
   });
 
   it('removes mask from phone number', () => {

--- a/packages/core/src/components/TextField/Mask.test.jsx
+++ b/packages/core/src/components/TextField/Mask.test.jsx
@@ -189,6 +189,20 @@ describe('Mask', function() {
       expect(input.prop('value')).toBe('123-45-6789');
     });
 
+    it('accepts obfuscated ssns', () => {
+      const data = render({ mask: 'ssn' }, { value: '*****6789' });
+      const input = data.wrapper.find('input');
+
+      expect(input.prop('value')).toBe('***-**-6789');
+    });
+
+    it('accepts masked, obfuscated ssns', () => {
+      const data = render({ mask: 'ssn' }, { value: '***-**-6789' });
+      const input = data.wrapper.find('input');
+
+      expect(input.prop('value')).toBe('***-**-6789');
+    });
+
     it('masks full ssn', () => {
       const data = render({ mask: 'ssn' }, { value: '123456789' });
       const input = data.wrapper.find('input');


### PR DESCRIPTION
This is a quick fix for formatting partially-obfuscated SSNs in App3 (but will also format fully obfuscated SSNs). Currently when we try to format a value like `*****1234` by passing it to a `<TextField mask="ssn" ...`, it formats it like `*****123-4`, when we really want `***-**-1234`.

Because these functions and our needs for the component are growing in complexity, I would like to in the near future change the `mask` prop to accept either one of those four strings **or** a masking function so developers can do the masking themselves while retaining the accessibility benefits of the debounced formatting.

### Changed
- SSNs obfuscated by replacing digits with asterisks still get formatted by the `Mask` component
