### PR TITLE
Fix IE11 support for masked components with Array.prototype.includes polyfill

### DIFF
--- a/packages/core/src/components/TextField/Mask.jsx
+++ b/packages/core/src/components/TextField/Mask.jsx
@@ -6,6 +6,7 @@ cues to a user about the expected value.
 
 Style guide: components.masked-field
 */
+import 'core-js/fn/array/includes';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { polyfill } from 'react-lifecycles-compat';


### PR DESCRIPTION
Sawyer pointed out in [#285](https://github.com/CMSgov/design-system/issues/285) that we started using `Array.prototype.includes` in [Mask.jsx](https://github.com/CMSgov/design-system/commit/752e14fd848c2ab26c2550e5f8e1142e7be3c88e#diff-bc403a3448d8591da046ffb97228eab1R102) without a polyfill (required for IE11 support). This happens elsewhere in our app where we include specific `core-js` polyfills (example: [MonthPicker.jsx](https://github.com/CMSgov/design-system/blob/master/packages/core/src/components/MonthPicker/MonthPicker.jsx#L1)).

### Fixed
- Added polyfill for `Array.prototype.includes` in the `Mask.jsx` module for IE11 support