### PR TITLE
[WNMGDS-290] - Update disabled styling for buttons

### DIFF
--- a/packages/core/src/components/Button/Button.scss
+++ b/packages/core/src/components/Button/Button.scss
@@ -24,6 +24,13 @@
     color: $color-primary-darker;
   }
 
+  &:disabled {
+    background-color: $color-white;
+    border-color: $color-gray-lighter;
+    color: $color-gray-lighter;
+    pointer-events: none;
+  }
+
   &:active,
   &.ds-c-button--active {
     border-color: $color-primary-darkest;
@@ -48,6 +55,13 @@
   border-color: transparent;
   color: $color-white;
 
+  &:disabled {
+    background-color: $color-gray-lighter;
+    border-color: transparent;
+    color: $color-gray-dark;
+    pointer-events: none;
+  }
+
   &:focus,
   &:hover,
   &:active,
@@ -58,7 +72,7 @@
     color: $color-white;
   }
 
-  &:focus,   
+  &:focus,
   &.ds-c-button--focus {
     background-color: $button-primary-bg--focus;
   }
@@ -80,6 +94,13 @@
   border-color: transparent;
   text-decoration: underline;
 
+  &:disabled {
+    background-color: transparent;
+    border-color: transparent;
+    color: $color-gray-lighter;
+    pointer-events: none;
+  }
+
   &:focus,
   &:hover,
   &:active,
@@ -94,6 +115,13 @@
   background-color: $color-error;
   border-color: transparent;
   color: $color-white;
+
+  &:disabled {
+    background-color: $color-gray-lighter;
+    border-color: transparent;
+    color: $color-gray-dark;
+    pointer-events: none;
+  }
 
   &:focus,
   &:hover,
@@ -117,6 +145,13 @@
   border-color: transparent;
   color: $color-white;
 
+  &:disabled {
+    background-color: $color-gray-lighter;
+    border-color: transparent;
+    color: $color-gray-dark;
+    pointer-events: none;
+  }
+
   &:focus,
   &:hover,
   &:active,
@@ -134,8 +169,8 @@
   }
 }
 
-.ds-c-button:disabled,
 .ds-c-button--disabled {
+
   background-color: $color-gray-lighter;
   border-color: transparent;
   color: $color-gray-dark;
@@ -161,6 +196,13 @@ Inverse buttons
   background-color: $color-background-inverse;
   border-color: $border-color-inverse;
 
+  &:disabled {
+    background-color: $color-background-inverse;
+    border-color: $color-gray-light;
+    color: $color-gray-light;
+    pointer-events: none;
+  }
+
   &:focus,
   &:hover,
   &:active,
@@ -176,7 +218,7 @@ Inverse buttons
   color: $color-base-inverse;
 
   &:focus,
-  &:hover, 
+  &:hover,
   &:active,
   &.ds-c-button--focus,
   &.ds-c-button--hover,

--- a/packages/core/src/components/Button/Button.scss
+++ b/packages/core/src/components/Button/Button.scss
@@ -90,30 +90,6 @@
   }
 }
 
-.ds-c-button--transparent,
-.ds-c-button--transparent-inverse {
-  background-color: transparent;
-  border-color: transparent;
-  text-decoration: underline;
-
-  &:disabled,
-  &.ds-c-button--disabled {
-    background-color: transparent;
-    border-color: transparent;
-    color: $color-gray-lighter;
-    pointer-events: none;
-  }
-
-  &:focus,
-  &:hover,
-  &:active,
-  &.ds-c-button--focus,
-  &.ds-c-button--hover,
-  &.ds-c-button--active {
-    border-color: transparent;
-  }
-}
-
 .ds-c-button--danger {
   background-color: $color-error;
   border-color: transparent;
@@ -174,11 +150,18 @@
   }
 }
 
-.ds-c-button--disabled {
-  background-color: $color-gray-lighter;
+.ds-c-button--transparent,
+.ds-c-button--transparent-inverse { 
+  background-color: transparent;
   border-color: transparent;
-  color: $color-gray-dark;
-  pointer-events: none;
+  text-decoration: underline;
+
+  &:disabled,
+  &.ds-c-button--disabled {
+    background-color: transparent;
+    border-color: transparent;
+    color: $color-gray-lighter;
+  }
 
   &:focus,
   &:hover,
@@ -186,38 +169,13 @@
   &.ds-c-button--focus,
   &.ds-c-button--hover,
   &.ds-c-button--active {
-    background-color: $color-gray-lighter;
     border-color: transparent;
-    color: $color-gray-dark;
   }
 }
 
 /*
 Inverse buttons
 */
-
-.ds-c-button--inverse {
-  background-color: $color-background-inverse;
-  border-color: $border-color-inverse;
-
-  &:disabled,
-  &.ds-c-button--disabled {
-    background-color: $color-background-inverse;
-    border-color: $color-gray-light;
-    color: $color-gray-light;
-    pointer-events: none;
-  }
-
-  &:focus,
-  &:hover,
-  &:active,
-  &.ds-c-button--focus,
-  &.ds-c-button--hover,
-  &.ds-c-button--active {
-    border-color: $color-base-inverse;
-  }
-}
-
 .ds-c-button--inverse,
 .ds-c-button--transparent-inverse {
   color: $color-base-inverse;
@@ -238,12 +196,17 @@ Inverse buttons
   }
 }
 
-.ds-c-button--disabled-inverse,
-.ds-c-button--disabled-inverse:disabled {
-  background-color: darken($color-background-inverse, 10%);
-  border-color: darken($color-background-inverse, 10%);
-  color: $color-muted-inverse;
-  pointer-events: none;
+.ds-c-button--inverse {
+  background-color: $color-background-inverse;
+  border-color: $border-color-inverse;
+
+  &:disabled,
+  &.ds-c-button--disabled {
+    background-color: darken($color-background-inverse, 10%);
+    border-color: darken($color-background-inverse, 10%);
+    color: $color-muted-inverse;
+    pointer-events: none;
+  }
 
   &:focus,
   &:hover,
@@ -251,8 +214,13 @@ Inverse buttons
   &.ds-c-button--focus,
   &.ds-c-button--hover,
   &.ds-c-button--active {
-    background-color: $color-background-inverse;
-    border-color: $color-background-inverse;
+    border-color: $color-base-inverse;
+  }
+}
+
+.ds-c-button--transparent-inverse {
+  &:disabled,
+  &.ds-c-button--disabled {
     color: $color-muted-inverse;
   }
 }

--- a/packages/core/src/components/Button/Button.scss
+++ b/packages/core/src/components/Button/Button.scss
@@ -24,7 +24,8 @@
     color: $color-primary-darker;
   }
 
-  &:disabled {
+  &:disabled,
+  &.ds-c-button--disabled {
     background-color: $color-white;
     border-color: $color-gray-lighter;
     color: $color-gray-lighter;
@@ -55,7 +56,8 @@
   border-color: transparent;
   color: $color-white;
 
-  &:disabled {
+  &:disabled,
+  &.ds-c-button--disabled {
     background-color: $color-gray-lighter;
     border-color: transparent;
     color: $color-gray-dark;
@@ -94,7 +96,8 @@
   border-color: transparent;
   text-decoration: underline;
 
-  &:disabled {
+  &:disabled,
+  &.ds-c-button--disabled {
     background-color: transparent;
     border-color: transparent;
     color: $color-gray-lighter;
@@ -116,7 +119,8 @@
   border-color: transparent;
   color: $color-white;
 
-  &:disabled {
+  &:disabled,
+  &.ds-c-button--disabled {
     background-color: $color-gray-lighter;
     border-color: transparent;
     color: $color-gray-dark;
@@ -145,7 +149,8 @@
   border-color: transparent;
   color: $color-white;
 
-  &:disabled {
+  &:disabled,
+  &.ds-c-button--disabled {
     background-color: $color-gray-lighter;
     border-color: transparent;
     color: $color-gray-dark;
@@ -170,7 +175,6 @@
 }
 
 .ds-c-button--disabled {
-
   background-color: $color-gray-lighter;
   border-color: transparent;
   color: $color-gray-dark;
@@ -196,7 +200,8 @@ Inverse buttons
   background-color: $color-background-inverse;
   border-color: $border-color-inverse;
 
-  &:disabled {
+  &:disabled,
+  &.ds-c-button--disabled {
     background-color: $color-background-inverse;
     border-color: $color-gray-light;
     color: $color-gray-light;

--- a/packages/core/src/components/Button/_Button.docs.scss
+++ b/packages/core/src/components/Button/_Button.docs.scss
@@ -74,7 +74,7 @@ Style guide: components.button.react
 **Disabled buttons**
 
 - Don’t disable buttons, unless there’s a good reason to.
-- If you do disable a button, make sure it receives the disabled styling. A `button` element will automatically be styled as a disabled button when it has the `disabled` HTML attribute, but an `a` element will need to have the disabled modifier class applied to it.
+- If you do disable a button, make sure it receives the disabled styling. A `button` element will automatically be styled as a disabled button when it has the `disabled` HTML attribute, but an `a` element will need to have the `.ds-c-button--disabled` class applied to it.
 
 ### Accessibility
 

--- a/packages/core/src/components/Button/button.example.html
+++ b/packages/core/src/components/Button/button.example.html
@@ -8,7 +8,7 @@
 <button type="button" class="ds-c-button ds-c-button--active">
   Active
 </button>
-<button type="button" class="ds-c-button ds-c-button--disabled">
+<button type="button" class="ds-c-button" disabled>
   Disabled
 </button>
 
@@ -22,7 +22,7 @@
 <button type="button" class="ds-c-button ds-c-button--primary ds-c-button--active">
   Active
 </button>
-<button type="button" class="ds-c-button ds-c-button--primary ds-c-button--disabled">
+<button type="button" class="ds-c-button ds-c-button--primary" disabled>
   Disabled
 </button>
 
@@ -36,7 +36,7 @@
 <button type="button" class="ds-c-button ds-c-button--danger ds-c-button--active">
   Active
 </button>
-<button type="button" class="ds-c-button ds-c-button--danger ds-c-button--disabled">
+<button type="button" class="ds-c-button ds-c-button--danger" disabled>
   Disabled
 </button>
 
@@ -50,7 +50,7 @@
 <button type="button" class="ds-c-button ds-c-button--success ds-c-button--active">
   Active
 </button>
-<button type="button" class="ds-c-button ds-c-button--success ds-c-button--disabled">
+<button type="button" class="ds-c-button ds-c-button--success" disabled>
   Disabled
 </button>
 
@@ -64,7 +64,7 @@
 <button type="button" class="ds-c-button ds-c-button--transparent ds-c-button--active">
   Active
 </button>
-<button type="button" class="ds-c-button ds-c-button--transparent ds-c-button--disabled">
+<button type="button" class="ds-c-button ds-c-button--transparent" disabled>
   Disabled
 </button>
 
@@ -86,7 +86,7 @@
   <button class="ds-c-button ds-c-button--transparent-inverse">
     Transparent
   </button>
-  <button disabled class="ds-c-button ds-c-button--disabled-inverse">
+  <button disabled class="ds-c-button ds-c-button--inverse">
     Disabled
   </button>
 </div>


### PR DESCRIPTION
Currently, the disabled button styling is the same for all non-inverse button styles. We should change the default disabled to match the default outline style, similar to USWDS

### Screenshot

![Screen Shot 2019-11-04 at 4 32 37 PM](https://user-images.githubusercontent.com/1449852/68160310-8280e600-ff21-11e9-8643-34d8489d6eb7.png)
