### PR TITLE
[WNMGDS-457] Change HelpDrawerToggle to use inline instead of inline-block

### DIFF
--- a/packages/design-system-docs/src/pages/utilities/display-visibility/_display-visibility.docs.scss
+++ b/packages/design-system-docs/src/pages/utilities/display-visibility/_display-visibility.docs.scss
@@ -11,9 +11,9 @@ Display
 
 > The display CSS property specifies the type of rendering box used for an element. In HTML, default display property values are taken from behaviors described in the HTML specifications or from the browser/user default stylesheet. &mdash; [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
 
-**Format**: `.ds-u-display--[inline|block|inline-block|flex|none]`
+**Format**: `.ds-u-display--[block|flex|inline|inline-block|none]`
 
-**Responsive format**: `.ds-u-[breakpoint]-display--[inline|block|inline-block|flex|none]`
+**Responsive format**: `.ds-u-[breakpoint]-display--[block|flex|inline|inline-block|none]`
 
 Markup: display.example.html
 

--- a/packages/design-system-docs/src/pages/utilities/display-visibility/_display-visibility.docs.scss
+++ b/packages/design-system-docs/src/pages/utilities/display-visibility/_display-visibility.docs.scss
@@ -11,9 +11,9 @@ Display
 
 > The display CSS property specifies the type of rendering box used for an element. In HTML, default display property values are taken from behaviors described in the HTML specifications or from the browser/user default stylesheet. &mdash; [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
 
-**Format**: `.ds-u-display--[block|inline-block|flex|none]`
+**Format**: `.ds-u-display--[inline|block|inline-block|flex|none]`
 
-**Responsive format**: `.ds-u-[breakpoint]-display--[block|inline-block|flex|none]`
+**Responsive format**: `.ds-u-[breakpoint]-display--[inline|block|inline-block|flex|none]`
 
 Markup: display.example.html
 

--- a/packages/design-system-docs/src/pages/utilities/display-visibility/display.example.html
+++ b/packages/design-system-docs/src/pages/utilities/display-visibility/display.example.html
@@ -1,6 +1,6 @@
 <div class="example--wrapper">
-  <% [ 'ds-u-display--inline', 'ds-u-display--block', 'ds-u-display--inline-block',
-  'ds-u-display--flex', 'ds-u-display--none'].forEach(util => { -%>
+  <% [ 'ds-u-display--block', 'ds-u-display--flex', 'ds-u-display--inline',
+  'ds-u-display--inline-block', 'ds-u-display--none'].forEach(util => { -%>
   <code class="<%= util %> ds-u-padding--1 preview__element">
     .<%= util %>
   </code>

--- a/packages/design-system-docs/src/pages/utilities/display-visibility/display.example.html
+++ b/packages/design-system-docs/src/pages/utilities/display-visibility/display.example.html
@@ -1,6 +1,6 @@
 <div class="example--wrapper">
-  <% ['ds-u-display--block', 'ds-u-display--inline-block', 'ds-u-display--flex',
-  'ds-u-display--none'].forEach(util => { -%>
+  <% [ 'ds-u-display--inline', 'ds-u-display--block', 'ds-u-display--inline-block',
+  'ds-u-display--flex', 'ds-u-display--none'].forEach(util => { -%>
   <code class="<%= util %> ds-u-padding--1 preview__element">
     .<%= util %>
   </code>

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
@@ -12,7 +12,7 @@ export class HelpDrawerToggle extends React.PureComponent {
   }
 
   render() {
-    const blockInlineClass = `ds-u-display--${this.props.inline ? 'inline-block' : 'block'}`;
+    const blockInlineClass = `ds-u-display--${this.props.inline ? 'inline' : 'block'}`;
     /* eslint-disable jsx-a11y/anchor-is-valid */
     return (
       // Use a <span> since a <div> may be invalid depending where this link is nested

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
@@ -32,15 +32,27 @@ export class HelpDrawerToggle extends React.PureComponent {
 
 /* eslint-disable react/no-unused-prop-types */
 HelpDrawerToggle.propTypes = {
-  /** Whether or not the Help Drawer controlled by this toggle is open or closed. This value is used to re-focus the toggle that opened the drawer when the drawer closes. */
+  /**
+   * Whether or not the Help Drawer controlled by this toggle is open or closed.
+   * This value is used to re-focus the toggle that opened the drawer when the drawer closes.
+   */
   helpDrawerOpen: PropTypes.bool.isRequired,
+  /**
+   * The HelpDrawerToggle content
+   */
   children: PropTypes.node.isRequired,
-  /** Additional classes for the toggle button anchor element */
+  /**
+   * Additional classes for the toggle button anchor element.
+   */
   className: PropTypes.string,
-  /** Adds display inline or block style to the HelpDrawerToggle */
+  /**
+   * Adds `display: inline` to the HelpDrawerToggle.
+   */
   inline: PropTypes.bool,
-  /** This function is called with an id that the toggle generates. It can
-   be used in implementing the help drawer for keeping track of the drawer the toggle controls */
+  /**
+   * This function is called with an id that the toggle generates.
+   * It can be used in implementing the help drawer for keeping track of the drawer the toggle controls
+   */
   showDrawer: PropTypes.func.isRequired,
 };
 

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
@@ -37,7 +37,7 @@ HelpDrawerToggle.propTypes = {
   children: PropTypes.node.isRequired,
   /** Additional classes for the toggle button anchor element */
   className: PropTypes.string,
-  /** Add display inline or block to parent span */
+  /** Adds display inline or block style to the HelpDrawerToggle */
   inline: PropTypes.bool,
   /** This function is called with an id that the toggle generates. It can
    be used in implementing the help drawer for keeping track of the drawer the toggle controls */

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
@@ -12,11 +12,11 @@ export class HelpDrawerToggle extends React.PureComponent {
   }
 
   render() {
-    const blockInlineClass = `ds-u-display--${this.props.inline ? 'inline' : 'block'}`;
+    const inlineClass = `ds-u-display--${this.props.inline ? 'inline' : 'block'}`;
     /* eslint-disable jsx-a11y/anchor-is-valid */
     return (
       // Use a <span> since a <div> may be invalid depending where this link is nested
-      <span className={blockInlineClass}>
+      <span className={inlineClass}>
         <a
           href="javascript:void(0);"
           className={this.props.className}

--- a/packages/design-system/src/components/HelpDrawer/__snapshots__/HelpDrawerToggle.test.jsx.snap
+++ b/packages/design-system/src/components/HelpDrawer/__snapshots__/HelpDrawerToggle.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`HelpDrawerToggle renders a snapshot 1`] = `
 <span
-  className="ds-u-display--inline-block"
+  className="ds-u-display--inline"
 >
   <a
     href="javascript:void(0);"

--- a/packages/design-system/src/styles/utilities/_display-visibility.scss
+++ b/packages/design-system/src/styles/utilities/_display-visibility.scss
@@ -9,6 +9,10 @@
   display: inline-block !important;
 }
 
+.ds-u-display--inline {
+  display: inline !important;
+}
+
 .ds-u-display--flex {
   display: flex !important;
 }


### PR DESCRIPTION
### Changed
- Change to use inline style when `inline` prop is set for `<HelpDrawerToggle>` component

### How to test
- Update HelpDrawer.example.jsx to replace this section `<HelpDrawerToggle ... </HelpDrawerToggle>` with below code
`        <p>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
          ut labore et dolore magna aliqua. <span> </span>
          <HelpDrawerToggle
            inline
            helpDrawerOpen={this.state.showHelp}
            showDrawer={() => this.handleDrawerOpen()}
          >
          Toggle the help drawer Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
          </HelpDrawerToggle>
          .
        </p>`
- Run the design system site locally and check that the drawer text link stays on the same line as the paragraph.

### Fixed
- Fixes #689
