### PR TITLE
Fix broken link to the measure utility

### DIFF
--- a/packages/core/src/components/Alert/Alert.scss
+++ b/packages/core/src/components/Alert/Alert.scss
@@ -105,7 +105,7 @@ $alert-icon-size: $spacer-5;
 /*
 Additional examples
 
-Alerts support various types and lengths of content, including lists and links. You can use the [measure utility]({{root}}/utilities/measure) to maintain a legible line length.
+Alerts support various types and lengths of content, including lists and links. You can use the [measure utility](/utilities/measure) to maintain a legible line length.
 
 Markup:
 <div class="ds-c-alert">


### PR DESCRIPTION
### Fixed
Broken link to the measure utility from the alerts component page. 
Before fix link was: https://design.cms.gov/components/alert/%7B%7Broot%7D%7D/utilities/measure
After fix link is: https://design.cms.gov/utilities/measure/