### PR TITLE
Adding info about creating a fork to contributing doc 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,9 @@ Use [our guides](https://github.com/CMSgov/design-system/tree/master/guides) to 
 
 Here are a few guidelines to follow when submitting a pull request:
 
-* [Create a branch](https://help.github.com/en/articles/creating-and-deleting-branches-within-your-repository) from master
-* Commit your changes
-* Push your changes
-* [Make a pull request](https://help.github.com/en/articles/creating-a-pull-request) against the master branch
+* [Fork the design system](https://guides.github.com/activities/forking/) into your GitHub account
+* [Create a branch](https://help.github.com/en/articles/creating-and-deleting-branches-within-your-repository) from `master` that defines what you’re working on (for example, fix-autocomplete-bug).
+* [Submit a pull request](https://help.github.com/en/articles/creating-a-pull-request) against the `master` branch
 
 **Note:** more information on the [GitHub flow](https://guides.github.com/introduction/flow/)
 


### PR DESCRIPTION
Most folks don't have write access to the design system and would need to create a fork in order to submit a PR.