### PR TITLE
[NO-TICKET] doc site update to usa flag path for header

### DIFF
--- a/packages/docs/src/scripts/components/UsaBanner.jsx
+++ b/packages/docs/src/scripts/components/UsaBanner.jsx
@@ -12,7 +12,7 @@ const UsaBanner = function(props) {
         <div className="ds-u-display--flex ds-u-flex-direction--row ds-u-align-items--start ds-u-sm-align-items--center">
           <img
             className="c-usa-banner__header-flag"
-            src="../../public/images/us_flag_small.png"
+            src="./public/images/us_flag_small.png"
             alt="U.S. flag"
           />
           <p className="c-usa-banner__header-text">

--- a/packages/docs/src/scripts/components/UsaBanner.jsx
+++ b/packages/docs/src/scripts/components/UsaBanner.jsx
@@ -37,7 +37,7 @@ const UsaBanner = function(props) {
           <div className="c-usa-banner__guidance ds-u-padding-right--0 ds-u-sm-padding-right--2">
             <img
               className="c-usa-banner__icon c-usa-banner__media-img"
-              src="/public/images/icon-dot-gov.svg"
+              src="./public/images/icon-dot-gov.svg"
               alt="Dot gov"
             />
             <p className="c-usa-banner__media-body">
@@ -49,7 +49,7 @@ const UsaBanner = function(props) {
           <div className="c-usa-banner__guidance ds-u-padding-top--2 ds-u-sm-padding-top--0">
             <img
               className="c-usa-banner__icon c-usa-banner__media-img"
-              src="/public/images/icon-https.svg"
+              src="./public/images/icon-https.svg"
               alt="Https"
             />
             <p className="c-usa-banner__media-body">

--- a/packages/docs/src/scripts/components/UsaBanner.jsx
+++ b/packages/docs/src/scripts/components/UsaBanner.jsx
@@ -12,7 +12,7 @@ const UsaBanner = function(props) {
         <div className="ds-u-display--flex ds-u-flex-direction--row ds-u-align-items--start ds-u-sm-align-items--center">
           <img
             className="c-usa-banner__header-flag"
-            src="/public/images/us_flag_small.png"
+            src="../../public/images/us_flag_small.png"
             alt="U.S. flag"
           />
           <p className="c-usa-banner__header-text">


### PR DESCRIPTION
I noticed when looking at the Medicare and Healthcare design system doc sites that the USA flag in the top banner is broken due to an incorrect reference.

This PR is to fix the broken USA flag in the USA banner for both medicare and healthcare doc sites 
https://github.cms.gov/pages/MedicareGov/ds-site-package/
https://github.cms.gov/pages/CMS-WDS/ds-healthcare-gov/


The path to the USA flag is currently
https://github.cms.gov/public/images/us_flag_small.png (which 404s)

and after the update, the path works as expected. 
https://github.cms.gov/pages/CMS-WDS/ds-healthcare-gov/public/images/us_flag_small.png