### PR TITLE
[WNMGDS-444] Fix dev console warning msg for VerticalNav

### DIFF
--- a/packages/design-system/src/components/VerticalNav/VerticalNav.jsx
+++ b/packages/design-system/src/components/VerticalNav/VerticalNav.jsx
@@ -73,7 +73,7 @@ VerticalNav.propTypes = {
   /**
    * An array of `VerticalNavItem` data objects
    */
-  items: PropTypes.arrayOf(PropTypes.shape(PropTypes.object)).isRequired,
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
   /**
    * Indicates this list is nested within another nav item.
    */


### PR DESCRIPTION
This PR fixed the VerticalNav warning message shown on developer console. 
I was not able to reproduce the other issues with failed tests on running `yarn test` and `yarn test:e2e`.
 
### Changed
- Changed items PropTypes to check for object type instead of `shape` of object type

### How to test
- Run the design system site locally and check the developer console to ensure that no warning message is displayed for VerticalNav

