### PR TITLE
removed up/down arrows from datefield via css; scroll capability stil…

### DIFF
--- a/packages/core/src/components/DateField/DateField.scss
+++ b/packages/core/src/components/DateField/DateField.scss
@@ -34,15 +34,6 @@ Markup:
 Style guide: components.date-field
 */
 
-input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-input[type="number"] {
-  -moz-appearance: textfield;
-}
-
 .ds-c-field--month,
 .ds-c-field--day,
 .ds-c-field--year {

--- a/packages/core/src/components/DateField/DateField.scss
+++ b/packages/core/src/components/DateField/DateField.scss
@@ -33,6 +33,16 @@ Markup:
 
 Style guide: components.date-field
 */
+
+input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type="number"] {
+  -moz-appearance: textfield;
+}
+
 .ds-c-field--month,
 .ds-c-field--day,
 .ds-c-field--year {

--- a/packages/core/src/components/TextField/TextField.example.jsx
+++ b/packages/core/src/components/TextField/TextField.example.jsx
@@ -11,6 +11,12 @@ ReactDOM.render(
       name="single_example"
       requirementLabel="Optional"
     />
+    <TextField
+      defaultValue="123"
+      label="Number field"
+      name="number_example"
+      type="number"
+    />
     <TextField label="Small size modifier" name="small_example" size="small" />
     <TextField
       label="Medium size modifier"

--- a/packages/core/src/components/TextField/TextField.scss
+++ b/packages/core/src/components/TextField/TextField.scss
@@ -41,16 +41,6 @@ Markup:
 Style guide: components.text-field
 */
 
-// input, textarea, select
-input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-input[type="number"] {
-  -moz-appearance: textfield;
-}
-
 .ds-c-field {
   appearance: none;
   border: $input-border-width solid $input-border-color;
@@ -71,6 +61,15 @@ input[type="number"] {
 
   &:focus {
     box-shadow: $focus-shadow;
+  }
+
+  &[type='number'] {
+    appearance: textfield;
+
+    &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
+      appearance: none;
+      margin: 0;
+    }
   }
 }
 

--- a/packages/core/src/components/TextField/TextField.scss
+++ b/packages/core/src/components/TextField/TextField.scss
@@ -42,6 +42,15 @@ Style guide: components.text-field
 */
 
 // input, textarea, select
+input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type="number"] {
+  -moz-appearance: textfield;
+}
+
 .ds-c-field {
   appearance: none;
   border: $input-border-width solid $input-border-color;


### PR DESCRIPTION
### Changed
- removed increment arrows from date field inputs per https://jira.cms.gov/browse/HDSG-234

The ultimate goal was the visual fix of the arrows; thus scrollwheel and keyboard incremental functionality is retained. 

Before:
<img width="266" alt="screen shot 2018-12-11 at 1 32 43 pm" src="https://user-images.githubusercontent.com/4895604/49821783-49f47e80-fd49-11e8-9356-43f0d33236cc.png">

After:
<img width="263" alt="screen shot 2018-12-11 at 1 32 51 pm" src="https://user-images.githubusercontent.com/4895604/49821794-4e209c00-fd49-11e8-9cb6-01ca47472242.png">


