### PR TITLE
Test babel register

### DIFF
--- a/packages/design-system-scripts/gulp/docs/generatePages/generatePages.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/generatePages.js
@@ -1,6 +1,6 @@
 // Run babel transforms on src files so we can run JSX scripts in Gulp tasks
 require('@babel/register')({
-  only: [/(@cmsgov\/design-system-docs|design-system\/packages\/([a-z-_]+)\/src|generateDocPage)/],
+  only: [/(@cmsgov\/design-system-docs|packages\/([a-z-_]+)\/src|generateDocPage)/],
   presets: [
     [
       '@babel/preset-env',

--- a/packages/design-system-scripts/gulp/docs/generatePages/generatePages.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/generatePages.js
@@ -1,6 +1,6 @@
 // Run babel transforms on src files so we can run JSX scripts in Gulp tasks
 require('@babel/register')({
-  only: [/(@cmsgov\/design-system-docs|packages\/([a-z-_]+)\/src|generateDocPage)/],
+  only: [/(design-system-docs)/],
   presets: [
     [
       '@babel/preset-env',


### PR DESCRIPTION
### Summary
CBJ isnt able to finish generating doc site because of the babel/register not working. This PR updates the regex to include CBJ's directory

CBJ error
<img width="732" alt="Screen Shot 2020-07-30 at 11 18 02 AM" src="https://user-images.githubusercontent.com/5424713/88947610-6151e980-d256-11ea-9f7c-47a49e38a547.png">
Notice the directory is `s3/packages/design-system-docs` rather than `design-system/packages/`

### How to test
- Ensure doc site generates in core and child ds