### PR TITLE
[MCT1802] - Update aria text on autocomplete to match visual

### DIFF
--- a/packages/core/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.jsx
@@ -222,7 +222,7 @@ export class Autocomplete extends React.PureComponent {
 }
 
 Autocomplete.defaultProps = {
-  ariaClearLabel: 'Clear typeahead and search again',
+  ariaClearLabel: 'Clear search to try again',
   autoCompleteLabel: 'off',
   clearInputText: 'Clear search',
   clearSearchButton: true,

--- a/packages/core/src/components/Autocomplete/Autocomplete.test.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.test.jsx
@@ -47,9 +47,7 @@ describe('Autocomplete', () => {
     const data = render({}, true);
     const wrapper = data.wrapper;
 
-    expect(wrapper.prop('ariaClearLabel')).toBe(
-      'Clear typeahead and search again'
-    );
+    expect(wrapper.prop('ariaClearLabel')).toBe('Clear search to try again');
     expect(wrapper.prop('clearInputText')).toBe('Clear search');
     expect(wrapper.prop('label')).toBe(undefined);
     expect(wrapper.prop('loading')).toBe(undefined);

--- a/packages/core/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
+++ b/packages/core/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`Autocomplete renders a snapshot 1`] = `
   role={null}
 >
   <button
-    aria-label="Clear typeahead and search again"
+    aria-label="Clear search to try again"
     className="ds-c-button ds-c-button--transparent ds-c-button--small ds-u-float--right ds-u-padding-right--0"
     onClick={[Function]}
     type="button"


### PR DESCRIPTION
Fixed
As put forth in the [new 2.1 criteria](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html), the aria label must match or start with the same text as the visual text. Given this, I edited the aria so that the:

beginning of the aria label of the autocomplete component is the same as the visual label.