### PR TITLE
[WNMGDS-483] Fix currency mask for Firefox

### DIFF
--- a/packages/design-system-docs/src/pages/components/TextField/Mask.example.jsx
+++ b/packages/design-system-docs/src/pages/components/TextField/Mask.example.jsx
@@ -12,7 +12,7 @@ class ControlledCurrencyField extends React.PureComponent {
     super(props);
 
     this.state = {
-      currencyValue: '2,500',
+      currencyValue: '2500',
     };
   }
 

--- a/packages/design-system-docs/src/pages/components/TextField/Mask.example.jsx
+++ b/packages/design-system-docs/src/pages/components/TextField/Mask.example.jsx
@@ -12,7 +12,7 @@ class ControlledCurrencyField extends React.PureComponent {
     super(props);
 
     this.state = {
-      currencyValue: '2500',
+      currencyValue: '2,500',
     };
   }
 
@@ -56,11 +56,10 @@ const Example = () => {
         label="Currency"
         mask="currency"
         inputMode="numeric"
-        pattern="[0-9]*"
         type="text"
         name="currency_example"
         onBlur={(evt) => handleBlur(evt, 'currency')}
-        defaultValue="2500"
+        defaultValue="2,500"
       />
 
       <TextField
@@ -76,7 +75,6 @@ const Example = () => {
         label="Social security number (SSN)"
         mask="ssn"
         inputMode="numeric"
-        pattern="[0-9]*"
         type="text"
         name="ssn_example"
         onBlur={(evt) => handleBlur(evt, 'ssn')}
@@ -87,7 +85,6 @@ const Example = () => {
         label="Zip code"
         mask="zip"
         inputMode="numeric"
-        pattern="[0-9]*"
         type="text"
         name="zip_example"
         onBlur={(evt) => handleBlur(evt, 'zip')}

--- a/packages/design-system/src/components/TextField/Mask.jsx
+++ b/packages/design-system/src/components/TextField/Mask.jsx
@@ -12,7 +12,7 @@ const maskPattern = {
   phone: '[0-9-]*',
   ssn: '[0-9-*]*',
   zip: '[0-9-]*',
-  currency: '[0-9.-]*',
+  currency: '^[0-9,]+(.[0-9]{1,2})?$',
 };
 
 const maskOverlayContent = {

--- a/packages/design-system/src/components/TextField/Mask.jsx
+++ b/packages/design-system/src/components/TextField/Mask.jsx
@@ -12,7 +12,7 @@ const maskPattern = {
   phone: '[0-9-]*',
   ssn: '[0-9-*]*',
   zip: '[0-9-]*',
-  currency: '^[0-9,]+(.[0-9]{1,2})?$',
+  currency: '[0-9.,-]*',
 };
 
 const maskOverlayContent = {

--- a/packages/design-system/src/components/TextField/__snapshots__/Mask.test.jsx.snap
+++ b/packages/design-system/src/components/TextField/__snapshots__/Mask.test.jsx.snap
@@ -30,7 +30,7 @@ exports[`Mask renders mask overlay 1`] = `
     name="foo"
     onBlur={[Function]}
     onChange={[Function]}
-    pattern="[0-9.-]*"
+    pattern="[0-9.,-]*"
     type="text"
     value=""
   />


### PR DESCRIPTION
### Changed
- Changed the regex for the currency mark pattern to be `^[0-9,]+(.[0-9]{1,2})?$`

### Removed
- Removed pattern attribute from examples as it is defined and added from the Mask.jsx 

### Fixed
- This fixes #702 

**How to test**
- Test the regex here - you can test here https://regex101.com/r/TEwmdB/1
- Run the site locally and open up firefox and navigate to the masked field page
    - Enter numbers in the currency field and ensure that no browser error is triggered
