### PR TITLE
[WNMGDS-50] - Fix formatting of docs page heading links 

### DIFF
--- a/packages/docs/src/scripts/components/PageHeader.jsx
+++ b/packages/docs/src/scripts/components/PageHeader.jsx
@@ -40,10 +40,9 @@ class PageHeader extends React.PureComponent {
           <Source
             reactComponentPath={this.props.reactComponentPath}
             source={this.props.source}
+            className="ds-u-margin-right--2"
           />
-          {this.props.uswds && (
-            <span className="ds-u-margin-x--1">&middot;</span>
-          )}
+
           {this.uswdsLink()}
         </div>
       </header>


### PR DESCRIPTION
Fix formatting for when there is only one link in the page header.
Removing the bullet and adding margin does the trick

**Screenshot**
the left is updated and right is the current
![Screen Shot 2019-04-11 at 1 58 26 PM](https://user-images.githubusercontent.com/1449852/55980225-057ae000-5c62-11e9-8edb-5c813e153539.png)
