### PR TITLE
[WNMGWINSHOP-196] Upgrade Downshift from 3.0.0 to 3.2.10

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
     "@cmsgov/design-system-support": "^2.0.2",
     "classnames": "^2.2.5",
     "core-js": "^2.5.3",
-    "downshift": "^3.0.0",
+    "downshift": "^3.2.10",
     "ev-emitter": "^1.1.1",
     "lodash.uniqueid": "^4.0.1",
     "react-aria-modal": "^2.11.1"

--- a/packages/core/yarn.lock
+++ b/packages/core/yarn.lock
@@ -22,10 +22,10 @@ core-js@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
-downshift@^3.0.0:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.2.7.tgz#0c40d78d1cbc24753c7a622cfc664df1c9480b4a"
-  integrity sha512-mbUO9ZFhMGtksIeVWRFFjNOPN237VsUqZSEYi0VS0Wj38XNLzpgOBTUcUjdjFeB8KVgmrcRa6GGFkTbACpG6FA==
+downshift@^3.2.10:
+  version "3.2.10"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.2.10.tgz#00f8e50383199c3f07ce63b575a840e2918b7b9f"
+  integrity sha512-fEYNbV/qDLUHTxF9wALNe51Xe5zauUhy2sqgYG1CtmAfUFMI30UuSaisU8CD0DEsFSIsaEvsVgtabb6nTEhtaA==
   dependencies:
     "@babel/runtime" "^7.1.2"
     compute-scroll-into-view "^1.0.9"


### PR DESCRIPTION
### Changed
- Upgrade the version of Downshift we use from `3.0.0` to `3.2.10` to get various bugfixes, including IE bugfixes

https://github.com/downshift-js/downshift/releases