### PR TITLE
Add CMS to the Design System header

### DIFF
--- a/packages/docs/src/scripts/components/Header.jsx
+++ b/packages/docs/src/scripts/components/Header.jsx
@@ -8,7 +8,7 @@ const Header = () => {
     <header className="ds-base--inverse ds-u-padding--3 ds-u-display--flex ds-u-justify-content--between ds-u-align-items--center">
       <h1 className="ds-h3 ds-u-margin-bottom--0">
         <a href={rootPath} className="c-header__title" title="Home">
-          Design System
+          CMS Design System
         </a>
       </h1>
       <GitHubLinks


### PR DESCRIPTION
This makes it more clear that it is the CMS Design System. 
CMS is already being used in the `<title>` tag.