### PR TITLE
[WNMGDS-354] Collapse React prop documentation table on small screens

### DIFF
--- a/packages/docs/src/scripts/components/ReactPropDoc.jsx
+++ b/packages/docs/src/scripts/components/ReactPropDoc.jsx
@@ -71,15 +71,15 @@ class ReactPropDoc extends React.PureComponent {
   render() {
     return (
       <tr>
-        <td>
+        <td data-title="Name">
           <code className="ds-u-font-weight--bold">{this.props.name}</code>
           {this.isRequired()}
         </td>
-        <td>
+        <td data-title="Type">
           <code>{this.type()}</code>
         </td>
-        <td>{this.defaultValue()}</td>
-        <td>{this.description()}</td>
+        <td data-title="Default">{this.defaultValue()}</td>
+        <td data-title="Description">{this.description()}</td>
       </tr>
     );
   }

--- a/packages/docs/src/scripts/components/ReactPropDoc.jsx
+++ b/packages/docs/src/scripts/components/ReactPropDoc.jsx
@@ -69,6 +69,7 @@ class ReactPropDoc extends React.PureComponent {
   }
 
   render() {
+    // Specify ARIA roles attribute for table to make responsive HTML table accessible to screen readers
     return (
       <tr role="row">
         <td role="cell" headers="columnname">

--- a/packages/docs/src/scripts/components/ReactPropDoc.jsx
+++ b/packages/docs/src/scripts/components/ReactPropDoc.jsx
@@ -13,7 +13,7 @@ class ReactPropDoc extends React.PureComponent {
 
   description() {
     if (this.props.description) {
-      return <div dangerouslySetInnerHTML={{ __html: this.props.description }} />;
+      return <span dangerouslySetInnerHTML={{ __html: this.props.description }} />;
     }
   }
 
@@ -70,16 +70,36 @@ class ReactPropDoc extends React.PureComponent {
 
   render() {
     return (
-      <tr>
-        <td data-title="Name">
+      <tr role="row">
+        <td role="cell" headers="columnname">
+          <span className="docs_table__column-header ds-u-font-weight--bold" aria-hidden="true">
+            Name
+            <br />
+          </span>
           <code className="ds-u-font-weight--bold">{this.props.name}</code>
           {this.isRequired()}
         </td>
-        <td data-title="Type">
+        <td role="cell" headers="columntype">
+          <span className="docs_table__column-header ds-u-font-weight--bold" aria-hidden="true">
+            Type
+            <br />
+          </span>
           <code>{this.type()}</code>
         </td>
-        <td data-title="Default">{this.defaultValue()}</td>
-        <td data-title="Description">{this.description()}</td>
+        <td role="cell" headers="columndefault">
+          <span className="docs_table__column-header ds-u-font-weight--bold" aria-hidden="true">
+            Default
+            <br />
+          </span>
+          {this.defaultValue()}
+        </td>
+        <td role="cell" headers="columndescription">
+          <span className="docs_table__column-header ds-u-font-weight--bold" aria-hidden="true">
+            Description
+            <br />
+          </span>
+          {this.description()}
+        </td>
       </tr>
     );
   }

--- a/packages/docs/src/scripts/components/ReactPropDocs.jsx
+++ b/packages/docs/src/scripts/components/ReactPropDocs.jsx
@@ -21,14 +21,27 @@ class ReactPropDocs extends React.PureComponent {
   render() {
     return [
       <h3 key="propDocsHeader">Props</h3>,
-      <div key="propDocsTable" className="docs_table--wrapper">
-        <table className="ds-c-table ds-c-table--borderless docs_table">
+      <div key="propDocsTable" className="docs_table--container">
+        <table className="ds-c-table ds-c-table--borderless docs_table" role="table">
+          <caption>
+            <span className="ds-u-padding--1 ds-u-visibility--screen-reader">
+              React Properties Documentation
+            </span>
+          </caption>
           <thead>
-            <tr>
-              <th scope="col">Type</th>
-              <th scope="col">Name</th>
-              <th scope="col">Default</th>
-              <th scope="col">Description</th>
+            <tr role="row">
+              <th id="columnname" role="columnheader" scope="col">
+                Name
+              </th>
+              <th id="columntype" role="columnheader" scope="col">
+                Type
+              </th>
+              <th id="columndefault" role="columnheader" scope="col">
+                Default
+              </th>
+              <th id="columndescription" role="columnheader" scope="col">
+                Description
+              </th>
             </tr>
           </thead>
           <tbody>{this.rows()}</tbody>

--- a/packages/docs/src/scripts/components/ReactPropDocs.jsx
+++ b/packages/docs/src/scripts/components/ReactPropDocs.jsx
@@ -22,13 +22,13 @@ class ReactPropDocs extends React.PureComponent {
     return [
       <h3 key="propDocsHeader">Props</h3>,
       <div key="propDocsTable" className="docs_table--wrapper">
-        <table className="ds-c-table docs_table">
+        <table className="ds-c-table ds-c-table--borderless docs_table">
           <thead>
             <tr>
-              <th>Name</th>
-              <th>Type</th>
-              <th>Default</th>
-              <th>Description</th>
+              <th scope="col">Type</th>
+              <th scope="col">Name</th>
+              <th scope="col">Default</th>
+              <th scope="col">Description</th>
             </tr>
           </thead>
           <tbody>{this.rows()}</tbody>

--- a/packages/docs/src/scripts/components/ReactPropDocs.jsx
+++ b/packages/docs/src/scripts/components/ReactPropDocs.jsx
@@ -21,17 +21,19 @@ class ReactPropDocs extends React.PureComponent {
   render() {
     return [
       <h3 key="propDocsHeader">Props</h3>,
-      <table key="propDocsTable" className="ds-c-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Default</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>{this.rows()}</tbody>
-      </table>
+      <div key="propDocsTable" className="docs_table--wrapper">
+        <table className="ds-c-table docs_table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Default</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>{this.rows()}</tbody>
+        </table>
+      </div>
     ];
   }
 }

--- a/packages/docs/src/scripts/components/ReactPropDocs.jsx
+++ b/packages/docs/src/scripts/components/ReactPropDocs.jsx
@@ -19,6 +19,7 @@ class ReactPropDocs extends React.PureComponent {
   }
 
   render() {
+    // Specify ARIA roles attribute for table to make responsive HTML table accessible to screen readers
     return [
       <h3 key="propDocsHeader">Props</h3>,
       <div key="propDocsTable" className="docs_table--container">

--- a/packages/docs/src/styles/components/_ReactPropDocs.scss
+++ b/packages/docs/src/styles/components/_ReactPropDocs.scss
@@ -3,3 +3,52 @@
 .docs_table--wrapper {
   overflow-x: auto;
 }
+
+.docs_table {
+  @media (max-width: $width-sm) {
+    table,
+    thead,
+    tbody,
+    th,
+    td,
+    tr {
+      display: block;
+    }
+
+    /* Hide table headers (.ds-u-visibility--screen-reader) */
+    thead tr {
+      border: 0;
+      clip: rect(0, 0, 0, 0);
+      height: 1px;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      width: 1px;
+      // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1241631
+      word-wrap: normal;
+    }
+
+    td {
+      border: 1px solid $color-gray;
+      margin-top: -1px;
+      min-height: 1.5em;
+      padding-left: 40%;
+      position: relative;
+      word-break: break-word;
+    }
+
+    tr:first-child {
+      border-top: 1px solid $color-gray;
+    }
+
+    td::before {
+      content: attr(data-title);
+      font-weight: $font-bold;
+      left: 0;
+      padding-left: 6px;
+      padding-right: 5%;
+      position: absolute;
+      width: 30%;
+    }
+  }
+}

--- a/packages/docs/src/styles/components/_ReactPropDocs.scss
+++ b/packages/docs/src/styles/components/_ReactPropDocs.scss
@@ -1,0 +1,5 @@
+// Responsive docs table
+
+.docs_table--wrapper {
+  overflow-x: auto;
+}

--- a/packages/docs/src/styles/components/_ReactPropDocs.scss
+++ b/packages/docs/src/styles/components/_ReactPropDocs.scss
@@ -1,12 +1,19 @@
 // Responsive docs table
 
-.docs_table--wrapper {
+.docs_table--container {
   overflow-x: auto;
 }
 
 .docs_table {
+  @media (min-width: $width-sm) {
+    /* Hide individual cell heading */
+    tbody .docs_table__column-header {
+      display: none;
+    }
+  }
+
   @media (max-width: $width-sm) {
-    thead {
+    thead tr {
       /* Hide table headers (.ds-u-visibility--screen-reader) */
       border: 0;
       clip: rect(0, 0, 0, 0);
@@ -26,9 +33,9 @@
     }
 
     td {
-      border-top: 1px solid $color-gray-lightest;
+      border: 0;
+      border-top: 1px solid $color-gray-lighter;
       display: block;
-      margin-top: -1px;
       word-break: break-word;
     }
 
@@ -38,13 +45,10 @@
 
     td:first-child {
       background-color: $color-gray-lightest;
-      border-top: 1px solid $color-gray;
     }
 
-    td::before {
-      content: attr(data-title) '\00000A';
-      font-weight: $font-bold;
-      white-space: pre-wrap;
+    td::before .docs_table__column-header {
+      display: block;
     }
   }
 }

--- a/packages/docs/src/styles/components/_ReactPropDocs.scss
+++ b/packages/docs/src/styles/components/_ReactPropDocs.scss
@@ -37,17 +37,26 @@
       word-break: break-word;
     }
 
+    tr {
+      margin: 0 0 0.5rem;
+    }
+
     tr:first-child {
       border-top: 1px solid $color-gray;
     }
 
     td::before {
+      background-color: $color-gray-lightest;
+      border-right: 1px solid $color-gray;
+      bottom: 0;
       content: attr(data-title);
       font-weight: $font-bold;
       left: 0;
       padding-left: 6px;
       padding-right: 5%;
+      padding-top: 18px;
       position: absolute;
+      top: 0;
       width: 30%;
     }
   }

--- a/packages/docs/src/styles/components/_ReactPropDocs.scss
+++ b/packages/docs/src/styles/components/_ReactPropDocs.scss
@@ -6,17 +6,8 @@
 
 .docs_table {
   @media (max-width: $width-sm) {
-    table,
-    thead,
-    tbody,
-    th,
-    td,
-    tr {
-      display: block;
-    }
-
-    /* Hide table headers (.ds-u-visibility--screen-reader) */
-    thead tr {
+    thead {
+      /* Hide table headers (.ds-u-visibility--screen-reader) */
       border: 0;
       clip: rect(0, 0, 0, 0);
       height: 1px;
@@ -28,36 +19,32 @@
       word-wrap: normal;
     }
 
-    td {
-      border: 1px solid $color-gray;
-      margin-top: -1px;
-      min-height: 1.5em;
-      padding-left: 40%;
-      position: relative;
-      word-break: break-word;
-    }
-
     tr {
+      border: 1px solid $color-gray;
+      display: block;
       margin: 0 0 0.5rem;
     }
 
-    tr:first-child {
+    td {
+      border-top: 1px solid $color-gray-lightest;
+      display: block;
+      margin-top: -1px;
+      word-break: break-word;
+    }
+
+    td:last-child {
+      border-bottom: 0;
+    }
+
+    td:first-child {
+      background-color: $color-gray-lightest;
       border-top: 1px solid $color-gray;
     }
 
     td::before {
-      background-color: $color-gray-lightest;
-      border-right: 1px solid $color-gray;
-      bottom: 0;
-      content: attr(data-title);
+      content: attr(data-title) '\00000A';
       font-weight: $font-bold;
-      left: 0;
-      padding-left: 6px;
-      padding-right: 5%;
-      padding-top: 18px;
-      position: absolute;
-      top: 0;
-      width: 30%;
+      white-space: pre-wrap;
     }
   }
 }

--- a/packages/docs/src/styles/docs.scss
+++ b/packages/docs/src/styles/docs.scss
@@ -27,6 +27,7 @@
 @import 'components/Frame';
 @import 'components/Header';
 @import 'components/UsaBanner';
+@import 'components/ReactPropDocs';
 
 // Utilities
 @import 'utilities/colors';


### PR DESCRIPTION
The React props documentation table for some components (i.e. Autocomplete, Date field, Vertical Nav) can get wider than the page. This PR explores the options to compact the table and add horizontal scrolling. 

### Changed
Update React props documentation table to:
- include horizontal scrolling when the table is wider than the page width
- be responsive on small screens (width <= 544px) and reformat the table to a row layout for each prop with it's corresponding title

### How to test
- Select a component and ensure that horizontal scrolling is enabled when the screen width is narrower than the table width
- Continue reducing the screen width, on small screen width, check that the table is reformatted to display each React prop with a card layout
- Accessibility test - check that screen reader can recognize the reformatted table on small screen width

