### PR TITLE
Update links in GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
-## Welcome!
+# Contributing to the CMS Design System 
 
 We're excited you're considering contributing to our design system. If you have a question, noticed a bug, or have suggestions, then please submit an issue or create a pull request.
 
-One of our goals is to ensure a welcoming environment for all contributors. 
+One of our goals is to ensure a welcoming environment for all contributors.
 Please take a look at our [Code of Conduct](CODE_OF_CONDUCT.md) to learn more.
 
-## Getting started 
+## Getting started
 
-If you are interested in running this site locally, please take a look at [setting up your local development environment](/README.md#running-locally). 
+If you are interested in running this site locally, please take a look at [setting up your local development environment](/README.md#running-locally).
 
 Use [our guides](https://github.com/CMSgov/design-system/tree/master/guides) to find additional information like:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ These scripts can all be run from the root level of the repo:
 * `yarn build`
   * Compile/transpile/uglify everything and makes things release-ready.
 * `yarn bump`
-  * Increments package versions. Read "[Versioning](https://github.com/CMSgov/design-system/wiki/Versioning)" for more info.
+  * Increments package versions. Read "[Versioning](/guides/RELEASE-PROCESS.md#versioning)" for more info.
 * `yarn generate`
   * Generates the necessary files for a new core component
   * Alias: `yarn g`
@@ -70,7 +70,7 @@ These scripts can all be run from the root level of the repo:
 
 #### Theme scripts
 
-You can also use the following scripts to [preview and build a theme](https://github.com/CMSgov/design-system/wiki/site-packages-and-themes):
+You can also use the following scripts to [build and preview a theme](/guides/SITE-PACKAGES-AND-THEMES.md):
 
 * `yarn start:theme`
 * `yarn build:theme`
@@ -86,4 +86,4 @@ If your documentation site will be uploaded to a subdirectory (ie. example.com/d
 
 To contact the CMS Design System product owners, please email `WPMG_Web@cms.hhs.gov`
 
-One of our goals is to ensure a welcoming environment for all contributors. Please take a look at our [Code of Conduct](/guides/CODE-OF-CONDUCT.md) to learn more.
+One of our goals is to ensure a welcoming environment for all contributors. Please take a look at our [Code of Conduct](CODE-OF-CONDUCT.md) to learn more.


### PR DESCRIPTION
### Changed
* Made the title of the contributing page more clear 
* Updated links still going to the wiki to go to guides pages
* Fixed broken link to the code of conduct page 

