### PR TITLE
add link to CMS survey per https://jira.cms.gov/browse/WNMGDS-3

### DIFF
--- a/packages/docs/src/pages/index.md
+++ b/packages/docs/src/pages/index.md
@@ -3,6 +3,13 @@ title: Introduction
 weight: -100
 ---
 
+<div class="ds-c-alert">
+  <div class="ds-c-alert__body">
+    <h3 class="ds-c-alert__heading">Tell us how the system is working for you</h3>
+    <p class="ds-c-alert__text">We're conducting a survey of design system users in order to understand how they use it, what’s working well, and where it has room to grow. <br><a href="https://forms.cms.gov/cms-wide-design-system-survey" target="_blank">Take the survey</a></p>
+  </div>
+</div>
+
 The design system is a set of open source design and front-end development resources for creating Section 508 compliant, responsive, and consistent websites. It builds on the U.S. Web Design Standards and extends it to support additional CSS and React components, [utility classes]({{root}}/utilities), and a [grid framework]({{root}}/layout/grid) to allow teams to quickly prototype and build accessible, responsive, production-ready websites.
 
 It is currently being applied to [HealthCare.gov](https://www.healthcare.gov/). It is open source and freely available to use by anyone.

--- a/packages/docs/src/pages/index.md
+++ b/packages/docs/src/pages/index.md
@@ -5,8 +5,8 @@ weight: -100
 
 <div class="ds-c-alert">
   <div class="ds-c-alert__body">
-    <h3 class="ds-c-alert__heading">Tell us how the system is working for you</h3>
-    <p class="ds-c-alert__text">We're conducting a survey of design system users in order to understand how they use it, what’s working well, and where it has room to grow. <br><a href="https://forms.cms.gov/cms-wide-design-system-survey" target="_blank">Take the survey</a></p>
+    <h2 class="ds-c-alert__heading">Tell us how the system is working for you</h2>
+    <p class="ds-c-alert__text">We're conducting a survey of design system users in order to understand how they use it, what’s working well, and where it has room to grow. <br><a href="https://forms.cms.gov/cms-wide-design-system-survey" target="_blank" rel="noopener noreferrer">Take the survey</a></p>
   </div>
 </div>
 


### PR DESCRIPTION
### Added
Per https://jira.cms.gov/projects/WNMGDS/issues/WNMGDS-3, added a blue info alert to the home page of the design system pointing people to a survey we'd like them to take.

<img width="1365" alt="screen shot 2019-01-28 at 1 46 13 pm" src="https://user-images.githubusercontent.com/4895604/51858594-1a9ece80-2303-11e9-9908-f2846627c70d.png">
