### PR TITLE
Datefield: replace For example: 4 28 1986 with For example: 4 / 28 / 1986 

### DIFF
--- a/packages/core/dist/components/DateField/DateField.js
+++ b/packages/core/dist/components/DateField/DateField.js
@@ -217,7 +217,7 @@ var DateField = exports.DateField = function (_React$PureComponent) {
 
 DateField.defaultProps = {
   label: 'Date',
-  hint: 'For example: 4 28 1986',
+  hint: 'For example: 4 / 28 / 1986',
   dayLabel: 'Day',
   dayName: 'day',
   monthLabel: 'Month',

--- a/packages/core/src/components/DateField/DateField.jsx
+++ b/packages/core/src/components/DateField/DateField.jsx
@@ -162,7 +162,7 @@ export class DateField extends React.PureComponent {
 
 DateField.defaultProps = {
   label: 'Date',
-  hint: 'For example: 4 28 1986',
+  hint: 'For example: 4 / 28 / 1986',
   dayLabel: 'Day',
   dayName: 'day',
   monthLabel: 'Month',

--- a/packages/core/src/components/DateField/DateField.scss
+++ b/packages/core/src/components/DateField/DateField.scss
@@ -11,7 +11,7 @@ Markup:
 <fieldset class="ds-c-fieldset">
   <legend class="ds-c-label">
     <span class="ds-u-font-weight--bold">Date of birth</span>
-    <span class="ds-c-field__hint">For example: 4 28 1986</span>
+    <span class="ds-c-field__hint">For example: 4 / 28 / 1986</span>
   </legend>
   <div class="ds-l-form-row ds-u-align-items--end">
     <div class="ds-l-col--auto">

--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 28 1986
+      For example: 4 / 28 / 1986
     </span>
   </legend>
   <div
@@ -155,7 +155,7 @@ exports[`DateField has errorMessage 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 28 1986
+      For example: 4 / 28 / 1986
     </span>
   </legend>
   <div
@@ -286,7 +286,7 @@ exports[`DateField has invalid day 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 28 1986
+      For example: 4 / 28 / 1986
     </span>
   </legend>
   <div
@@ -417,7 +417,7 @@ exports[`DateField has invalid month 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 28 1986
+      For example: 4 / 28 / 1986
     </span>
   </legend>
   <div
@@ -548,7 +548,7 @@ exports[`DateField has invalid year 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 28 1986
+      For example: 4 / 28 / 1986
     </span>
   </legend>
   <div
@@ -681,7 +681,7 @@ exports[`DateField has requirementLabel 1`] = `
     >
       Optional.
        
-      For example: 4 28 1986
+      For example: 4 / 28 / 1986
     </span>
   </legend>
   <div
@@ -812,7 +812,7 @@ exports[`DateField is inversed 1`] = `
     <span
       className="ds-c-field__hint ds-c-field__hint--inverse"
     >
-      For example: 4 28 1986
+      For example: 4 / 28 / 1986
     </span>
   </legend>
   <div
@@ -943,7 +943,7 @@ exports[`DateField renders with all defaultProps 1`] = `
     <span
       className="ds-c-field__hint"
     >
-      For example: 4 28 1986
+      For example: 4 / 28 / 1986
     </span>
   </legend>
   <div


### PR DESCRIPTION
### Changed
In Datefield, added `/` to the help text.

<img width="282" alt="screen shot 2019-01-09 at 11 05 15 am" src="https://user-images.githubusercontent.com/4895604/50911752-8ece0c80-13fe-11e9-9666-fa671b407ed2.png">


