### PR TITLE
Add ARIA roles to child content container

### DIFF
--- a/packages/core/src/components/ChoiceList/Choice.example.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.example.jsx
@@ -66,16 +66,16 @@ ReactDOM.render(
     <div className="ds-u-margin-top--4">
       <fieldset className="ds-c-fieldset">
         <legend className="ds-c-label">Radios with children</legend>
-        <Choice name="radio_choice" type="radio" value="a">
-          Radio A
+        <Choice name="radio_choice_children" type="radio" value="c">
+          Radio C
         </Choice>
         <Choice
-          name="radio_choice"
+          name="radio_choice_children"
           type="radio"
-          value="b"
+          value="d"
           checkedChildren={childSelect}
         >
-          Radio B - with children
+          Radio D - with children
         </Choice>
       </fieldset>
     </div>

--- a/packages/core/src/components/ChoiceList/Choice.example.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.example.jsx
@@ -1,6 +1,26 @@
 import Choice from './Choice';
+import ChoiceList from './ChoiceList';
 import React from 'react';
 import ReactDOM from 'react-dom';
+
+const selectChoices = [
+  { label: 'A', value: 'A' },
+  { defaultChecked: true, label: 'B', value: 'B' },
+  { label: 'C', value: 'C' },
+  { label: 'D', value: 'D' },
+  { label: 'E', value: 'E' },
+  { label: 'F', value: 'F' },
+  { label: 'G', value: 'G' },
+  { label: 'H', value: 'H' }
+];
+
+const childSelect = (
+  <ChoiceList
+    choices={selectChoices}
+    label="Select example"
+    name="select_choices_field"
+  />
+);
 
 ReactDOM.render(
   <div>
@@ -20,12 +40,44 @@ ReactDOM.render(
     </Choice>
 
     <div className="ds-u-margin-top--4">
-      <Choice defaultChecked name="radio_choice" type="radio" value="a">
+      <fieldset className="ds-c-fieldset">
+        <legend className="ds-c-label">Checkboxes with children</legend>
+        <Choice defaultChecked name="radio_choice" value="a">
+          Checkbox A
+        </Choice>
+        <Choice name="radio_choice" value="b" checkedChildren={childSelect}>
+          Checkbox B - with children
+        </Choice>
+        <Choice name="checkbox_choice" value="c">
+          Checkbox C
+        </Choice>
+      </fieldset>
+    </div>
+
+    <div className="ds-u-margin-top--4">
+      <Choice name="radio_choice" type="radio" value="a">
         Radio A
       </Choice>
       <Choice name="radio_choice" type="radio" value="b">
         Radio B
       </Choice>
+    </div>
+
+    <div className="ds-u-margin-top--4">
+      <fieldset className="ds-c-fieldset">
+        <legend className="ds-c-label">Radios with children</legend>
+        <Choice name="radio_choice" type="radio" value="a">
+          Radio A
+        </Choice>
+        <Choice
+          name="radio_choice"
+          type="radio"
+          value="b"
+          checkedChildren={childSelect}
+        >
+          Radio B - with children
+        </Choice>
+      </fieldset>
     </div>
   </div>,
   document.getElementById('js-example')

--- a/packages/core/src/components/ChoiceList/Choice.example.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.example.jsx
@@ -18,67 +18,77 @@ const childSelect = (
   <ChoiceList
     choices={selectChoices}
     label="Select example"
+    className=""
     name="select_choices_field"
   />
 );
 
 ReactDOM.render(
   <div>
-    <Choice
-      defaultChecked
-      hint="Checkbox A hint"
-      name="checkbox_choice"
-      value="a"
-    >
-      Checkbox A
-    </Choice>
-    <Choice name="checkbox_choice" value="b">
-      Checkbox B
-    </Choice>
-    <Choice name="checkbox_choice" value="c">
-      Checkbox C
-    </Choice>
+    <fieldset className="ds-c-fieldset">
+      <legend className="ds-c-label">Checkbox example</legend>
+      <Choice
+        defaultChecked
+        hint="Checkbox A hint"
+        name="checkbox_choice"
+        value="a"
+      >
+        Checkbox A
+      </Choice>
+      <Choice name="checkbox_choice" value="b">
+        Checkbox B
+      </Choice>
+      <Choice name="checkbox_choice" value="c">
+        Checkbox C
+      </Choice>
+    </fieldset>
 
-    <div className="ds-u-margin-top--4">
-      <fieldset className="ds-c-fieldset">
-        <legend className="ds-c-label">Checkboxes with children</legend>
-        <Choice defaultChecked name="radio_choice" value="a">
-          Checkbox A
-        </Choice>
-        <Choice name="radio_choice" value="b" checkedChildren={childSelect}>
-          Checkbox B - with children
-        </Choice>
-        <Choice name="checkbox_choice" value="c">
-          Checkbox C
-        </Choice>
-      </fieldset>
-    </div>
+    <fieldset className="ds-c-fieldset">
+      <legend className="ds-c-label">Checkbox example with children</legend>
+      <Choice
+        hint="Checkbox A hint"
+        defaultChecked
+        name="checkbox_choice_children"
+        value="a"
+      >
+        Checkbox A
+      </Choice>
+      <Choice
+        name="checkbox_choice_children"
+        value="b"
+        checkedChildren={childSelect}
+      >
+        Checkbox B - with children
+      </Choice>
+      <Choice name="checkbox_choice_children" value="c">
+        Checkbox C
+      </Choice>
+    </fieldset>
 
-    <div className="ds-u-margin-top--4">
+    <fieldset className="ds-c-fieldset">
+      <legend className="ds-c-label">Radio example</legend>
       <Choice name="radio_choice" type="radio" value="a">
         Radio A
       </Choice>
       <Choice name="radio_choice" type="radio" value="b">
         Radio B
       </Choice>
-    </div>
+    </fieldset>
 
-    <div className="ds-u-margin-top--4">
-      <fieldset className="ds-c-fieldset">
-        <legend className="ds-c-label">Radios with children</legend>
-        <Choice name="radio_choice_children" type="radio" value="c">
-          Radio C
-        </Choice>
-        <Choice
-          name="radio_choice_children"
-          type="radio"
-          value="d"
-          checkedChildren={childSelect}
-        >
-          Radio D - with children
-        </Choice>
-      </fieldset>
-    </div>
+    <fieldset className="ds-c-fieldset">
+      <legend className="ds-c-label">Radio example with children</legend>
+      <Choice name="radio_choice_children" type="radio" value="c">
+        Radio A
+      </Choice>
+      <Choice
+        name="radio_choice_children"
+        type="radio"
+        value="d"
+        checkedChildren={childSelect}
+      >
+        Radio B - with children
+      </Choice>
+    </fieldset>
   </div>,
   document.getElementById('js-example')
 );

--- a/packages/core/src/components/ChoiceList/Choice.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.jsx
@@ -104,7 +104,12 @@ export class Choice extends React.PureComponent {
     if (inputProps.onChange) delete inputProps.onChange;
 
     return (
-      <div className={className}>
+      <div
+        className={className}
+        aria-live={checkedChildren ? 'polite' : null}
+        aria-relevant={checkedChildren ? 'additions text' : null}
+        aria-atomic={checkedChildren ? 'false' : null}
+      >
         <input
           className={inputClasses}
           id={this.id}

--- a/packages/core/src/components/ChoiceList/ChoiceList.example.jsx
+++ b/packages/core/src/components/ChoiceList/ChoiceList.example.jsx
@@ -17,6 +17,20 @@ ReactDOM.render(
   <div>
     <ChoiceList
       choices={[
+        { label: 'Option 1 - no children', value: 'option1' },
+        {
+          label: 'Option 2 - children',
+          value: 'option2',
+          checkedChildren: '123,ABC'
+        }
+      ]}
+      className="ds-u-margin-top--0"
+      label="Radio example with children"
+      name="choices_field_children"
+    />
+
+    <ChoiceList
+      choices={[
         { label: 'Choice 1', value: 'A' },
         { defaultChecked: true, label: 'Choice 2', value: 'B' }
       ]}

--- a/packages/core/src/components/ChoiceList/ChoiceList.example.jsx
+++ b/packages/core/src/components/ChoiceList/ChoiceList.example.jsx
@@ -17,20 +17,6 @@ ReactDOM.render(
   <div>
     <ChoiceList
       choices={[
-        { label: 'Option 1 - no children', value: 'option1' },
-        {
-          label: 'Option 2 - children',
-          value: 'option2',
-          checkedChildren: '123,ABC'
-        }
-      ]}
-      className="ds-u-margin-top--0"
-      label="Radio example with children"
-      name="choices_field_children"
-    />
-
-    <ChoiceList
-      choices={[
         { label: 'Choice 1', value: 'A' },
         { defaultChecked: true, label: 'Choice 2', value: 'B' }
       ]}

--- a/packages/core/src/components/MonthPicker/MonthPicker.test.jsx
+++ b/packages/core/src/components/MonthPicker/MonthPicker.test.jsx
@@ -237,7 +237,7 @@ describe('MonthPicker', () => {
 
   it('renders a snapshot', () => {
     const tree = renderer
-      .create(<MonthPicker name="months" label="Months" />)
+      .create(<MonthPicker name="months" label="Months" locale="en" />)
       .toJSON();
 
     expect(tree).toMatchSnapshot();

--- a/packages/core/src/components/MonthPicker/__snapshots__/MonthPicker.test.jsx.snap
+++ b/packages/core/src/components/MonthPicker/__snapshots__/MonthPicker.test.jsx.snap
@@ -58,11 +58,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
       >
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M01"
+              aria-label="January"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -80,18 +83,21 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M01
+                Jan
               </span>
             </label>
           </div>
         </li>
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M02"
+              aria-label="February"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -109,18 +115,21 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M02
+                Feb
               </span>
             </label>
           </div>
         </li>
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M03"
+              aria-label="March"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -138,18 +147,21 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M03
+                Mar
               </span>
             </label>
           </div>
         </li>
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M04"
+              aria-label="April"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -167,18 +179,21 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M04
+                Apr
               </span>
             </label>
           </div>
         </li>
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M05"
+              aria-label="May"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -196,18 +211,21 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M05
+                May
               </span>
             </label>
           </div>
         </li>
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M06"
+              aria-label="June"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -225,18 +243,21 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M06
+                Jun
               </span>
             </label>
           </div>
         </li>
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M07"
+              aria-label="July"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -254,18 +275,21 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M07
+                Jul
               </span>
             </label>
           </div>
         </li>
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M08"
+              aria-label="August"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -283,18 +307,21 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M08
+                Aug
               </span>
             </label>
           </div>
         </li>
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M09"
+              aria-label="September"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -312,18 +339,21 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M09
+                Sep
               </span>
             </label>
           </div>
         </li>
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M10"
+              aria-label="October"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -341,18 +371,21 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M10
+                Oct
               </span>
             </label>
           </div>
         </li>
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M11"
+              aria-label="November"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -370,18 +403,21 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M11
+                Nov
               </span>
             </label>
           </div>
         </li>
         <li>
           <div
+            aria-atomic={null}
+            aria-live={null}
+            aria-relevant={null}
             className="ds-c-month-picker__month"
           >
             <input
               aria-describedby={null}
-              aria-label="M12"
+              aria-label="December"
               checked={false}
               className="ds-c-choice"
               disabled={false}
@@ -399,7 +435,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <span
                 className=""
               >
-                M12
+                Dec
               </span>
             </label>
           </div>


### PR DESCRIPTION
### Added
- `aria-live="polite" and aria-relevant="additions text" and aria-atomic="false"` to choice when  `checkedChildren` prop is used. 
- Example of `checkedChildren` to `choice` example for both radios and checkboxes 

### Looking to Fix
This is working to fix an issue where the choice element is not to announcing the content in `checkedChildren` when it is revealed.

### To do
- [x] Check against screen readers @1Copenut 
- [x] Add styles for the child content container. This should be a follow on issue 