### PR TITLE
[WNMGDS-459] Add red border to Dropdown with error message

### DIFF
--- a/packages/design-system-docs/src/pages/components/Dropdown/Dropdown.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Dropdown/Dropdown.example.jsx
@@ -40,7 +40,7 @@ ReactDOM.render(
       options={dropdownOptions}
       defaultValue={'1'}
       errorMessage="Error message example"
-      label="Dropdown example"
+      label="Error dropdown example "
       name="dropdown_field"
     />
     <Dropdown

--- a/packages/design-system-docs/src/pages/components/Dropdown/Dropdown.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Dropdown/Dropdown.example.jsx
@@ -39,6 +39,13 @@ ReactDOM.render(
     <Dropdown
       options={dropdownOptions}
       defaultValue={'1'}
+      errorMessage="Error message example"
+      label="Dropdown example"
+      name="dropdown_field"
+    />
+    <Dropdown
+      options={dropdownOptions}
+      defaultValue={'1'}
       label="Disabled dropdown example"
       disabled
       name="disabled_dropdown_field"

--- a/packages/design-system/src/components/Dropdown/Dropdown.jsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.jsx
@@ -72,7 +72,10 @@ export class Dropdown extends React.PureComponent {
     const classes = classNames(className);
     const fieldClasses = classNames(
       'ds-c-field',
-      { 'ds-c-field--inverse': inversed },
+      {
+        'ds-c-field--error': errorMessage,
+        'ds-c-field--inverse': inversed,
+      },
       size && `ds-c-field--${size}`,
       fieldClassName
     );

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.jsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.jsx
@@ -136,6 +136,18 @@ describe('Dropdown', () => {
     }, 20);
   });
 
+  describe('has error', () => {
+    let data;
+
+    beforeEach(() => {
+      data = render({ errorMessage: 'Error' });
+    });
+
+    it('adds error class to field', () => {
+      expect(data.wrapper.find('.ds-c-field').first().hasClass('ds-c-field--error')).toBe(true);
+    });
+  });
+
   describe('event handlers', () => {
     let wrapper;
     let onBlurMock;

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.jsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.jsx
@@ -121,6 +121,12 @@ describe('Dropdown', () => {
     expect(data.wrapper.find('select').hasClass('ds-c-field--inverse')).toBe(true);
   });
 
+  it('has error', () => {
+    const data = render({ errorMessage: 'Error' });
+
+    expect(data.wrapper.find('select').hasClass('ds-c-field--error')).toBe(true);
+  });
+
   it('focuses the select when focusTrigger is passed', () => {
     const data = render(
       {
@@ -134,18 +140,6 @@ describe('Dropdown', () => {
     setTimeout(() => {
       expect(data.wrapper.find('select').props().id).toEqual(document.activeElement.id);
     }, 20);
-  });
-
-  describe('has error', () => {
-    let data;
-
-    beforeEach(() => {
-      data = render({ errorMessage: 'Error' });
-    });
-
-    it('adds error class to field', () => {
-      expect(data.wrapper.find('.ds-c-field').first().hasClass('ds-c-field--error')).toBe(true);
-    });
   });
 
   describe('event handlers', () => {


### PR DESCRIPTION
### Changed
- Add red border to dropdown with error message
- Add example of dropdown with error message

### How to test
- Run the design system site locally and check that dropdown with error message is displayed with red border

