### PR TITLE
[WNMGDS-269] Make children not required in <Alert>

### DIFF
--- a/packages/core/src/components/Alert/Alert.example.jsx
+++ b/packages/core/src/components/Alert/Alert.example.jsx
@@ -3,8 +3,15 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 ReactDOM.render(
-  <Alert heading="A react component">
-    This is an example of a React Alert component.
-  </Alert>,
+  <div>
+    <Alert heading="Alert heading">This is a React Alert component.</Alert>
+    <Alert className={'ds-u-margin-top--2'}>
+      This is a React Alert component without a heading
+    </Alert>
+    <Alert
+      heading="Alert with only a heading"
+      className={'ds-u-margin-top--2'}
+    />
+  </div>,
   document.getElementById('js-example')
 );

--- a/packages/core/src/components/Alert/Alert.jsx
+++ b/packages/core/src/components/Alert/Alert.jsx
@@ -17,11 +17,13 @@ export class Alert extends React.PureComponent {
   }
 
   heading() {
-    return (
-      <h3 className="ds-c-alert__heading" id={this.headingId}>
-        {this.props.heading}
-      </h3>
-    );
+    if (this.props.heading) {
+      return (
+        <h3 className="ds-c-alert__heading" id={this.headingId}>
+          {this.props.heading}
+        </h3>
+      );
+    }
   }
 
   render() {
@@ -36,7 +38,7 @@ export class Alert extends React.PureComponent {
       <div
         className={classes}
         role={this.props.role}
-        aria-labelledby={this.headingId}
+        aria-labelledby={this.props.heading ? this.headingId : undefined}
       >
         <div className="ds-c-alert__body">
           {this.heading()}

--- a/packages/core/src/components/Alert/Alert.jsx
+++ b/packages/core/src/components/Alert/Alert.jsx
@@ -8,6 +8,12 @@ export class Alert extends React.PureComponent {
     super(props);
 
     this.headingId = this.props.headingId || uniqueId('alert_');
+
+    if (!props.heading && !props.children) {
+      console.error(
+        `Empty <Alert> components are not allowed, please use the 'heading' prop or include children.`
+      );
+    }
   }
 
   heading() {
@@ -44,12 +50,26 @@ Alert.defaultProps = {
   role: 'region'
 };
 Alert.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
+  /**
+   * Text for the alert heading
+   */
   heading: PropTypes.string,
+  /**
+   * Optional id used to link the `aria-labelledby` attribute to the heading. If not provided, a unique id will be automatically generated and used.
+   */
   headingId: PropTypes.string,
+  /**
+   * Boolean to hide the `Alert` icon
+   */
   hideIcon: PropTypes.bool,
-  /** ARIA `role` */
+  /**
+   * ARIA `role`, defaults to 'region'
+   */
   role: PropTypes.oneOf(['alert', 'alertdialog', 'region']),
+  /**
+   * A string corresponding to the `Alert` variation classes (`error`, `warn`, `success`)
+   */
   variation: PropTypes.oneOf(['error', 'warn', 'success'])
 };
 


### PR DESCRIPTION
### Changed
`children` is no longer a required prop in <Alert>, and an error is added for empty Alerts.

### Added
Added missing React prop documentation and some extra React examples

### Fixed
Previously empty headers would still cause a small margin to be added, this was fixed so a header would only be included in the HTML if its not empty

