### PR TITLE
[WNMGDS-527] Add disabled prop to DateField

### DIFF
--- a/packages/design-system-docs/src/pages/components/DateField/DateField.example.jsx
+++ b/packages/design-system-docs/src/pages/components/DateField/DateField.example.jsx
@@ -1,5 +1,5 @@
-import React, { Fragment } from 'react';
 import { DateField } from '@cmsgov/design-system';
+import React from 'react';
 import ReactDOM from 'react-dom';
 
 class ControlledDateField extends React.PureComponent {
@@ -22,7 +22,7 @@ class ControlledDateField extends React.PureComponent {
               DateField using default <code>dateFormatter</code>
             </span>
           }
-          hint={'Try to enter a date with invalid number of digits'}
+          hint="Try to enter a date with invalid number of digits"
           monthValue={this.state.month}
           dayValue={this.state.day}
           yearValue={this.state.year}
@@ -34,16 +34,17 @@ class ControlledDateField extends React.PureComponent {
 }
 
 ReactDOM.render(
-  <Fragment>
+  <div>
     <DateField
-      label="DateField example"
+      label="DateField example with invalid year"
       errorMessage="Please enter a year in the past"
       monthDefaultValue="10"
       dayDefaultValue="31"
-      yearDefaultValue="2020"
+      yearDefaultValue="2050"
       yearInvalid
     />
+
     <ControlledDateField />
-  </Fragment>,
+  </div>,
   document.getElementById('js-example')
 );

--- a/packages/design-system-docs/src/pages/components/DateField/DateField.example.jsx
+++ b/packages/design-system-docs/src/pages/components/DateField/DateField.example.jsx
@@ -34,7 +34,7 @@ class ControlledDateField extends React.PureComponent {
 }
 
 ReactDOM.render(
-  <div>
+  <>
     <DateField
       label="DateField example with invalid year"
       errorMessage="Please enter a year in the past"
@@ -45,6 +45,6 @@ ReactDOM.render(
     />
 
     <ControlledDateField />
-  </div>,
+  </>,
   document.getElementById('js-example')
 );

--- a/packages/design-system/src/components/DateField/DateField.jsx
+++ b/packages/design-system/src/components/DateField/DateField.jsx
@@ -190,7 +190,7 @@ DateField.propTypes = {
    */
   dateFormatter: PropTypes.func,
   /**
-   * Disables the entire field.
+   * Disables all three input fields.
    */
   disabled: PropTypes.bool,
   errorMessage: PropTypes.node,

--- a/packages/design-system/src/components/DateField/DateField.jsx
+++ b/packages/design-system/src/components/DateField/DateField.jsx
@@ -110,6 +110,7 @@ export class DateField extends React.PureComponent {
               if (this.props.monthFieldRef) this.props.monthFieldRef(el);
             }}
             defaultValue={this.props.monthDefaultValue}
+            disabled={this.props.disabled}
             label={this.props.monthLabel}
             name={this.props.monthName}
             value={this.props.monthValue}
@@ -127,6 +128,7 @@ export class DateField extends React.PureComponent {
               if (this.props.dayFieldRef) this.props.dayFieldRef(el);
             }}
             defaultValue={this.props.dayDefaultValue}
+            disabled={this.props.disabled}
             label={this.props.dayLabel}
             name={this.props.dayName}
             value={this.props.dayValue}
@@ -144,6 +146,7 @@ export class DateField extends React.PureComponent {
               if (this.props.yearFieldRef) this.props.yearFieldRef(el);
             }}
             defaultValue={this.props.yearDefaultValue}
+            disabled={this.props.disabled}
             label={this.props.yearLabel}
             name={this.props.yearName}
             value={this.props.yearValue}
@@ -186,6 +189,10 @@ DateField.propTypes = {
    * By default `dateFormatter` will be set to the `defaultDateFormatter` function, which prevents days/months more than 2 digits & years more than 4 digits.
    */
   dateFormatter: PropTypes.func,
+  /**
+   * Disables the entire field.
+   */
+  disabled: PropTypes.bool,
   errorMessage: PropTypes.node,
   /**
    * Additional hint text to display above the individual month/day/year fields

--- a/packages/design-system/src/components/DateField/DateField.test.jsx
+++ b/packages/design-system/src/components/DateField/DateField.test.jsx
@@ -38,6 +38,10 @@ describe('DateField', () => {
     expect(renderer.create(<DateField yearMax={2000} yearMin="1990" />)).toMatchSnapshot();
   });
 
+  it('is disabled', () => {
+    expect(renderer.create(<DateField disabled />)).toMatchSnapshot();
+  });
+
   it('returns reference to input fields', () => {
     const refs = {};
     const props = {

--- a/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -657,6 +657,117 @@ exports[`DateField has requirementLabel 1`] = `
 </fieldset>
 `;
 
+exports[`DateField is disabled 1`] = `
+<fieldset
+  className="ds-c-fieldset"
+>
+  <legend
+    className="ds-c-label"
+    id="datefield_label_snapshot"
+  >
+    <span
+      className=""
+    >
+      Date
+    </span>
+    <span
+      className="ds-c-field__hint"
+    >
+      For example: 4 / 28 / 1986
+    </span>
+  </legend>
+  <div
+    className="ds-l-form-row ds-u-align-items--end"
+  >
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+        id="textfield_label_snapshot"
+      >
+        <span
+          className=""
+        >
+          Month
+        </span>
+      </label>
+      <input
+        aria-describedby="datefield_label_snapshot"
+        className="ds-c-field ds-c-field--month"
+        disabled={true}
+        id="textfield_snapshot"
+        inputMode="numeric"
+        name="month"
+        pattern="[0-9]*"
+        type="text"
+      />
+    </div>
+    <span
+      className="ds-c-datefield__separator"
+    >
+      /
+    </span>
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+        id="textfield_label_snapshot"
+      >
+        <span
+          className=""
+        >
+          Day
+        </span>
+      </label>
+      <input
+        aria-describedby="datefield_label_snapshot"
+        className="ds-c-field ds-c-field--day"
+        disabled={true}
+        id="textfield_snapshot"
+        inputMode="numeric"
+        name="day"
+        pattern="[0-9]*"
+        type="text"
+      />
+    </div>
+    <span
+      className="ds-c-datefield__separator"
+    >
+      /
+    </span>
+    <div
+      className="ds-u-clearfix ds-l-col--auto"
+    >
+      <label
+        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        htmlFor="textfield_snapshot"
+        id="textfield_label_snapshot"
+      >
+        <span
+          className=""
+        >
+          Year
+        </span>
+      </label>
+      <input
+        aria-describedby="datefield_label_snapshot"
+        className="ds-c-field ds-c-field--year"
+        disabled={true}
+        id="textfield_snapshot"
+        inputMode="numeric"
+        name="year"
+        pattern="[0-9]*"
+        type="text"
+      />
+    </div>
+  </div>
+</fieldset>
+`;
+
 exports[`DateField is inversed 1`] = `
 <fieldset
   className="ds-c-fieldset"


### PR DESCRIPTION
### Added
- Added `disabled` prop to disable the entire `DateField` component.
- Added test for `disabled` `DateField`

### Changed
- Updated React example name to be more explicit 


## How to test

1. Run the doc site locally and navigate to the Date field page
1. Update the React `DateField` example by adding the `disabled` prop 
1. See that the day, month, and year fields are disabled 

