### PR TITLE
[WNMGDS-81] Updating measure variables to use ex instead of em.

### DIFF
--- a/packages/core/src/utilities/index.scss
+++ b/packages/core/src/utilities/index.scss
@@ -29,7 +29,7 @@ Style guide: utilities
 @import 'font-weight';
 @import 'line-height';
 @import 'margin';
-@import 'measure';
+@import 'measure/measure';
 @import 'overflow';
 @import 'padding';
 @import 'text-align';

--- a/packages/core/src/utilities/measure/measure.example.html
+++ b/packages/core/src/utilities/measure/measure.example.html
@@ -1,0 +1,1 @@
+<div class="{{modifier}}">{{ lorem-l }}</div>

--- a/packages/core/src/utilities/measure/measure.scss
+++ b/packages/core/src/utilities/measure/measure.scss
@@ -4,23 +4,15 @@
 /*
 Measure
 
-Line length, also called "measure", is an important part of readability.
+Line length, also called "measure", is an important part of readability. CMSDS has 3 measure options to control reading length.
 
-The design system includes 3 measure modifiers:
+**Format:** `ds-u-measure--[NAME]`
 
-- **narrow** = line length ~45 characters
-- **base** = line length ~65 characters
-- **wide** = line length ~80 characters
+.ds-u-measure--narrow - line length ~45 characters
+.ds-u-measure--base - line length ~65 characters
+.ds-u-measure--wide - line length ~80 characters
 
-**Format**: `ds-u-measure--[NAME]`
-
-Markup:
-<h2 class="preview__label">ds-u-measure--narrow</h2>
-<div class="ds-u-measure--narrow">{{ lorem-l }}</div>
-<h2 class="preview__label">ds-u-measure--base</h2>
-<div class="ds-u-measure--base ds-u-font-size--small">{{ lorem-l }}</div>
-<h2 class="preview__label">ds-u-measure--wide</h2>
-<div class="ds-u-measure--wide ds-u-font-size--small">{{ lorem-l }}</div>
+Markup: measure.example.html
 
 Style guide: utilities.measure
 */

--- a/packages/support/src/settings/_variables.type.scss
+++ b/packages/support/src/settings/_variables.type.scss
@@ -5,6 +5,6 @@ $font-semibold: 600;
 $reset-line-height: 1 !default;
 
 // measure
-$measure-narrow: 21em;
-$measure-base: 31em;
-$measure-wide: 41em;
+$measure-narrow: 45ex;
+$measure-base: 65ex;
+$measure-wide: 80ex;


### PR DESCRIPTION
### Added
List new features or components. Include a screenshot for new visual elements.

### Changed
- Changed the variables for `base`, `narrow` and `wide` from `em` values to `ex`. `Ex` is a better path than `ch` which was what was originally proposed. 
  - https://www.w3schools.com/cssref/css_units.asp
  - https://v2.designsystem.digital.gov/design-tokens/typesetting/measure/
- Updated the measure utility to have a separate HTML example and it's own folder (similar to components) There could be some follow on work to placing utilities inside folders to follow a consistent approach. 
- Showing each example `base`, `narrow` and `wide` in its own code snippet instead of combined. This follows the convention of the components which I think is stronger than grouping everything into one code snippet box. This also shows the modifier and seems easier to read and get information about the style you are looking for without having to comb through the code box. 

## Screenshot before
![Screen Shot 2019-05-20 at 12 21 36 PM](https://user-images.githubusercontent.com/1449852/58036762-e04b7e00-7af9-11e9-8f50-843f22fe46b6.png)

## Screenshot after
![Screen Shot 2019-05-20 at 12 21 48 PM](https://user-images.githubusercontent.com/1449852/58036786-eb061300-7af9-11e9-8a8e-b41ce0a9adbe.png)
