### PR TITLE
Remove `focusTrigger` prop from basic Autocomplete example

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.example.jsx
@@ -40,7 +40,6 @@ ReactDOM.render(
           name: 'Cook County, OR'
         }
       ]}
-      focusTrigger
       label="Select from the options below:"
       onChange={selectedItem => console.log(selectedItem)}
       onInputValueChange={inputVal => console.log('[Autocomplete]: ' + inputVal)}

--- a/packages/design-system/src/components/Autocomplete/_Autocomplete.docs.scss
+++ b/packages/design-system/src/components/Autocomplete/_Autocomplete.docs.scss
@@ -44,7 +44,7 @@ Style guide: components.autocomplete.react
 ### Focus Management
 
 - `<Autocomplete>` has a new Boolean prop called `focusTrigger`. Adding this prop will set keyboard focus on the internal `<Textfield>`. Focus is set immediately when the `componentDidMount()` lifecycle method fires.
-- This is useful when components are added dynamically, after the application has been rendered. All major screen readers (JAWS, NVDA, VoiceOver) have been tested with this feature, and announce the new input correctly.
+- In most cases, this isn't needed. It's useful when components are added dynamically, after the application has been rendered. All major screen readers (JAWS, NVDA, VoiceOver) have been tested with this feature, and announce the new input correctly.
 - Instances that contain the `focusTrigger` prop may fire Downshift's [onInputValueChange](https://github.com/paypal/downshift#oninputvaluechange) method, causing the `inputValue` to be set back to an empty string. In these cases, you may want to access Downshift's [state reducer](https://github.com/paypal/downshift#statereducer) and manage your component's local state for `blur` and `click` events.
 
 Style guide: components.autocomplete.guidance


### PR DESCRIPTION
## Changed
- Remove `focusTrigger` prop for basic example. This isn't needed for this example.
- Update docs in Autocomplete for better guidance around `focusTrigger`

See: #667 

