### PR TITLE
[WNMGDS-210] Fix Inversed FormLabel

### DIFF
--- a/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/core/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -776,7 +776,7 @@ exports[`DateField is inversed 1`] = `
   className="ds-c-fieldset"
 >
   <legend
-    className="ds-c-label"
+    className="ds-c-label ds-c-label--inverse"
     htmlFor={undefined}
     id="datefield_label_snapshot"
   >
@@ -798,7 +798,7 @@ exports[`DateField is inversed 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1 ds-c-label--inverse"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -833,7 +833,7 @@ exports[`DateField is inversed 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1 ds-c-label--inverse"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -868,7 +868,7 @@ exports[`DateField is inversed 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1 ds-c-label--inverse"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >

--- a/packages/core/src/components/FormLabel/FormLabel.jsx
+++ b/packages/core/src/components/FormLabel/FormLabel.jsx
@@ -9,9 +9,13 @@ import classNames from 'classnames';
 export class FormLabel extends React.PureComponent {
   errorMessage() {
     if (this.props.errorMessage) {
+      const classes = classNames('ds-c-field__hint', 'ds-u-color--error', {
+        'ds-u-color--error-light': this.props.inversed
+      });
+
       return (
         <span
-          className="ds-c-field__hint ds-u-color--error"
+          className={classes}
           id={`${this.props.fieldId}-message`}
           role="alert"
         >
@@ -57,7 +61,9 @@ export class FormLabel extends React.PureComponent {
     const { fieldId, id, children } = this.props;
     const ComponentType = this.props.component;
     const labelTextClasses = classNames(this.props.labelClassName);
-    const classes = classNames('ds-c-label', this.props.className);
+    const classes = classNames('ds-c-label', this.props.className, {
+      'ds-c-label--inverse': this.props.inversed
+    });
 
     return (
       <ComponentType className={classes} htmlFor={fieldId} id={id}>

--- a/packages/core/src/components/FormLabel/FormLabel.scss
+++ b/packages/core/src/components/FormLabel/FormLabel.scss
@@ -24,6 +24,10 @@ Style guide: components.form-label
   padding: 0;
 }
 
+.ds-c-label--inverse {
+  color: $color-base-inverse;
+}
+
 // Webkit won't render a top margin on a fieldset's <legend>, so we apply
 // the top margin to the fieldset instead.
 .ds-c-fieldset > .ds-c-label:first-child {

--- a/packages/core/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
+++ b/packages/core/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
@@ -63,7 +63,7 @@ exports[`FormLabel avoids duplicate punctuation after requirementLabel 1`] = `
 
 exports[`FormLabel is inversed 1`] = `
 <label
-  className="ds-c-label"
+  className="ds-c-label ds-c-label--inverse"
 >
   <span
     className=""


### PR DESCRIPTION
### Fixed
Previously, examples of `inversed` in other components simply use `ds-base--inverse` on the container div to correctly style the inversed components. However, a user should be able to inverse a component using just the provided `inversed` prop, and also the error message was never styled correctly in either case. 

The `inversed` prop now styles the label and error message of a `FormLabel` and no longer relies on the  container's styling

### Testing
Go to a component like `TextField` or `Select` and add an `inversed` prop to the react example. If you darken the background you should see something like this:
<img width="1007" alt="Screen Shot 2019-06-26 at 4 05 54 PM" src="https://user-images.githubusercontent.com/5424713/60216815-aaa06000-9830-11e9-8366-cc21013de1d3.png">
Notice the label is white, the requirement label is lighter, and the error message is lighter.