### PR TITLE
Fixing two ARIA bugs, adding documentation for Autocomplete.

### DIFF
--- a/packages/core/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.jsx
@@ -69,13 +69,14 @@ export class Autocomplete extends React.PureComponent {
     );
   }
 
-  renderChildren(getInputProps) {
+  renderChildren(getInputProps, listboxOpen) {
+    const isOpen = listboxOpen;
     // Extend props on the TextField, by passing them
     // through Downshift's `getInputProps` method
     return React.Children.map(this.props.children, child => {
       if (isTextField(child)) {
         const propOverrides = {
-          'aria-controls': this.listboxId,
+          'aria-controls': isOpen ? this.listboxId : null,
           autoComplete: this.props.autoCompleteLabel,
           focusTrigger: this.props.focusTrigger,
           id: this.id,
@@ -120,7 +121,7 @@ export class Autocomplete extends React.PureComponent {
           isOpen
         }) => (
           <div className={rootClassName}>
-            {this.renderChildren(getInputProps)}
+            {this.renderChildren(getInputProps, isOpen)}
 
             {isOpen && (loading || items) ? (
               <div className="ds-u-border--1 ds-u-padding--1 ds-c-autocomplete__list">
@@ -170,7 +171,7 @@ export class Autocomplete extends React.PureComponent {
 
 Autocomplete.defaultProps = {
   ariaClearLabel: 'Clear typeahead and search again',
-  autoCompleteLabel: 'nope',
+  autoCompleteLabel: 'off',
   clearInputText: 'Clear search',
   itemToString: item => (item ? item.name : ''),
   loadingMessage: 'Loading...',
@@ -183,8 +184,7 @@ Autocomplete.propTypes = {
    */
   ariaClearLabel: PropTypes.string,
   /**
-   * Control the `TextField` autocomplete attribute. Defaults to 'nope' to prevent Chrome
-   * from autofilling user presets.
+   * Control the `TextField` autocomplete attribute. Changed to "off" to support accessibility. Chrome 70 appears to support this correct behavior in early testing.
    *
    * https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
    */

--- a/packages/core/src/components/Autocomplete/Autocomplete.scss
+++ b/packages/core/src/components/Autocomplete/Autocomplete.scss
@@ -64,9 +64,9 @@ Style guide: components.autocomplete.react
 
 ## Guidance
 
-- `<Autocomplete>` makes use of the `<Downshift>` component from Paypal: https://github.com/paypal/downshift
+- `<Autocomplete>` makes use of the `<Downshift>` component, maintained by Paypal: [Downshift docs on Github](https://github.com/paypal/downshift). Currently we are holding to version 1.31.16. This will be changing in the future, but has been held to ensure good compatibility with assistive devices (JAWS, NVDA, VoiceOver). 
 - Don't use placeholder text in autocomplete fields. Try to write a descriptive label that identifies what the user is searching for. People who have cognitive or visual disabilities have additional problems with placeholder text.
-- The length of the text field provides a hint to users as to how much text to write. Do not require users to write paragraphs of text into a single-line `input` box; use a `textarea` instead.
+- The length of the text field provides a hint to users as to how much text to write. Do not ask users to write paragraphs of text in this component; use a `textarea` instead.
 
 **[View the "Forms" guidelines for additional guidance and best practices.]({{root}}/guidelines/forms/)**
 
@@ -74,7 +74,13 @@ Style guide: components.autocomplete.react
 
 - The `<Autocomplete>` component has taken special care to ensure accessibility for screenreader devices. It announces the number of results based on `items` matches with the `inputValue` string. The component also reads out the name of each list item when users arrow up or down.
 - `<Autocomplete>` has visually hidden hint text nested in the `<label>` element. This hint `<span>` is being used to provide contextual instructions for the typeahead, and can be overriden by passing a custom `String` into the `labelHint` prop.
-- `<Autocomplete>` has a link to clear the search, and refocus the `<input>` element. This resets the `selectedItem` prop to `null`, and will re-read the label and screenreader hint text.
+- `<Autocomplete>` has a button (styled visually as a link) to clear the search, and refocus the `<input>` element. This resets the local state `selectedItem` to `null`, and will re-read the label and screenreader hint text.
 
-Style guide: components.autocomplete-field.guidance
+## Focus Management
+
+- `<Autocomplete>` has a new Boolean prop called `focusTrigger`. Adding this prop will set keyboard focus on the internal `<Textfield>`. Focus is set immediately when the `componentDidMount()` lifecycle method fires.
+- This is useful when components are added dynamically, after the application has been rendered. All major screen readers (JAWS, NVDA, VoiceOver) have been tested with this feature, and announce the new input correctly.
+- Instances that contain the `focusTrigger` prop may fire Downshift's [onInputValueChange](https://github.com/paypal/downshift#oninputvaluechange) method, causing the `inputValue` to be set back to an empty string. In these cases, you may want to access Downshift's [state reducer](https://github.com/paypal/downshift#statereducer) and manage your component's local state for `blur` and `click` events.
+
+Style guide: components.autocomplete.guidance
 */


### PR DESCRIPTION
### Descritption

Axe.js was reporting two errors, one critical and one serious, about invalid ARIA markup and improper autocomplete attribute values. This PR fixes both of those issues and improves documentation around the focusTrigger prop, based on things I've learned working with Downshift and local state management.

### Added
* Improved documentation for `focusTrigger` prop

### Changed
* `aria-controls` attribute is now added dynamically, to remove an axe.js error
* `autocompleteLabel` default text changed from "nope" to "off". Fixes another axe.js error.