### PR TITLE
[WNMGDS-590] Apply 'autoFocus' props 

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
@@ -45,7 +45,7 @@ export class Autocomplete extends React.PureComponent {
     if (process.env.NODE_ENV !== 'production') {
       if (props.focusTrigger) {
         console.warn(
-          `[Deprecated]: Please remove the React property 'focusTrigger' for the <Autocomplete> component. It is no longer supported and will be removed in a future release, use 'autoFocus' instead.`
+          `[Deprecated]: Please remove the 'focusTrigger' prop in <Autocomplete>, use 'autoFocus' instead. This prop has been renamed and will be removed in a future release.`
         );
       }
     }
@@ -224,7 +224,7 @@ Autocomplete.propTypes = {
    */
   autoCompleteLabel: PropTypes.string,
   /**
-   * Used to focus child `TextField` on `componentDidMount()`
+   * Focus the control on child `TextField` when it is mounted.
    */
   autoFocus: PropTypes.bool,
   /**

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
@@ -41,6 +41,14 @@ export class Autocomplete extends React.PureComponent {
     this.listboxId = uniqueId('autocomplete_owned_listbox_');
     this.listboxContainerId = uniqueId('autocomplete_owned_container_');
     this.listboxHeadingId = uniqueId('autocomplete_header_');
+
+    if (process.env.NODE_ENV !== 'production') {
+      if (props.focusTrigger) {
+        console.warn(
+          `[Deprecated]: Please remove the React property 'focusTrigger' for the <Autocomplete> component. It is no longer supported and will be removed in a future release, use 'autoFocus' instead.`
+        );
+      }
+    }
   }
 
   filterItems(items, inputValue, getInputProps, getItemProps, highlightedIndex) {
@@ -93,6 +101,7 @@ export class Autocomplete extends React.PureComponent {
           'aria-labelledby': null,
           'aria-owns': isOpen ? this.listboxId : null,
           autoComplete: this.props.autoCompleteLabel,
+          autoFocus: this.props.autoFocus,
           focusTrigger: this.props.focusTrigger,
           id: this.id,
           inputRef: this.props.inputRef,
@@ -215,6 +224,10 @@ Autocomplete.propTypes = {
    */
   autoCompleteLabel: PropTypes.string,
   /**
+   * Used to focus child `TextField` on `componentDidMount()`
+   */
+  autoFocus: PropTypes.bool,
+  /**
    * Must contain a `TextField` component
    */
   children: PropTypes.node.isRequired,
@@ -232,7 +245,7 @@ Autocomplete.propTypes = {
    */
   clearSearchButton: PropTypes.bool,
   /**
-   * Used to focus child `TextField` on `componentDidMount()`
+   * (Deprecated) Used to focus child `TextField` on `componentDidMount()`
    */
   focusTrigger: PropTypes.bool,
   /**

--- a/packages/design-system/src/components/Dropdown/Dropdown.jsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.jsx
@@ -28,7 +28,7 @@ export class Dropdown extends React.PureComponent {
       }
       if (props.focusTrigger) {
         console.warn(
-          `[Deprecated]: Please remove the React property 'focusTrigger' for the <Dropdown> component. It is no longer supported and will be removed in a future release, use 'focusTrigger' instead.`
+          `[Deprecated]: Please remove the 'focusTrigger' prop in <Dropdown>, use 'autoFocus' instead. This prop has been renamed and will be removed in a future release.`
         );
       }
     }
@@ -135,7 +135,7 @@ Dropdown.propTypes = {
    */
   ariaLabel: PropTypes.string,
   /**
-   * Used to focus `select` on `componentDidMount()`
+   * Focus the control on `select` when it is mounted.
    */
   autoFocus: PropTypes.bool,
   /**

--- a/packages/design-system/src/components/Dropdown/Dropdown.jsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.jsx
@@ -26,6 +26,11 @@ export class Dropdown extends React.PureComponent {
           `Please provide an 'ariaLabel' when using the <Dropdown> component without a 'label' prop.`
         );
       }
+      if (props.focusTrigger) {
+        console.warn(
+          `[Deprecated]: Please remove the React property 'focusTrigger' for the <Dropdown> component. It is no longer supported and will be removed in a future release, use 'focusTrigger' instead.`
+        );
+      }
     }
   }
 
@@ -52,6 +57,7 @@ export class Dropdown extends React.PureComponent {
     /* eslint-disable prefer-const */
     const {
       ariaLabel,
+      autoFocus,
       className,
       children,
       errorMessage,
@@ -90,7 +96,7 @@ export class Dropdown extends React.PureComponent {
       <div className={classes}>
         <FormLabel
           className={labelClassName}
-          component={'label'}
+          component="label"
           errorMessage={errorMessage}
           fieldId={this.id()}
           hint={hint}
@@ -103,6 +109,8 @@ export class Dropdown extends React.PureComponent {
           aria-label={ariaLabel}
           className={fieldClasses}
           id={this.id()}
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus={autoFocus}
           /* eslint-disable no-return-assign */
           ref={(ref) => {
             if (focusTrigger) {
@@ -127,6 +135,10 @@ Dropdown.propTypes = {
    */
   ariaLabel: PropTypes.string,
   /**
+   * Used to focus `select` on `componentDidMount()`
+   */
+  autoFocus: PropTypes.bool,
+  /**
    * Additional classes to be added to the root element.
    */
   className: PropTypes.string,
@@ -149,7 +161,7 @@ Dropdown.propTypes = {
    */
   fieldClassName: PropTypes.string,
   /**
-   * Used to focus `select` on `componentDidMount()`
+   * (Deprecated) Used to focus `select` on `componentDidMount()`
    */
   focusTrigger: PropTypes.bool,
   /**

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.jsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.jsx
@@ -127,11 +127,11 @@ describe('Dropdown', () => {
     expect(data.wrapper.find('select').hasClass('ds-c-field--error')).toBe(true);
   });
 
-  it('focuses the select when focusTrigger is passed', () => {
+  it('focuses the select when autoFocus is passed', () => {
     const data = render(
       {
         id: 'focus',
-        focusTrigger: true,
+        autoFocus: true,
       },
       null,
       true

--- a/packages/design-system/src/components/TextField/TextField.jsx
+++ b/packages/design-system/src/components/TextField/TextField.jsx
@@ -19,6 +19,11 @@ export class TextField extends React.PureComponent {
           `Please use the 'numeric' prop instead of 'type="number"' unless your user research suggests otherwise.`
         );
       }
+      if (props.focusTrigger) {
+        console.warn(
+          `[Deprecated]: Please remove the React property 'focusTrigger' for the <TextField> component. It is no longer supported and will be removed in a future release, use 'autoFocus' instead.`
+        );
+      }
     }
   }
 
@@ -48,6 +53,7 @@ export class TextField extends React.PureComponent {
   render() {
     const {
       ariaLabel,
+      autoFocus,
       className,
       errorMessage,
       fieldClassName,
@@ -100,6 +106,8 @@ export class TextField extends React.PureComponent {
         aria-label={this.ariaLabel()}
         className={fieldClasses}
         id={this.id}
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={autoFocus}
         /* eslint-disable no-return-assign */
         ref={(ref) => {
           if (focusTrigger) {
@@ -149,6 +157,10 @@ TextField.propTypes = {
    */
   ariaLabel: PropTypes.string,
   /**
+   * Used to focus `input` on `componentDidMount()`
+   */
+  autoFocus: PropTypes.bool,
+  /**
    * Additional classes to be added to the root `div` element
    */
   className: PropTypes.string,
@@ -164,7 +176,7 @@ TextField.propTypes = {
    */
   fieldClassName: PropTypes.string,
   /**
-   * Used to focus `input` on `componentDidMount()`
+   * (Deprecated) Used to focus `input` on `componentDidMount()`
    */
   focusTrigger: PropTypes.bool,
   /**

--- a/packages/design-system/src/components/TextField/TextField.jsx
+++ b/packages/design-system/src/components/TextField/TextField.jsx
@@ -21,7 +21,7 @@ export class TextField extends React.PureComponent {
       }
       if (props.focusTrigger) {
         console.warn(
-          `[Deprecated]: Please remove the React property 'focusTrigger' for the <TextField> component. It is no longer supported and will be removed in a future release, use 'autoFocus' instead.`
+          `[Deprecated]: Please remove the 'focusTrigger' prop in <TextField>, use 'autoFocus' instead. This prop has been renamed and will be removed in a future release.`
         );
       }
     }
@@ -157,7 +157,7 @@ TextField.propTypes = {
    */
   ariaLabel: PropTypes.string,
   /**
-   * Used to focus `input` on `componentDidMount()`
+   * Focus the control on `input` when it is mounted.
    */
   autoFocus: PropTypes.bool,
   /**

--- a/packages/design-system/src/components/TextField/TextField.test.jsx
+++ b/packages/design-system/src/components/TextField/TextField.test.jsx
@@ -197,11 +197,11 @@ describe('TextField', function () {
     expect(ref.value).toBe(data.props.defaultValue);
   });
 
-  it('focuses the input when focusTrigger is passed', () => {
+  it('focuses the input when autoFocus is passed', () => {
     const data = render(
       {
         id: 'focus',
-        focusTrigger: true,
+        autoFocus: true,
       },
       true
     );

--- a/packages/design-system/src/types/Autocomplete/Autocomplete.d.ts
+++ b/packages/design-system/src/types/Autocomplete/Autocomplete.d.ts
@@ -11,7 +11,7 @@ export interface AutocompleteProps {
    */
   ariaClearLabel?: string;
   /**
-   * Used to focus child `TextField` on `componentDidMount()`
+   * Focus the control on child `TextField` when it is mounted.
    */
   autoFocus?: boolean;
   /**

--- a/packages/design-system/src/types/Autocomplete/Autocomplete.d.ts
+++ b/packages/design-system/src/types/Autocomplete/Autocomplete.d.ts
@@ -11,6 +11,10 @@ export interface AutocompleteProps {
    */
   ariaClearLabel?: string;
   /**
+   * Used to focus child `TextField` on `componentDidMount()`
+   */
+  autoFocus?: boolean;
+  /**
    * Control the `TextField` autocomplete attribute. Defaults to "off" to support accessibility. [Read more.](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion)
    */
   autoCompleteLabel?: string;
@@ -32,7 +36,7 @@ export interface AutocompleteProps {
    */
   clearSearchButton?: boolean;
   /**
-   * Used to focus child `TextField` on `componentDidMount()`
+   * (Deprecated) Used to focus child `TextField` on `componentDidMount()`
    */
   focusTrigger?: boolean;
   /**

--- a/packages/design-system/src/types/Dropdown/Dropdown.d.ts
+++ b/packages/design-system/src/types/Dropdown/Dropdown.d.ts
@@ -17,6 +17,10 @@ export interface DropdownProps {
    */
   ariaLabel?: string;
   /**
+   * Used to focus `select` on `componentDidMount()`
+   */
+  autoFocus?: boolean;
+  /**
    * Additional classes to be added to the root element.
    */
   className?: string;
@@ -39,7 +43,7 @@ export interface DropdownProps {
    */
   fieldClassName?: string;
   /**
-   * Used to focus `select` on `componentDidMount()`
+   * (Deprecated) Used to focus `select` on `componentDidMount()`
    */
   focusTrigger?: boolean;
   /**

--- a/packages/design-system/src/types/Dropdown/Dropdown.d.ts
+++ b/packages/design-system/src/types/Dropdown/Dropdown.d.ts
@@ -17,7 +17,7 @@ export interface DropdownProps {
    */
   ariaLabel?: string;
   /**
-   * Used to focus `select` on `componentDidMount()`
+   * Focus the control on `select` when it is mounted.
    */
   autoFocus?: boolean;
   /**

--- a/packages/design-system/src/types/TextField/TextField.d.ts
+++ b/packages/design-system/src/types/TextField/TextField.d.ts
@@ -17,7 +17,7 @@ export interface TextFieldProps {
    */
   ariaLabel?: string;
   /**
-   * Used to focus `input` on `componentDidMount()`
+   * Focus the control on `input` when it is mounted.
    */
   autoFocus?: boolean;
   /**

--- a/packages/design-system/src/types/TextField/TextField.d.ts
+++ b/packages/design-system/src/types/TextField/TextField.d.ts
@@ -17,6 +17,10 @@ export interface TextFieldProps {
    */
   ariaLabel?: string;
   /**
+   * Used to focus `input` on `componentDidMount()`
+   */
+  autoFocus?: boolean;
+  /**
    * Additional classes to be added to the root `div` element
    */
   className?: string;
@@ -32,7 +36,7 @@ export interface TextFieldProps {
    */
   fieldClassName?: string;
   /**
-   * Used to focus `input` on `componentDidMount()`
+   * (Deprecated) Used to focus `input` on `componentDidMount()`
    */
   focusTrigger?: boolean;
   /**


### PR DESCRIPTION
### Chnaged
Change `Autocomplete`, `TextField` and `Dropdown` to use react's `autoFocus` props and deprecate the old versions of `focusTrigger` props.

### How to test
- Apply the `autoFocus` prop to the various component and check for focus on first mount of the page. 
- Apply the old `focusTrigger` prop to the various component and check for focus on first mount of the page and check that a deprecated warning message is logged to the developer console.

### TODO
Add `autoFocus` prop to other components such as FormLabel and maybe Choice