### PR TITLE
[WNMGDS-226] - Add SCSS to pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,10 @@
       "prettier --write",
       "eslint --fix",
       "git add"
+    ],
+    "*.scss": [
+      "stylelint",
+      "stylelint --syntax=scss"
     ]
   },
   "resolutions": {


### PR DESCRIPTION

### Added
pre-commit hook to the package.json file

### Screenshot
Showing the pre-commit finding an SCSS issue

<img width="886" alt="Screen Shot 2019-09-13 at 1 09 39 PM" src="https://user-images.githubusercontent.com/1449852/64881249-479cb900-d628-11e9-9d3f-8bdc7a05608f.png">


