### PR TITLE
[WNMGWINSHOP-196] Fix broken autocomplete in stateful tree

### DIFF
--- a/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
@@ -3,107 +3,121 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TextField from '../TextField/TextField';
 
-ReactDOM.render(
-  <div>
-    <Autocomplete
-      items={[
-        {
-          id: 'kRf6c2fY',
-          name: 'Cook County, IL'
-        },
-        {
-          id: 'lYf5cGfM',
-          name: 'Cook County, MD'
-        },
-        {
-          id: 'mZfKcGf9',
-          name: 'Cook County, TN'
-        },
-        {
-          id: 'xFz6dLba',
-          name: 'Cook County, AK'
-        },
-        {
-          id: 'vTr5c99',
-          name: 'Cook County, FL'
-        },
-        {
-          id: 'ntY8Lha',
-          name: 'Cook County, AL'
-        },
-        {
-          id: 'uRe0Wqo',
-          name: 'Cook County, WA'
-        },
-        {
-          id: 'yUR7MWl',
-          name: 'Cook County, OR'
-        }
-      ]}
-      focusTrigger
-      label="Select from the options below:"
-      onChange={selectedItem => console.log(selectedItem)}
-      onInputValueChange={inputVal =>
-        console.log('[Autocomplete]: ' + inputVal)
-      }
-    >
-      <TextField
-        hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
-        label="Labeled list"
-        name="Downshift_autocomplete"
-      />
-    </Autocomplete>
+class AutocompleteExample extends React.PureComponent {
+  constructor(props) {
+    super(props);
 
-    <Autocomplete
-      items={[
-        {
-          id: 'kRf6c2fY',
-          name: 'Cook County, IL'
-        },
-        {
-          id: 'lYf5cGfM',
-          name: 'Cook County, MD'
-        },
-        {
-          id: 'mZfKcGf9',
-          name: 'Cook County, TN'
-        }
-      ]}
-      onChange={selectedItem => console.log(selectedItem)}
-      onInputValueChange={inputVal =>
-        console.log('[Autocomplete]: ' + inputVal)
-      }
-    >
-      <TextField
-        hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
-        label="Simple list"
-        name="Downshift_autocomplete"
-      />
-    </Autocomplete>
+    this.state = {
+      inputValue: ''
+    };
+  }
 
-    <Autocomplete items={[]} loading clearSearchButton={false}>
-      <TextField
-        hint="List should return string Loading to simulate async data call."
-        label="Loading message"
-        name="Downshift_autocomplete"
-      />
-    </Autocomplete>
+  render() {
+    return (
+      <div>
+        <Autocomplete
+          items={[
+            {
+              id: 'kRf6c2fY',
+              name: 'Cook County, IL'
+            },
+            {
+              id: 'lYf5cGfM',
+              name: 'Cook County, MD'
+            },
+            {
+              id: 'mZfKcGf9',
+              name: 'Cook County, TN'
+            },
+            {
+              id: 'xFz6dLba',
+              name: 'Cook County, AK'
+            },
+            {
+              id: 'vTr5c99',
+              name: 'Cook County, FL'
+            },
+            {
+              id: 'ntY8Lha',
+              name: 'Cook County, AL'
+            },
+            {
+              id: 'uRe0Wqo',
+              name: 'Cook County, WA'
+            },
+            {
+              id: 'yUR7MWl',
+              name: 'Cook County, OR'
+            }
+          ]}
+          focusTrigger
+          label="Select from the options below:"
+          onChange={selectedItem => console.log(selectedItem)}
+          onInputValueChange={inputValue => {
+            console.log('[Autocomplete]: ' + inputValue);
+            this.setState({ inputValue });
+          }}
+        >
+          <TextField
+            hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
+            label="Labeled list"
+            name="Downshift_autocomplete"
+          />
+        </Autocomplete>
 
-    <Autocomplete items={[]} clearSearchButton={false}>
-      <TextField
-        hint="List should return string No results found."
-        label="No results message"
-        name="Downshift_autocomplete"
-      />
-    </Autocomplete>
+        <Autocomplete
+          items={[
+            {
+              id: 'kRf6c2fY',
+              name: 'Cook County, IL'
+            },
+            {
+              id: 'lYf5cGfM',
+              name: 'Cook County, MD'
+            },
+            {
+              id: 'mZfKcGf9',
+              name: 'Cook County, TN'
+            }
+          ]}
+          onChange={selectedItem => console.log(selectedItem)}
+          onInputValueChange={inputVal =>
+            console.log('[Autocomplete]: ' + inputVal)
+          }
+        >
+          <TextField
+            hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
+            label="Simple list"
+            name="Downshift_autocomplete"
+          />
+        </Autocomplete>
 
-    <Autocomplete clearSearchButton={false}>
-      <TextField
-        hint="No list should be shown if no item array is provided and it's not loading. This could be the case if a user has not yet entered the minimum number of characters required for a search."
-        label="Nothing shown"
-        name="Downshift_autocomplete"
-      />
-    </Autocomplete>
-  </div>,
-  document.getElementById('js-example')
-);
+        <Autocomplete items={[]} loading clearSearchButton={false}>
+          <TextField
+            hint="List should return string Loading to simulate async data call."
+            label="Loading message"
+            name="Downshift_autocomplete"
+          />
+        </Autocomplete>
+
+        <Autocomplete items={[]} clearSearchButton={false}>
+          <TextField
+            hint="List should return string No results found."
+            label="No results message"
+            name="Downshift_autocomplete"
+          />
+        </Autocomplete>
+
+        <Autocomplete clearSearchButton={false}>
+          <TextField
+            hint="No list should be shown if no item array is provided and it's not loading. This could be the case if a user has not yet entered the minimum number of characters required for a search."
+            label="Nothing shown"
+            name="Downshift_autocomplete"
+          />
+        </Autocomplete>
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<AutocompleteExample />, document.getElementById('js-example'));

--- a/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.example.jsx
@@ -3,121 +3,107 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TextField from '../TextField/TextField';
 
-class AutocompleteExample extends React.PureComponent {
-  constructor(props) {
-    super(props);
+ReactDOM.render(
+  <div>
+    <Autocomplete
+      items={[
+        {
+          id: 'kRf6c2fY',
+          name: 'Cook County, IL'
+        },
+        {
+          id: 'lYf5cGfM',
+          name: 'Cook County, MD'
+        },
+        {
+          id: 'mZfKcGf9',
+          name: 'Cook County, TN'
+        },
+        {
+          id: 'xFz6dLba',
+          name: 'Cook County, AK'
+        },
+        {
+          id: 'vTr5c99',
+          name: 'Cook County, FL'
+        },
+        {
+          id: 'ntY8Lha',
+          name: 'Cook County, AL'
+        },
+        {
+          id: 'uRe0Wqo',
+          name: 'Cook County, WA'
+        },
+        {
+          id: 'yUR7MWl',
+          name: 'Cook County, OR'
+        }
+      ]}
+      focusTrigger
+      label="Select from the options below:"
+      onChange={selectedItem => console.log(selectedItem)}
+      onInputValueChange={inputVal =>
+        console.log('[Autocomplete]: ' + inputVal)
+      }
+    >
+      <TextField
+        hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
+        label="Labeled list"
+        name="Downshift_autocomplete"
+      />
+    </Autocomplete>
 
-    this.state = {
-      inputValue: ''
-    };
-  }
+    <Autocomplete
+      items={[
+        {
+          id: 'kRf6c2fY',
+          name: 'Cook County, IL'
+        },
+        {
+          id: 'lYf5cGfM',
+          name: 'Cook County, MD'
+        },
+        {
+          id: 'mZfKcGf9',
+          name: 'Cook County, TN'
+        }
+      ]}
+      onChange={selectedItem => console.log(selectedItem)}
+      onInputValueChange={inputVal =>
+        console.log('[Autocomplete]: ' + inputVal)
+      }
+    >
+      <TextField
+        hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
+        label="Simple list"
+        name="Downshift_autocomplete"
+      />
+    </Autocomplete>
 
-  render() {
-    return (
-      <div>
-        <Autocomplete
-          items={[
-            {
-              id: 'kRf6c2fY',
-              name: 'Cook County, IL'
-            },
-            {
-              id: 'lYf5cGfM',
-              name: 'Cook County, MD'
-            },
-            {
-              id: 'mZfKcGf9',
-              name: 'Cook County, TN'
-            },
-            {
-              id: 'xFz6dLba',
-              name: 'Cook County, AK'
-            },
-            {
-              id: 'vTr5c99',
-              name: 'Cook County, FL'
-            },
-            {
-              id: 'ntY8Lha',
-              name: 'Cook County, AL'
-            },
-            {
-              id: 'uRe0Wqo',
-              name: 'Cook County, WA'
-            },
-            {
-              id: 'yUR7MWl',
-              name: 'Cook County, OR'
-            }
-          ]}
-          focusTrigger
-          label="Select from the options below:"
-          onChange={selectedItem => console.log(selectedItem)}
-          onInputValueChange={inputValue => {
-            console.log('[Autocomplete]: ' + inputValue);
-            this.setState({ inputValue });
-          }}
-        >
-          <TextField
-            hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
-            label="Labeled list"
-            name="Downshift_autocomplete"
-          />
-        </Autocomplete>
+    <Autocomplete items={[]} loading clearSearchButton={false}>
+      <TextField
+        hint="List should return string Loading to simulate async data call."
+        label="Loading message"
+        name="Downshift_autocomplete"
+      />
+    </Autocomplete>
 
-        <Autocomplete
-          items={[
-            {
-              id: 'kRf6c2fY',
-              name: 'Cook County, IL'
-            },
-            {
-              id: 'lYf5cGfM',
-              name: 'Cook County, MD'
-            },
-            {
-              id: 'mZfKcGf9',
-              name: 'Cook County, TN'
-            }
-          ]}
-          onChange={selectedItem => console.log(selectedItem)}
-          onInputValueChange={inputVal =>
-            console.log('[Autocomplete]: ' + inputVal)
-          }
-        >
-          <TextField
-            hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
-            label="Simple list"
-            name="Downshift_autocomplete"
-          />
-        </Autocomplete>
+    <Autocomplete items={[]} clearSearchButton={false}>
+      <TextField
+        hint="List should return string No results found."
+        label="No results message"
+        name="Downshift_autocomplete"
+      />
+    </Autocomplete>
 
-        <Autocomplete items={[]} loading clearSearchButton={false}>
-          <TextField
-            hint="List should return string Loading to simulate async data call."
-            label="Loading message"
-            name="Downshift_autocomplete"
-          />
-        </Autocomplete>
-
-        <Autocomplete items={[]} clearSearchButton={false}>
-          <TextField
-            hint="List should return string No results found."
-            label="No results message"
-            name="Downshift_autocomplete"
-          />
-        </Autocomplete>
-
-        <Autocomplete clearSearchButton={false}>
-          <TextField
-            hint="No list should be shown if no item array is provided and it's not loading. This could be the case if a user has not yet entered the minimum number of characters required for a search."
-            label="Nothing shown"
-            name="Downshift_autocomplete"
-          />
-        </Autocomplete>
-      </div>
-    );
-  }
-}
-
-ReactDOM.render(<AutocompleteExample />, document.getElementById('js-example'));
+    <Autocomplete clearSearchButton={false}>
+      <TextField
+        hint="No list should be shown if no item array is provided and it's not loading. This could be the case if a user has not yet entered the minimum number of characters required for a search."
+        label="Nothing shown"
+        name="Downshift_autocomplete"
+      />
+    </Autocomplete>
+  </div>,
+  document.getElementById('js-example')
+);

--- a/packages/core/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.jsx
@@ -20,6 +20,7 @@ import Downshift from 'downshift';
 import PropTypes from 'prop-types';
 import React from 'react';
 import TextField from '../TextField/TextField';
+import WrapperDiv from './WrapperDiv';
 import classNames from 'classnames';
 import uniqueId from 'lodash.uniqueid';
 
@@ -144,10 +145,6 @@ export class Autocomplete extends React.PureComponent {
       'ds-u-clearfix',
       'ds-c-autocomplete',
       className
-    );
-
-    const WrapperDiv = ({ innerRef, ...rest }) => (
-      <div ref={innerRef} {...rest} />
     );
 
     return (

--- a/packages/core/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.jsx
@@ -20,7 +20,6 @@ import Downshift from 'downshift';
 import PropTypes from 'prop-types';
 import React from 'react';
 import TextField from '../TextField/TextField';
-import WrapperDiv from './WrapperDiv';
 import classNames from 'classnames';
 import uniqueId from 'lodash.uniqueid';
 
@@ -145,6 +144,10 @@ export class Autocomplete extends React.PureComponent {
       'ds-u-clearfix',
       'ds-c-autocomplete',
       className
+    );
+
+    const WrapperDiv = ({ innerRef, ...rest }) => (
+      <div ref={innerRef} {...rest} />
     );
 
     return (

--- a/packages/core/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.jsx
@@ -20,6 +20,7 @@ import Downshift from 'downshift';
 import PropTypes from 'prop-types';
 import React from 'react';
 import TextField from '../TextField/TextField';
+import WrapperDiv from './WrapperDiv';
 import classNames from 'classnames';
 import uniqueId from 'lodash.uniqueid';
 
@@ -140,12 +141,6 @@ export class Autocomplete extends React.PureComponent {
       ...autocompleteProps
     } = this.props;
 
-    // See https://github.com/downshift-js/downshift#getrootprops
-    // Custom container returns a plain div, without the ARIA markup
-    // required for a WAI-ARIA 1.1 combobox. See the comments at the
-    // top of the component file for an explanation of this decision.
-    const MyDiv = ({ innerRef, ...rest }) => <div ref={innerRef} {...rest} />;
-
     const rootClassName = classNames(
       'ds-u-clearfix',
       'ds-c-autocomplete',
@@ -163,7 +158,7 @@ export class Autocomplete extends React.PureComponent {
           inputValue,
           isOpen
         }) => (
-          <MyDiv
+          <WrapperDiv
             {...getRootProps({
               'aria-expanded': null,
               'aria-haspopup': null,
@@ -219,7 +214,7 @@ export class Autocomplete extends React.PureComponent {
                 {clearInputText}
               </Button>
             )}
-          </MyDiv>
+          </WrapperDiv>
         )}
       </Downshift>
     );

--- a/packages/core/src/components/Autocomplete/WrapperDiv.jsx
+++ b/packages/core/src/components/Autocomplete/WrapperDiv.jsx
@@ -1,0 +1,9 @@
+/* eslint-disable */
+
+// See https://github.com/downshift-js/downshift#getrootprops
+// Custom container returns a plain div, without the ARIA markup
+// required for a WAI-ARIA 1.1 combobox. See the comments at the
+// top of the component file for an explanation of this decision.
+const WrapperDiv = ({ innerRef, ...rest }) => <div ref={innerRef} {...rest} />;
+
+export default WrapperDiv;

--- a/packages/core/src/components/Autocomplete/WrapperDiv.jsx
+++ b/packages/core/src/components/Autocomplete/WrapperDiv.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import React from 'react';
 
 // See https://github.com/downshift-js/downshift#getrootprops
 // Custom container returns a plain div, without the ARIA markup

--- a/packages/core/src/components/__tests__/index.test.js
+++ b/packages/core/src/components/__tests__/index.test.js
@@ -40,7 +40,8 @@ const ignoredComponents = [
   'Step',
   'SubStep',
   'StepLink',
-  'HelpDrawerToggle'
+  'HelpDrawerToggle',
+  'WrapperDiv'
 ];
 
 describe('Components index', () => {


### PR DESCRIPTION
### Fixed
- Fixed a bug where if the `Autocomplete` component were to be rendered in any kind of stateful tree (stateful parent or ancestor) and that state were to change (even if it didn't directly relate to one of the Autocomplete's props), the component would not be able to maintain its browser focus and would start to behave erratically.
  - The root cause of this was the `MyDiv` that functional component that was being defined inside the render function. It was not able to persist the instance of `MyDiv` between renders because the component function itself could not persist between renders. Moving it out of the render function fixed it.
  - I wanted to define it at the top of the `Autocomplete.jsx` module, but that generated too many eslint errors that I was not able to suppress with a reasonable number of _eslint-disable-line_ comments. (It didn't like multiple components being defined in the same module, components without propTypes, etc.)

### How to test this fix
1. Check out 61e5fe8f1f2e5e762f131810b2cae52ed3cbe45d, which has a modified, stateful example and the bug. 
2. Run the example and try typing into the first Autocomplete on the Autocomplete documentation page. Notice the erratic behavior of the input.
3. Switch to 6157c2a16c899910a305500cd6354bcea299d916, which has the modified, stateful example but a fix for the bug, and notice that it behaves as expected