### PR TITLE
Use variable for button border width

### DIFF
--- a/packages/core/src/components/Button/Button.scss
+++ b/packages/core/src/components/Button/Button.scss
@@ -22,7 +22,7 @@ Style guide: components.button
 .ds-c-button {
   appearance: none;
   background-color: transparent;
-  border: 1px solid $color-primary;
+  border: $button-border-width solid $color-primary;
   border-radius: $border-radius;
   color: $color-primary;
   cursor: pointer;

--- a/packages/support/src/settings/_variables.forms.scss
+++ b/packages/support/src/settings/_variables.forms.scss
@@ -9,6 +9,7 @@ $choice-border-width: 2px !default;
 $choice-size: $spacer-4 !default;
 $choice-size-small: 20px !default;
 
+$button-border-width: 1px !default;
 $button-primary-bg: $color-primary !default;
 $button-primary-bg--hover: $color-primary-darker !default;
 $button-primary-bg--focus: $button-primary-bg--hover !default;


### PR DESCRIPTION
### Changed
- Defined the button component's border width with a variable (`$button-border-width`) so we can easily override it in site packages