### PR TITLE
[WNMGDS-261] - Update NPM publish script

### DIFF
--- a/guides/RELEASE-PROCESS.md
+++ b/guides/RELEASE-PROCESS.md
@@ -25,7 +25,8 @@
       git commit -m "Release v1.1.0"
       git push --set-upstream origin v1.1.0
       ```
-   1. Create a new release on GitHub 
+   1. Create a new release on GitHub
+
       1. [Draft a new release on GitHub](https://github.com/CMSgov/design-system/releases/new)
       1. Tag the release using the [SemVer specification release format](#versioning). For example, `v1.1.0`
       1. Title the release using the release number. For example, `1.1.0`
@@ -40,37 +41,44 @@
       ## 🚫 Deprecated
       ```
 
-      **Note**: View commits since the last release on github by going to the [releases page](https://github.com/CMSgov/design-system/releases) or run: ```git log `git describe --tags --abbrev=0`..HEAD --oneline```
-      
+      **Note**: View commits since the last release on github by going to the [releases page](https://github.com/CMSgov/design-system/releases) or run: `` git log `git describe --tags --abbrev=0`..HEAD --oneline ``
+
 1. **Publish to NPM**
 
    1. Log into NPM as `cmsgov` with `npm adduser`. Check your user account with `npm whoami`.
+
       1. To use an access token, edit your `~/.npmrc` file so the contents are `//registry.npmjs.org/:_authToken={token}`
 
    1. Run the publish to NPM script.
+
       ```
       ./scripts/publish.sh
       ```
+
       This will run `npm publish` for each public package in `packages/`.
       **Note**: You should only publish the `master` branch to NPM. The publish script above will check out the `master` branch if it isn't currently the `HEAD`.
-   
+
+      **Note:** You will need to have your own NPM account and get access to the cmsgov NPM org in order to publish.
+
    1. Publish the release notes after the npm package is updated
-      
+
 1. **Update the design.cms.gov documentation website**
 
    1. [Log in to CBJ](https://cloudbeesjenkins.cms.gov/prod-master/job/wds/job/Design%20System/job/Deploy%20design-system/) to Deploy the CMS Design System documentation website.
-   
+
       **Note**: Your CBJ user will need to be a member of the `wd-user` group or you will be unable to see the linked job above.
-   
+
    1. Select the branch you'd like to deploy. The default is set to `master`.
 
    Deploying the documentation website is a multi-stage pipeline that executes the deploy in two stages:
-      * The first child job builds `design-system`, creates a tarball from the resulting artifacts, then uploads the tarball to S3.
-      * The second child job downloads the tarball from S3, expands it onto the node Jenkins is using for the deploy, then copies the files to Netstorage via `scp`.
-      
+
+   - The first child job builds `design-system`, creates a tarball from the resulting artifacts, then uploads the tarball to S3.
+   - The second child job downloads the tarball from S3, expands it onto the node Jenkins is using for the deploy, then copies the files to Netstorage via `scp`.
+
    **Note**: For a manual process: Visit the [Documentation deploy process page](https://confluence.cms.gov/display/HCDSG/Documentation+deploy+proces) in Confluence for these instructions.
 
    1. After the new site is deployed, update the visual regression references and put up a PR for the updates.
+
    ```
    backstop reference
    ```
@@ -87,8 +95,8 @@ Bug fixes and other minor changes: Increment the last number, e.g. `1.0.1`
 
 Examples:
 
-* Backwards compatible Sass/JS bug fixes
-* Tiny visual changes to make the UI more consistent
+- Backwards compatible Sass/JS bug fixes
+- Tiny visual changes to make the UI more consistent
 
 ### Minor release
 
@@ -96,9 +104,9 @@ Backwards compatible new functionality, newly deprecated APIs, or substantial ne
 
 Examples:
 
-* Addition of a new component
-* New classes, global variables, mixins, functions, or deprecated code
-* Minor visual changes to existing components
+- Addition of a new component
+- New classes, global variables, mixins, functions, or deprecated code
+- Minor visual changes to existing components
 
 ### Major release
 
@@ -106,5 +114,5 @@ Changes which break backwards compatibility: Increment the first number, e.g. `2
 
 Example changes:
 
-* Renamed or removed classes, mixins, functions, placeholders, or global variables.
-* Major visual changes to existing components
+- Renamed or removed classes, mixins, functions, placeholders, or global variables.
+- Major visual changes to existing components

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -6,11 +6,6 @@ RED="\033[0;31m"
 GREEN='\033[0;32m'
 NC='\033[0m' # No color
 
-if npm whoami | grep cmsgov -v
-then
-  echo "${RED}✘ Not logged in as correct NPM user"
-  exit 0
-fi
 
 git stash
 git checkout master


### PR DESCRIPTION
Remove **cmsgov** user check from publish script. 
That user account is no longer usable and you must have an individual NPM account and get access to the **cmsgov** NPM org 