### PR TITLE
[WNMGDS-427] Update Download SVG links for Style Icons

### DIFF
--- a/packages/design-system/src/styles/icons/interaction-icons.example.html
+++ b/packages/design-system/src/styles/icons/interaction-icons.example.html
@@ -5,7 +5,7 @@
     <span class="icon-container <%= icon %>"></span
     ><span class="icon-text"
       ><%= icon %> |
-      <a href="{{root}}/public/images/<%= icon%>.svg" target="_blank">Download SVG</a></span
+      <a href="{{root}}/public/images/<%= icon%>.svg" download>Download SVG</a></span
     >
   </div>
   <% }) -%>

--- a/packages/design-system/src/styles/icons/status-icons.example.html
+++ b/packages/design-system/src/styles/icons/status-icons.example.html
@@ -5,7 +5,7 @@
     <span class="icon-container <%= icon %>"></span
     ><span class="icon-text"
       ><%= icon %> |
-      <a href="{{root}}/public/images/<%= icon%>.svg" target="_blank">Download SVG</a></span
+      <a href="{{root}}/public/images/<%= icon%>.svg" download>Download SVG</a></span
     >
   </div>
   <% }) -%>

--- a/packages/design-system/src/styles/icons/supplemental-icons.example.html
+++ b/packages/design-system/src/styles/icons/supplemental-icons.example.html
@@ -6,7 +6,7 @@
     <span class="icon-container <%= icon %>"></span
     ><span class="icon-text"
       ><%= icon %> |
-      <a href="{{root}}/public/images/<%= icon%>.svg" target="_blank">Download SVG</a></span
+      <a href="{{root}}/public/images/<%= icon%>.svg" download>Download SVG</a></span
     >
   </div>
   <% }) -%>


### PR DESCRIPTION
### Changed
* Add download attribute to specify that the icon will be downloaded when user clicks on the Download SVG link

### How to test
* Style Icons page - Ensure the style icon is downloaded when the user clicks on the Download SVG link
