### PR TITLE
[WNMGDS-341] Misc Button fixes

### DIFF
--- a/packages/core/src/base/body.scss
+++ b/packages/core/src/base/body.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 @import '@cmsgov/design-system-support/src/settings/index';
 
 /*
@@ -37,3 +38,4 @@ Style guide: style.base
   background-color: $color-background-inverse;
   color: $color-base-inverse;
 }
+/* stylelint-enable */

--- a/packages/core/src/base/body.scss
+++ b/packages/core/src/base/body.scss
@@ -37,18 +37,5 @@ Style guide: style.base
   @extend %ds-base;
   background-color: $color-background-inverse;
   color: $color-base-inverse;
-  a {
-    color: $color-base-inverse;
-
-    &:visited,
-    &:active,
-    &:focus,
-    &:hover {
-      // :visited links can only style color, not opacity. This color styling is equivalent to:
-      // color: $color-base-inverse;
-      // opacity: 0.8;
-      color: #cfd5dc;
-    }
-  }
 }
 /* stylelint-enable */

--- a/packages/core/src/base/body.scss
+++ b/packages/core/src/base/body.scss
@@ -1,4 +1,3 @@
-/* stylelint-disable selector-class-pattern */
 @import '@cmsgov/design-system-support/src/settings/index';
 
 /*
@@ -38,4 +37,3 @@ Style guide: style.base
   background-color: $color-background-inverse;
   color: $color-base-inverse;
 }
-/* stylelint-enable */

--- a/packages/core/src/base/typography/link.scss
+++ b/packages/core/src/base/typography/link.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 @import '@cmsgov/design-system-support/src/settings/index';
 
 @if $ds-include-base-html-rulesets {
@@ -40,3 +41,4 @@
     color: #cfd5dc;
   }
 }
+/* stylelint-enable */

--- a/packages/core/src/base/typography/link.scss
+++ b/packages/core/src/base/typography/link.scss
@@ -24,3 +24,19 @@
     }
   }
 }
+
+// Change color of links that are descendants of .ds-base--inverse
+// Exclude <a> that are being styled as a button
+.ds-base--inverse a:not(.ds-u-button) {
+  color: $color-base-inverse;
+
+  &:visited,
+  &:active,
+  &:focus,
+  &:hover {
+    // :visited links can only style color, not opacity. This color styling is equivalent to:
+    // color: $color-base-inverse;
+    // opacity: 0.8;
+    color: #cfd5dc;
+  }
+}

--- a/packages/core/src/components/Button/Button.jsx
+++ b/packages/core/src/components/Button/Button.jsx
@@ -58,7 +58,7 @@ export class Button extends React.PureComponent {
 
   classNames() {
     const variationClass = this.props.variation && `ds-c-button--${this.props.variation}`;
-    const disabledClass = this.props.disabled && 'ds-c-button--disabled';
+    const disabledClass = this.props.disabled && this.props.href && 'ds-c-button--disabled';
     const sizeClass = this.props.size && `ds-c-button--${this.props.size}`;
     const inverseClass = this.props.inverse && 'ds-c-button--inverse';
 

--- a/packages/core/src/components/Button/Button.jsx
+++ b/packages/core/src/components/Button/Button.jsx
@@ -60,16 +60,7 @@ export class Button extends React.PureComponent {
     const variationClass = this.props.variation && `ds-c-button--${this.props.variation}`;
     const disabledClass = this.props.disabled && 'ds-c-button--disabled';
     const sizeClass = this.props.size && `ds-c-button--${this.props.size}`;
-    let inverseClass = this.props.inverse && 'ds-c-button--inverse';
-
-    // primary/danger/success variations don't need the inverse class
-    if (
-      this.props.variation === 'primary' ||
-      this.props.variation === 'danger' ||
-      this.props.variation === 'success'
-    ) {
-      inverseClass = '';
-    }
+    const inverseClass = this.props.inverse && 'ds-c-button--inverse';
 
     return classNames(
       'ds-c-button',

--- a/packages/core/src/components/Button/Button.scss
+++ b/packages/core/src/components/Button/Button.scss
@@ -44,6 +44,10 @@
   @include inline-icon;
 }
 
+/**
+ *  Size variants
+ */
+
 .ds-c-button--big {
   font-size: $h3-font-size;
   padding-bottom: $spacer-2;
@@ -56,6 +60,114 @@
   padding: $spacer-half $spacer-1;
 }
 
+.ds-c-button--transparent,
+.ds-c-button--transparent:visited,
+.ds-c-button--transparent-inverse,
+.ds-c-button--transparent-inverse:visited {
+  background-color: transparent;
+  border-color: transparent;
+  text-decoration: underline;
+
+  &:disabled,
+  &.ds-c-button--disabled {
+    background-color: transparent;
+    border-color: transparent;
+    color: $color-gray-lighter;
+  }
+
+  &:focus,
+  &:hover,
+  &:active,
+  &.ds-c-button--focus,
+  &.ds-c-button--hover,
+  &.ds-c-button--active {
+    border-color: transparent;
+  }
+}
+
+/**
+ *  Inverse buttons (mainly affects default and transparent buttons)
+ */
+.ds-c-button--inverse,
+.ds-c-button--inverse:visited {
+  background-color: $color-background-inverse;
+  border-color: $border-color-inverse;
+  color: $color-base-inverse;
+
+  &:focus,
+  &:hover,
+  &:active,
+  &.ds-c-button--focus,
+  &.ds-c-button--hover,
+  &.ds-c-button--active {
+    border-color: rgba($border-color-inverse, 0.8);
+    color: rgba($color-base-inverse, 0.8);
+  }
+
+  &:active,
+  &.ds-c-button--active {
+    border-color: rgba($border-color-inverse, 0.6);
+    color: rgba($color-base-inverse, 0.6);
+  }
+}
+
+/* Equivalent to ".ds-c-button--disabled-inverse" */
+.ds-c-button--inverse:disabled,
+.ds-c-button--inverse.ds-c-button--disabled {
+  background-color: darken($color-background-inverse, 10%);
+  border-color: darken($color-background-inverse, 10%);
+  color: $color-muted-inverse;
+  pointer-events: none;
+}
+
+/* Equivalent to ".ds-c-button--transparent-inverse" */
+.ds-c-button--inverse.ds-c-button--transparent,
+.ds-c-button--inverse.ds-c-button--transparent:visited {
+  border-color: $color-background-inverse;
+
+  &:disabled,
+  &:focus,
+  &:hover,
+  &:active,
+  &.ds-c-button--disabled,
+  &.ds-c-button--focus,
+  &.ds-c-button--hover,
+  &.ds-c-button--active {
+    border-color: $color-background-inverse;
+  }
+}
+
+/* stylelint-disable */
+.ds-c-button--transparent-inverse,
+.ds-c-button--transparent-inverse:visited {
+  @extend .ds-c-button--inverse;
+  border-color: $color-background-inverse;
+
+  &:disabled,
+  &:focus,
+  &:hover,
+  &:active,
+  &.ds-c-button--disabled,
+  &.ds-c-button--focus,
+  &.ds-c-button--hover,
+  &.ds-c-button--active {
+    border-color: $color-background-inverse;
+  }
+}
+
+.ds-c-button--disabled-inverse,
+.ds-c-button--disabled-inverse:visited {
+  @extend .ds-c-button--inverse;
+  background-color: darken($color-background-inverse, 10%);
+  border-color: darken($color-background-inverse, 10%);
+  color: $color-muted-inverse;
+  pointer-events: none;
+}
+/* stylelint-enable */
+
+/**
+ *  Status variants
+ */
 .ds-c-button--primary,
 .ds-c-button--primary:visited {
   background-color: $button-primary-bg;
@@ -157,112 +269,3 @@
     background-color: $color-success-darker;
   }
 }
-
-.ds-c-button--transparent,
-.ds-c-button--transparent:visited,
-.ds-c-button--transparent-inverse,
-.ds-c-button--transparent-inverse:visited {
-  background-color: transparent;
-  border-color: transparent;
-  text-decoration: underline;
-
-  &:disabled,
-  &.ds-c-button--disabled {
-    background-color: transparent;
-    border-color: transparent;
-    color: $color-gray-lighter;
-  }
-
-  &:focus,
-  &:hover,
-  &:active,
-  &.ds-c-button--focus,
-  &.ds-c-button--hover,
-  &.ds-c-button--active {
-    border-color: transparent;
-  }
-}
-
-/*
-Inverse buttons
-*/
-.ds-c-button--inverse,
-.ds-c-button--inverse:visited {
-  background-color: $color-background-inverse;
-  border-color: $border-color-inverse;
-  color: $color-base-inverse;
-
-  &:focus,
-  &:hover,
-  &:active,
-  &.ds-c-button--focus,
-  &.ds-c-button--hover,
-  &.ds-c-button--active {
-    color: $color-base-inverse;
-    opacity: 0.8;
-  }
-
-  &:active,
-  &.ds-c-button--active {
-    opacity: 0.6;
-  }
-}
-
-/*
-Equivalent to ".ds-c-button--disabled-inverse"
-*/
-.ds-c-button--inverse:disabled,
-.ds-c-button--inverse.ds-c-button--disabled {
-  background-color: darken($color-background-inverse, 10%);
-  border-color: darken($color-background-inverse, 10%);
-  color: $color-muted-inverse;
-  pointer-events: none;
-}
-
-/*
-Equivalent to ".ds-c-button--transparent-inverse"
-*/
-.ds-c-button--inverse.ds-c-button--transparent,
-.ds-c-button--inverse.ds-c-button--transparent:visited {
-  border-color: $color-background-inverse;
-
-  &:disabled,
-  &:focus,
-  &:hover,
-  &:active,
-  &.ds-c-button--disabled,
-  &.ds-c-button--focus,
-  &.ds-c-button--hover,
-  &.ds-c-button--active {
-    border-color: $color-background-inverse;
-  }
-}
-
-/* stylelint-disable */
-.ds-c-button--transparent-inverse,
-.ds-c-button--transparent-inverse:visited {
-  @extend .ds-c-button--inverse;
-  border-color: $color-background-inverse;
-
-  &:disabled,
-  &:focus,
-  &:hover,
-  &:active,
-  &.ds-c-button--disabled,
-  &.ds-c-button--focus,
-  &.ds-c-button--hover,
-  &.ds-c-button--active {
-    border-color: $color-background-inverse;
-  }
-}
-
-.ds-c-button--disabled-inverse,
-.ds-c-button--disabled-inverse:visited {
-  @extend .ds-c-button--inverse;
-  background-color: darken($color-background-inverse, 10%);
-  border-color: darken($color-background-inverse, 10%);
-  color: $color-muted-inverse;
-  pointer-events: none;
-}
-
-/* stylelint-enable */

--- a/packages/core/src/components/Button/Button.test.jsx
+++ b/packages/core/src/components/Button/Button.test.jsx
@@ -23,7 +23,7 @@ describe('Button', () => {
 
     expect(wrapper.text()).toBe(buttonText);
     expect(wrapper.prop('disabled')).toBe(disabled);
-    expect(wrapper.hasClass('ds-c-button--disabled')).toBe(disabled);
+    expect(wrapper.hasClass('ds-c-button--disabled')).toBe(false);
     expect(onClickMock.mock.calls.length).toBe(expectedCallCount);
   }
 
@@ -71,6 +71,16 @@ describe('Button', () => {
     expect(wrapper.render().text()).toBe(buttonText);
   });
 
+  it('renders disabled Link correctly', () => {
+    const props = {
+      href: 'javascript:void(0)',
+      disabled: true
+    };
+    const wrapper = shallow(<Button {...props}>Link button</Button>);
+    expect(wrapper.prop('disabled')).not.toBe(true);
+    expect(wrapper.hasClass('ds-c-button--disabled')).toBe(true);
+  });
+
   it('applies additional classes', () => {
     const props = { className: 'foobar' };
     const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
@@ -99,7 +109,7 @@ describe('Button', () => {
     const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
 
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
-    expect(wrapper.hasClass('ds-c-button--disabled')).toBe(true);
+    expect(wrapper.prop('disabled')).toBe(true);
   });
 
   it('applies disabled, inverse, and variation classes together', () => {
@@ -112,19 +122,8 @@ describe('Button', () => {
 
     expect(wrapper.hasClass('ds-c-button--transparent')).toBe(true);
     expect(wrapper.hasClass('ds-c-button--inverse')).toBe(true);
-    expect(wrapper.hasClass('ds-c-button--disabled')).toBe(true);
+    expect(wrapper.prop('disabled')).toBe(true);
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
-  });
-
-  it('doesnt apply inverse to primary/danger/success variations', () => {
-    const props = {
-      inverse: true,
-      variation: 'primary'
-    };
-    const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
-
-    expect(wrapper.hasClass('ds-c-button--inverse')).toBe(false);
-    expect(wrapper.hasClass('ds-c-button--primary')).toBe(true);
   });
 
   it('applies inverse to default/transparent variations', () => {

--- a/packages/core/src/components/Button/button.example.html
+++ b/packages/core/src/components/Button/button.example.html
@@ -80,10 +80,10 @@
 <h6 class="preview__label">Inverse buttons</h6>
 <div class="example--inverse">
   <button class="ds-c-button ds-c-button--inverse">Default</button>
-  <button class="ds-c-button ds-c-button--primary">Primary</button>
-  <button class="ds-c-button ds-c-button--danger">Danger</button>
-  <button class="ds-c-button ds-c-button--success">Success</button>
-  <button class="ds-c-button ds-c-button--transparent-inverse">
+  <button class="ds-c-button ds-c-button--inverse ds-c-button--primary">Primary</button>
+  <button class="ds-c-button ds-c-button--inverse ds-c-button--danger">Danger</button>
+  <button class="ds-c-button ds-c-button--inverse ds-c-button--success">Success</button>
+  <button class="ds-c-button ds-c-button--inverse ds-c-button--transparent">
     Transparent
   </button>
   <button disabled class="ds-c-button ds-c-button--inverse">

--- a/packages/docs/src/scripts/components/GitHubLinks.jsx
+++ b/packages/docs/src/scripts/components/GitHubLinks.jsx
@@ -1,3 +1,4 @@
+import { Button } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -7,25 +8,26 @@ import pkg from '../../../package.json';
 const zipUrl = githubUrl(`releases/download/${pkg.version}/design-system-v${pkg.version}.zip`);
 
 const GitHubLinks = props => {
-  const downloadBtnClassName = classNames(
-    'ds-c-button ds-c-button--primary ds-u-font-weight--normal',
-    {
-      'ds-u-display--block': props.vertical
-    }
-  );
-  const githubBtnClassName = classNames('ds-c-button ds-u-font-weight--normal', {
+  const downloadBtnClassName = classNames('ds-u-font-weight--normal', {
+    'ds-u-display--block': props.vertical
+  });
+  const githubBtnClassName = classNames('ds-u-font-weight--normal', {
     'ds-u-margin-left--2': !props.vertical,
-    'ds-u-margin-top--2 ds-u-display--block': props.vertical,
-    'ds-c-button--inverse': props.inverse
+    'ds-u-margin-top--2 ds-u-display--block': props.vertical
   });
   return (
     <div className={props.className}>
-      <a href={zipUrl} className={downloadBtnClassName}>
+      <Button
+        href={zipUrl}
+        inverse={props.inverse}
+        variation="primary"
+        className={downloadBtnClassName}
+      >
         Download code and design files
-      </a>
-      <a href={githubUrl()} className={githubBtnClassName}>
+      </Button>
+      <Button href={githubUrl()} inverse={props.inverse} className={githubBtnClassName}>
         View on GitHub
-      </a>
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
### Changed
- Allow the usage of `ds-u-button--inverse` with primary/success/danger variations

### Fixed
- Fix border color not styled correctly for inverse buttons
- Fix disabled styling for buttons using the `href` prop
- Use updated buttons on doc site GithubLinks
- Fix doc site GithubLink styling


