### PR TITLE
[WNMGDS-6/checked-child-css] Adding CSS support for Choice checked children

### DIFF
--- a/packages/core/src/components/ChoiceList/Choice.example.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.example.jsx
@@ -101,7 +101,7 @@ ReactDOM.render(
         </legend>
         <Choice
           className="ds-c-choice--inverse"
-          name="radio_choice_children"
+          name="radio_choice_children_inv"
           type="radio"
           value="c"
         >
@@ -109,7 +109,7 @@ ReactDOM.render(
         </Choice>
         <Choice
           className="ds-c-choice--inverse"
-          name="radio_choice_children"
+          name="radio_choice_children_inv"
           type="radio"
           value="d"
           checkedChildren={

--- a/packages/core/src/components/ChoiceList/Choice.example.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.example.jsx
@@ -18,7 +18,7 @@ const childSelect = (
   <ChoiceList
     choices={selectChoices}
     label="Select example"
-    className=""
+    labelClassName="ds-c-label ds-u-margin-top--0"
     name="select_choices_field"
   />
 );
@@ -56,7 +56,9 @@ ReactDOM.render(
       <Choice
         name="checkbox_choice_children"
         value="b"
-        checkedChildren={childSelect}
+        checkedChildren={
+          <div className="ds-c-choice__checkedChild">{childSelect}</div>
+        }
       >
         Checkbox B - with children
       </Choice>
@@ -84,11 +86,40 @@ ReactDOM.render(
         name="radio_choice_children"
         type="radio"
         value="d"
-        checkedChildren={childSelect}
+        checkedChildren={
+          <div className="ds-c-choice__checkedChild">{childSelect}</div>
+        }
       >
         Radio B - with children
       </Choice>
     </fieldset>
+
+    <div className="ds-base ds-base--inverse ds-u-padding--2 ds-u-margin-top--2">
+      <fieldset className="ds-c-fieldset ds-u-margin-top--0">
+        <legend className="ds-c-label">
+          Inverse radio example with children
+        </legend>
+        <Choice
+          className="ds-c-choice--inverse"
+          name="radio_choice_children"
+          type="radio"
+          value="c"
+        >
+          Radio A
+        </Choice>
+        <Choice
+          className="ds-c-choice--inverse"
+          name="radio_choice_children"
+          type="radio"
+          value="d"
+          checkedChildren={
+            <div className="ds-c-choice__checkedChild">{childSelect}</div>
+          }
+        >
+          Radio B - with children
+        </Choice>
+      </fieldset>
+    </div>
   </div>,
   document.getElementById('js-example')
 );

--- a/packages/core/src/components/ChoiceList/Choice.example.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.example.jsx
@@ -99,21 +99,17 @@ ReactDOM.render(
         <legend className="ds-c-label">
           Inverse radio example with children
         </legend>
-        <Choice
-          className="ds-c-choice--inverse"
-          name="radio_choice_children_inv"
-          type="radio"
-          value="c"
-        >
+        <Choice name="radio_choice_children_inv" type="radio" value="c">
           Radio A
         </Choice>
         <Choice
-          className="ds-c-choice--inverse"
           name="radio_choice_children_inv"
           type="radio"
           value="d"
           checkedChildren={
-            <div className="ds-c-choice__checkedChild">{childSelect}</div>
+            <div className="ds-c-choice__checkedChild ds-c-choice__checkedChild--inverse">
+              {childSelect}
+            </div>
           }
         >
           Radio B - with children

--- a/packages/core/src/components/ChoiceList/Choice.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.jsx
@@ -148,7 +148,9 @@ Choice.propTypes = {
    */
   checked: PropTypes.bool,
   /**
-   * Content to be shown when the choice is checked
+   * Content to be shown when the choice is checked. See
+   * **Checked children and the expose within pattern** on
+   * the Guidance tab for detailed instructions.
    */
   checkedChildren: PropTypes.node,
   /**

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -172,6 +172,22 @@ Style guide: components.choice.inversed
   border-radius: 100%;
 }
 
+// Checked child container
+$ds-c-inset-border-width: $spacer-half;
+
+.ds-c-choice__checkedChild {
+  border-left: $ds-c-inset-border-width solid $color-primary;
+  margin-bottom: $spacer-2;
+  margin-left: ($choice-size / 2) - ($ds-c-inset-border-width / 2);
+  padding: $spacer-2;
+}
+
+.ds-c-choice--inverse {
+  .ds-c-choice__checkedChild {
+    border-left-color: $color-white;
+  }
+}
+
 /*
 Right-to-Left
 
@@ -315,6 +331,19 @@ Style guide: components.choice.react
 - Use caution if you decide to set a default value. Setting a default value can discourage users from making conscious decisions, seem pushy, or alienate users who don’t fit into your assumptions. In addition, you'll never know if the user explicitly chose that option or just didn't notice the question. If you're unsure, leave nothing selected by default.
 
 **[View the "Forms" guidelines for additional guidance and best practices.]({{root}}/guidelines/forms/)**
+
+## Checked children and the expose within pattern
+
+- The `<Choice>` component includes a `checkedChildren` prop that can expose hidden text information or form elements. This **expose within** pattern is especially useful if you need to collect data from follow up questions or give just-in-time feedback.
+- Checked children can be exposed by checking the parent checkbox or radio button
+- Checked children will be announced to screen readers when they are exposed. They have been tested with the following devices:
+  - Windows 10 + Internet Explorer 11 + JAWS screen reader
+  - Windows 10 + Chrome + JAWS
+  - Windows 10 + Firefox + NVDA
+  - MacOS Mojave + Safari + VoiceOver
+- The checkedChildren prop should return one or more items wrapped in a `div` with the following className: `ds-c-choice__checkedChild`. This class sets the spacing and border color for the exposed elements.
+- Add the className `ds-c-choice--inverse` to the parent `<Choice />` component for the inverse white border
+- You may need to add the className `ds-u-margin--0` to your child element(s) to avoid extra top margin
 
 ## Accessibility
 

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -91,12 +91,16 @@ $ds-c-inset-border-width: $spacer-half;
   opacity: 0;
   position: absolute;
 
-  // Checked child container
+  // Checked children container
   &__checkedChild {
     border-left: $ds-c-inset-border-width solid $color-primary;
     margin-bottom: $spacer-2;
     margin-left: ($choice-size / 2) - ($ds-c-inset-border-width / 2);
     padding: $spacer-2;
+
+    &--inverse {
+      border-left-color: $color-white;
+    }
   }
 }
 
@@ -163,13 +167,6 @@ $ds-c-inset-border-width: $spacer-half;
       border: 1px solid $color-gray-light;
       cursor: not-allowed;
     }
-  }
-}
-
-.ds-c-choice--inverse {
-  // Checked child border override
-  .ds-c-choice__checkedChild {
-    border-left-color: $color-white;
   }
 }
 
@@ -343,7 +340,7 @@ Style guide: components.choice.react
   - Windows 10 + Firefox + NVDA
   - MacOS Mojave + Safari + VoiceOver
 - The checkedChildren prop should return one or more items wrapped in a `div` with the following className: `ds-c-choice__checkedChild`. This class sets the spacing and border color for the exposed elements.
-- Add the className `ds-c-choice--inverse` to the parent `<Choice />` component for the inverse white border
+- Add the className `ds-c-choice__checkedChild--inverse` to the `div` to show the inverse white border
 - You may need to add the className `ds-u-margin--0` to your child element(s) to avoid extra top margin
 
 ## Accessibility

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -168,7 +168,7 @@ $ds-c-inset-border-width: $spacer-half;
 
 .ds-c-choice--inverse {
   // Checked child border override
-  &__checkedChild {
+  .ds-c-choice__checkedChild {
     border-left-color: $color-white;
   }
 }

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -82,12 +82,22 @@ Markup:
 Style guide: components.choice.inversed
 */
 
+$ds-c-inset-border-width: $spacer-half;
+
 // Hide the default browser checkbox/radio button since we'll
 // create our own custom version
 .ds-c-choice {
   left: -999em;
   opacity: 0;
   position: absolute;
+
+  // Checked child container
+  &__checkedChild {
+    border-left: $ds-c-inset-border-width solid $color-primary;
+    margin-bottom: $spacer-2;
+    margin-left: ($choice-size / 2) - ($ds-c-inset-border-width / 2);
+    padding: $spacer-2;
+  }
 }
 
 .ds-c-choice + label {
@@ -156,6 +166,13 @@ Style guide: components.choice.inversed
   }
 }
 
+.ds-c-choice--inverse {
+  // Checked child border override
+  &__checkedChild {
+    border-left-color: $color-white;
+  }
+}
+
 .ds-c-choice--inverse:disabled {
   + label {
     color: $color-muted-inverse;
@@ -170,22 +187,6 @@ Style guide: components.choice.inversed
 // Display a circular radio button
 .ds-c-choice[type='radio'] + label::before {
   border-radius: 100%;
-}
-
-// Checked child container
-$ds-c-inset-border-width: $spacer-half;
-
-.ds-c-choice__checkedChild {
-  border-left: $ds-c-inset-border-width solid $color-primary;
-  margin-bottom: $spacer-2;
-  margin-left: ($choice-size / 2) - ($ds-c-inset-border-width / 2);
-  padding: $spacer-2;
-}
-
-.ds-c-choice--inverse {
-  .ds-c-choice__checkedChild {
-    border-left-color: $color-white;
-  }
 }
 
 /*


### PR DESCRIPTION
### UPDATE
* Fixed the CSS and class placement
* Verified the inverse theme is working correctly
* Updated docs to call out `checkedChild` handling

### Added
* CSS support for the `<Choice />` checked children prop to match the older Healthcare.gov site package expose within pattern
* Documentation for proper use of the expose within pattern

---
![screen shot 2019-02-18 at 2 20 41 pm](https://user-images.githubusercontent.com/934879/52974810-86b3a600-3388-11e9-8760-5ea6a03371dc.png)

