### PR TITLE
[WNMGDS-543] Allow markdown in typescript documentation

### DIFF
--- a/packages/design-system-scripts/gulp/docs/extractReactData/reactDocgenHandler.js
+++ b/packages/design-system-scripts/gulp/docs/extractReactData/reactDocgenHandler.js
@@ -2,30 +2,32 @@ const defaultHandlers = require('react-docgen').defaultHandlers;
 const marked = require('marked');
 const replaceTemplateTags = require('../../common/replaceTemplateTags');
 
+function processDocgenTemplates(doc, options) {
+  if (doc.props) {
+    Object.keys(doc.props).forEach((propName) => {
+      const propObject = doc.getPropDescriptor ? doc.getPropDescriptor(propName) : doc.props[propName];
+      if (propObject.description !== '') {
+        propObject.description = marked(
+          replaceTemplateTags(propObject.description, options)
+        );
+      }
+    });
+  }
+}
 function markdownHandler(options) {
   /**
    * @param {Documentation} doc - react-docgen Documentation instance
    */
   return function (doc) {
     const docObject = doc.toObject();
-
-    if (docObject.props) {
-      Object.keys(docObject.props).forEach((propName) => {
-        const propDescriptor = doc.getPropDescriptor(propName);
-
-        if (propDescriptor.description !== '') {
-          propDescriptor.description = marked(
-            replaceTemplateTags(propDescriptor.description, options)
-          );
-        }
-      });
-    }
+    processDocgenTemplates(docObject, options)
   };
 }
 
 /**
  * Add our custom handlers to react-docgen's default list of handlers
  */
-module.exports = (options) => {
-  return defaultHandlers.concat([markdownHandler(options)]);
+module.exports = {
+  reactDocgenHandler: (options) => defaultHandlers.concat([markdownHandler(options)]),
+  processDocgenTemplates
 };


### PR DESCRIPTION
### Changed
- Refactor `reactDocgenHandler` to export and use `processDocgenTemplates()`
- Use `processDocgenTemplates` in `parseReactFile` to ensure typescript prop documentation can use markdown

### How to test
- Setup Mgov child ds to use the local branch for CMSDS scripts
- Add prop documentation to a `tsx` file that uses markdown
- Run the doc site and ensure the correct HTML is generated in the prop documentation table