### PR TITLE
Allow Tabs to detect TabPanels in React

### DIFF
--- a/packages/core/dist/components/Tabs/Tabs.js
+++ b/packages/core/dist/components/Tabs/Tabs.js
@@ -78,8 +78,8 @@ function panelTabId(panel) {
  * @return {Boolean} Is this a TabPanel component?
  */
 function isTabPanel(child) {
-  // Preact doesn't support child.type
-  return child && (child.type === _TabPanel2.default || child.props && child.props.tab);
+  // Preact doesn't support child.type, React doesn't support child.attributes
+  return child && (child.type === _TabPanel2.default || child.attributes && child.attributes.tab);
 }
 
 /**

--- a/packages/core/dist/components/Tabs/Tabs.js
+++ b/packages/core/dist/components/Tabs/Tabs.js
@@ -78,8 +78,8 @@ function panelTabId(panel) {
  * @return {Boolean} Is this a TabPanel component?
  */
 function isTabPanel(child) {
-  // Preact doesn't support child.type, React doesn't support child.attributes
-  return child && (child.type === _TabPanel2.default || child.attributes && child.attributes.tab);
+  // Preact doesn't support child.type
+  return child && (child.type === _TabPanel2.default || child.props && child.props.tab);
 }
 
 /**

--- a/packages/core/src/components/Tabs/Tabs.jsx
+++ b/packages/core/src/components/Tabs/Tabs.jsx
@@ -46,11 +46,8 @@ function panelTabId(panel) {
  * @return {Boolean} Is this a TabPanel component?
  */
 function isTabPanel(child) {
-  // Preact doesn't support child.type, React doesn't support child.attributes
-  return (
-    child &&
-    (child.type === TabPanel || (child.attributes && child.attributes.tab))
-  );
+  // Preact doesn't support child.type
+  return child && (child.type === TabPanel || (child.props && child.props.tab));
 }
 
 /**


### PR DESCRIPTION
### Changed
Changed the isTabPanel function to check for child.props.tab instead of child.attributes.tab. This will still support Preact, but will also account for wrapped TabPanel React components where the type is not TabPanel.

### Fixed
Fixes #271