### PR TITLE
Set HelpDrawer close button text via props

### DIFF
--- a/packages/core/src/components/HelpDrawer/HelpDrawer.jsx
+++ b/packages/core/src/components/HelpDrawer/HelpDrawer.jsx
@@ -15,6 +15,7 @@ export class HelpDrawer extends React.PureComponent {
   render() {
     const {
       ariaLabel,
+      closeButtonText,
       title,
       children,
       onCloseClick,
@@ -44,7 +45,7 @@ export class HelpDrawer extends React.PureComponent {
               onClick={onCloseClick}
               variation="secondary"
             >
-              Close
+              {closeButtonText}
             </Button>
           </div>
         </div>
@@ -60,10 +61,14 @@ export class HelpDrawer extends React.PureComponent {
   }
 }
 
-HelpDrawer.defaultProps = { ariaLabel: 'Close help drawer' };
+HelpDrawer.defaultProps = {
+  ariaLabel: 'Close help drawer',
+  closeButtonText: 'Close'
+};
 HelpDrawer.propTypes = {
   /** Helps give more context to screen readers on the button that closes the Help Drawer */
   ariaLabel: PropTypes.string,
+  closeButtonText: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   footerBody: PropTypes.node,
   footerTitle: PropTypes.string,

--- a/packages/core/src/components/HelpDrawer/HelpDrawer.jsx
+++ b/packages/core/src/components/HelpDrawer/HelpDrawer.jsx
@@ -68,7 +68,7 @@ HelpDrawer.defaultProps = {
 HelpDrawer.propTypes = {
   /** Helps give more context to screen readers on the button that closes the Help Drawer */
   ariaLabel: PropTypes.string,
-  closeButtonText: PropTypes.string.isRequired,
+  closeButtonText: PropTypes.string,
   children: PropTypes.node.isRequired,
   footerBody: PropTypes.node,
   footerTitle: PropTypes.string,


### PR DESCRIPTION
### Changed
The `HelpDrawer` not has a `closeButtonText` prop so developers can customize the text inside the button that hides the drawer. Defaults to "Close".