### PR TITLE
[WNMGDS-282] Add editAriaLabel to Review

### DIFF
--- a/packages/core/src/components/Review/Review.example.jsx
+++ b/packages/core/src/components/Review/Review.example.jsx
@@ -16,7 +16,7 @@ ReactDOM.render(
       Multiple Review components can be combined together one after another.
     </Review>
     <Review
-      heading="A Review component with edit content"
+      heading="A Review component with custom edit content"
       editContent={
         <div>
           <a href={editButtonHref}>Edit</a>
@@ -33,7 +33,11 @@ ReactDOM.render(
     <Review heading="Date of Birth" editHref={editButtonHref}>
       October 11, 1980
     </Review>
-    <Review heading="Shopping List" editHref={editButtonHref}>
+    <Review
+      heading="Shopping List"
+      editHref={editButtonHref}
+      editAriaLabel="Edit this shopping list"
+    >
       <ul>
         <li>Milk</li>
         <li>Eggs</li>

--- a/packages/core/src/components/Review/Review.jsx
+++ b/packages/core/src/components/Review/Review.jsx
@@ -5,9 +5,7 @@ import classNames from 'classnames';
 
 export class Review extends React.PureComponent {
   heading() {
-    const Heading = this.props.headingLevel
-      ? `h${this.props.headingLevel}`
-      : `h3`;
+    const Heading = this.props.headingLevel ? `h${this.props.headingLevel}` : `h3`;
     if (this.props.heading) {
       return (
         <Heading className="ds-c-review__heading ds-text ds-u-margin-bottom--0 ds-u-font-weight--bold ds-u-display--inline-block">
@@ -21,6 +19,7 @@ export class Review extends React.PureComponent {
     const {
       children,
       className,
+      editAriaLabel,
       editHref,
       editText,
       onEditClick,
@@ -38,7 +37,7 @@ export class Review extends React.PureComponent {
         </div>
         {editContent}
         {!editContent && editHref && (
-          <ReviewLink onClick={onEditClick} href={editHref}>
+          <ReviewLink onClick={onEditClick} href={editHref} ariaLabel={editAriaLabel}>
             {editText}
           </ReviewLink>
         )}
@@ -54,25 +53,33 @@ Review.defaultProps = {
 Review.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  /**
+   * Optional label to give screenreaders longer, more descriptive text to
+   * explain the context of an edit link.
+   */
+  editAriaLabel: PropTypes.string,
+  /**
+   * An optional node in place of the edit link. If this defined, no edit link will be shown.
+   */
+  editContent: PropTypes.node,
+  /**
+   * Href for the edit link. If this is undefined, no edit link will be shown.
+   */
+  editHref: PropTypes.string,
+  editText: PropTypes.node,
   heading: PropTypes.node,
   /**
    * Heading type to override default `<h3>`.
    */
   headingLevel: PropTypes.number,
   /**
-   * Href for the edit link. If this is undefined, no edit link will be shown.
-   */
-  editHref: PropTypes.string,
-  editText: PropTypes.node,
-  /**
    * An optional function that is executed on edit link click. The event and
    * props.editHref value are passed to this function.
    */
-  onEditClick: PropTypes.func,
+  onEditClick: PropTypes.func
   /**
    * An optional node in place of the edit link. If this defined, no edit link will be shown.
    */
-  editContent: PropTypes.node
 };
 
 export default Review;

--- a/packages/core/src/components/Review/ReviewLink.jsx
+++ b/packages/core/src/components/Review/ReviewLink.jsx
@@ -13,12 +13,7 @@ export class ReviewLink extends React.PureComponent {
     const onClick = event => this.handleClick(event);
     return (
       <div>
-        <a
-          href={href}
-          onClick={onClick}
-          className={className}
-          aria-label={ariaLabel}
-        >
+        <a href={href} onClick={onClick} className={className} aria-label={ariaLabel}>
           {children}
         </a>
       </div>
@@ -27,15 +22,15 @@ export class ReviewLink extends React.PureComponent {
 }
 
 ReviewLink.propTypes = {
-  children: PropTypes.node.isRequired,
-  href: PropTypes.string.isRequired,
-  className: PropTypes.string,
-  onClick: PropTypes.func,
   /**
    * Provide this value to give screenreaders longer, more descriptive text to
    * explain the context of the link.
    */
-  ariaLabel: PropTypes.string
+  ariaLabel: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  href: PropTypes.string.isRequired,
+  onClick: PropTypes.func
 };
 
 export default ReviewLink;


### PR DESCRIPTION
### Summary
<ReviewLink> takes an `ariaLabel` prop to add extra info for screenreaders, but <Review> did not use this prop.

### Added
This PR adds `editAriaLabel` to <Review>, and passes that along to <ReviewLink>

