### PR TITLE
[WNMGDS-157] [WNMGDS-53] - Add privacy and contact links to footer

### DIFF
--- a/packages/docs/src/scripts/components/Footer.jsx
+++ b/packages/docs/src/scripts/components/Footer.jsx
@@ -10,7 +10,8 @@ const helpfulLinks = {
     'No Fear Act',
   'http://www.medicare.gov/about-us/plain-writing/plain-writing.html':
     'Plain Writing',
-  'http://www.usa.gov': 'USA.gov'
+  'http://www.usa.gov': 'USA.gov',
+  'https://cms.gov/privacy/': 'Privacy Policy'
 };
 
 const cmsLinks = {
@@ -69,6 +70,16 @@ const Footer = () => {
             <h2 className="ds-h4">Additional resources</h2>
             <ul className="ds-c-list ds-c-list--bare ds-u-font-size--small">
               {renderLinks(helpfulLinks)}
+              <li>
+                <button
+                  type="button"
+                  className="ds-c-button ds-c-button--small ds-c-button--transparent ds-u-padding--0"
+                  onClick="window.location.href = '#';"
+                  data-privacy-policy="modal-trigger-footer"
+                >
+                  Privacy settings
+                </button>
+              </li>
             </ul>
           </article>
         </div>

--- a/packages/docs/src/scripts/components/Footer.jsx
+++ b/packages/docs/src/scripts/components/Footer.jsx
@@ -55,6 +55,11 @@ const Footer = () => {
             >
               Ask questions on GitHub
             </a>
+            <p>
+              <a href="https://forms.cms.gov/cms-wds-design-system-contact-form/responses/new">
+                Contact the CMSDS team
+              </a>
+            </p>
             <p className="ds-text ds-u-color--primary-darkest ds-u-font-size--small ds-u-margin-top--3 ds-u-measure--base">
               A federal government website managed by the Centers for Medicare &
               Medicaid Services 7500 Security Boulevard, Baltimore, MD 21124


### PR DESCRIPTION
### Added
- Privacy policy link to footer
- Privacy settings link to footer 
- Contact link to screendoor form to the footer 

**_I'm unsure if the privacy settings link works because we don't have an imp or dev environment to test on._** 

### screenshots of update form my local machine
![Screen Shot 2019-06-06 at 9 24 58 AM](https://user-images.githubusercontent.com/1449852/59038429-06cf2000-8841-11e9-8db1-297017d3672a.png)
![Screen Shot 2019-06-06 at 9 25 11 AM](https://user-images.githubusercontent.com/1449852/59038430-06cf2000-8841-11e9-938f-14a8da8cfb5a.png)


