### PR TITLE
Fix gulp stats task

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint tools/ examples/**/src/ packages/**/src/ --ext .js --ext .jsx -f table && gulp lint --env=test --theme"
   },
   "devDependencies": {
+    "@cmsgov/design-system-core": "latest",
     "@cmsgov/eslint-config-design-system": "file:./packages/eslint-config-design-system",
     "@cmsgov/stylelint-config-design-system": "file:./packages/stylelint-config-design-system",
     "autoprefixer": "9.6.0",
@@ -53,7 +54,6 @@
     "eslint-config-nava": "^2.1.0",
     "front-matter": "^2.3.0",
     "generator-cmsgov": "file:./packages/generator-cmsgov",
-    "github": "^13.0.1",
     "glob": "7.1.4",
     "gulp": "^4.0.2",
     "gulp-babel": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bytes": "3.1.0",
     "chalk": "^2.4.2",
     "chromedriver": "80.0.1",
-    "cli-table": "^0.3.1",
+    "cli-table2": "^0.2.0",
     "colors": "1.3.3",
     "core-js": "^2.5.3",
     "cssnano": "4.1.10",

--- a/tools/gulp/stats/__tests__/getValues.test.js
+++ b/tools/gulp/stats/__tests__/getValues.test.js
@@ -10,28 +10,28 @@ describe('getValues', () => {
       current: {
         size: 10
       },
-      master: {
+      latest: {
         size: 25
       }
     };
   });
 
-  it('returns array of current value, master value, and difference between the two', () => {
+  it('returns array of current value, latest value, and difference between the two', () => {
     const values = getValues(retrievalMethod);
     expect(values).toEqual([
       stats.current.size,
-      stats.master.size,
-      colors.green(stats.current.size - stats.master.size)
+      stats.latest.size,
+      colors.green(stats.current.size - stats.latest.size)
     ]);
   });
 
-  it('colors difference with red when less than master value', () => {
+  it('colors difference with red when less than latest value', () => {
     const values = getValues(retrievalMethod, false);
-    expect(values[2]).toEqual(colors.red(stats.current.size - stats.master.size));
+    expect(values[2]).toEqual(colors.red(stats.current.size - stats.latest.size));
   });
 
   it('skips color when no difference', () => {
-    stats.master.size = stats.current.size;
+    stats.latest.size = stats.current.size;
     const values = getValues(retrievalMethod, false);
     expect(values[2]).toEqual(0);
   });

--- a/tools/gulp/stats/getValues.js
+++ b/tools/gulp/stats/getValues.js
@@ -1,14 +1,14 @@
 const colors = require('colors/safe');
 
 /**
- * Get value from each branch (current and master), and calculate the difference.
- * @param {Function} retrievalMethod - A method returning the value for the given branch
+ * Get value from current and latest release, and calculate the difference.
+ * @param {Function} retrievalMethod - A method returning the value for the given location
  * @param {Boolean} preferSmaller - Whether a negative difference is good or bad
  * @param {Function} diffMethod - Optional method for calculating the difference
- * @return {Array} [currentValue, masterValue, difference]
+ * @return {Array} [currentValue, latestValue, difference]
  */
 function getValues(retrievalMethod, preferSmaller = true, diffMethod) {
-  const values = ['current', 'master'].map(retrievalMethod);
+  const values = ['current', 'latest'].map(retrievalMethod);
   let diff = typeof diffMethod === 'function' ? diffMethod() : parseInt(values[0] - values[1]);
 
   if (parseInt(diff) > 0) {

--- a/tools/gulp/stats/stats.js
+++ b/tools/gulp/stats/stats.js
@@ -1,11 +1,9 @@
 /**
- * Analyze the transpiled files and compare against the files in the master
- * branch. This is a useful way to track the impact of any changes made in the
+ * Analyze the transpiled files and compare against the files in the latest release. This is a useful way to track the impact of any changes made in the
  * current branch, allowing us to track effects on filesize, specificity, etc.
  * This task assumes the file has already been transpiled, so it should be
  * preceded by other build tasks.
  */
-const GitHub = require('github');
 const Table = require('cli-table'); // cli-table2 is available and is a newer, forked version
 const _ = require('lodash');
 const argv = require('yargs').argv;
@@ -15,11 +13,6 @@ const dutil = require('../common/log-util');
 const fs = require('mz/fs');
 const getValues = require('./getValues');
 const path = require('path');
-
-const fontsDir = 'packages/core/fonts';
-const git = new GitHub();
-// repoParts[0] = Owner, repoParts[1] = Repo name
-const repoParts = require('../../../package.json').repository.split('/');
 
 /**
  * Creates an HTML file where a specificity graph can be viewed.
@@ -54,33 +47,30 @@ function createSpecificityGraph(stats, filename) {
 }
 
 /**
- * Retrieves a master branch file's content. Useful when comparing a file from
+ * Retrieves the latest release file's css. Useful when comparing a file from
  * the current branch to identify a change in a particular stat.
  */
-function getMasterContent(filepath) {
-  return git.repos
-    .getContent({
-      owner: repoParts[0],
-      repo: repoParts[1],
-      path: filepath
-    })
+function getLatestCSS() {
+  const latestPath = `node_modules/@cmsgov/design-system-core/dist/index.css`;
+  return fs
+    .readFile(latestPath, 'utf8')
     .catch(() => {
-      // Catch connection errors
-      dutil.logError('getMasterContent', 'Connection error. Skipping master branch stats.');
+      // Catch errors
+      dutil.logError('getLatestCSS', 'Skipping latest release stats.');
       return {};
     });
 }
 
 /**
- * Get the CSS stats from a file on the current branch as well as master branch.
+ * Get the CSS stats from a file on the current branch as well as latest release.
  * @param {string} cssPath - Path to the file to analyze, relative to project root
- * @param {boolean} skipmaster - Whether to also get stats for the file on the master branch
- * @return {Promise<{current, master}>}
+ * @param {boolean} skiplatest - Whether to also get stats for the file in the latest release
+ * @return {Promise<{current, latest}>}
  */
-function getCSSStats(cssPath, skipmaster = false) {
+function getCSSStats(cssPath, skiplatest = false) {
   const stats = {
     current: {},
-    master: {}
+    latest: {}
   };
 
   return fs
@@ -90,21 +80,20 @@ function getCSSStats(cssPath, skipmaster = false) {
       stats.current = data;
     })
     .then(() => {
-      // Conditionally check the file on the master branch. Allowing this step to
-      // be skipped enables us to run it on files that don't yet exist on master
-      if (!skipmaster) {
-        return getMasterContent(cssPath)
-          .then(response => Buffer.from(response.data.content, 'base64').toString())
+      // Conditionally check the file in the latest release. Allowing this step to
+      // be skipped enables us to run it on files that don't yet exist in the latest release
+      if (!skiplatest) {
+        return getLatestCSS()
           .then(css => cssstats(css))
           .then(data => {
-            stats.master = data;
+            stats.latest = data;
           })
           .catch(() => {
-            stats.master = stats.current;
+            stats.latest = stats.current;
           });
       } else {
-        dutil.logMessage('getCSSStats', 'Not checking against master branch');
-        stats.master = stats.current;
+        dutil.logMessage('getCSSStats', 'Not checking against latest release');
+        stats.latest = stats.current;
       }
     })
     .then(() => stats);
@@ -113,65 +102,56 @@ function getCSSStats(cssPath, skipmaster = false) {
 /**
  * @return {Promise} Resolves with the sum of all .woff2 file sizes
  */
-function getCurrentBranchFontSizes() {
-  const dir = path.resolve(__dirname, `../../../${fontsDir}`);
-
+function getFontSizes(fontDir) {
   return fs
-    .readdir(dir)
+    .readdir(fontDir)
     .then(files => {
       return Promise.all(
         // Array of .woff2 file sizes
         files
           .filter(name => name.match(/\.woff2$/))
           .map(name => {
-            return fs.stat(path.resolve(dir, name)).then(stats => stats.size);
+            return fs.stat(path.resolve(fontDir, name)).then(stats => stats.size);
           })
       );
     })
     .then(_.sum);
 }
 
-function getMasterBranchFontSizes() {
-  return getMasterContent(fontsDir)
-    .then(response => response.data.filter(e => e.name.match(/\.woff2$/))) // return .woff2 entries
-    .then(files => _.sumBy(files, 'size'))
-    .catch(() => 0);
-}
-
 /**
  * Output the CSS Stats to the CLI and create a specificity graph
- * @param {Object} branchStats - Current and master branch stats
+ * @param {Object} currentStats - Current and latest release stats
  * @param {String} filename - Name of the CSS file being analyzed
  * @return {Promise}
  */
-function logCSSStats(branchStats, filename) {
-  logCSSStatsTable(branchStats);
+function logCSSStats(currentStats, filename) {
+  logCSSStatsTable(currentStats);
 
-  return createSpecificityGraph(branchStats.current, filename).then(() => branchStats);
+  return createSpecificityGraph(currentStats.current, filename).then(() => currentStats);
 }
 
 /**
  * Log stats table to CLI
- * @param {Object} stats - Current and master branch stats
+ * @param {Object} stats - Current and latest release stats
  */
 function logCSSStatsTable(stats) {
   const table = new Table({
-    head: ['index.css', 'Current', 'Master', 'Diff', 'Description'],
+    head: ['index.css', 'Current', 'Latest', 'Diff', 'Description'],
     style: {
       head: ['cyan']
     }
   });
 
   const gzipValues = getValues(branch => stats[branch].humanizedGzipSize, true, () =>
-    bytes(stats.current.gzipSize - stats.master.gzipSize)
+    bytes(stats.current.gzipSize - stats.latest.gzipSize)
   );
 
   const sizeValues = getValues(branch => stats[branch].humanizedSize, true, () =>
-    bytes(stats.current.size - stats.master.size)
+    bytes(stats.current.size - stats.latest.size)
   );
 
   const fontSizeValues = getValues(branch => bytes(stats[branch].totalFontFileSize), true, () =>
-    bytes(stats.current.totalFontFileSize - stats.master.totalFontFileSize)
+    bytes(stats.current.totalFontFileSize - stats.latest.totalFontFileSize)
   );
 
   table.push(
@@ -247,9 +227,9 @@ over time as browser support improves`
 /**
  * Form an array of tabel row values
  * @param {String} label - Row label
- * @param {Array} values - Current and Master branch values, and their difference
+ * @param {Array} values - Current and latest release values, and their difference
  * @param {String} description
- * @return {Array} [label, currentValue, masterValue, difference, description]
+ * @return {Array} [label, currentValue, latestValue, difference, description]
  */
 function row(label, values, description) {
   const data = [label].concat(values);
@@ -259,44 +239,44 @@ function row(label, values, description) {
 
 // IMPORTANT: This needs to be called AFTER any method that relies on the
 // functions within the object.
-function saveCurrentCSSStats(branchStats, filename) {
+function saveCurrentCSSStats(currentStats, filename) {
   const outputPath = path.resolve(__dirname, '../../../tmp', `cssstats.${filename}.json`);
-  const body = JSON.stringify(branchStats.current);
+  const body = JSON.stringify(currentStats.current);
 
   return fs.writeFile(outputPath, body, 'utf8').then(() => {
     dutil.logMessage('cssstats', `Exported cssstats: ${outputPath}`);
-    return branchStats;
+    return currentStats;
   });
 }
 
 /**
  * Analyze the file sizes of all .woff2 font files and add to the stats object
- * @param {Object} branchStats - Current and master branch stats
+ * @param {Object} currentStats - Current and latest release stats
  * @return {Promise}
  */
-function setTotalFontFileSize(branchStats) {
-  return getCurrentBranchFontSizes()
+function setTotalFontFileSize(currentStats) {
+  const currentFontDir = path.resolve(__dirname, `../../../packages/core/fonts`);
+  const latestFontDir = 'node_modules/@cmsgov/design-system-core/fonts';
+  return getFontSizes(currentFontDir)
     .then(total => {
-      branchStats.current.totalFontFileSize = total;
+      currentStats.current.totalFontFileSize = total;
     })
-    .then(getMasterBranchFontSizes)
+    .then(() => getFontSizes(latestFontDir))
     .then(total => {
-      branchStats.master.totalFontFileSize = total;
+      currentStats.latest.totalFontFileSize = total;
     })
-    .then(() => branchStats);
+    .then(() => currentStats);
 }
 
 module.exports = gulp => {
   gulp.task('stats', () => {
-    dutil.logMessage('🔍 ', 'Gathering stats and comparing against master');
-    // Run CSSStats on another CSS file by running:
-    // yarn run gulp stats -- --path=foo/bar/path/file.css --skipmaster
+    dutil.logMessage('🔍 ', 'Gathering stats and comparing against the latest release');
     const cssPath = argv.path || 'packages/core/dist/index.css';
     const filename = path.parse(cssPath).name;
 
-    return getCSSStats(cssPath, argv.skipmaster)
+    return getCSSStats(cssPath, argv.skiplatest)
       .then(setTotalFontFileSize)
-      .then(branchStats => logCSSStats(branchStats, filename))
-      .then(branchStats => saveCurrentCSSStats(branchStats, filename));
+      .then(currentStats => logCSSStats(currentStats, filename))
+      .then(currentStats => saveCurrentCSSStats(currentStats, filename));
   });
 };

--- a/tools/gulp/stats/stats.js
+++ b/tools/gulp/stats/stats.js
@@ -4,7 +4,7 @@
  * This task assumes the file has already been transpiled, so it should be
  * preceded by other build tasks.
  */
-const Table = require('cli-table'); // cli-table2 is available and is a newer, forked version
+const Table = require('cli-table2');
 const _ = require('lodash');
 const argv = require('yargs').argv;
 const bytes = require('bytes');

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,6 +134,24 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@cmsgov/design-system-core@latest":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@cmsgov/design-system-core/-/design-system-core-3.6.0.tgz#1d280d8b799f925a267a47c1ef18c4d5c51908e2"
+  integrity sha512-zfDXuLH1vGXqyPp6kX/tjomT9yJAC7i1MicX5kZqHTjtc5aq2s6i3mYowKuNztvqSFbb1xEZxcjsSwvU0s8PCg==
+  dependencies:
+    "@cmsgov/design-system-support" "^3.6.0"
+    classnames "^2.2.5"
+    core-js "^2.5.3"
+    downshift "^3.2.10"
+    ev-emitter "^1.1.1"
+    lodash.uniqueid "^4.0.1"
+    react-aria-modal "^2.11.1"
+
+"@cmsgov/design-system-support@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@cmsgov/design-system-support/-/design-system-support-3.6.0.tgz#e4af0b14cad9e7e3b35966f8788704c5085088e6"
+  integrity sha512-8n354Wxp0LLtJ8IXZE0SCVrADIm7j14D6vgk3QOb2V0qnYf0oKZ2Taz1UfUfgHumhutSGB+trVcImR3qnsuSWg==
+
 "@cmsgov/eslint-config-design-system@file:./packages/eslint-config-design-system":
   version "1.3.0"
   dependencies:
@@ -520,13 +538,6 @@ after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
   integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
-
-agent-base@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
-  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
-  dependencies:
-    es6-promisify "^5.0.0"
 
 aggregate-error@^1.0.0:
   version "1.0.0"
@@ -2565,6 +2576,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-stack@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-1.3.0.tgz#9e821501ae979986c46b1d66d2d432db2fd4ae31"
@@ -2858,6 +2874,11 @@ component-inherit@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
   integrity sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
+
+compute-scroll-into-view@^1.0.9:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.13.tgz#be1b1663b0e3f56cd5f7713082549f562a3477e2"
+  integrity sha512-o+w9w7A98aAFi/GjK8cxSV+CdASuPa2rR5UWs3+yHkJzWqaKoBEufFNWYaXInCSmUfDCVhesG+v9MTWqOjsxFg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -3957,11 +3978,6 @@ dot-prop@^4.1.0, dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
-  integrity sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=
-
 downgrade-root@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/downgrade-root/-/downgrade-root-1.2.2.tgz#531319715b0e81ffcc22eb28478ba27643e12c6c"
@@ -3969,6 +3985,16 @@ downgrade-root@^1.0.0:
   dependencies:
     default-uid "^1.0.0"
     is-root "^1.0.0"
+
+downshift@^3.2.10:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.4.8.tgz#06b7ad9e9c423a58e8a9049b2a00a5d19c7ef954"
+  integrity sha512-dZL3iNL/LbpHNzUQAaVq/eTD1ocnGKKjbAl/848Q0KEp6t81LJbS37w3f93oD6gqqAnjdgM7Use36qZSipHXBw==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    compute-scroll-into-view "^1.0.9"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 duplexer2@0.0.2:
   version "0.0.2"
@@ -4330,17 +4356,10 @@ es6-iterator@^2.0.1, es6-iterator@^2.0.3, es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
-es6-promise@^4.0.3, es6-promise@^4.2.5:
+es6-promise@^4.2.5:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
-  dependencies:
-    es6-promise "^4.0.3"
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   version "3.1.3"
@@ -4615,6 +4634,11 @@ etag@1.8.1, etag@^1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+ev-emitter@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ev-emitter/-/ev-emitter-1.1.1.tgz#8f18b0ce5c76a5d18017f71c0a795c65b9138f2a"
+  integrity sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q==
 
 event-emitter@^0.3.5:
   version "0.3.5"
@@ -5223,6 +5247,20 @@ flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-trap-react@^3.0.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-3.1.4.tgz#e95f4aece5c493be4d3653dfccd5036d11ad24d5"
+  integrity sha512-uqMKMg9Xlny0LKHW0HqA7ncLafW57SxgeedjE7/Xt+NB7sdOBUG4eD/9sMsq1O0+7zD3palpniTs2n0PDLc3uA==
+  dependencies:
+    focus-trap "^2.0.1"
+
+focus-trap@^2.0.1:
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-2.4.6.tgz#332b475b317cec6a4a129f5307ce7ebc0da90b40"
+  integrity sha512-vWZTPtBU6pBoyWZDRZJHkXsyP2ZCZBHE3DRVXnSVdQKH/mcDtu9S5Kz8CUDyIqpfZfLEyI9rjKJLnc4Y40BRBg==
+  dependencies:
+    tabbable "^1.0.3"
+
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
@@ -5562,19 +5600,6 @@ github-username@^4.0.0:
   integrity sha1-y+KABBiDIG2kISrp5LXxacML9Bc=
   dependencies:
     gh-got "^6.0.0"
-
-github@^13.0.1:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/github/-/github-13.1.1.tgz#e4775be32c3a72e44d5cbec965dbeb8c0aac7c1f"
-  integrity sha512-BpItPaOCuvotnNUGXSSEDkB86eqQ7+k7j8/+lu5gbRmNnFPW/uQyFezH1fjy7XojieVNzD/+MgPhBngaw+Ocfw==
-  dependencies:
-    debug "^3.1.0"
-    dotenv "^4.0.0"
-    https-proxy-agent "^2.1.0"
-    is-stream "^1.1.0"
-    lodash "^4.17.4"
-    proxy-from-env "^1.0.0"
-    url-template "^2.0.8"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -6434,14 +6459,6 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
-
-https-proxy-agent@^2.1.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
-  integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
-  dependencies:
-    agent-base "^4.3.0"
-    debug "^3.1.0"
 
 humanize-string@^1.0.2:
   version "1.0.2"
@@ -8487,6 +8504,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
+lodash.uniqueid@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz#3268f26a7c88e4f4b1758d679271814e31fa5b26"
+  integrity sha1-MmjyanyI5PSxdY1nknGBTjH6WyY=
+
 lodash.upperfirst@4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
@@ -9194,6 +9216,11 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+no-scroll@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/no-scroll/-/no-scroll-2.1.1.tgz#f37e08cb159b75a5bdbfc0a87cd9223e120e6e27"
+  integrity sha512-YTzGAJOo/B6hkodeT5SKKHpOhAzjMfkUCCXjLJwjWk2F4/InIg+HbdH9kmT7bKpleDuqLZDTRy2OdNtAj0IVyQ==
 
 node-dir@^0.1.10:
   version "0.1.17"
@@ -10785,11 +10812,6 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
-proxy-from-env@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
-  integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
-
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -10974,6 +10996,20 @@ rc@^1.0.1, rc@^1.1.6:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-aria-modal@^2.11.1:
+  version "2.12.3"
+  resolved "https://registry.yarnpkg.com/react-aria-modal/-/react-aria-modal-2.12.3.tgz#6d8ea702c96682418d4cd1bf84f1b03fcc2dc36a"
+  integrity sha512-XIsB9mFRJe5c4MJ/CIZPRci6ZTEEWzUSRslM63rxwCFAV0HbC8KkaSlA2CtvwYmMwVd+lAsGDN7yUtOQXOGkQQ==
+  dependencies:
+    focus-trap-react "^3.0.4"
+    no-scroll "^2.0.0"
+    react-displace "^2.3.0"
+
+react-displace@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-displace/-/react-displace-2.3.0.tgz#6915f8f2f279a29a7b58442405c26edc3d441429"
+  integrity sha512-T8g/lyn3IX8kxLO4k4vJ/oIO9G72pRTc9GYslqKsfPcN4gY5+FYR5OHxeTH1skPjVylJrveGE3OC2qCt3BuHeA==
 
 react-docgen@4.1.1:
   version "4.1.1"
@@ -12792,6 +12828,11 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+tabbable@^1.0.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-1.1.3.tgz#0e4ee376f3631e42d7977a074dbd2b3827843081"
+  integrity sha512-nOWwx35/JuDI4ONuF0ZTo6lYvI0fY0tZCH1ErzY2EXfu4az50ZyiUX8X073FLiZtmWUVlkRnuXsehjJgCw9tYg==
+
 table@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
@@ -13531,11 +13572,6 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
-
-url-template@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
-  integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
 
 url-to-options@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,6 +2615,16 @@ cli-list@^0.2.0:
   resolved "https://registry.yarnpkg.com/cli-list/-/cli-list-0.2.0.tgz#7e673ee0dd39a611a486476e53f3c6b3941cb582"
   integrity sha1-fmc+4N05phGkhkduU/PGs5QctYI=
 
+cli-table2@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/cli-table2/-/cli-table2-0.2.0.tgz#2d1ef7f218a0e786e214540562d4bd177fe32d97"
+  integrity sha1-LR738hig54biFFQFYtS9F3/jLZc=
+  dependencies:
+    lodash "^3.10.1"
+    string-width "^1.0.1"
+  optionalDependencies:
+    colors "^1.1.2"
+
 cli-table@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
@@ -2814,6 +2824,11 @@ colors@1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
   integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
+
+colors@^1.1.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 columnify@^1.5.4:
   version "1.5.4"
@@ -8518,6 +8533,11 @@ lodash@4.17.15, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11,
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Summary 
Ever since we removed the `dist` folder from Github, our `stats` task is unable to compare the css using the Github repo, so it has not been working properly. This PR updates the task to compare with the latest `@cmsgov/design-system-core` release in `node-modules`. It also simplifies the task to only support running stats on the entire css bundle, and not on a specific file. I removed this feature because I figured it's better to make the gulp task simpler and easier to maintain than to support a use case we current aren't even using.

One downside is that `@cmsgov/design-system-core@latest` is a new dev dependency, and we will need to do a `yarn install` after each release for accurate stats (I believe we do this anyway during releases)

### How to test
- Install gulp globally if you have not already
- Run `gulp stats`
- Add a bunch of new css that will increase the bundle size or increase specificity of a selector
- Run it again to see the difference 

