### PR TITLE
Handle non-numeric values in currency mask

### DIFF
--- a/packages/core/dist/components/TextField/Mask.js
+++ b/packages/core/dist/components/TextField/Mask.js
@@ -103,6 +103,10 @@ function toNumber(value) {
   // 0 = number, 1 = decimals
   var parts = value.split('.');
   var digitsRegex = /^-|\d/g; // include a check for a beginning "-" for negative numbers
+
+  // If this doesn't appear to be a number, just return 0
+  if (!digitsRegex.test(value)) return 0;
+
   var a = parts[0].match(digitsRegex).join('');
   var b = parts.length >= 2 && parts[1].match(digitsRegex).join('');
 
@@ -287,20 +291,20 @@ Mask.propTypes = {
  */
 function unmask(value, mask) {
   if (!value || typeof value !== 'string') return value;
+
   var rawValue = value;
   value = value.trim();
 
   if (mask === 'currency') {
     // Preserve only digits, decimal point, or negative symbol
-    value = value.match(/^-|[\d.]/g).join('');
+    var matches = value.match(/^-|[\d.]/g);
+    return matches ? matches.join('') : rawValue;
   } else if (Object.keys(deliminatedMaskRegex).includes(mask)) {
     // Remove the deliminators and revert to single ungrouped string
-    value = toDigitsAndAsterisks(value);
+    return toDigitsAndAsterisks(value);
   } else {
     return rawValue;
   }
-
-  return value;
 }
 
 exports.default = Mask;

--- a/packages/core/src/components/TextField/Mask.jsx
+++ b/packages/core/src/components/TextField/Mask.jsx
@@ -79,6 +79,10 @@ function toNumber(value) {
   // 0 = number, 1 = decimals
   const parts = value.split('.');
   const digitsRegex = /^-|\d/g; // include a check for a beginning "-" for negative numbers
+
+  // If this doesn't appear to be a number, just return 0
+  if (!digitsRegex.test(value)) return 0;
+
   const a = parts[0].match(digitsRegex).join('');
   const b = parts.length >= 2 && parts[1].match(digitsRegex).join('');
 
@@ -230,20 +234,20 @@ Mask.propTypes = {
  */
 export function unmask(value, mask) {
   if (!value || typeof value !== 'string') return value;
+
   const rawValue = value;
   value = value.trim();
 
   if (mask === 'currency') {
     // Preserve only digits, decimal point, or negative symbol
-    value = value.match(/^-|[\d.]/g).join('');
+    const matches = value.match(/^-|[\d.]/g);
+    return matches ? matches.join('') : rawValue;
   } else if (Object.keys(deliminatedMaskRegex).includes(mask)) {
     // Remove the deliminators and revert to single ungrouped string
-    value = toDigitsAndAsterisks(value);
+    return toDigitsAndAsterisks(value);
   } else {
     return rawValue;
   }
-
-  return value;
 }
 
 export default Mask;

--- a/packages/core/src/components/TextField/Mask.test.jsx
+++ b/packages/core/src/components/TextField/Mask.test.jsx
@@ -125,6 +125,13 @@ describe('Mask', function() {
 
       expect(input.prop('value')).toBe('-1,234');
     });
+
+    it('converts non-number values to 0', () => {
+      const data = render({ mask: 'currency' }, { value: 'wat' });
+      const input = data.wrapper.find('input');
+
+      expect(input.prop('value')).toBe('0');
+    });
   });
 
   describe('Phone', () => {


### PR DESCRIPTION
### Changed
- `<TextField mask="currency" />` will now convert non-numerical values to `0`. 
![2018-09-28 09 46 18](https://user-images.githubusercontent.com/655500/46215584-60229f00-c303-11e8-9b5f-08dcc8bb880b.gif)

### Fixed
- `<TextField mask="currency" />` was throwing an error on non-numeric inputs, `Cannot read property 'join' of null`, because it expected the value to be numeric. The above functional change resolves this error.