### PR TITLE
[NO-TICKET] Fix inverse disabled link button styling

### DIFF
--- a/packages/core/src/base/typography/link.scss
+++ b/packages/core/src/base/typography/link.scss
@@ -27,8 +27,7 @@
 }
 
 // Change color of links that are descendants of .ds-base--inverse
-// Exclude <a> that are being styled as a button
-.ds-base--inverse a:not(.ds-u-button) {
+.ds-base--inverse a {
   color: $color-base-inverse;
 
   &:visited,

--- a/packages/core/src/components/Button/Button.test.jsx
+++ b/packages/core/src/components/Button/Button.test.jsx
@@ -10,41 +10,19 @@ const Link = props => {
 describe('Button', () => {
   const buttonText = 'Foo';
 
-  function testDisabledState(disabled) {
-    const onClickMock = jest.fn();
-    const expectedCallCount = disabled ? 0 : 1;
-    const props = {
-      onClick: onClickMock,
-      disabled: disabled
-    };
-    const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
-
-    wrapper.simulate('click');
-
-    expect(wrapper.text()).toBe(buttonText);
-    expect(wrapper.prop('disabled')).toBe(disabled);
-    expect(wrapper.hasClass('ds-c-button--disabled')).toBe(false);
-    expect(onClickMock.mock.calls.length).toBe(expectedCallCount);
-  }
-
-  it('appears disabled', () => {
-    testDisabledState(true);
-  });
-
-  it('appears enabled', () => {
-    testDisabledState(false);
-  });
-
   it('renders as button', () => {
     const wrapper = shallow(<Button>{buttonText}</Button>);
     expect(wrapper.is('button')).toBe(true);
     expect(wrapper.prop('type')).toBe('button');
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('renders as submit button', () => {
     const props = { type: 'submit' };
     const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
+    expect(wrapper.is('button')).toBe(true);
     expect(wrapper.prop('type')).toBe('submit');
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('renders as an anchor with custom prop', () => {
@@ -58,6 +36,7 @@ describe('Button', () => {
     expect(wrapper.prop('href')).toBe('/example');
     expect(wrapper.prop('target')).toBe('_blank');
     expect(wrapper.prop('type')).toBeUndefined();
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('renders as a Link', () => {
@@ -69,6 +48,7 @@ describe('Button', () => {
     expect(wrapper.is('Link')).toBe(true);
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
     expect(wrapper.render().text()).toBe(buttonText);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('renders disabled Link correctly', () => {
@@ -79,6 +59,7 @@ describe('Button', () => {
     const wrapper = shallow(<Button {...props}>Link button</Button>);
     expect(wrapper.prop('disabled')).not.toBe(true);
     expect(wrapper.hasClass('ds-c-button--disabled')).toBe(true);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('applies additional classes', () => {
@@ -86,6 +67,7 @@ describe('Button', () => {
     const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
     expect(wrapper.hasClass('foobar')).toBe(true);
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('applies variation classes', () => {
@@ -94,6 +76,7 @@ describe('Button', () => {
 
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
     expect(wrapper.hasClass('ds-c-button--danger')).toBe(true);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('applies size classes', () => {
@@ -102,14 +85,20 @@ describe('Button', () => {
 
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
     expect(wrapper.hasClass('ds-c-button--small')).toBe(true);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('applies disabled class', () => {
-    const props = { disabled: true };
+    const onClick = jest.fn();
+    const disabled = true;
+    const props = { onClick, disabled };
     const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
+    wrapper.simulate('click');
 
-    expect(wrapper.hasClass('ds-c-button')).toBe(true);
-    expect(wrapper.prop('disabled')).toBe(true);
+    expect(wrapper.prop('disabled')).toBe(disabled);
+    expect(wrapper.hasClass('ds-c-button--disabled')).toBe(false);
+    expect(onClick.mock.calls.length).toBe(0);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('applies disabled, inverse, and variation classes together', () => {
@@ -124,6 +113,7 @@ describe('Button', () => {
     expect(wrapper.hasClass('ds-c-button--inverse')).toBe(true);
     expect(wrapper.prop('disabled')).toBe(true);
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('applies inverse to default/transparent variations', () => {
@@ -135,5 +125,6 @@ describe('Button', () => {
 
     expect(wrapper.hasClass('ds-c-button--inverse')).toBe(true);
     expect(wrapper.hasClass('ds-c-button--transparent')).toBe(true);
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/core/src/components/Button/__snapshots__/Button.test.jsx.snap
+++ b/packages/core/src/components/Button/__snapshots__/Button.test.jsx.snap
@@ -1,0 +1,104 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button applies additional classes 1`] = `
+<button
+  className="ds-c-button foobar"
+  type="button"
+>
+  Foo
+</button>
+`;
+
+exports[`Button applies disabled class 1`] = `
+<button
+  className="ds-c-button"
+  disabled={true}
+  onClick={[Function]}
+  type="button"
+>
+  Foo
+</button>
+`;
+
+exports[`Button applies disabled, inverse, and variation classes together 1`] = `
+<button
+  className="ds-c-button ds-c-button--transparent ds-c-button--inverse"
+  disabled={true}
+  type="button"
+>
+  Foo
+</button>
+`;
+
+exports[`Button applies inverse to default/transparent variations 1`] = `
+<button
+  className="ds-c-button ds-c-button--transparent ds-c-button--inverse"
+  type="button"
+>
+  Foo
+</button>
+`;
+
+exports[`Button applies size classes 1`] = `
+<button
+  className="ds-c-button ds-c-button--small"
+  type="button"
+>
+  Foo
+</button>
+`;
+
+exports[`Button applies variation classes 1`] = `
+<button
+  className="ds-c-button ds-c-button--danger"
+  type="button"
+>
+  Foo
+</button>
+`;
+
+exports[`Button renders as a Link 1`] = `
+<Link
+  className="ds-c-button"
+  type="submit"
+>
+  Foo
+</Link>
+`;
+
+exports[`Button renders as an anchor with custom prop 1`] = `
+<a
+  className="ds-c-button"
+  href="/example"
+  target="_blank"
+>
+  Foo
+</a>
+`;
+
+exports[`Button renders as button 1`] = `
+<button
+  className="ds-c-button"
+  type="button"
+>
+  Foo
+</button>
+`;
+
+exports[`Button renders as submit button 1`] = `
+<button
+  className="ds-c-button"
+  type="submit"
+>
+  Foo
+</button>
+`;
+
+exports[`Button renders disabled Link correctly 1`] = `
+<a
+  className="ds-c-button ds-c-button--disabled"
+  href="javascript:void(0)"
+>
+  Link button
+</a>
+`;


### PR DESCRIPTION
### Fixed
Previously a button with `inverse`, `disabled`, and an `href` prop would be styled incorrectly (color: white). Now it should look the same as a normal inverse disabled button. 

To test, add this code to `button.example.html` to test:
```
  <a href="https://www.google.com" class="ds-c-button ds-c-button--inverse ds-c-button--disabled">
    Disabled
  </a>
```