### PR TITLE
Fix visual regressions

### DIFF
--- a/packages/core/src/components/DateField/DateField.scss
+++ b/packages/core/src/components/DateField/DateField.scss
@@ -1,4 +1,3 @@
-@import 'DateField.docs';
 @import '@cmsgov/design-system-support/src/settings/index';
 
 .ds-c-field--month,

--- a/packages/core/src/components/Tabs/_Tabs.docs.scss
+++ b/packages/core/src/components/Tabs/_Tabs.docs.scss
@@ -27,6 +27,14 @@ Style guide: components.tabs.react-tabpanel
 */
 
 /*
+`<Tab>`
+
+@react-component Tab
+
+Style guide: components.tabs.react-tab
+*/
+
+/*
 ---
 
 ## When to use

--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -5,7 +5,6 @@
 @import 'Button/Button';
 @import 'ChoiceList/Choice';
 @import 'ChoiceList/Select';
-@import 'DateField/DateField';
 @import 'Dialog/Dialog';
 @import 'Dropdown/Dropdown';
 @import 'FormLabel/FormLabel';
@@ -17,8 +16,11 @@
 @import 'StepList/StepList';
 @import 'Table/Table';
 @import 'Tabs/Tabs';
+// Mask and Date field styles need imported
+// after TextField since they modify it
 @import 'TextField/TextField';
 @import 'TextField/Mask';
+@import 'DateField/DateField';
 @import 'VerticalNav/VerticalNav';
 
 // Documentation


### PR DESCRIPTION
With backstop I discovered 2 regressions introduced by the separating out inline CSS/HTML work. This PR fixes them before the release

### Fixed
1. Date field css is changed
https://gyazo.com/ca29a5ed8363562539f9d5dd4f3b3609
2. Documentation for <Tab> is no longer there https://gyazo.com/56a87571e1af402778258009bcd893d7

