### PR TITLE
ChoiceList: add `ariaLabel` prop for select component type

### DIFF
--- a/packages/core/src/components/ChoiceList/ChoiceList.jsx
+++ b/packages/core/src/components/ChoiceList/ChoiceList.jsx
@@ -91,6 +91,7 @@ export class ChoiceList extends React.PureComponent {
         onBlur={this.props.onBlur}
         onChange={this.props.onChange}
         className={classes}
+        aria-label={this.props.ariaLabel}
         {...selectProps}
       >
         {options}
@@ -216,7 +217,11 @@ ChoiceList.propTypes = {
    * `checkbox` fields will be rendered. If less than 10 choices are passed in,
    * then `radio` buttons will be rendered.
    */
-  type: PropTypes.oneOf(['checkbox', 'radio', 'select'])
+  type: PropTypes.oneOf(['checkbox', 'radio', 'select']),
+  /**
+   * Adds `aria-label` attribute if component renders a select
+   */
+  ariaLabel: PropTypes.string
 };
 
 export default ChoiceList;

--- a/packages/core/src/components/ChoiceList/Select.jsx
+++ b/packages/core/src/components/ChoiceList/Select.jsx
@@ -119,7 +119,12 @@ Select.propTypes = {
    * Sets the field's `value`. Use this in combination with `onChange`
    * for a controlled component; otherwise, set `defaultValue`.
    */
-  value: PropTypes.string
+  value: PropTypes.string,
+
+  /**
+   * Adds `aria-label` attribute
+   */
+  'aria-label': PropTypes.string
 };
 
 export default Select;


### PR DESCRIPTION
### Added
* A new prop - `ariaLabel` - to the `ChoiceList` component. `ChoiceList` will pass the value of this prop as the `aria-label` attribute when it renders a `Select` component. This addition is necessary for 508 compliance in some instances. See https://jira.cms.gov/browse/WNMGAPPIII-201.