### PR TITLE
[WNMGDS-579] Fix console warnings for HelpDrawer and Dialog

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.jsx
@@ -26,7 +26,7 @@ export const Dialog = function (props) {
   if (process.env.NODE_ENV !== 'production') {
     if (props.title) {
       console.warn(
-        `[Deprecated]: Please remove the 'title' prop in <Button>, use 'heading' instead. This prop has been renamed and will be removed in a future release.`
+        `[Deprecated]: Please remove the 'title' prop in <Dialog>, use 'heading' instead. This prop has been renamed and will be removed in a future release.`
       );
     }
   }

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
@@ -10,12 +10,12 @@ export class HelpDrawer extends React.PureComponent {
     if (process.env.NODE_ENV !== 'production') {
       if (props.title) {
         console.warn(
-          `[Deprecated]: Please remove the 'title' prop in <Button>, use 'heading' instead. This prop has been renamed and will be removed in a future release.`
+          `[Deprecated]: Please remove the 'title' prop in <HelpDrawer>, use 'heading' instead. This prop has been renamed and will be removed in a future release.`
         );
       }
       if (!props.title && !props.heading) {
         console.warn(
-          `The 'heading' prop in <Button> is required. The 'title' prop has been renamed to 'heading' and will be removed in a future release.`
+          `The 'heading' prop in <HelpDrawer> is required. The 'title' prop has been renamed to 'heading' and will be removed in a future release.`
         );
       }
     }


### PR DESCRIPTION
Updated the HelpDrawer and Dialog component warnings to reference the propper component and not the `<button>`

