### PR TITLE
Give solid buttons transparent borders rather than no borders

### DIFF
--- a/packages/core/src/components/Button/Button.scss
+++ b/packages/core/src/components/Button/Button.scss
@@ -61,7 +61,7 @@ Style guide: components.button
 
 .ds-c-button--primary {
   background-color: $button-primary-bg;
-  border: 0; // Remove the default border to support easier theming
+  border-color: transparent;
   color: $color-white;
 
   &:focus,
@@ -71,14 +71,17 @@ Style guide: components.button
 
   &:focus {
     background-color: $button-primary-bg--focus;
+    border-color: transparent;
   }
 
   &:hover {
     background-color: $button-primary-bg--hover;
+    border-color: transparent;
   }
 
   &:active {
     background-color: $button-primary-bg--active;
+    border-color: transparent;
   }
 }
 
@@ -96,37 +99,37 @@ Style guide: components.button
 
 .ds-c-button--danger {
   background-color: $color-error;
-  border-color: $color-error;
+  border-color: transparent;
   color: $color-white;
 
   &:focus,
   &:hover {
     background-color: $color-error-dark;
-    border-color: $color-error-dark;
+    border-color: transparent;
     color: $color-white;
   }
 
   &:active {
     background-color: $color-error-darkest;
-    border-color: $color-error-darkest;
+    border-color: transparent;
   }
 }
 
 .ds-c-button--success {
   background-color: $color-success;
-  border-color: $color-success;
+  border-color: transparent;
   color: $color-white;
 
   &:focus,
   &:hover {
     background-color: $color-success-dark;
-    border-color: $color-success-dark;
+    border-color: transparent;
     color: $color-white;
   }
 
   &:active {
     background-color: $color-success-darker;
-    border-color: $color-success-darker;
+    border-color: transparent;
   }
 }
 
@@ -145,7 +148,7 @@ Style guide: components.button.disabled
 .ds-c-button:disabled,
 .ds-c-button--disabled {
   background-color: $color-gray-lighter;
-  border-color: $color-gray-lighter;
+  border-color: transparent;
   color: $color-gray-dark;
   pointer-events: none;
 
@@ -153,7 +156,7 @@ Style guide: components.button.disabled
   &:active,
   &:focus {
     background-color: $color-gray-lighter;
-    border-color: $color-gray-lighter;
+    border-color: transparent;
     color: $color-gray-dark;
   }
 }


### PR DESCRIPTION
### Changed
- Solid-colored buttons now have transparent borders (which fills the space with the background color) rather than having a border width of 0, which makes those buttons smaller than the default buttons. 
  <img width="269" alt="size-difference" src="https://user-images.githubusercontent.com/7595652/58572773-2b981780-81f1-11e9-9468-e85770a13c5c.png">
