### PR TITLE
Updating chromedriver to 2.46.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "browser-sync": "^2.20.0",
     "bytes": "^3.0.0",
     "chalk": "^2.4.2",
-    "chromedriver": "^2.45.0",
+    "chromedriver": "^2.46.0",
     "cli-table": "^0.3.1",
     "colors": "^1.1.2",
     "core-js": "^2.5.3",


### PR DESCRIPTION
End to End tests were failing because chromedirver needed to be updated

```
FAIL  packages/core/src/components/Badge/Badge.e2e.test.js
  ● Test suite failed to run
    SessionNotCreatedError: session not created: Chrome version must be between 70 and 73
      (Driver info: chromedriver=2.45.615279 (12b89733300bd268cff3b78fc76cb8f3a7cc44e5),platform=Linux 4.4.0-101-generic x86_64)
      
      at Object.checkLegacyResponse (node_modules/selenium-webdriver/lib/error.js:585:15)
      at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:533:13)
      at Executor.execute (node_modules/selenium-webdriver/lib/http.js:468:26)
```