### PR TITLE
[WNMGDS-534] Generate ts definition files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/CMSgov/design-system",
   "scripts": {
     "start": "yarn cmsds start ./packages/design-system ./packages/design-system-docs --core",
-    "build": "yarn cmsds build-docs ./packages/design-system ./packages/design-system-docs --core",
+    "build": "yarn cmsds build-docs ./packages/design-system ./packages/design-system-docs --core -t",
     "release": "./prepublish.sh && yarn lerna publish from-git",
     "precommit": "lint-staged",
     "test": "yarn test:unit",

--- a/packages/design-system-scripts/cli.js
+++ b/packages/design-system-scripts/cli.js
@@ -209,7 +209,7 @@ function describeSourceOptions(yargs) {
     })
     .option('typescript', {
       desc:
-        'Alias: -t. Use this flag enable typescript support. Requires tsconfig.json to be defined.',
+        'Alias: -t. Use this flag enable typescript support and generate typescript definition files. Requires tsconfig.json to be defined.',
       alias: 't',
       type: 'boolean',
       default: false,

--- a/packages/design-system-scripts/gulp/docs/webpack/createReactExampleWebpackConfig.js
+++ b/packages/design-system-scripts/gulp/docs/webpack/createReactExampleWebpackConfig.js
@@ -1,6 +1,5 @@
 const webpack = require('webpack');
 const path = require('path');
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 /**
@@ -67,7 +66,6 @@ module.exports = (sourceDir, reactExampleEntry, typescript) => {
         },
       ],
     });
-    config.plugins.push(new ForkTsCheckerWebpackPlugin());
     config.resolve.extensions.push('.ts', '.tsx');
     config.resolve.plugins.push(new TsconfigPathsPlugin());
   }

--- a/packages/design-system-scripts/package.json
+++ b/packages/design-system-scripts/package.json
@@ -52,6 +52,7 @@
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "2.6.5",
     "gulp-stylelint": "^13.0.0",
+    "gulp-typescript": "^6.0.0-alpha.1",
     "jest": "^25.5.2",
     "kss": "^3.0.0-beta.18",
     "marked": "^0.3.17",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  // `tsconfig.json` is defined so the core CMSDS can generate typescript definition files
+  // The build scripts will automatically add `allowJs` and `declaration` options to an existing tsconfig
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,10 @@
 {
   // `tsconfig.json` is defined so the core CMSDS can generate typescript definition files
   // The build scripts will automatically add `allowJs` and `declaration` options to an existing tsconfig
+
+  // Allows `*.example.tsx` files in `docs` to import directly from `src`
+  "baseUrl": ".",
+  "paths": {
+    "@src/*": ["src/*"]
+  },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,11 @@
   // `tsconfig.json` is defined so the core CMSDS can generate typescript definition files
   // The build scripts will automatically add `allowJs` and `declaration` options to an existing tsconfig
 
-  // Allows `*.example.tsx` files in `docs` to import directly from `src`
-  "baseUrl": ".",
-  "paths": {
-    "@src/*": ["src/*"]
-  },
+  "compilerOptions": {
+    // Allows `*.example.tsx` files in `docs` to import directly from `src`, baseUrl is required
+    "baseUrl": ".",
+    "paths": {
+      "@src/*": ["src/*"]
+    },
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -766,13 +766,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-object-assign@^7.8.3":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.10.1.tgz#e563cb225a4812c072a415f3216f53326195b004"
-  integrity sha512-poBEVwzcTjv6p92ZcnWBUftzyXFCy/Zg/eCQsayu5/ot2+qwnasNvCCKPwdgprgDRzbHVUhh/fzI9rCoFOHLbg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.1"
-
 "@babel/plugin-transform-object-super@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.1.tgz#2e3016b0adbf262983bf0d5121d676a5ed9c4fde"
@@ -2780,6 +2773,11 @@ ansi-colors@^3.0.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
+
+ansi-colors@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-cyan@^0.1.1:
   version "0.1.1"
@@ -7388,6 +7386,18 @@ gulp-stylelint@^13.0.0:
     source-map "^0.7.3"
     strip-ansi "^6.0.0"
     through2 "^3.0.1"
+
+gulp-typescript@^6.0.0-alpha.1:
+  version "6.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/gulp-typescript/-/gulp-typescript-6.0.0-alpha.1.tgz#fcb0dbbc79c34201f0945c6323c194a8f5455a04"
+  integrity sha512-KoT0TTfjfT7w3JItHkgFH1T/zK4oXWC+a8xxKfniRfVcA0Fa1bKrIhztYelYmb+95RB80OLMBreknYkdwzdi2Q==
+  dependencies:
+    ansi-colors "^4.1.1"
+    plugin-error "^1.0.1"
+    source-map "^0.7.3"
+    through2 "^3.0.1"
+    vinyl "^2.2.0"
+    vinyl-fs "^3.0.3"
 
 gulp-util@^3.0:
   version "3.0.8"
@@ -15112,7 +15122,7 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
-vinyl-fs@^3.0.0:
+vinyl-fs@^3.0.0, vinyl-fs@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-3.0.3.tgz#c85849405f67428feabbbd5c5dbdd64f47d31bc7"
   integrity sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==
@@ -15164,7 +15174,7 @@ vinyl@^0.5.0:
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
 
-vinyl@^2.0.0, vinyl@^2.1.0:
+vinyl@^2.0.0, vinyl@^2.1.0, vinyl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.2.0.tgz#d85b07da96e458d25b2ffe19fece9f2caa13ed86"
   integrity sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==


### PR DESCRIPTION
### Added
- This PR adds the ability to generate ts definition files when using the `--typescript` option

### How to test
- Test the build scripts with and without the `--typescript` option, and check if `types` is being outputted in the `dist` folder
- Test that the definition files are updated when running `yarn start`
- Test everything works with mgov child ds
[mgov 2.zip](https://github.com/CMSgov/design-system/files/4887014/mgov.2.zip)


