### PR TITLE
[NO-TICKET] Remove unnecessary core js imports

### DIFF
--- a/packages/core/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/core/src/components/Autocomplete/Autocomplete.jsx
@@ -14,7 +14,6 @@
  * an unacceptable regression of the user experience.
  */
 
-import 'core-js/fn/array/find';
 import Button from '../Button/Button';
 import Downshift from 'downshift';
 import PropTypes from 'prop-types';

--- a/packages/core/src/components/MonthPicker/MonthPicker.jsx
+++ b/packages/core/src/components/MonthPicker/MonthPicker.jsx
@@ -1,4 +1,3 @@
-import 'core-js/fn/array/includes';
 import Button from '../Button/Button';
 import Choice from '../ChoiceList/Choice';
 import FormLabel from '../FormLabel/FormLabel';

--- a/packages/core/src/components/Tabs/Tabs.jsx
+++ b/packages/core/src/components/Tabs/Tabs.jsx
@@ -1,4 +1,3 @@
-import 'core-js/fn/array/find-index';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Tab from './Tab';

--- a/packages/core/src/components/TextField/Mask.jsx
+++ b/packages/core/src/components/TextField/Mask.jsx
@@ -1,4 +1,3 @@
-import 'core-js/fn/array/includes';
 import PropTypes from 'prop-types';
 import React from 'react';
 


### PR DESCRIPTION
### Summary
Our babel uses `corejs@3`, so this PR removes a few unnecessary imports