### PR TITLE
[WNMGDS-537] Update "Download code and design files" button

### DIFF
--- a/packages/design-system-docs/src/scripts/components/GitHubLinks.jsx
+++ b/packages/design-system-docs/src/scripts/components/GitHubLinks.jsx
@@ -15,7 +15,7 @@ const GitHubLinks = (props) => {
   return (
     <div className={props.className}>
       <Button
-        href="download.tgz"
+        href="download.zip"
         inversed={props.inversed}
         variation="primary"
         className={downloadBtnClassName}

--- a/packages/design-system-docs/src/scripts/components/GitHubLinks.jsx
+++ b/packages/design-system-docs/src/scripts/components/GitHubLinks.jsx
@@ -3,12 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import githubUrl from '../helpers/githubUrl';
-import pkg from '../../../package.json';
 
-// TODO: Replace with link to self hosted download
-const zipUrl = githubUrl(
-  `releases/download/${pkg.version}/cmsgov-design-system-${pkg.version}.tgz`
-);
 const GitHubLinks = (props) => {
   const downloadBtnClassName = classNames('ds-u-font-weight--normal', {
     'ds-u-display--block': props.vertical,
@@ -20,7 +15,7 @@ const GitHubLinks = (props) => {
   return (
     <div className={props.className}>
       <Button
-        href={zipUrl}
+        href="download.tgz"
         inversed={props.inversed}
         variation="primary"
         className={downloadBtnClassName}

--- a/packages/design-system-scripts/gulp/docs/assets.js
+++ b/packages/design-system-scripts/gulp/docs/assets.js
@@ -40,7 +40,7 @@ async function copyCode(sourceDir, docsDir) {
           path.join(sourceDir, 'package.json'),
           path.join(sourceDir, 'README.md'),
         ],
-        { base: sourceDir }
+        { base: sourceDir, allowEmpty: true }
       )
       .pipe(gulp.dest(path.join(docsDir, 'dist', 'download', 'design-system')))
   );
@@ -49,7 +49,7 @@ async function copyCode(sourceDir, docsDir) {
 async function copyDesignAssets(sourceDir, docsDir) {
   return streamPromise(
     gulp
-      .src('./design-assets/**', { base: './' })
+      .src('./design-assets/**', { base: './', allowEmpty: true })
       .pipe(gulp.dest(path.join(docsDir, 'dist', 'download')))
   );
 }

--- a/packages/design-system-scripts/gulp/docs/assets.js
+++ b/packages/design-system-scripts/gulp/docs/assets.js
@@ -1,0 +1,62 @@
+const copyAssets = require('../common/copyAssets');
+const del = require('del');
+const gulp = require('gulp');
+const path = require('path');
+const rename = require('gulp-rename');
+const streamPromise = require('../common/streamPromise');
+const util = require('util');
+const { getDocsDirs } = require('../common/getDirsToProcess');
+const { logTask } = require('../common/logUtil');
+
+/**
+ * Copies all the fonts and images from the source package and the core design system package
+ * In the case of a child DS, the source dir will already contain assets from the core npm package
+ * from the `buildSrc` task that preceded `buildDocs`
+ */
+function copySourceAssets(sourceDir, docsDir) {
+  logTask('🏞  ', `Copying fonts and images from source package into ${path.join(docsDir, 'dist')}`);
+  // Handle rootPath when copying
+  return copyAssets(path.join(sourceDir, 'dist'), path.join(docsDir, 'dist'));
+}
+
+/**
+ * Copies all the fonts and images from our docs packages
+ * Usually there will only be images in the docs package
+ */
+async function copyDocsAssets(docsDir) {
+  logTask('🏞  ', `Copying fonts and images from docs packages into ${path.join(docsDir, 'dist')}`);
+  // Handle rootPath when copying
+  const docs = await getDocsDirs(docsDir);
+  return Promise.all([
+    docs.map((doc) => copyAssets(path.join(doc, 'src'), path.join(docsDir, 'dist'))),
+  ]);
+}
+
+async function copyDownloadZip(sourceDir, docsDir) {
+  logTask('📦 ', `Creating download zip for the source package`);
+
+  // Run `npm pack` to create the download zip
+  const exec = util.promisify(require('child_process').exec);
+  await exec(`npm pack ${sourceDir}`);
+
+  return streamPromise(
+    gulp
+      .src('./*.tgz')
+      .pipe(
+        rename((path) => {
+          // Rename it to `download.tgz`
+          path.basename = 'download';
+        })
+      )
+      .pipe(gulp.dest(path.join(docsDir, 'dist')))
+  ).then(() => {
+    // Delete the original file
+    del('./*.tgz');
+  });
+}
+
+module.exports = {
+  copySourceAssets,
+  copyDocsAssets,
+  copyDownloadZip,
+};

--- a/packages/design-system-scripts/gulp/docs/docs.js
+++ b/packages/design-system-scripts/gulp/docs/docs.js
@@ -3,39 +3,13 @@
  * like parsing our CSS/JSX comments, generating JSON data files, and ultimately
  * generating the HTML files which get published as the public site.
  */
-const copyAssets = require('../common/copyAssets');
 const cleanDist = require('../common/cleanDist');
 const generatePages = require('./generatePages');
-const path = require('path');
+const { copySourceAssets, copyDocsAssets, copyDownloadZip } = require('./assets');
 const { compileDocsSass } = require('../sass');
 const { extractReactData } = require('./extractReactData');
-const { getDocsDirs } = require('../common/getDirsToProcess');
 const { logTask, log } = require('../common/logUtil');
 const { runWebpackStatically } = require('./webpack');
-
-/**
- * Copies all the fonts and images from the source package and the core design system package
- * In the case of a child DS, the source dir will already contain assets from the core npm package
- * from the `buildSrc` task that preceded `buildDocs`
- */
-function copySourceAssets(sourceDir, docsDir) {
-  logTask('🏞  ', `Copying fonts and images from source package into ${path.join(docsDir, 'dist')}`);
-  // Handle rootPath when copying
-  return copyAssets(path.join(sourceDir, 'dist'), path.join(docsDir, 'dist'));
-}
-
-/**
- * Copies all the fonts and images from our docs packages
- * Usually there will only be images in the docs package
- */
-async function copyDocsAssets(docsDir) {
-  logTask('🏞  ', `Copying fonts and images from docs packages into ${path.join(docsDir, 'dist')}`);
-  // Handle rootPath when copying
-  const docs = await getDocsDirs(docsDir);
-  return Promise.all([
-    docs.map((doc) => copyAssets(path.join(doc, 'src'), path.join(docsDir, 'dist'))),
-  ]);
-}
 
 module.exports = {
   /**
@@ -54,6 +28,7 @@ module.exports = {
     await cleanDist(docsDir);
     await copySourceAssets(sourceDir, docsDir);
     await copyDocsAssets(docsDir);
+    await copyDownloadZip(sourceDir, docsDir);
     await extractReactData(sourceDir, docsDir, options);
     await generatePages(sourceDir, docsDir, options);
     await compileDocsSass(docsDir, options);

--- a/packages/design-system-scripts/package.json
+++ b/packages/design-system-scripts/package.json
@@ -52,6 +52,7 @@
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "2.6.5",
     "gulp-stylelint": "^13.0.0",
+    "gulp-zip": "^5.0.2",
     "jest": "^25.5.2",
     "kss": "^3.0.0-beta.18",
     "marked": "^0.3.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -766,13 +766,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-object-assign@^7.8.3":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.10.1.tgz#e563cb225a4812c072a415f3216f53326195b004"
-  integrity sha512-poBEVwzcTjv6p92ZcnWBUftzyXFCy/Zg/eCQsayu5/ot2+qwnasNvCCKPwdgprgDRzbHVUhh/fzI9rCoFOHLbg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.1"
-
 "@babel/plugin-transform-object-super@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.1.tgz#2e3016b0adbf262983bf0d5121d676a5ed9c4fde"
@@ -7413,6 +7406,17 @@ gulp-util@^3.0:
     through2 "^2.0.0"
     vinyl "^0.5.0"
 
+gulp-zip@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/gulp-zip/-/gulp-zip-5.0.2.tgz#2edf797ec842e770f4dfde8bef97d139015b1972"
+  integrity sha512-rZd0Ppuc8Bf7J2/WzcdNaeb+lcEXf1R8mV/PJ9Kdu7PmnInWVeLSmiXIka/2QSe6uhAsGVFAMffWSaMzAPGTBg==
+  dependencies:
+    get-stream "^5.1.0"
+    plugin-error "^1.0.1"
+    through2 "^3.0.1"
+    vinyl "^2.1.0"
+    yazl "^2.5.1"
+
 gulp@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/gulp/-/gulp-4.0.2.tgz#543651070fd0f6ab0a0650c6a3e6ff5a7cb09caa"
@@ -10592,7 +10596,7 @@ node-releases@^1.1.53:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
 
-node-sass@>=4.7.2, node-sass@^4.8.3:
+node-sass@^4.8.3:
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
   integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==
@@ -10776,7 +10780,7 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-nunjucks@>=3.2.0, nunjucks@^3.2.1:
+nunjucks@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.1.tgz#f229539281e92c6ad25d8c578c9bdb41655caf83"
   integrity sha512-LYlVuC1ZNSalQQkLNNPvcgPt2M9FTY9bs39mTCuFXtqh7jWbYzhDlmz2M6onPiXEhdZo+b9anRhc+uBGuJZ2bQ==
@@ -15749,6 +15753,13 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yazl@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
+  dependencies:
+    buffer-crc32 "~0.2.3"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
### Summary
- Instead of linking to our Github release for the "Download code and design files" button, we generate a zip for the doc site to link to.
- Added new gulp task to generate the release via "npm pack", and then move that zip to the doc dist folder

### How to test
- Run the scripts on the core and child ds
- Ensure the Download code and design files button is working
- Ensure the download zip has all the necessary files