### PR TITLE
[NO-TICKET] Fix issue in <Dropdown/> where <option/>s do not have `value` attributes.

### DIFF
--- a/packages/core/dist/components/Dropdown/Dropdown.js
+++ b/packages/core/dist/components/Dropdown/Dropdown.js
@@ -101,7 +101,7 @@ var Dropdown = exports.Dropdown = function (_React$PureComponent) {
       var optionElements = options.map(function (option) {
         return _react2.default.createElement(
           'option',
-          { key: option.value },
+          { key: option.value, value: option.value },
           option.label
         );
       });

--- a/packages/core/src/components/Dropdown/Dropdown.jsx
+++ b/packages/core/src/components/Dropdown/Dropdown.jsx
@@ -56,7 +56,9 @@ export class Dropdown extends React.PureComponent {
     );
 
     const optionElements = options.map(option => (
-      <option key={option.value}>{option.label}</option>
+      <option key={option.value} value={option.value}>
+        {option.label}
+      </option>
     ));
 
     return (

--- a/packages/core/src/components/Dropdown/__snapshots__/Dropdown.test.jsx.snap
+++ b/packages/core/src/components/Dropdown/__snapshots__/Dropdown.test.jsx.snap
@@ -18,6 +18,7 @@ exports[`Dropdown renders a select menu 1`] = `
   >
     <option
       key="1"
+      value="1"
     >
       1
     </option>
@@ -43,51 +44,61 @@ exports[`Dropdown renders options correctly 1`] = `
   >
     <option
       key="1"
+      value="1"
     >
       1
     </option>
     <option
       key="2"
+      value="2"
     >
       2
     </option>
     <option
       key="3"
+      value="3"
     >
       3
     </option>
     <option
       key="4"
+      value="4"
     >
       4
     </option>
     <option
       key="5"
+      value="5"
     >
       5
     </option>
     <option
       key="6"
+      value="6"
     >
       6
     </option>
     <option
       key="7"
+      value="7"
     >
       7
     </option>
     <option
       key="8"
+      value="8"
     >
       8
     </option>
     <option
       key="9"
+      value="9"
     >
       9
     </option>
     <option
       key="10"
+      value="10"
     >
       10
     </option>


### PR DESCRIPTION
This should be a pretty straightforward change, but let me know if I did something wrong!

### Fixed
Fixed an issue where the `<option/>` tags under the `<select/>` generated by `<Dropdown/>` did not have `value` attributes.  This caused the function provided to `onChange` to be unable to grab the option's value via `event.target.value` (since it would return the option's label instead). 