### PR TITLE
Add email address for point of contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ Examples of the design system in use can be found in the [`examples` directory](
 ## Contributing
 
 Please read the [CONTRIBUTING.md](CONTRIBUTING.md) document to learn about setting up a local development environment, contributing to the design system, and our coding guidelines.
+
+## Contact
+
+To contact the CMS Design System product owners, please email `WPMG_Web@cms.hhs.gov`


### PR DESCRIPTION
### Added

Added contact details to the README for teams outside of WDS who want to contact the product owners directly. This has come up a few times, some people reaching out to me directly since I'm a contributor on the repo. I've confirmed with Melissa that this is the email address we can publish.