### PR TITLE
Fix differences between vertical nav HTML and React versions

### DIFF
--- a/packages/core/src/components/VerticalNav/VerticalNav.example.jsx
+++ b/packages/core/src/components/VerticalNav/VerticalNav.example.jsx
@@ -7,26 +7,44 @@ ReactDOM.render(
     selectedId="team"
     items={[
       {
-        label: 'Home',
+        label: 'Parent link',
         url: 'javascript:void(0);'
       },
       {
-        label: 'About',
+        label: 'Current page',
+        selected: true,
         items: [
           {
-            id: 'team',
-            label: 'Team',
+            id: 'childlink1',
+            label: 'Child link',
             url: 'javascript:void(0);'
           },
           {
-            id: 'company',
-            label: 'Company',
+            label: 'Child link',
+            selected: true,
+            items: [
+              {
+                id: 'grandchildlink1',
+                label: 'Grandchild link',
+                url: 'javascript:void(0);'
+              },
+              {
+                id: 'grandchildlink2',
+                label: 'Grandchild link',
+                url: 'javascript:void(0);',
+                selected: true
+              }
+            ]
+          },
+          {
+            id: 'childlink3',
+            label: 'Child link',
             url: 'javascript:void(0);'
           }
         ]
       },
       {
-        label: 'Contact',
+        label: 'Parent link',
         url: 'javascript:void(0);'
       }
     ]}

--- a/packages/core/src/components/VerticalNav/VerticalNav.scss
+++ b/packages/core/src/components/VerticalNav/VerticalNav.scss
@@ -13,13 +13,13 @@ Markup:
     <a class="ds-c-vertical-nav__label" href="javascript:void(0);">Parent link</a>
   </li>
   <li class="ds-c-vertical-nav__item">
-    <a class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current" href="javascript:void(0);">Current page</a>
+    <button class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current ds-c-vertical-nav__label--parent" title="Collapse sub-navigation" aria-expanded="true">Current page</button>
     <ul class="ds-c-vertical-nav__subnav">
       <li class="ds-c-vertical-nav__item">
         <a class="ds-c-vertical-nav__label" href="javascript:void(0);">Child link</a>
       </li>
       <li class="ds-c-vertical-nav__item">
-        <a class="ds-c-vertical-nav__label" href="javascript:void(0);">Child link</a>
+        <button class="ds-c-vertical-nav__label ds-c-vertical-nav__label--current ds-c-vertical-nav__label--parent" title="Collapse sub-navigation" aria-expanded="true">Child link</button>
         <ul class="ds-c-vertical-nav__subnav">
           <li class="ds-c-vertical-nav__item">
             <a class="ds-c-vertical-nav__label" href="javascript:void(0);">Grandchild link</a>


### PR DESCRIPTION
### Fixed
Fixes #313 

Added Caret to the vertical navigation and updated the HTML and React versions to be the same.
**I'm not sure how many levels the caret is supposed to be on**

#### HTML version
![screen shot 2019-02-19 at 2 55 59 pm](https://user-images.githubusercontent.com/1449852/53043477-871a7280-3456-11e9-9f53-761da5f79ac4.png)

#### React version
![screen shot 2019-02-19 at 2 56 10 pm](https://user-images.githubusercontent.com/1449852/53043596-cfd22b80-3456-11e9-93ee-1cbe489d8696.png)
