### PR TITLE
[WNMGDS-297] Prevent accessing null refs on DateField

### DIFF
--- a/packages/core/src/components/DateField/DateField.jsx
+++ b/packages/core/src/components/DateField/DateField.jsx
@@ -22,7 +22,7 @@ export class DateField extends React.PureComponent {
   }
 
   formatDate() {
-    if (this.props.dateFormatter) {
+    if (this.props.dateFormatter && this.monthInput && this.dayInput && this.yearInput) {
       const values = {
         month: this.monthInput.value,
         day: this.dayInput.value,


### PR DESCRIPTION
### Fixed
Added a check for invalid refs in DateField blur.

Unsure how to reprod the original issue
