### PR TITLE
Add compiled index.css file back to dist folder 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # Documentation is generated into this directory
 /docs
 
-# Do not commit package build files to github
-/packages/core/dist
+# Do not commit package build files other than the compiled CSS
+/packages/core/dist/**/
+/packages/core/dist/index.js
 /packages/layout/dist
 
 # Themes should be in their own repo, but can be included in this directory


### PR DESCRIPTION
Add index.css file back to the GitHub repo per the https://design.cms.gov/startup/sass-and-css/ documentation

Fixes https://github.com/CMSgov/design-system/issues/562
