### PR TITLE
No ticket/background color utility page fix

### DIFF
--- a/packages/core/src/utilities/background-color/background-color.example.html
+++ b/packages/core/src/utilities/background-color/background-color.example.html
@@ -1,4 +1,3 @@
-<!-- prettier-ignore -->
 <div class="example--list">
   <% var groups = { 'Primary colors': ['primary', 'primary-darker', 'primary-darkest', 'black',
   'base', 'gray-dark', 'gray-light', 'white'], 'Secondary colors': ['primary-alt',
@@ -7,11 +6,11 @@
   'gray-lightest'], 'Status colors': ['success', 'success-light',
   'success-lighter','success-lightest', 'warn', 'warn-light', 'warn-lighter', 'warn-lightest',
   'error', 'error-dark', 'error-darkest', 'error-light', 'error-lighter','error-lightest'],
-  'Additional colors': ['muted-inverse', 'transparent'], }; -%> 
-  <% Object.keys(groups).forEach(fill => { -%>
+  'Additional colors': ['muted-inverse', 'transparent'], }; -%> <%
+  Object.keys(groups).forEach(function(fill){ -%>
   <section>
     <h1 class="preview__label"><%= fill%></h1>
-    <% groups[fill].forEach(color => { -%>
+    <% groups[fill].forEach(function(color){ -%>
     <article class="ds-u-margin-bottom--1">
       <div
         class="c-swatch__preview c-swatch__preview--condensed ds-u-radius--circle ds-u-fill--<%= color %>"

--- a/packages/core/src/utilities/background-color/background-color.example.html
+++ b/packages/core/src/utilities/background-color/background-color.example.html
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 <div class="example--list">
   <% var groups = { 'Primary colors': ['primary', 'primary-darker', 'primary-darkest', 'black',
   'base', 'gray-dark', 'gray-light', 'white'], 'Secondary colors': ['primary-alt',
@@ -6,8 +7,8 @@
   'gray-lightest'], 'Status colors': ['success', 'success-light',
   'success-lighter','success-lightest', 'warn', 'warn-light', 'warn-lighter', 'warn-lightest',
   'error', 'error-dark', 'error-darkest', 'error-light', 'error-lighter','error-lightest'],
-  'Additional colors': ['muted-inverse', 'transparent'], }; -%> <% Object.keys(groups).forEach(fill
-  => { -%>
+  'Additional colors': ['muted-inverse', 'transparent'], }; -%> 
+  <% Object.keys(groups).forEach(fill => { -%>
   <section>
     <h1 class="preview__label"><%= fill%></h1>
     <% groups[fill].forEach(color => { -%>


### PR DESCRIPTION
Noticed that when running locally I was getting an error on the background-color.example.html file.
Prettier was formatting the var block in a way that wasn't allowing it to render 

it was doing this, which was causing issues 
```
<% Object.keys(groups).forEach(fill
  => { -%>
```