### PR TITLE
[WNMGDS-536] Add more doc content templates

### DIFF
--- a/packages/design-system-docs/src/pages/guidelines/accessibility.md
+++ b/packages/design-system-docs/src/pages/guidelines/accessibility.md
@@ -2,7 +2,7 @@
 title: Accessibility
 ---
 
-CMS strives to make its Design System work for as many people as possible, including people with disabilities.
+The {{name}} strives to work for as many people as possible, including people with disabilities.
 
 ## What we do to help meet and exceed standards
 
@@ -14,7 +14,7 @@ CMS strives to make its Design System work for as many people as possible, inclu
 
 ## What level we meet currently
 
-The CMS Design System currently meets or exceeds [WCAG 2.0 AA](https://www.w3.org/TR/WCAG20/) and [Section 508](http://www.section508.gov/) standards, which requires information and communications technology developed, procured, maintained, or used by the federal government be accessible to both employees and members of the public with disabilities.
+The {{name}} currently meets or exceeds [WCAG 2.0 AA](https://www.w3.org/TR/WCAG20/) and [Section 508](http://www.section508.gov/) standards, which requires information and communications technology developed, procured, maintained, or used by the federal government be accessible to both employees and members of the public with disabilities.
 
 More information on Section 508 can be found at:
 

--- a/packages/design-system-docs/src/pages/guidelines/i18n.md
+++ b/packages/design-system-docs/src/pages/guidelines/i18n.md
@@ -7,7 +7,7 @@ The design system's React components accepts all text as `props`, and it is the 
 For example:
 
 ```jsx
-import { Alert } from '@cmsgov/design-system';
+import { Alert } from '{{npm}}';
 import i18n from 'i18n';
 
 export default function () {

--- a/packages/design-system-docs/src/pages/startup/browser-support.md
+++ b/packages/design-system-docs/src/pages/startup/browser-support.md
@@ -3,6 +3,6 @@ title: Browser support
 weight: 7
 ---
 
-The CMS design system follows the [2% rule](https://gds.blog.gov.uk/2012/01/25/support-for-browsers/): we officially support any browser above 2% usage and the last 2 browsers versions for each browser as observed by [analytics.usa.gov](https://analytics.usa.gov/). For specific browser details check out [browserlist](https://browserl.ist/?q=last+2+versions%2C+%3E2%25). **Currently, the latest 2 versions of Chrome, Firefox, Safari, Internet Explorer 11, and Edge are supported.**
+The {{name}} follows the [2% rule](https://gds.blog.gov.uk/2012/01/25/support-for-browsers/): we officially support any browser above 2% usage and the last 2 browsers versions for each browser as observed by [analytics.usa.gov](https://analytics.usa.gov/). For specific browser details check out [browserlist](https://browserl.ist/?q=last+2+versions%2C+%3E2%25). **Currently, the latest 2 versions of Chrome, Firefox, Safari, Internet Explorer 11, and Edge are supported.**
 
 The CMSDS is designed to be compatible with different operating systems and browser versions in order to provide a broad range of support. [Progressive enhancement and graceful degredation](https://www.w3.org/wiki/Graceful_degradation_versus_progressive_enhancement) methodologies are used to accomplish this.

--- a/packages/design-system-docs/src/pages/startup/components.md
+++ b/packages/design-system-docs/src/pages/startup/components.md
@@ -23,18 +23,18 @@ Components can be imported from the package entry point using the syntax below.
 </div>
 
 ```jsx
-import { Button, TextField } from '@cmsgov/design-system';
+import { Button, TextField } from '{{npm}}';
 ```
 
-The `@cmsgov/design-system` package provides an ES modules version of our code (located in `dist/esnext`) to support Webpack 4's tree shaking optimizations. Our package is configured to let Webpack know to resolve imports from `"@cmsgov/design-system"` to the ES modules version when preferred.
+The `{{npm}}` package provides an ES modules version of our code to support Webpack 4's tree shaking optimizations. Our package is configured to let Webpack know to resolve imports from `"{{npm}}"` to the ES modules version when preferred.
 
 ### Individual imports
 
 Components can also be imported from their individual export file. This method carries no risk of including unused or extra code, as you are only importing from a specific file.
 
 ```jsx
-import Button from '@cmsgov/design-system/dist/components/Button/Button';
-import TextField from '@cmsgov/design-system/dist/components/Button/TextField';
+import Button from '{{npm}}/dist/components/Button/Button';
+import TextField from '{{npm}}/dist/components/Button/TextField';
 ```
 
 ### Usage
@@ -85,4 +85,4 @@ Additional examples of the design system in use can be viewed on GitHub. These p
 
 <h2 id="need-help" class="ds-h2 ds-u-color--primary-darker">Need help or ran into an issue?</h2>
 
-If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub](https://github.com/CMSgov/design-system/issues).
+If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub]({{github}}/issues).

--- a/packages/design-system-docs/src/pages/startup/examples.md
+++ b/packages/design-system-docs/src/pages/startup/examples.md
@@ -3,7 +3,7 @@ title: Examples
 weight: 10
 ---
 
-Additional examples of the design system in use can be viewed on [GitHub](https://github.com/CMSgov/design-system). These projects demonstrate the various ways you can incorporate the design system into your development process and various use cases.
+Additional examples of the CMS Design System (CMSDS) in use can be viewed on the core [CMSDS GitHub](https://github.com/CMSgov/design-system). These projects demonstrate the various ways you can incorporate the design system into your development process and various use cases.
 
 ## HTML/CSS examples
 
@@ -18,4 +18,4 @@ Additional examples of the design system in use can be viewed on [GitHub](https:
 
 ## Need help or ran into an issue?
 
-If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub](https://github.com/CMSgov/design-system/tree/master/examples).
+If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub]({{github}}/tree/master/examples).

--- a/packages/design-system-docs/src/pages/startup/fonts-and-images.md
+++ b/packages/design-system-docs/src/pages/startup/fonts-and-images.md
@@ -36,4 +36,4 @@ Without overriding these variables, it's possible that your fonts and images wil
 
 <h2 id="need-help" class="ds-h2 ds-u-color--primary-darker">Need help or ran into an issue?</h2>
 
-If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub](https://github.com/CMSgov/design-system/issues).
+If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub]({{github}}/issues).

--- a/packages/design-system-docs/src/pages/startup/installation.md
+++ b/packages/design-system-docs/src/pages/startup/installation.md
@@ -3,9 +3,9 @@ title: Install with NPM
 weight: 0
 ---
 
-The design system is available an NPM package or via a <a href="https://github.com/CMSgov/design-system/releases/latest">.zip download</a>.
+The design system is available an NPM package or via a <a href="{{root}}/download.zip">.zip download</a>.
 
-The [@cmsgov/design-system](https://www.npmjs.com/package/@cmsgov/design-system) package includes:
+The [{{npm}}](https://www.npmjs.com/package/{{npm}}) package includes:
 
 - Base styles
 - Utility classes
@@ -15,7 +15,7 @@ The [@cmsgov/design-system](https://www.npmjs.com/package/@cmsgov/design-system)
 - Fonts and images
 
 ```
-npm install --save @cmsgov/design-system
+npm install --save {{npm}}
 ```
 
 <h2>Usage</h2>
@@ -24,4 +24,4 @@ We offer two versions of design system assets: a minified + compiled version (lo
 
 <h2 id="need-help" class="ds-h2 ds-u-color--primary-darker">Need help or ran into an issue?</h2>
 
-If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub](https://github.com/CMSgov/design-system/issues).
+If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub]({{githubUrl}}/issues).

--- a/packages/design-system-docs/src/pages/startup/sass-and-css.md
+++ b/packages/design-system-docs/src/pages/startup/sass-and-css.md
@@ -7,8 +7,8 @@ weight: 1
 
 The easiest way to add the design system's styles to your site is by referencing its minified CSS.
 
-1. Download the zip file from the latest CMS design system release and open that file.
-1. Copy the `packages/design-system/index.css` file into a relevant place in your code base — likely a directory where you keep third-party libraries. In the example below, our directory is `css/vendor`.
+1. Download the zip file from the latest design system release and open that file.
+1. Copy the `dist/css/index.css` file into a relevant place in your code base — likely a directory where you keep third-party libraries. In the example below, our directory is `css/vendor`.
 1. Add a `<link>` to the stylesheet in your site's `<head>`
 
 For example:
@@ -27,7 +27,7 @@ If you're already using Sass to style your site, another way to include the desi
 2. Add the following to your Sass file:
 
 ```css
-@import '@cmsgov/design-system/dist/scss/index';
+@import '{{npm}}/dist/scss/index';
 ```
 
 [Learn how to override and theme Sass variables]({{root}}/startup/theming/).
@@ -53,4 +53,4 @@ Once your page is loading the design system's CSS, you can then begin applying i
 
 <h2 id="need-help" class="ds-h2 ds-u-color--primary-darker">Need help or ran into an issue?</h2>
 
-If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub](https://github.com/CMSgov/design-system/issues).
+If you're having trouble installing or setting up the design system, or if you think you've found a bug, feel free to [open an issue on GitHub]({{github}}/issues).

--- a/packages/design-system-docs/src/pages/startup/theming.md
+++ b/packages/design-system-docs/src/pages/startup/theming.md
@@ -27,12 +27,12 @@ Then, in your main stylesheet, import your overrides file _before_ you [import t
 ```css
 /* main.scss */
 @import 'overrides';
-@import '@cmsgov/design-system/dist/scss/index';
+@import '{{npm}}/dist/scss/index';
 ```
 
 ### Available variables
 
-Sass variables are documented on the relevant documentation pages, and are defined in the `@cmsgov/design-system` package:
+Sass variables are documented on the relevant documentation pages, and are defined in the `{{npm}}` package:
 
 - [Breakpoints]({{root}}/guidelines/responsive/)
 - [Colors]({{root}}/styles/color/)

--- a/packages/design-system-docs/src/scripts/components/Header.jsx
+++ b/packages/design-system-docs/src/scripts/components/Header.jsx
@@ -33,14 +33,16 @@ class Header extends React.PureComponent {
           </h1>
           <GitHubLinks className="ds-u-display--none ds-u-sm-display--block" inversed />
         </header>
-        <div className="ds-c-alert ds-c-alert--warn  ds-c-alert--hide-icon ds-u-border--0 ">
-          <div className="ds-c-alert__body">
-            <p className="ds-c-alert__text">
-              <strong>CMS Design System v2 has been released!</strong>
-              &nbsp; See our <a href="/startup/migrating-v2/">migration guide</a>.
-            </p>
+        {process.env.core && (
+          <div className="ds-c-alert ds-c-alert--warn  ds-c-alert--hide-icon ds-u-border--0 ">
+            <div className="ds-c-alert__body">
+              <p className="ds-c-alert__text">
+                <strong>CMS Design System v2 has been released!</strong>
+                &nbsp; See our <a href="/startup/migrating-v2/">migration guide</a>.
+              </p>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     );
   }

--- a/packages/design-system-scripts/cli.js
+++ b/packages/design-system-scripts/cli.js
@@ -246,6 +246,11 @@ function describeDocsOptions(yargs) {
       desc: 'The base path for your GitHub repository URLs.',
       default: 'https://github.com/CMSgov/design-system',
     })
+    .option('npmPackage', {
+      type: 'string',
+      desc: 'The name of your design system NPM package',
+      default: '@cmsgov/design-system',
+    })
     .option('rootPath', {
       desc:
         'The path of the docs site relative to the domain root. For example, if your docs site is hosted at www.domain.com/design/ your rootPath would be `design/`',

--- a/packages/design-system-scripts/gulp/common/__tests__/replaceTemplateTags.test.js
+++ b/packages/design-system-scripts/gulp/common/__tests__/replaceTemplateTags.test.js
@@ -7,13 +7,23 @@ describe('replaceTemplateTags', () => {
     markup = '{{root}}/bar';
   });
 
-  describe('rootPath is a string', () => {
-    it('replaces {{root}} with empty string', () => {
-      expect(replaceTemplateTags(markup, { rootPath: '' })).toBe('/bar');
-    });
-
-    it('replaces {{root}} with rootPath, formatted as a relative URL', () => {
-      expect(replaceTemplateTags(markup, { rootPath: '1.0.0' })).toBe('/1.0.0/bar');
-    });
+  it('replaces {{root}} with empty string', () => {
+    expect(replaceTemplateTags(markup, { rootPath: '' })).toBe('/bar');
+  });
+  it('replaces {{root}} with rootPath, formatted as a relative URL', () => {
+    expect(replaceTemplateTags(markup, { rootPath: '1.0.0' })).toBe('/1.0.0/bar');
+  });
+  it('replaces {{npm}} with npmPackage', () => {
+    expect(replaceTemplateTags('import {{npm}}', { npmPackage: '@cmsgov/package' })).toBe(
+      'import @cmsgov/package'
+    );
+  });
+  it('replaces {{github}} with githubUrl', () => {
+    expect(replaceTemplateTags('{{github}}', { githubUrl: 'www.github.com' })).toBe(
+      'www.github.com'
+    );
+  });
+  it('replaces {{name}} with name', () => {
+    expect(replaceTemplateTags('{{name}}', { name: 'Design System' })).toBe('Design System');
   });
 });

--- a/packages/design-system-scripts/gulp/common/__tests__/replaceTemplateTags.test.js
+++ b/packages/design-system-scripts/gulp/common/__tests__/replaceTemplateTags.test.js
@@ -7,19 +7,13 @@ describe('replaceTemplateTags', () => {
     markup = '{{root}}/bar';
   });
 
-  describe('rootPath is null', () => {
-    it('replaces {{root}} with empty string', () => {
-      expect(replaceTemplateTags(markup)).toBe('/bar');
-    });
-  });
-
   describe('rootPath is a string', () => {
     it('replaces {{root}} with empty string', () => {
-      expect(replaceTemplateTags(markup, '')).toBe('/bar');
+      expect(replaceTemplateTags(markup, { rootPath: '' })).toBe('/bar');
     });
 
     it('replaces {{root}} with rootPath, formatted as a relative URL', () => {
-      expect(replaceTemplateTags(markup, '1.0.0')).toBe('/1.0.0/bar');
+      expect(replaceTemplateTags(markup, { rootPath: '1.0.0' })).toBe('/1.0.0/bar');
     });
   });
 });

--- a/packages/design-system-scripts/gulp/common/replaceTemplateTags.js
+++ b/packages/design-system-scripts/gulp/common/replaceTemplateTags.js
@@ -8,6 +8,27 @@ function replaceTemplateTags(str, options) {
     str = str.replace(/{{root}}/g, '');
   }
 
+  if (options.npmPackage) {
+    str = str.replace(/{{npm}}/g, `${options.npmPackage}`);
+  } else {
+    str = str.replace(/{{npm}}/g, '');
+    console.log(str);
+  }
+
+  if (options.githubUrl) {
+    str = str.replace(/{{github}}/g, `${options.githubUrl}`);
+  } else {
+    str = str.replace(/{{github}}/g, '');
+    console.log(str);
+  }
+
+  if (options.name) {
+    str = str.replace(/{{name}}/g, `${options.name}`);
+  } else {
+    str = str.replace(/{{name}}/g, '');
+    console.log(str);
+  }
+
   return str;
 }
 

--- a/packages/design-system-scripts/gulp/common/replaceTemplateTags.js
+++ b/packages/design-system-scripts/gulp/common/replaceTemplateTags.js
@@ -12,21 +12,18 @@ function replaceTemplateTags(str, options) {
     str = str.replace(/{{npm}}/g, `${options.npmPackage}`);
   } else {
     str = str.replace(/{{npm}}/g, '');
-    console.log(str);
   }
 
   if (options.githubUrl) {
     str = str.replace(/{{github}}/g, `${options.githubUrl}`);
   } else {
     str = str.replace(/{{github}}/g, '');
-    console.log(str);
   }
 
   if (options.name) {
     str = str.replace(/{{name}}/g, `${options.name}`);
   } else {
     str = str.replace(/{{name}}/g, '');
-    console.log(str);
   }
 
   return str;

--- a/packages/design-system-scripts/gulp/common/replaceTemplateTags.js
+++ b/packages/design-system-scripts/gulp/common/replaceTemplateTags.js
@@ -1,12 +1,9 @@
 /**
  * Replace template tags with string values
- * @param {String} str - String with template tags to be replaced
- * @param {String} rootPath - Root docs site path
- * @return {String}
  */
-function replaceTemplateTags(str, rootPath) {
-  if (rootPath) {
-    str = str.replace(/{{root}}/g, `/${rootPath}`);
+function replaceTemplateTags(str, options) {
+  if (options.rootPath) {
+    str = str.replace(/{{root}}/g, `/${options.rootPath}`);
   } else {
     str = str.replace(/{{root}}/g, '');
   }

--- a/packages/design-system-scripts/gulp/docs/__tests__/processKssSection.test.js
+++ b/packages/design-system-scripts/gulp/docs/__tests__/processKssSection.test.js
@@ -31,7 +31,7 @@ describe('processKssSection', () => {
   let promise;
 
   beforeAll(() => {
-    promise = processKssSection(section('components.button'), 'root');
+    promise = processKssSection(section('components.button'), { rootPath: 'root' });
   });
 
   it('sets and replaces flags', () => {

--- a/packages/design-system-scripts/gulp/docs/__tests__/processMarkdownPage.test.js
+++ b/packages/design-system-scripts/gulp/docs/__tests__/processMarkdownPage.test.js
@@ -19,13 +19,13 @@ hide-example: true
     });
 
     it('converts Markdown to HTML', () => {
-      return processMarkdownPage(filePath, markdown).then((output) => {
+      return processMarkdownPage(filePath, markdown, {}).then((output) => {
         expect(output.description.match(/<strong>/).length).toBe(1);
       });
     });
 
     it('sets source.path relative to project directory', () => {
-      return processMarkdownPage(filePath, markdown).then((output) => {
+      return processMarkdownPage(filePath, markdown, {}).then((output) => {
         const relativePath = filePath.match(/\/design-system\/packages\/[a-zA-Z.\-_/]+/)[0];
         expect(output.source.path).toBe(relativePath);
         expect(output.source.path).toMatch(/\.md$/);
@@ -33,7 +33,7 @@ hide-example: true
     });
 
     it('sets required page props', () => {
-      return processMarkdownPage(filePath, markdown).then((output) => {
+      return processMarkdownPage(filePath, markdown, {}).then((output) => {
         expect(output.depth).toBe(1);
         expect(output.header).toBe('Foo');
         expect(output.description).toBe('<p><strong>Bar</strong></p>\n');
@@ -44,32 +44,32 @@ hide-example: true
     });
 
     it('processes flags', () => {
-      return processMarkdownPage(filePath, markdown).then((output) => {
+      return processMarkdownPage(filePath, markdown, {}).then((output) => {
         expect(output.hideExample).toBe(true);
         expect(output.title).toBeUndefined();
       });
     });
 
     it('has no nested sections', () => {
-      return processMarkdownPage(filePath, markdown).then((output) => {
+      return processMarkdownPage(filePath, markdown, {}).then((output) => {
         expect(output.sections).toBeUndefined();
       });
     });
 
     it('prepends rootPath', () => {
-      return processMarkdownPage(filePath, markdown, '1.0').then((output) => {
+      return processMarkdownPage(filePath, markdown, { rootPath: '1.0' }).then((output) => {
         expect(output.referenceURI).toBe('1.0/boom-bap');
       });
     });
 
     it('sets reference property', () => {
-      return processMarkdownPage(filePath, markdown, '1.0').then((output) => {
+      return processMarkdownPage(filePath, markdown, { rootPath: '1.0' }).then((output) => {
         expect(output.reference).toBe('boom-bap');
       });
     });
 
     it('clears referenceURI for index.md', () => {
-      return processMarkdownPage(filePath.replace('boom-bap.md', 'index.md'), markdown).then(
+      return processMarkdownPage(filePath.replace('boom-bap.md', 'index.md'), markdown, {}).then(
         (output) => {
           expect(output.referenceURI).toBe('');
         }
@@ -78,7 +78,7 @@ hide-example: true
 
     it('replaces {{root}}', () => {
       const markdown2 = markdown + '{{root}}';
-      return processMarkdownPage(filePath, markdown2, 'foo').then((output) => {
+      return processMarkdownPage(filePath, markdown2, { rootPath: 'foo' }).then((output) => {
         expect(output.description.match(/foo/).length).toBe(1);
       });
     });
@@ -97,19 +97,19 @@ Guidance`;
     });
 
     it('sets usage as top-level description', () => {
-      return processMarkdownPage(filePath, markdown).then((output) => {
+      return processMarkdownPage(filePath, markdown, {}).then((output) => {
         expect(output.description.trim()).toBe('<h1 id="hello-world">Hello world</h1>');
       });
     });
 
     it('excludes usage from page properties', () => {
-      return processMarkdownPage(filePath, markdown).then((output) => {
+      return processMarkdownPage(filePath, markdown, {}).then((output) => {
         expect(output.usage).toBeUndefined();
       });
     });
 
     it('adds child section with guidance', () => {
-      return processMarkdownPage(filePath, markdown).then((output) => {
+      return processMarkdownPage(filePath, markdown, {}).then((output) => {
         const section = output.sections[0];
         expect(output.sections.length).toBe(1);
         expect(section.depth).toBe(output.depth + 1);

--- a/packages/design-system-scripts/gulp/docs/__tests__/processMarkup.test.js
+++ b/packages/design-system-scripts/gulp/docs/__tests__/processMarkup.test.js
@@ -29,7 +29,7 @@ describe('processMarkup', () => {
   it('processes template tags', () => {
     const page = createPage('{{root}}/bar');
 
-    return processMarkup(page, 'foo').then((data) => {
+    return processMarkup(page, { rootPath: 'foo' }).then((data) => {
       expect(data.markup).toBe('/foo/bar');
     });
   });
@@ -37,7 +37,7 @@ describe('processMarkup', () => {
   it('renders EJS tags', () => {
     const page = createPage('<% var foo="bar" %><%= foo %>');
 
-    return processMarkup(page).then((data) => {
+    return processMarkup(page, {}).then((data) => {
       expect(data.markup).toBe('bar');
     });
   });
@@ -45,7 +45,7 @@ describe('processMarkup', () => {
   it('loads markup from .html file', () => {
     const page = createPage('foo.html');
 
-    return processMarkup(page).then((data) => {
+    return processMarkup(page, {}).then((data) => {
       expect(data.markup).toMatch(/foo\.html contents/);
       expect(fs.readFile.mock.calls.length).toBe(1);
     });

--- a/packages/design-system-scripts/gulp/docs/extractReactData/parseReactFile.js
+++ b/packages/design-system-scripts/gulp/docs/extractReactData/parseReactFile.js
@@ -112,7 +112,7 @@ function parseComponent(file, options) {
       : reactDocgen.parse(
           file.contents,
           reactDocgen.resolver.findAllExportedComponentDefinitions,
-          reactDocgenHandler(options.rootPath),
+          reactDocgenHandler(options),
           { filename: file.basename }
         );
 

--- a/packages/design-system-scripts/gulp/docs/extractReactData/reactDocgenHandler.js
+++ b/packages/design-system-scripts/gulp/docs/extractReactData/reactDocgenHandler.js
@@ -2,10 +2,7 @@ const defaultHandlers = require('react-docgen').defaultHandlers;
 const marked = require('marked');
 const replaceTemplateTags = require('../../common/replaceTemplateTags');
 
-/**
- * @param {String} rootPath - Root docs site path
- */
-function markdownHandler(rootPath) {
+function markdownHandler(options) {
   /**
    * @param {Documentation} doc - react-docgen Documentation instance
    */
@@ -18,7 +15,7 @@ function markdownHandler(rootPath) {
 
         if (propDescriptor.description !== '') {
           propDescriptor.description = marked(
-            replaceTemplateTags(propDescriptor.description, rootPath)
+            replaceTemplateTags(propDescriptor.description, options)
           );
         }
       });
@@ -28,9 +25,7 @@ function markdownHandler(rootPath) {
 
 /**
  * Add our custom handlers to react-docgen's default list of handlers
- * @param {String} rootPath - Root docs site path
- * @return {Array}
  */
-module.exports = (rootPath) => {
-  return defaultHandlers.concat([markdownHandler(rootPath)]);
+module.exports = (options) => {
+  return defaultHandlers.concat([markdownHandler(options)]);
 };

--- a/packages/design-system-scripts/gulp/docs/generatePages/convertMarkdownPages.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/convertMarkdownPages.js
@@ -12,18 +12,16 @@ const processMarkdownPage = require('./processMarkdownPage');
 /**
  * Reads a path, and creates a JSON representation of the Markdown file. If
  * the path points to a directory, it creates objects for every child file.
- * @param {String} rootPath - Root docs site path
  * @param {String} dir - Directory path
  * @param {String} filename
+ * @param {String} options
  * @return {Promise<Object[]|Object>} Can resolve with a single page object
  *   or an array of page objects
  */
-function createPageObject(rootPath, dir, filename) {
+function createPageObject(dir, filename, options) {
   const filePath = path.join(dir, filename);
 
-  return fs
-    .readFile(filePath, 'utf8')
-    .then((data) => processMarkdownPage(filePath, data, rootPath));
+  return fs.readFile(filePath, 'utf8').then((data) => processMarkdownPage(filePath, data, options));
 }
 
 /**
@@ -33,13 +31,13 @@ function createPageObject(rootPath, dir, filename) {
  * @param {Array} dir - Directory containing the src directory where we will find markdown files
  * @return {Promise<Object[]>} Resolves with an array of JSON pages
  */
-async function convertMarkdownPages(rootPath, dir) {
+async function convertMarkdownPages(dir, options) {
   const pages = [];
   const filenames = glob.sync('src/**/*.md', { cwd: dir });
 
   await Promise.all(
     filenames.map((filename) =>
-      createPageObject(rootPath, dir, filename).then((data) => {
+      createPageObject(dir, filename, options).then((data) => {
         pages.push(data);
       })
     )

--- a/packages/design-system-scripts/gulp/docs/generatePages/generateDocPage.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/generateDocPage.js
@@ -7,7 +7,7 @@ const savePage = require('./savePage');
  * Create an HTML page with the documentation's UI
  * @return {Promise}
  */
-function generateDocPage(routes, page, docsPath, { rootPath, githubUrl, name }) {
+function generateDocPage(routes, page, docsPath, options) {
   if (typeof page.referenceURI !== 'string') {
     return Promise.resolve(false);
   }
@@ -20,21 +20,25 @@ function generateDocPage(routes, page, docsPath, { rootPath, githubUrl, name }) 
       return '';
     }
 
-    // On the client-side the "rootPath" and "githubUrl" variables are defined
-    // via Webpack, but we also need to define them here for "server-side" rendering
-    process.env.rootPath = rootPath;
-    process.env.githubUrl = githubUrl;
-    process.env.name = name;
+    // On the client-side the config options are defined via Webpack
+    // but we also need to define them here for "server-side" rendering
+    process.env.core = options.core;
+    process.env.rootPath = options.rootPath;
+    process.env.name = options.name;
+    process.env.githubUrl = options.githubUrl;
+    process.env.npmPackage = options.npmPackage;
 
     return ReactDOMServer.renderToString(React.createElement(Docs, { page, routes: [] }, null));
   };
 
-  if (rootPath) rootPath = `${rootPath}/`;
+  if (options.rootPath) options.rootPath = `${options.rootPath}/`;
 
-  const head = `${seo(page, rootPath)}
-  <link rel="shortcut icon" type="image/x-icon" href="/${rootPath || ''}images/favicon.ico" />
+  const head = `${seo(page, options.rootPath)}
+  <link rel="shortcut icon" type="image/x-icon" href="/${
+    options.rootPath || ''
+  }images/favicon.ico" />
   <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,700" rel="stylesheet" />
-  <link rel="stylesheet" href="/${rootPath || ''}index.css" />
+  <link rel="stylesheet" href="/${options.rootPath || ''}index.css" />
   ${analytics()}`;
 
   const body = `
@@ -43,7 +47,7 @@ function generateDocPage(routes, page, docsPath, { rootPath, githubUrl, name }) 
   window.page = ${JSON.stringify(page)};
   window.routes = ${JSON.stringify(routes)};
 </script>
-<script src="/${rootPath || ''}index.js"></script>`;
+<script src="/${options.rootPath || ''}index.js"></script>`;
 
   return savePage(
     {

--- a/packages/design-system-scripts/gulp/docs/generatePages/generatePages.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/generatePages.js
@@ -185,7 +185,7 @@ module.exports = async function generatePages(sourceDir, docsDir, options, chang
   // Parse Markdown files, and return the data in the same format as a KssSection
   const markdownSections = await Promise.all(
     docsDirs.map(async (dir) => {
-      return convertMarkdownPages(options.rootPath, dir);
+      return convertMarkdownPages(dir, options);
     })
   ).then((dirPages) => dirPages.flat());
 
@@ -200,7 +200,7 @@ module.exports = async function generatePages(sourceDir, docsDir, options, chang
   const kssSections = await Promise.all(
     kssStyleGuide.sections().map((kssSection) =>
       // Cleanup and extend the section's properties
-      processKssSection(kssSection, options.rootPath)
+      processKssSection(kssSection, options)
     )
   );
 

--- a/packages/design-system-scripts/gulp/docs/generatePages/processKssSection.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/processKssSection.js
@@ -23,7 +23,7 @@ function convertMarkdownCode(value) {
  * @param  {KssSection} kssSection
  * @return {Promise<Object>}
  */
-function processKssSection(kssSection, rootPath) {
+function processKssSection(kssSection, options) {
   let section = kssSection.toJSON();
 
   // Remove properties we don't need. This is useful for a couple reasons, like
@@ -37,18 +37,18 @@ function processKssSection(kssSection, rootPath) {
   });
 
   section = processFlags(section);
-  section.description = replaceTemplateTags(section.description, rootPath);
+  section.description = replaceTemplateTags(section.description, options);
   section.referenceURI = section.reference.replace(/\./g, '/');
 
-  if (rootPath) {
-    section.referenceURI = `${rootPath}/${section.referenceURI}`;
+  if (options.rootPath) {
+    section.referenceURI = `${options.rootPath}/${section.referenceURI}`;
   }
 
   // We only need to support Markdown's code syntax in headers, so we manually
   // parse those rather than running it through the marked library.
   section.header = convertMarkdownCode(section.header);
 
-  const sectionPromise = processMarkup(section, rootPath);
+  const sectionPromise = processMarkup(section, options);
   return sectionPromise;
 }
 

--- a/packages/design-system-scripts/gulp/docs/generatePages/processMarkdownPage.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/processMarkdownPage.js
@@ -32,10 +32,10 @@ function setFlags(page, attributes) {
  * that will later get passed into the React app.
  * @param {String} filePath - Absolute path to Markdown file
  * @param {String} body - Markdown file contents
- * @param {String} rootPath - Root docs site path
+ * @param {Object} options
  * @return {Promise<Object>} Resolves with the page object
  */
-function processMarkdownPage(filePath, body, rootPath = '') {
+function processMarkdownPage(filePath, body, options) {
   const parts = fm(body); // parse page properties from top of file
   const description = parts.attributes.usage || parts.body;
 
@@ -59,8 +59,8 @@ function processMarkdownPage(filePath, body, rootPath = '') {
 
     reference = referenceURI.replace('/', '.');
 
-    if (rootPath !== '') {
-      referenceURI = path.join(rootPath, referenceURI);
+    if (options.rootPath) {
+      referenceURI = path.join(options.rootPath, referenceURI);
     }
   }
 
@@ -69,7 +69,7 @@ function processMarkdownPage(filePath, body, rootPath = '') {
     depth: depth,
     label: parts.attributes.label || header,
     header,
-    description: formatText(description, rootPath),
+    description: formatText(description, options),
     markup: parts.attributes.markup || '',
     reference: reference,
     referenceURI: referenceURI,
@@ -88,7 +88,7 @@ function processMarkdownPage(filePath, body, rootPath = '') {
       {
         depth: depth + 1,
         header: '---',
-        description: formatText(parts.body, rootPath),
+        description: formatText(parts.body, options),
         reference: `${reference}.guidance`,
         referenceURI: path.join(referenceURI, 'guidance'),
       },
@@ -101,7 +101,7 @@ function processMarkdownPage(filePath, body, rootPath = '') {
   delete parts.attributes.title;
   page = setFlags(page, parts.attributes);
 
-  return processMarkup(page, rootPath);
+  return processMarkup(page, options);
 }
 
 /**
@@ -109,8 +109,8 @@ function processMarkdownPage(filePath, body, rootPath = '') {
  * @param {String} rootPath
  * @return {String}
  */
-function formatText(text, rootPath) {
-  return marked(replaceTemplateTags(text, rootPath));
+function formatText(text, options) {
+  return marked(replaceTemplateTags(text, options));
 }
 
 module.exports = processMarkdownPage;

--- a/packages/design-system-scripts/gulp/docs/generatePages/processMarkup.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/processMarkup.js
@@ -8,10 +8,10 @@ const { logData, logError } = require('../../common/logUtil');
  * Take the raw markup value and convert or retrieve the markup to be displayed
  * to the user.
  * @param {Object} page
- * @param {rootPath}
+ * @param {Object}
  * @return {Promise<Object>} page updated `markup` property
  */
-function processMarkup(page, rootPath = '') {
+function processMarkup(page, options) {
   let markup = page.markup;
 
   if (markup && markup !== '') {
@@ -19,11 +19,11 @@ function processMarkup(page, rootPath = '') {
       return loadMarkup(page).then(({ markup, markupPath }) => {
         page.markup = markup;
         page.markupPath = markupPath;
-        return processMarkup(page, rootPath);
+        return processMarkup(page, options);
       });
     }
 
-    markup = replaceTemplateTags(markup, rootPath);
+    markup = replaceTemplateTags(markup, options);
 
     // Render EJS
     try {

--- a/packages/design-system-scripts/gulp/docs/webpack/createWebpackConfig.js
+++ b/packages/design-system-scripts/gulp/docs/webpack/createWebpackConfig.js
@@ -44,9 +44,12 @@ module.exports = async function createWebpackConfig(sourceDir, docsDir, options)
     plugins: [
       new webpack.DefinePlugin({
         'process.env': {
+          // Copy over config options
+          core: JSON.stringify(options.core),
           rootPath: JSON.stringify(options.rootPath),
-          githubUrl: JSON.stringify(options.githubUrl),
           name: JSON.stringify(options.name),
+          githubUrl: JSON.stringify(options.githubUrl),
+          npmPackage: JSON.stringify(options.npmPackage),
           NODE_ENV: JSON.stringify(process.env.NODE_ENV),
         },
       }),


### PR DESCRIPTION
### Summary
- Added `npmPackage` option
- Added support for `{{npm}}`, `{{github}}`, and `{{name}}` templates

### How to test
- Run the doc site and ensure all the content using the new templates is correct
- Try changing various template values to see the doc site update

