### PR TITLE
Adding small and right inputs, fixing frame height on Choice.

### DIFF
--- a/packages/core/src/components/ChoiceList/Choice.example.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.example.jsx
@@ -26,7 +26,7 @@ const childSelect = (
 ReactDOM.render(
   <div>
     <fieldset className="ds-c-fieldset">
-      <legend className="ds-c-label">Checkbox example</legend>
+      <legend className="ds-c-label">Checkboxes</legend>
       <Choice
         defaultChecked
         hint="Checkbox A hint"
@@ -44,16 +44,12 @@ ReactDOM.render(
     </fieldset>
 
     <fieldset className="ds-c-fieldset">
-      <legend className="ds-c-label">Checkbox example with children</legend>
-      <Choice
-        hint="Checkbox A hint"
-        defaultChecked
-        name="checkbox_choice_children"
-        value="a"
-      >
+      <legend className="ds-c-label">Checkboxes with children</legend>
+      <Choice hint="Checkbox A hint" name="checkbox_choice_children" value="a">
         Checkbox A
       </Choice>
       <Choice
+        defaultChecked
         name="checkbox_choice_children"
         value="b"
         checkedChildren={
@@ -67,9 +63,11 @@ ReactDOM.render(
       </Choice>
     </fieldset>
 
+    <hr className="ds-u-margin-top--2" />
+
     <fieldset className="ds-c-fieldset">
-      <legend className="ds-c-label">Radio example</legend>
-      <Choice name="radio_choice" type="radio" value="a">
+      <legend className="ds-c-label">Radio buttons</legend>
+      <Choice defaultChecked name="radio_choice" type="radio" value="a">
         Radio A
       </Choice>
       <Choice name="radio_choice" type="radio" value="b">
@@ -78,11 +76,12 @@ ReactDOM.render(
     </fieldset>
 
     <fieldset className="ds-c-fieldset">
-      <legend className="ds-c-label">Radio example with children</legend>
+      <legend className="ds-c-label">Radio buttons with children</legend>
       <Choice name="radio_choice_children" type="radio" value="c">
         Radio A
       </Choice>
       <Choice
+        defaultChecked
         name="radio_choice_children"
         type="radio"
         value="d"
@@ -94,15 +93,74 @@ ReactDOM.render(
       </Choice>
     </fieldset>
 
+    <hr className="ds-u-margin-top--2" />
+
+    <fieldset className="ds-c-fieldset">
+      <legend className="ds-c-label">Small checkboxes with children</legend>
+      <Choice name="checkbox_choice_children_small" size="small" value="a">
+        Checkbox A
+      </Choice>
+      <Choice
+        defaultChecked
+        name="checkbox_choice_children_small"
+        value="b"
+        checkedChildren={
+          <div className="ds-c-choice__checkedChild ds-c-choice__checkedChild--small">
+            {childSelect}
+          </div>
+        }
+        size="small"
+      >
+        Checkbox B - with children
+      </Choice>
+      <Choice name="checkbox_choice_children_small" size="small" value="c">
+        Checkbox C
+      </Choice>
+    </fieldset>
+
+    <div className="ds-u-measure--narrow ds-u-margin-top--4 ds-u-margin-bottom--5 ds-u-padding--2 ds-u-border--2">
+      <fieldset className="ds-c-fieldset ds-u-margin-top--0">
+        <legend className="ds-c-label">Right checkboxes with children</legend>
+        <Choice
+          inputPlacement="right"
+          name="checkbox_choice_children"
+          value="a"
+        >
+          Checkbox A
+        </Choice>
+        <Choice
+          defaultChecked
+          inputPlacement="right"
+          name="checkbox_choice_children"
+          value="b"
+          checkedChildren={
+            <div className="ds-c-choice__checkedChild ds-c-choice__checkedChild--right">
+              {childSelect}
+            </div>
+          }
+        >
+          Checkbox B - with children
+        </Choice>
+        <Choice
+          inputPlacement="right"
+          name="checkbox_choice_children"
+          value="c"
+        >
+          Checkbox C
+        </Choice>
+      </fieldset>
+    </div>
+
     <div className="ds-base ds-base--inverse ds-u-padding--2 ds-u-margin-top--2">
       <fieldset className="ds-c-fieldset ds-u-margin-top--0">
         <legend className="ds-c-label">
-          Inverse radio example with children
+          Inverse radio buttons with children
         </legend>
         <Choice name="radio_choice_children_inv" type="radio" value="c">
           Radio A
         </Choice>
         <Choice
+          defaultChecked
           name="radio_choice_children_inv"
           type="radio"
           value="d"

--- a/packages/core/src/components/ChoiceList/Choice.example.jsx
+++ b/packages/core/src/components/ChoiceList/Choice.example.jsx
@@ -118,39 +118,6 @@ ReactDOM.render(
       </Choice>
     </fieldset>
 
-    <div className="ds-u-measure--narrow ds-u-margin-top--4 ds-u-margin-bottom--5 ds-u-padding--2 ds-u-border--2">
-      <fieldset className="ds-c-fieldset ds-u-margin-top--0">
-        <legend className="ds-c-label">Right checkboxes with children</legend>
-        <Choice
-          inputPlacement="right"
-          name="checkbox_choice_children"
-          value="a"
-        >
-          Checkbox A
-        </Choice>
-        <Choice
-          defaultChecked
-          inputPlacement="right"
-          name="checkbox_choice_children"
-          value="b"
-          checkedChildren={
-            <div className="ds-c-choice__checkedChild ds-c-choice__checkedChild--right">
-              {childSelect}
-            </div>
-          }
-        >
-          Checkbox B - with children
-        </Choice>
-        <Choice
-          inputPlacement="right"
-          name="checkbox_choice_children"
-          value="c"
-        >
-          Checkbox C
-        </Choice>
-      </fieldset>
-    </div>
-
     <div className="ds-base ds-base--inverse ds-u-padding--2 ds-u-margin-top--2">
       <fieldset className="ds-c-fieldset ds-u-margin-top--0">
         <legend className="ds-c-label">

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -340,7 +340,7 @@ Style guide: components.choice.react
 
 - The `<Choice>` component includes a `checkedChildren` prop that can expose hidden text information or form elements. This **expose within** pattern is especially useful if you need to collect data from follow up questions or give just-in-time feedback.
 - Checked children can be exposed by checking the parent checkbox or radio button
-- The checkedChildren prop should return one or more items wrapped in a `div` with the following className: `ds-c-choice__checkedChild`. This class sets the spacing and border color for the exposed elements.
+- The `checkedChildren` prop should return one or more items wrapped in a `div` with the following className: `ds-c-choice__checkedChild`. This class sets the spacing and border color for the exposed elements.
 - Add the className `ds-c-choice__checkedChild--inverse` to the `div` to show the inverse white border
 - You may need to add the className `ds-u-margin--0` to your child element(s) to avoid extra top margin
 - If you opt for smaller radio buttons or checkboxes, add className `ds-c-choice__checkedChild--small` to your checked child container

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -98,8 +98,28 @@ $ds-c-inset-border-width: $spacer-half;
     margin-left: ($choice-size / 2) - ($ds-c-inset-border-width / 2);
     padding: $spacer-2;
 
+    // Checked children container on dark background
     &--inverse {
       border-left-color: $color-white;
+    }
+
+    // Inputs to the right of labels
+    &--right {
+      border-left: 0;
+      border-right: $ds-c-inset-border-width solid $color-primary;
+      margin-left: 0;
+      margin-right: ($choice-size / 2) - ($ds-c-inset-border-width / 2);
+      padding: $spacer-1 0 $spacer-1 ($spacer-2 * 0.75);
+    }
+
+    // Max recommended parent width is $ds-u-measure--narrow (12em)
+    &--right select {
+      max-width: $input-medium-width;
+    }
+
+    // Small input variant
+    &--small {
+      margin-left: $spacer-1;
     }
   }
 }
@@ -334,14 +354,11 @@ Style guide: components.choice.react
 
 - The `<Choice>` component includes a `checkedChildren` prop that can expose hidden text information or form elements. This **expose within** pattern is especially useful if you need to collect data from follow up questions or give just-in-time feedback.
 - Checked children can be exposed by checking the parent checkbox or radio button
-- Checked children will be announced to screen readers when they are exposed. They have been tested with the following devices:
-  - Windows 10 + Internet Explorer 11 + JAWS screen reader
-  - Windows 10 + Chrome + JAWS
-  - Windows 10 + Firefox + NVDA
-  - MacOS Mojave + Safari + VoiceOver
 - The checkedChildren prop should return one or more items wrapped in a `div` with the following className: `ds-c-choice__checkedChild`. This class sets the spacing and border color for the exposed elements.
 - Add the className `ds-c-choice__checkedChild--inverse` to the `div` to show the inverse white border
 - You may need to add the className `ds-u-margin--0` to your child element(s) to avoid extra top margin
+- If you opt for smaller radio buttons or checkboxes, add className `ds-c-choice__checkedChild--small` to your checked child container
+- If you opt for labels before inputs (right inputs), we recommend using the measure className `ds-u-measure--narrow` to maintain readability. You should also add className `ds-c-choice__checkedChild--right` to your checked child container to set the proper spacing and borders.
 
 ## Accessibility
 
@@ -349,6 +366,12 @@ Style guide: components.choice.react
 - Some screen readers read the `legend` text for each `fieldset`, so it should be brief and descriptive.
 - Each input should have a semantic `id` attribute, and its corresponding `label` should have the same value in its `for` attribute.
 - The custom checkboxes and radio buttons here are accessible to screen readers because the default fields are moved off-screen.
+- `checkedChildren` will be announced to screen readers when they are exposed. They have been tested with the following devices:
+  - Windows 10 + Internet Explorer 11 + JAWS screen reader
+  - Windows 10 + Chrome + JAWS
+  - Windows10 - Firefox + NVDA
+    - NVDA reads out the `<select>` label and every `<option>` value
+  - MacOS Mojave + Safari + VoiceOver 
 
 ## Theming
 

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -8,7 +8,7 @@ Markup:
 */
 .ds-c-fieldset {
   border: 0;
-  // We apply the same margin as a label has, since in the context of a fieldset
+  // We apply the same margin as a label, since in the context of a fieldset
   // this would be a <legend>. See .ds-c-fieldset > .ds-c-label for more info.
   margin: $spacer-3 0 0;
   min-width: 0;

--- a/packages/core/src/components/ChoiceList/Choice.scss
+++ b/packages/core/src/components/ChoiceList/Choice.scss
@@ -103,20 +103,6 @@ $ds-c-inset-border-width: $spacer-half;
       border-left-color: $color-white;
     }
 
-    // Inputs to the right of labels
-    &--right {
-      border-left: 0;
-      border-right: $ds-c-inset-border-width solid $color-primary;
-      margin-left: 0;
-      margin-right: ($choice-size / 2) - ($ds-c-inset-border-width / 2);
-      padding: $spacer-1 0 $spacer-1 ($spacer-2 * 0.75);
-    }
-
-    // Max recommended parent width is $ds-u-measure--narrow (12em)
-    &--right select {
-      max-width: $input-medium-width;
-    }
-
     // Small input variant
     &--small {
       margin-left: $spacer-1;
@@ -358,7 +344,6 @@ Style guide: components.choice.react
 - Add the className `ds-c-choice__checkedChild--inverse` to the `div` to show the inverse white border
 - You may need to add the className `ds-u-margin--0` to your child element(s) to avoid extra top margin
 - If you opt for smaller radio buttons or checkboxes, add className `ds-c-choice__checkedChild--small` to your checked child container
-- If you opt for labels before inputs (right inputs), we recommend using the measure className `ds-u-measure--narrow` to maintain readability. You should also add className `ds-c-choice__checkedChild--right` to your checked child container to set the proper spacing and borders.
 
 ## Accessibility
 


### PR DESCRIPTION
### Added
* CSS for proper handling of checked children with small inputs
* CSS for checked children with right to left order
* `<Choice />` component examples to support the previous two items
* Documentation for using these examples

### Changed
* Fixed the choice frame example by setting all children open with `defaultChecked`

### Design considerations
I made a few judgment calls on the inputs to the right of labels, with regard to padding and margin. Please advise if these need tweaked. The full-width didn't feel right, so I capped width, and sight-adjusted, dipping back into UI design for a moment.

### Related Issues
* Closes https://github.com/CMSgov/design-system/issues/333
* Closes https://github.com/CMSgov/design-system/issues/337

---
<img width="614" alt="screen shot 2019-02-21 at 9 03 59 am" src="https://user-images.githubusercontent.com/934879/53178559-ab419500-35b7-11e9-8e19-ce497d38198c.png">
