### PR TITLE
Added missing "flex" option for responsive display utilities

### DIFF
--- a/packages/core/src/utilities/display-visibility.scss
+++ b/packages/core/src/utilities/display-visibility.scss
@@ -110,6 +110,9 @@ Markup:
   <div class="ds-u-<%= breakpoint %>-display--block">
     Displayed as block on <%= breakpoint %> screens and larger
   </div>
+  <div class="ds-u-<%= breakpoint %>-display--flex">
+    Displayed as flex on <%= breakpoint %> screens and larger
+  </div>
   <div class="ds-u-<%= breakpoint %>-visibility--hidden ds-u-color--muted">
     Invisible on <%= breakpoint %> screens and larger
   </div>
@@ -130,6 +133,10 @@ Style guide: utilities.display-visibility.responsive
 
     .ds-u-#{$breakpoint}-display--inline-block {
       display: inline-block !important;
+    }
+
+    .ds-u-#{$breakpoint}-display--flex {
+      display: flex !important;
     }
 
     .ds-u-#{$breakpoint}-display--none {


### PR DESCRIPTION
### Added
- `ds-u-#{$breakpoint}-display--flex` utility classes that were missing from the set of responsive utility classes for `display`-property values
