### PR TITLE
[NO-TICKET] Status badge update

### DIFF
--- a/guides/WRITING-DOCUMENTATION.md
+++ b/guides/WRITING-DOCUMENTATION.md
@@ -68,7 +68,7 @@ Supported flags:
   - `[NAME]` is the filename of the react example to be displayed
 
 - **`@responsive`** Renders breakpoint toggles for the markup example.
-- **`@status [NAME]`** Displays a status badge. Supported values: `Draft`, `Work in progress`, `Ready`, `Deprecated`.
+- **`@status [NAME]`** Displays a status badge. Supported values: `Draft`, `Ready` and `Deprecated`.
 - **`@uswds [URL]`** Marks the component as a US Web Design System component. Enter the URL so the documentation can link to the corresponding USWDS page.
 
 ### Modifiers

--- a/packages/design-system-docs/src/pages/guidelines/component-maturity.md
+++ b/packages/design-system-docs/src/pages/guidelines/component-maturity.md
@@ -13,7 +13,7 @@ Each component in the design system is tested and validated before deciding on t
 
 ## <span class="ds-u-fill--error">&nbsp;&nbsp;</span> Draft
 
-- **Do not implement**
+- **Implement with caution**
 - Documentation and guidance is incomplete
 - Testing and validation is incomplete
 - Could be buggy or have accessibility issues

--- a/packages/design-system-docs/src/scripts/components/PageBlock.jsx
+++ b/packages/design-system-docs/src/scripts/components/PageBlock.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactContent from './ReactContent';
 import Source from './Source';
+import classNames from 'classnames';
 
 class PageBlock extends React.PureComponent {
   markupExamples() {
@@ -42,6 +43,24 @@ class PageBlock extends React.PureComponent {
     );
   }
 
+  statusBadge() {
+    if (this.props.status) {
+      const classes = classNames(
+        'ds-c-badge ds-u-margin-right--1 ds-u-text-transform--capitalize',
+        {
+          'ds-c-badge--success': this.props.status === 'Ready',
+          'ds-c-badge--alert': this.props.status === 'Draft',
+        }
+      );
+
+      return (
+        <div>
+          <span className={classes}>{this.props.status}</span>
+        </div>
+      );
+    }
+  }
+
   description() {
     if (this.props.description) {
       return (
@@ -55,6 +74,15 @@ class PageBlock extends React.PureComponent {
     }
   }
 
+  GitHubSource() {
+    if (this.props.hideHeader || this.props.header.match(/---/)) return;
+
+    const source = this.props.reactComponentPath && (
+      <Source key="reactSource" reactComponentPath={this.props.reactComponentPath} />
+    );
+    return [source];
+  }
+
   header() {
     // The regex conditional allows us to create KSS comments that provide additional
     // descriptive text below a section that already has a title. For example,
@@ -63,33 +91,31 @@ class PageBlock extends React.PureComponent {
     // text below the title + code snippet block. It's hacky, but works.
     if (this.props.hideHeader || this.props.header.match(/---/)) return;
 
-    const source = this.props.reactComponentPath && (
-      <Source key="reactSource" reactComponentPath={this.props.reactComponentPath} />
-    );
+    const subheader = this.props.reactComponentPath && <span key="subheader">React&nbsp;</span>;
 
-    const subheader = this.props.reactComponentPath && (
-      <span className="ds-h6" key="subheader">
-        React
-      </span>
+    const subheaderComponent = this.props.reactComponentPath && (
+      <span key="subheader">&nbsp;Component</span>
     );
 
     return [
       subheader,
-      <h2
+      <span
         className="ds-h2 ds-u-margin-top--0"
         // Headers can contain HTML markup, therefore dangerously set...
         dangerouslySetInnerHTML={{ __html: this.props.header }}
         id={this.props.reference}
         key="header"
       />,
-      source,
+      subheaderComponent,
     ];
   }
 
   render() {
     return (
       <article className="ds-u-margin-y--3 ds-u-sm-margin-y--6 l-content">
-        {this.header()}
+        <h2>{this.header()}</h2>
+        {this.statusBadge()}
+        {this.GitHubSource()}
         {this.description()}
         {this.markupExamples()}
         <ReactContent
@@ -115,6 +141,7 @@ PageBlock.propTypes = {
   reactExampleSource: ReactContent.propTypes.reactExampleSource,
   reference: PropTypes.string,
   responsive: PropTypes.bool,
+  status: PropTypes.string,
 };
 
 export default PageBlock;

--- a/packages/design-system-docs/src/scripts/components/PageBlock.jsx
+++ b/packages/design-system-docs/src/scripts/components/PageBlock.jsx
@@ -100,7 +100,6 @@ class PageBlock extends React.PureComponent {
     return [
       subheader,
       <span
-        className="ds-h2 ds-u-margin-top--0"
         // Headers can contain HTML markup, therefore dangerously set...
         dangerouslySetInnerHTML={{ __html: this.props.header }}
         id={this.props.reference}
@@ -113,7 +112,7 @@ class PageBlock extends React.PureComponent {
   render() {
     return (
       <article className="ds-u-margin-y--3 ds-u-sm-margin-y--6 l-content">
-        <h2>{this.header()}</h2>
+        <h2 className="ds-h2 ds-u-margin-top--0">{this.header()}</h2>
         {this.statusBadge()}
         {this.GitHubSource()}
         {this.description()}


### PR DESCRIPTION
### Added
- The ability to set status badge for individual page blocks (for example setting status of `Draft` on a react component and not the entire page) 

### Changed
- Changed the `Draft` definition to `Implement with caution` instead of `Do not implement`
- Changed the react component sections to make the word React part of the header, so the components in page now read like **React `<Alert>` Component** 

### Removed
- Removed `Work in progress` badge option from docs as we don't use that or have it documented.


### Header comparison screenshots
Left is current and right is the new updated version
![Screen Shot 2020-06-15 at 9 17 26 AM](https://user-images.githubusercontent.com/1449852/84662432-ce4d3200-aee9-11ea-937a-856818015cc7.png)

### Status badge applied at the page block level screenshot

![Screen Shot 2020-06-15 at 9 17 38 AM](https://user-images.githubusercontent.com/1449852/84662495-e329c580-aee9-11ea-861c-72fd6c20be7b.png)
