### PR TITLE
[NO TICKET] Update github link to use uploaded zip

### DIFF
--- a/guides/RELEASE-PROCESS.md
+++ b/guides/RELEASE-PROCESS.md
@@ -1,5 +1,23 @@
 # Release process
 
+1. **Create a release draft on GitHub**
+
+   1. [Draft a new release on GitHub](https://github.com/CMSgov/design-system/releases/new)
+   1. Tag the release using the [SemVer specification release format](#versioning). For example, `v1.1.0`
+   1. Title the release using the release number. For example, `1.1.0`
+   1. Follow the format below for the release notes
+
+   ```
+   ## 🚨 Breaking/Behavioral changes
+   ## 🚀 Added
+   ## 💅 Changed
+   ## 🛠 Fixed
+   ## 📦 Internal
+   ## 🚫 Deprecated
+   ```
+
+   **Note**: View commits since the last release on github by going to the [releases page](https://github.com/CMSgov/design-system/releases) or run: `` git log `git describe --tags --abbrev=0`..HEAD --oneline ``
+
 1. **Create a release commit**
 
    1. Checkout the latest `master` branch and ensure that you don't have any local changes. If you do have local changes [stash or discard](https://docs.gitlab.com/ee/topics/git/numerous_undo_possibilities_in_git/#quickly-save-local-changes) them before going to the next step.
@@ -14,6 +32,7 @@
       ```
       backstop test
       ```
+      If there are expected visual changes, run `backstop approve` to save the new reference files.
    1. Run the prepublish script from the root of your local git repo. This will bump the version, build the documentation, and transpile + bundle `dist` assets.
       ```
       ./scripts/prepublish.sh
@@ -25,6 +44,7 @@
       git commit -m "Release v1.1.0"
       git push --set-upstream origin v1.1.0
       ```
+
 1. **Publish to NPM**
 
    1. Log into NPM as `cmsgov` with `npm adduser`. Check your user account with `npm whoami`.
@@ -65,24 +85,17 @@
    backstop reference
    ```
 
-1. **Create a new release on GitHub**
+1. **Finalize and publish release on GitHub**
 
-      1. [Draft a new release on GitHub](https://github.com/CMSgov/design-system/releases/new)
-      1. Tag the release using the [SemVer specification release format](#versioning). For example, `v1.1.0`
-      1. Title the release using the release number. For example, `1.1.0`
-      1. Follow the format below for the release notes, then publish.
+   1. Create a release zip that includes all the build files
+   1. Name it according to the following naming convention (i.e. design-system-v1.1.0.zip)
 
-      ```
-      ## 🚨 Breaking/Behavioral changes
-      ## 🚀 Added
-      ## 💅 Changed
-      ## 🛠 Fixed
-      ## 📦 Internal
-      ## 🚫 Deprecated
-      ```
+   ```
+   design-system-v{version}.zip
+   ```
 
-      **Note**: View commits since the last release on github by going to the [releases page](https://github.com/CMSgov/design-system/releases) or run: `` git log `git describe --tags --abbrev=0`..HEAD --oneline ``
-
+   1. Upload the zip as a release asset
+   1. Review the release notes and publish
 
 # Versioning
 

--- a/packages/docs/src/pages/index.md
+++ b/packages/docs/src/pages/index.md
@@ -15,7 +15,8 @@ The design system is a set of open source design and front-end development resou
 It is currently being applied to [HealthCare.gov](https://www.healthcare.gov/). It is open source and freely available to use by anyone.
 
 ## Getting started
-Get started by [downloading the code as a zip file](https://github.com/CMSgov/design-system/archive/master.zip), [installing with NPM](/startup/installation/), or [downloading the Sketch UI kit](https://github.com/CMSgov/design-system/raw/master/design-assets/CMS-Design-System-UI-kit.sketch) for wireframes and prototypes.
+
+Get started by [downloading the code as a zip file](https://github.com/CMSgov/design-system/releases), [installing with NPM](/startup/installation/), or [downloading the Sketch UI kit](https://github.com/CMSgov/design-system/raw/master/design-assets/CMS-Design-System-UI-kit.sketch) for wireframes and prototypes.
 
 ## Goals
 

--- a/packages/docs/src/pages/index.md
+++ b/packages/docs/src/pages/index.md
@@ -16,7 +16,7 @@ It is currently being applied to [HealthCare.gov](https://www.healthcare.gov/). 
 
 ## Getting started
 
-Get started by [downloading the code as a zip file](https://github.com/CMSgov/design-system/releases), [installing with NPM](/startup/installation/), or [downloading the Sketch UI kit](https://github.com/CMSgov/design-system/raw/master/design-assets/CMS-Design-System-UI-kit.sketch) for wireframes and prototypes.
+Get started by [downloading the code as a zip file](https://github.com/CMSgov/design-system/releases/latest), [installing with NPM](/startup/installation/), or [downloading the Sketch UI kit](https://github.com/CMSgov/design-system/raw/master/design-assets/CMS-Design-System-UI-kit.sketch) for wireframes and prototypes.
 
 ## Goals
 

--- a/packages/docs/src/pages/startup/installation.md
+++ b/packages/docs/src/pages/startup/installation.md
@@ -3,17 +3,17 @@ title: Install with NPM
 weight: 0
 ---
 
-The design system is available as NPM packages or via a <a href="https://github.com/CMSgov/design-system/releases">.zip download</a>.
+The design system is available as NPM packages or via a <a href="https://github.com/CMSgov/design-system/releases/latest">.zip download</a>.
 
 The design system consists of two packages which are installed separately.
 
 The [**core** package](https://www.npmjs.com/package/@cmsgov/design-system-core) includes the bulk of the design system:
 
-* Base styles
-* Utility classes
-* Sass/CSS and React components
-* Sass mixins and variables
-* Fonts and images
+- Base styles
+- Utility classes
+- Sass/CSS and React components
+- Sass mixins and variables
+- Fonts and images
 
 ```
 npm install --save @cmsgov/design-system-core
@@ -21,7 +21,7 @@ npm install --save @cmsgov/design-system-core
 
 The [**layout** package](https://www.npmjs.com/package/@cmsgov/design-system-layout) includes:
 
-* Responsive flexbox grid framework
+- Responsive flexbox grid framework
 
 ```
 npm install --save @cmsgov/design-system-layout

--- a/packages/docs/src/scripts/components/GitHubLinks.jsx
+++ b/packages/docs/src/scripts/components/GitHubLinks.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import githubUrl from '../shared/githubUrl';
 import pkg from '../../../package.json';
 
-const zipUrl = githubUrl(`archive/v${pkg.version}.zip`);
+const zipUrl = githubUrl(`releases/download/${pkg.version}/design-system-v${pkg.version}.zip`);
 
 const GitHubLinks = props => {
   const downloadBtnClassName = classNames(
@@ -13,14 +13,11 @@ const GitHubLinks = props => {
       'ds-u-display--block': props.vertical
     }
   );
-  const githubBtnClassName = classNames(
-    'ds-c-button ds-u-font-weight--normal',
-    {
-      'ds-u-margin-left--2': !props.vertical,
-      'ds-u-margin-top--2 ds-u-display--block': props.vertical,
-      'ds-c-button--inverse': props.inverse
-    }
-  );
+  const githubBtnClassName = classNames('ds-c-button ds-u-font-weight--normal', {
+    'ds-u-margin-left--2': !props.vertical,
+    'ds-u-margin-top--2 ds-u-display--block': props.vertical,
+    'ds-c-button--inverse': props.inverse
+  });
   return (
     <div className={props.className}>
       <a href={zipUrl} className={downloadBtnClassName}>


### PR DESCRIPTION
### Changed
The "download code and design files" button no longer uses the default source code zip file, it uses the following URL:
```
https://github.com/CMSgov/design-system/releases/download/3.4.2/design-system-v3.4.2.zip
```
From now on, each release should have a zip uploaded with build files named in the following format:
`design-system-v${pkg.version}.zip`