### PR TITLE
[WIP WNMGDS-281] Add initial custom form label

### DIFF
--- a/packages/core/src/components/ChoiceList/ChoiceList.example.jsx
+++ b/packages/core/src/components/ChoiceList/ChoiceList.example.jsx
@@ -1,5 +1,6 @@
+import React, { Fragment } from 'react';
 import ChoiceList from './ChoiceList';
-import React from 'react';
+import FormLabel from '../FormLabel/FormLabel';
 import ReactDOM from 'react-dom';
 
 ReactDOM.render(
@@ -43,6 +44,28 @@ ReactDOM.render(
       multiple
       name="some_optional_choices_field"
       requirementLabel="Optional"
+    />
+
+    <ChoiceList
+      choices={[
+        { label: 'Choice 1', value: 'A' },
+        { label: 'Choice 2', value: 'B' }
+      ]}
+      formLabel={
+        <Fragment>
+          <FormLabel component="legend">Custom LabelForm</FormLabel>
+          <a
+            href="https://design.cms.gov"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Custom link element
+          </a>
+        </Fragment>
+      }
+      label=""
+      name="some_optional_choices_field"
+      multiple
     />
   </div>,
   document.getElementById('js-example')

--- a/packages/core/src/components/ChoiceList/ChoiceList.jsx
+++ b/packages/core/src/components/ChoiceList/ChoiceList.jsx
@@ -70,6 +70,29 @@ export class ChoiceList extends React.PureComponent {
     return choices;
   }
 
+  formLabel() {
+    // Return custom FormLabel component if provided
+    if (this.props.formLabel) {
+      return this.props.formLabel;
+    }
+
+    const type = this.type();
+    const FormLabelComponent = type === 'select' ? 'label' : 'legend';
+    return (
+      <FormLabel
+        className={this.props.labelClassName}
+        component={FormLabelComponent}
+        errorMessage={this.props.errorMessage}
+        fieldId={this.id()}
+        hint={this.props.hint}
+        requirementLabel={this.props.requirementLabel}
+        inversed={this.props.inversed}
+      >
+        {this.props.label}
+      </FormLabel>
+    );
+  }
+
   /**
    * If this is a <select> element, then we need to generate the ID here
    * so it can be shared between the FormLabel and Select component
@@ -160,21 +183,10 @@ export class ChoiceList extends React.PureComponent {
       this.props.className
     );
     const RootComponent = type === 'select' ? 'div' : 'fieldset';
-    const FormLabelComponent = type === 'select' ? 'label' : 'legend';
 
     return (
       <RootComponent className={classes || null}>
-        <FormLabel
-          className={this.props.labelClassName}
-          component={FormLabelComponent}
-          errorMessage={this.props.errorMessage}
-          fieldId={this.id()}
-          hint={this.props.hint}
-          requirementLabel={this.props.requirementLabel}
-          inversed={this.props.inversed}
-        >
-          {this.props.label}
-        </FormLabel>
+        {this.formLabel()}
         {this.field()}
       </RootComponent>
     );
@@ -206,6 +218,10 @@ ChoiceList.propTypes = {
    */
   disabled: PropTypes.bool,
   errorMessage: PropTypes.node,
+  /**
+   * Custom FormLabel component
+   */
+  formLabel: PropTypes.node,
   /**
    * Additional hint text to display
    */


### PR DESCRIPTION
From this discussion: https://adhoc.slack.com/archives/C645GLLNN/p1571929043180500
We needed a way to pass a value to `FormLabel`'s `labelClassName` prop while using `ChoiceList`. Rather than add more props `ChoiceList` to pass through to `FormLabel`, we allow a custom label element by adding a `formLabel` prop

### Added
`formLabel` prop for supplying a custom label element