### PR TITLE
Export HelpDrawerToggle component

### DIFF
--- a/packages/core/src/components/index.js
+++ b/packages/core/src/components/index.js
@@ -11,6 +11,7 @@ export * from './DateField/DateField';
 export * from './Dialog/Dialog';
 export * from './FormLabel/FormLabel';
 export * from './HelpDrawer/HelpDrawer';
+export * from './HelpDrawer/HelpDrawerToggle';
 export * from './MonthPicker/MonthPicker';
 export * from './Review/Review';
 export * from './SkipNav/SkipNav';


### PR DESCRIPTION
### Fixed
`<HelpDrawerToggle />` wasn't being properly exported - I think this should do it.