### PR TITLE
[NO_TICKET] Update default font image path

### DIFF
--- a/packages/design-system-docs/src/example.scss
+++ b/packages/design-system-docs/src/example.scss
@@ -1,4 +1,7 @@
 // Loaded within the markup example iframes
+$font-path: './fonts';
+$image-path: './images';
+
 @import '@cmsgov/design-system/dist/scss/index';
 
 @import 'styles/settings/index';

--- a/packages/design-system-docs/src/index.scss
+++ b/packages/design-system-docs/src/index.scss
@@ -1,4 +1,7 @@
 // Libraries
+$font-path: './fonts';
+$image-path: './images';
+
 @import '@cmsgov/design-system/dist/scss/index';
 
 // Sass settings

--- a/packages/design-system-docs/src/pages/startup/sass-and-css.md
+++ b/packages/design-system-docs/src/pages/startup/sass-and-css.md
@@ -39,7 +39,8 @@ By default, the design system expects a file structure like this:
 └── Your site's build folder/
     ├── images/
     ├── fonts/
-    └── index.css
+    └── css/
+      └── index.css/
 ```
 
 You can manually copy the image and font directories, or you could integrate this step into your build process.
@@ -59,15 +60,14 @@ For example, if your project build directory file structure looked like this:
 └── Your site's build folder/
     ├── images/
     ├── fonts/
-    └── css/
-      └── index.css/
+    └── index.css
 ```
 
 The asset paths would have to be redefined like so:
 
 ```css
-$font-path: '../fonts';
-$image-path: '../image';
+$font-path: './fonts';
+$image-path: './image';
 ```
 
 Without overriding these variables, it's possible that your fonts and images will not render correctly in your project.

--- a/packages/design-system/src/styles/settings/variables/_build.scss
+++ b/packages/design-system/src/styles/settings/variables/_build.scss
@@ -1,6 +1,6 @@
 // Paths
-$font-path: './fonts' !default;
-$image-path: './images' !default;
+$font-path: '../fonts' !default;
+$image-path: '../images' !default;
 
 // Override these variables to change what CSS rulesets get outputted when
 // the Sass is transpiled to CSS


### PR DESCRIPTION
### Summary
- Update the default font and image path to `../fonts` rather than `./fonts`

### How to test
- Ensure the core builds
- Ensure both child design systems build