### PR TITLE
[WNMGDS-350] Add autoComplete prop to Date field component

### DIFF
--- a/packages/design-system-docs/src/pages/components/DateField/DateField.example.jsx
+++ b/packages/design-system-docs/src/pages/components/DateField/DateField.example.jsx
@@ -44,6 +44,20 @@ ReactDOM.render(
       yearInvalid
     />
     <ControlledDateField />
+    <fieldset className="ds-u-margin-top--3 ds-u-padding-left--3 ds-u-padding-bottom--3 ds-u-border--2">
+      <legend className="ds-u-font-size--h3">Autocomplete Example</legend>
+      <DateField
+        label={
+          <span>
+            DateField using <code>autoComplete</code> for a date of birth
+          </span>
+        }
+        autoComplete
+        monthName="dob-month"
+        dayName="dob-day"
+        yearName="dob-year"
+      />
+    </fieldset>
   </Fragment>,
   document.getElementById('js-example')
 );

--- a/packages/design-system-docs/src/pages/components/DateField/DateField.example.jsx
+++ b/packages/design-system-docs/src/pages/components/DateField/DateField.example.jsx
@@ -44,20 +44,6 @@ ReactDOM.render(
       yearInvalid
     />
     <ControlledDateField />
-    <fieldset className="ds-u-margin-top--3 ds-u-padding-left--3 ds-u-padding-bottom--3 ds-u-border--2">
-      <legend className="ds-u-font-size--h3">Autocomplete Example</legend>
-      <DateField
-        label={
-          <span>
-            DateField using <code>autoComplete</code> for a date of birth
-          </span>
-        }
-        autoComplete
-        monthName="dob-month"
-        dayName="dob-day"
-        yearName="dob-year"
-      />
-    </fieldset>
   </Fragment>,
   document.getElementById('js-example')
 );

--- a/packages/design-system/src/scripts/components/DateField/DateField.jsx
+++ b/packages/design-system/src/scripts/components/DateField/DateField.jsx
@@ -170,7 +170,7 @@ DateField.defaultProps = {
 
 DateField.propTypes = {
   /**
-   * Controls autocomplete attributes `bday-day`, `bday-month` and `bday-year` 
+   * Adds `autocomplete` attributes `bday-day`, `bday-month` and `bday-year` to the corresponding `<DateField>` inputs
    */
   autoComplete: PropTypes.bool,
   /**

--- a/packages/design-system/src/scripts/components/DateField/DateField.jsx
+++ b/packages/design-system/src/scripts/components/DateField/DateField.jsx
@@ -114,6 +114,7 @@ export class DateField extends React.PureComponent {
             name={this.props.monthName}
             value={this.props.monthValue}
             aria-describedby={labelId}
+            autoComplete={this.props.autoComplete && 'bday-month'}
           />
           <span className="ds-c-datefield__separator">/</span>
           <TextField
@@ -130,6 +131,7 @@ export class DateField extends React.PureComponent {
             name={this.props.dayName}
             value={this.props.dayValue}
             aria-describedby={labelId}
+            autoComplete={this.props.autoComplete && 'bday-day'}
           />
           <span className="ds-c-datefield__separator">/</span>
           <TextField
@@ -146,6 +148,7 @@ export class DateField extends React.PureComponent {
             name={this.props.yearName}
             value={this.props.yearValue}
             aria-describedby={labelId}
+            autoComplete={this.props.autoComplete && 'bday-year'}
           />
         </div>
       </fieldset>
@@ -166,6 +169,10 @@ DateField.defaultProps = {
 };
 
 DateField.propTypes = {
+  /**
+   * Controls autocomplete attributes `bday-day`, `bday-month` and `bday-year` 
+   */
+  autoComplete: PropTypes.bool,
   /**
    * Optional method to format the `input` field values. If this
    * method is provided, the returned value will be passed as a second argument


### PR DESCRIPTION
Add autoComplete prop to Date field component to enable autofill of birthday day, month and year.

### Changed
- New `autoComplete` prop to set the `autocomplete` attribute on the date fields to `bday-day`, `bday-month` and `bday-year`.

### How to test
Go to Components "Date field" page and check React props table for `autoComplete` prop

[https://github.com/CMSgov/design-system/issues/565]
[https://design-system.service.gov.uk/components/date-input/] 
