### PR TITLE
[WNMGWINSHOP-226] Can have alternative linkText for steps in StepList

### DIFF
--- a/packages/core/src/components/StepList/Step.jsx
+++ b/packages/core/src/components/StepList/Step.jsx
@@ -48,7 +48,7 @@ export const Step = ({ step, ...props }) => {
               screenReaderText={`"${step.title}"`}
               onClick={props.onStepLinkClick}
             >
-              {props.editText}
+              {step.linkText || props.editText}
             </StepLink>
           )}
         {start && (
@@ -59,7 +59,7 @@ export const Step = ({ step, ...props }) => {
             onClick={props.onStepLinkClick}
             className="ds-c-button ds-c-button--primary"
           >
-            {props.startText}
+            {step.linkText || props.startText}
           </StepLink>
         )}
         {resume && (
@@ -70,7 +70,7 @@ export const Step = ({ step, ...props }) => {
             onClick={props.onStepLinkClick}
             className="ds-c-button ds-c-button--primary"
           >
-            {props.resumeText}
+            {step.linkText || props.resumeText}
           </StepLink>
         )}
       </div>

--- a/packages/core/src/components/StepList/Step.test.jsx
+++ b/packages/core/src/components/StepList/Step.test.jsx
@@ -153,6 +153,19 @@ describe('Step', () => {
     expect(spy).toHaveBeenCalled();
   });
 
+  it('renders alternative linkText', () => {
+    const linkText = 'Hello';
+    const hasAlternateLinkText = step => {
+      const { wrapper } = renderStep(step);
+      const link = wrapper.find('.ds-c-step__actions').find('StepLink');
+      return link.length > 0 && link.prop('children') === linkText;
+    };
+
+    expect(hasAlternateLinkText({ linkText, isNextStep: true })).toBe(true);
+    expect(hasAlternateLinkText({ linkText, completed: true })).toBe(true);
+    expect(hasAlternateLinkText({ linkText, started: true })).toBe(true);
+  });
+
   it('renders substeps', () => {
     const steps = [generateStep('1'), generateStep('2'), generateStep('c')];
     const { wrapper, props } = renderStep({ steps });

--- a/packages/core/src/components/StepList/StepList.jsx
+++ b/packages/core/src/components/StepList/StepList.jsx
@@ -10,7 +10,9 @@ import Step from './Step';
  */
 export const StepList = ({ steps, ...props }) => (
   <ol className="ds-c-step-list ds-u-margin-top--4">
-    {steps.map((step, i) => <Step step={step} key={step.id || i} {...props} />)}
+    {steps.map((step, i) => (
+      <Step step={step} key={step.id || i} {...props} />
+    ))}
   </ol>
 );
 
@@ -22,6 +24,7 @@ export const stepShape = {
   href: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
+  linkText: PropTypes.string,
   completed: PropTypes.bool,
   started: PropTypes.bool,
   isNextStep: PropTypes.bool

--- a/packages/core/src/components/StepList/StepList.scss
+++ b/packages/core/src/components/StepList/StepList.scss
@@ -357,6 +357,8 @@ Step object properties:
 - **isNextStep** (`bool`) - Whether this is the next unstarted step
 - **title** (`string`) - Text to display as the step title
 - **description** (`string`) - Additional text to display under (only rendered for top-level steps)
+- **linkText** (`string`) - Alternative text for the link or button for this step. Will override the defaults
+- **steps** (`Step[]`) - Array of substeps
 
 Style guide: patterns.step-list.step-object
 */

--- a/packages/core/src/components/StepList/SubStep.jsx
+++ b/packages/core/src/components/StepList/SubStep.jsx
@@ -14,7 +14,7 @@ export const SubStep = ({ step, ...props }) => (
         onClick={props.onStepLinkClick}
         className="ds-c-substep__edit"
       >
-        {props.editText}
+        {step.linkText || props.editText}
       </StepLink>
     )}
     {step.steps &&


### PR DESCRIPTION
### Added
- `StepList` steps now support a `linkText` property which allows for alternative text for that step's start/continue/edit links.
- Added the `steps` property to the documentation of `step` objects, which was previously missing

### Review notes
To see it in action, change the `StepList` example by adding the `linkText` property to one of the steps, like
```js
{
  id: 'household.overall',
  title: 'Overall household',
  href: '#step-2a',
  started: true,
  completed: true,
  linkText: 'Hello'
},
```
after [this line](https://github.com/CMSgov/design-system/blob/master/packages/core/src/components/StepList/StepList.example.jsx#L34) or [this line](https://github.com/CMSgov/design-system/blob/master/packages/core/src/components/StepList/StepList.example.jsx#L27)