### PR TITLE
[WNMGDS-456] Remove aria-labels from StepList list items

### DIFF
--- a/packages/design-system-docs/src/pages/components/StepList/StepList.example.jsx
+++ b/packages/design-system-docs/src/pages/components/StepList/StepList.example.jsx
@@ -16,10 +16,6 @@ Link.propTypes = { children: PropTypes.node };
 ReactDOM.render(
   <div style={{ maxWidth: '628px' }}>
     <StepList
-      completedText="Completed"
-      editText="Edit"
-      resumeText="Resume"
-      startText="Start"
       steps={[
         {
           id: 'taxYear',

--- a/packages/design-system/src/components/StepList/Step.jsx
+++ b/packages/design-system/src/components/StepList/Step.jsx
@@ -19,6 +19,11 @@ export const Step = ({ step, ...props }) => {
     }
   }
 
+  const getAriaLabel = (text) => {
+    const isValidTemplate = text && text.length > 0;
+    const label = isValidTemplate ? text.replace('%{step}', step.heading || step.title) : undefined;
+    return { 'aria-label': label };
+  };
   const Heading = `h${step.headingLevel || '2'}`;
   const start = step.isNextStep;
   const resume = step.started && !step.completed;
@@ -30,24 +35,9 @@ export const Step = ({ step, ...props }) => {
     'ds-c-step__content--with-content': step.description || step.steps,
   });
   const { actionsLabelText, substepsLabelText, descriptionLabelText } = props;
-  const actionsLabel =
-    actionsLabelText === ''
-      ? {}
-      : {
-          'aria-label': actionsLabelText.replace('%{step}', step.heading || step.title),
-        };
-  const substepsLabel =
-    substepsLabelText === ''
-      ? {}
-      : {
-          'aria-label': substepsLabelText.replace('%{step}', step.heading || step.title),
-        };
-  const descriptionLabel =
-    descriptionLabelText === ''
-      ? {}
-      : {
-          'aria-label': descriptionLabelText.replace('%{step}', step.heading || step.title),
-        };
+  const actionsLabel = getAriaLabel(actionsLabelText);
+  const substepsLabel = getAriaLabel(substepsLabelText);
+  const descriptionLabel = getAriaLabel(descriptionLabelText);
 
   let linkLabel;
   if (step.completed && !step.steps) {

--- a/packages/design-system/src/components/StepList/Step.jsx
+++ b/packages/design-system/src/components/StepList/Step.jsx
@@ -102,9 +102,9 @@ Step.propTypes = {
   editText: PropTypes.string.isRequired,
   resumeText: PropTypes.string.isRequired,
   startText: PropTypes.string.isRequired,
-  actionsLabelText: PropTypes.string.isRequired,
-  descriptionLabelText: PropTypes.string.isRequired,
-  substepsLabelText: PropTypes.string.isRequired,
+  actionsLabelText: PropTypes.string,
+  descriptionLabelText: PropTypes.string,
+  substepsLabelText: PropTypes.string,
 };
 
 export default Step;

--- a/packages/design-system/src/components/StepList/Step.jsx
+++ b/packages/design-system/src/components/StepList/Step.jsx
@@ -30,9 +30,24 @@ export const Step = ({ step, ...props }) => {
     'ds-c-step__content--with-content': step.description || step.steps,
   });
   const { actionsLabelText, substepsLabelText, descriptionLabelText } = props;
-  const actionsLabel = actionsLabelText.replace('%{step}', step.heading || step.title);
-  const substepsLabel = substepsLabelText.replace('%{step}', step.heading || step.title);
-  const descriptionLabel = descriptionLabelText.replace('%{step}', step.heading || step.title);
+  const actionsLabel =
+    actionsLabelText === ''
+      ? {}
+      : {
+          'aria-label': actionsLabelText.replace('%{step}', step.heading || step.title),
+        };
+  const substepsLabel =
+    substepsLabelText === ''
+      ? {}
+      : {
+          'aria-label': substepsLabelText.replace('%{step}', step.heading || step.title),
+        };
+  const descriptionLabel =
+    descriptionLabelText === ''
+      ? {}
+      : {
+          'aria-label': descriptionLabelText.replace('%{step}', step.heading || step.title),
+        };
 
   let linkLabel;
   if (step.completed && !step.steps) {
@@ -54,12 +69,12 @@ export const Step = ({ step, ...props }) => {
       <div className={contentClassName}>
         <Heading className="ds-c-step__heading">{step.heading || step.title}</Heading>
         {step.description && (
-          <div className="ds-c-step__description" aria-label={descriptionLabel}>
+          <div className="ds-c-step__description" {...descriptionLabel}>
             {step.description}
           </div>
         )}
         {step.steps && (
-          <ol className="ds-c-step__substeps" aria-label={substepsLabel}>
+          <ol className="ds-c-step__substeps" {...substepsLabel}>
             {step.steps.map((s, i) => (
               <SubStep
                 step={{ ...s, ...{ component: step.component || s.component } }}
@@ -70,7 +85,7 @@ export const Step = ({ step, ...props }) => {
           </ol>
         )}
       </div>
-      <div className="ds-c-step__actions" aria-label={actionsLabel}>
+      <div className="ds-c-step__actions" {...actionsLabel}>
         {step.completed && <div className="ds-c-step__completed-text">{props.completedText}</div>}
         {linkLabel && (
           <StepLink

--- a/packages/design-system/src/components/StepList/StepList.jsx
+++ b/packages/design-system/src/components/StepList/StepList.jsx
@@ -74,21 +74,18 @@ StepList.propTypes = {
   /**
    * A template string for the aria-label describing a step's actions where
    * the substring `%{step}` is replaced with that step's `heading`.
-   * To remove `aria-label` from a step's actions,  set `actionsLabelText=""`
    */
-  actionsLabelText: PropTypes.string.isRequired,
+  actionsLabelText: PropTypes.string,
   /**
    * A template string for the aria-label for a step's description where
    * the substring `%{step}` is replaced with that step's `heading`.
-   * To remove `aria-label` from a step's description,  set `descriptionLabelText=""`
    */
-  descriptionLabelText: PropTypes.string.isRequired,
+  descriptionLabelText: PropTypes.string,
   /**
    * A template string for the aria-label describing a step's substeps where
    * the substring `%{step}` is replaced with that step's `heading`.
-   * To remove `aria-label` from a step's substeps,  set `substepsLabelText=""`
    */
-  substepsLabelText: PropTypes.string.isRequired,
+  substepsLabelText: PropTypes.string,
 };
 
 export default StepList;

--- a/packages/design-system/src/components/StepList/StepList.jsx
+++ b/packages/design-system/src/components/StepList/StepList.jsx
@@ -86,7 +86,7 @@ StepList.propTypes = {
   /**
    * A template string for the aria-label describing a step's substeps where
    * the substring `%{step}` is replaced with that step's `heading`.
-   * To remove `aria-label` from a step's subseps,  set `substepsLabelText=""`
+   * To remove `aria-label` from a step's substeps,  set `substepsLabelText=""`
    */
   substepsLabelText: PropTypes.string.isRequired,
 };

--- a/packages/design-system/src/components/StepList/StepList.jsx
+++ b/packages/design-system/src/components/StepList/StepList.jsx
@@ -74,16 +74,19 @@ StepList.propTypes = {
   /**
    * A template string for the aria-label describing a step's actions where
    * the substring `%{step}` is replaced with that step's `heading`.
+   * To remove `aria-label` from a step's actions,  set `actionsLabelText=""`
    */
   actionsLabelText: PropTypes.string.isRequired,
   /**
    * A template string for the aria-label for a step's description where
    * the substring `%{step}` is replaced with that step's `heading`.
+   * To remove `aria-label` from a step's description,  set `descriptionLabelText=""`
    */
   descriptionLabelText: PropTypes.string.isRequired,
   /**
    * A template string for the aria-label describing a step's substeps where
    * the substring `%{step}` is replaced with that step's `heading`.
+   * To remove `aria-label` from a step's subseps,  set `substepsLabelText=""`
    */
   substepsLabelText: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
### Changed
- Removed `aria-label` attribute for list items with no label text

### How to test
- Add the below lines of code to StepList.example.jsx file, just below line 18 `<StepList` 
```
descriptionLabelText=""
substepsLabelText=""
actionsLabelText=""
```
- Run the design system site locally and inspect the html elements to ensure that aria-label is not shown for the step's description, step's actions and step's substeps.
