### PR TITLE
Add info about examples

### DIFF
--- a/packages/docs/src/pages/startup/examples.md
+++ b/packages/docs/src/pages/startup/examples.md
@@ -3,7 +3,7 @@ title: Examples
 weight: 4
 ---
 
-Additional examples of the design system in use can be viewed on GitHub. These projects demonstrate the various ways you can incorporate the design system into your development process and various use cases.
+Additional examples of the design system in use can be viewed on [GitHub](https://github.com/CMSgov/design-system). These projects demonstrate the various ways you can incorporate the design system into your development process and various use cases.
 
 ## HTML/CSS examples
 - [Basic article page](https://github.com/CMSgov/design-system/tree/master/examples/article)
@@ -14,6 +14,6 @@ Additional examples of the design system in use can be viewed on GitHub. These p
 ## React application example
 [This example](https://github.com/CMSgov/design-system/tree/master/examples/react-app) shows how you can incorporate the design system into your build process. It uses [Webpack](https://webpack.js.org) to bundle and optimize JavaScript files, [Babel](https://babeljs.io/) to transpile JSX, and [Gulp](http://gulpjs.com/) to transpile Sass and copy static assets from the design system.
 
-<h2 id="need-help" class="ds-h2 ds-u-color--primary-darker">Need help or ran into an issue?</h2>
+## Need help or ran into an issue?
 
-If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub](https://github.com/CMSgov/design-system/issues).
+If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub](https://github.com/CMSgov/design-system/tree/master/examples).

--- a/packages/docs/src/pages/startup/examples.md
+++ b/packages/docs/src/pages/startup/examples.md
@@ -13,3 +13,7 @@ Additional examples of the design system in use can be viewed on GitHub. These p
 
 ## React application example
 [This example](https://github.com/CMSgov/design-system/tree/master/examples/react-app) shows how you can incorporate the design system into your build process. It uses [Webpack](https://webpack.js.org) to bundle and optimize JavaScript files, [Babel](https://babeljs.io/) to transpile JSX, and [Gulp](http://gulpjs.com/) to transpile Sass and copy static assets from the design system.
+
+<h2 id="need-help" class="ds-h2 ds-u-color--primary-darker">Need help or ran into an issue?</h2>
+
+If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub](https://github.com/CMSgov/design-system/issues).

--- a/packages/docs/src/pages/startup/examples.md
+++ b/packages/docs/src/pages/startup/examples.md
@@ -5,8 +5,11 @@ weight: 4
 
 Additional examples of the design system in use can be viewed on GitHub. These projects demonstrate the various ways you can incorporate the design system into your development process and various use cases.
 
-<a href="https://github.com/CMSgov/design-system/tree/master/examples/" class="ds-c-button">Browse example projects</a>
+## HTML/CSS examples
+- [Basic article page](https://github.com/CMSgov/design-system/tree/master/examples/article)
+- [Simple form with submit button](https://github.com/CMSgov/design-system/tree/master/examples/form)
+- [Using responsive classes](https://github.com/CMSgov/design-system/tree/master/examples/responsive)
+- [Using webpack](https://github.com/CMSgov/design-system/tree/master/examples/webpack-demo)
 
-<h2 id="need-help" class="ds-h2 ds-u-color--primary-darker">Need help or ran into an issue?</h2>
-
-If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub](https://github.com/CMSgov/design-system/issues).
+## React application example
+[This example](https://github.com/CMSgov/design-system/tree/master/examples/react-app) shows how you can incorporate the design system into your build process. It uses [Webpack](https://webpack.js.org) to bundle and optimize JavaScript files, [Babel](https://babeljs.io/) to transpile JSX, and [Gulp](http://gulpjs.com/) to transpile Sass and copy static assets from the design system.


### PR DESCRIPTION
### Added
Added descriptions for the various examples that we have in the GitHub repo to help people find them easier. 

I'm not sure how helpful the form and article examples are and am thinking that the responsive examples could be explained in the context of the https://design.cms.gov/utilities/display-visibility/ page

