### PR TITLE
Improve zip code masking

### DIFF
--- a/packages/core/src/components/TextField/Mask.jsx
+++ b/packages/core/src/components/TextField/Mask.jsx
@@ -13,7 +13,7 @@ import React from 'react';
 const deliminatedMaskRegex = {
   phone: /(\d{3})(\d{1,3})?(\d+)?/,
   ssn: /([*\d]{3})([*\d]{1,2})?([*\d]+)?/,
-  zip: /(\d{5})(\d+)/
+  zip: /(\d{5})(\d*)/
 };
 
 /**

--- a/packages/core/src/components/TextField/Mask.test.jsx
+++ b/packages/core/src/components/TextField/Mask.test.jsx
@@ -247,6 +247,20 @@ describe('Mask', function() {
       expect(input.prop('value')).toBe('12345');
     });
 
+    it('accepts five-digits with bad extra chars', () => {
+      const data = render({ mask: 'zip' }, { value: '1234-5' });
+      const input = data.wrapper.find('input');
+
+      expect(input.prop('value')).toBe('12345');
+    });
+
+    it('accepts nine-digits with bad extra chars', () => {
+      const data = render({ mask: 'zip' }, { value: '1234-5-67-89' });
+      const input = data.wrapper.find('input');
+
+      expect(input.prop('value')).toBe('12345-6789');
+    });
+
     it('accepts nine-digit zip code', () => {
       const data = render({ mask: 'zip' }, { value: '123456789' });
       const input = data.wrapper.find('input');


### PR DESCRIPTION
### Background

There was an error in app3 that allowed a user to enter a zip code like `1234-5`. While this was a problem with the app3 validation, it was pointed out that the zip code masking could be improved to strip out the `-`, since it appeared to do so if you provided a 9 digit zip with some extra `-`s.

### Changed
- `TextField/Mask.jsx` -- updated the regex for the zip code masking to allow it to trigger when only a 5 digit zip code is provided. Provided a couple new test cases to cover these scenarios.


## Example

### Before
![2018-09-24 06 58 09](https://user-images.githubusercontent.com/655500/45950934-3f86dc00-bfc7-11e8-93c2-f7d700895318.gif)

Notice that the masking doesn't kick in with just 5 digits, only once we have 9.

### After
![2018-09-24 06 55 09](https://user-images.githubusercontent.com/655500/45950817-e8810700-bfc6-11e8-8273-2ed4bad73a22.gif)

Here the masking kicks in and corrects format when only providing 5 digits as well.