### PR TITLE
[WNMGTAXTOOLS-73] Export getMonthNames function from MonthPicker module

### DIFF
--- a/packages/design-system-docs/src/pages/components/MonthPicker/MonthPicker.example.jsx
+++ b/packages/design-system-docs/src/pages/components/MonthPicker/MonthPicker.example.jsx
@@ -1,6 +1,8 @@
-import { MonthPicker } from '@cmsgov/design-system';
+import { MonthPicker, getMonthNames } from '@cmsgov/design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
+
+console.log(getMonthNames('en'));
 
 ReactDOM.render(
   <div>

--- a/packages/design-system-docs/src/pages/components/MonthPicker/MonthPicker.example.jsx
+++ b/packages/design-system-docs/src/pages/components/MonthPicker/MonthPicker.example.jsx
@@ -1,8 +1,6 @@
-import { MonthPicker, getMonthNames } from '@cmsgov/design-system';
+import { MonthPicker } from '@cmsgov/design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
-
-console.log(getMonthNames('en'));
 
 ReactDOM.render(
   <div>

--- a/packages/design-system/src/components/index.js
+++ b/packages/design-system/src/components/index.js
@@ -16,7 +16,7 @@ export { Dropdown } from './Dropdown/Dropdown';
 export { FormLabel } from './FormLabel/FormLabel';
 export { HelpDrawer } from './HelpDrawer/HelpDrawer';
 export { HelpDrawerToggle } from './HelpDrawer/HelpDrawerToggle';
-export { MonthPicker } from './MonthPicker/MonthPicker';
+export { MonthPicker, getMonthNames } from './MonthPicker/MonthPicker';
 export { Review } from './Review/Review';
 export { SkipNav } from './SkipNav/SkipNav';
 export { Spinner } from './Spinner/Spinner';


### PR DESCRIPTION
### Fixed
- Export `getMonthNames` function from `MonthPicker` module, which one of our products relied on

### How to test
1. Check out 4b38710 locally, which has some temporary debugging code in it
2. `yarn install && yarn start`
3. Go to the `MonthPicker` page of the docs site
4. Open up the developer console and see the debug output from that commit