### PR TITLE
[WNMGDS-89] Use size prop

### DIFF
--- a/packages/core/src/components/ChoiceList/ChoiceList.jsx
+++ b/packages/core/src/components/ChoiceList/ChoiceList.jsx
@@ -234,6 +234,9 @@ ChoiceList.propTypes = {
    */
   onComponentBlur: PropTypes.func,
   onChange: PropTypes.func,
+  /**
+   * Sets the size of the checkbox or radio button
+   */
   size: PropTypes.oneOf(['small']),
   /**
    * You can manually set the `type` if you prefer things to be less magical.

--- a/packages/core/src/components/ChoiceList/ChoiceList.jsx
+++ b/packages/core/src/components/ChoiceList/ChoiceList.jsx
@@ -38,13 +38,13 @@ export class ChoiceList extends React.PureComponent {
         props.disabled = props.disabled || this.props.disabled;
         props.inversed = this.props.inversed;
         props.name = this.props.name;
-        props.onBlur =
-          (this.props.onBlur || this.props.onComponentBlur) && this.handleBlur;
+        props.onBlur = (this.props.onBlur || this.props.onComponentBlur) && this.handleBlur;
         props.onChange = this.props.onChange;
         props.type = type;
         props.inputRef = ref => {
           this.choiceRefs.push(ref);
         };
+        props.size = this.props.size;
       }
 
       return (
@@ -146,10 +146,7 @@ export class ChoiceList extends React.PureComponent {
 
   render() {
     const type = this.type();
-    const classes = classNames(
-      { 'ds-c-fieldset': type !== 'select' },
-      this.props.className
-    );
+    const classes = classNames({ 'ds-c-fieldset': type !== 'select' }, this.props.className);
     const RootComponent = type === 'select' ? 'div' : 'fieldset';
     const FormLabelComponent = type === 'select' ? 'label' : 'legend';
 
@@ -237,10 +234,7 @@ ChoiceList.propTypes = {
    */
   onComponentBlur: PropTypes.func,
   onChange: PropTypes.func,
-  /**
-   * If the component renders a select, set the max-width of the input either to `'small'` or `'medium'`.
-   */
-  size: PropTypes.oneOf(['small', 'medium']),
+  size: PropTypes.oneOf(['small']),
   /**
    * You can manually set the `type` if you prefer things to be less magical.
    * Otherwise, the type will be inferred by the other `props`, based


### PR DESCRIPTION
### Changed
Used `size` prop in `ChoiceList`, removed ability to pass in a 'medium' size value which only applied to  `Select`, which is currently deprecated and discouraged from use anyway