### PR TITLE
Remove beta status from autocomplete

### DIFF
--- a/packages/core/src/components/Autocomplete/Autocomplete.scss
+++ b/packages/core/src/components/Autocomplete/Autocomplete.scss
@@ -4,8 +4,6 @@
 /*
 Autocomplete
 
-@status beta
-
 Autocompletes allow users to enter any combination of letters, numbers, or symbols of their choosing (unless otherwise restricted), and receive one or more suggested matches in a list below the input.
 
 Style guide: components.autocomplete


### PR DESCRIPTION
This was missed in the previous update to remove maturity badges until we got the audit completed.

### Screenshot before
![Screen Shot 2019-05-17 at 11 54 15 AM](https://user-images.githubusercontent.com/1449852/57940477-8ef18380-789a-11e9-96e0-d4c1302fae84.png)

### Screenshot after
![Screen Shot 2019-05-17 at 11 54 26 AM](https://user-images.githubusercontent.com/1449852/57940487-944ece00-789a-11e9-9942-58e896981283.png)
