### PR TITLE
Add ref focus for HelpDrawerToggle to componentDidUpdate

### DIFF
--- a/packages/core/src/components/HelpDrawer/HelpDrawerToggle.jsx
+++ b/packages/core/src/components/HelpDrawer/HelpDrawerToggle.jsx
@@ -5,10 +5,13 @@ import React from 'react';
  * A link that triggers the visibility of a help drawer
  */
 export class HelpDrawerToggle extends React.PureComponent {
-  render() {
-    if (!this.props.helpDrawerOpen && this.buttonRef) {
+  componentDidUpdate(prevProps) {
+    if (!this.props.helpDrawerOpen && prevProps.helpDrawerOpen) {
       this.buttonRef.focus();
     }
+  }
+
+  render() {
     const blockInlineClass = `ds-u-display--${
       this.props.inline ? 'inline-block' : 'block'
     }`;


### PR DESCRIPTION
### Changed
I moved the `buttonRef.focus()` for the `HelpDrawerToggle` from `render` to `componentDidUpdate`.

I ran into an issue in tax tools with the button ref focus when it used to be in `render` causing `Cannot update during an existing state transition` warnings because state change in a parent component was causing a re-render. I don't fully understand why this was happening (the parent state change was via an onBlur event related to another ref), but I do think handling the focus in `componentDidUpdate` rather than `render` here makes sense. Please let me know if you see any concerns with this.
