### PR TITLE
[NO-TICKET] Update ARIA role prop to include `status`

### DIFF
--- a/packages/design-system/src/components/Alert/Alert.jsx
+++ b/packages/design-system/src/components/Alert/Alert.jsx
@@ -79,7 +79,7 @@ Alert.propTypes = {
   /**
    * ARIA `role`, defaults to 'region'
    */
-  role: PropTypes.oneOf(['alert', 'alertdialog', 'region']),
+  role: PropTypes.oneOf(['alert', 'alertdialog', 'region', 'status']),
   /**
    * A string corresponding to the `Alert` variation classes (`error`, `warn`, `success`)
    */


### PR DESCRIPTION
### Summary
Update ARIA role prop to accept `status` type. This `status` type was requested for displaying scrollable notice on TableCaption Component.

