### PR TITLE
[WNMGDS-616] Fix disabled choice style bug

### DIFF
--- a/packages/design-system/src/styles/components/_Choice.scss
+++ b/packages/design-system/src/styles/components/_Choice.scss
@@ -111,7 +111,7 @@ $ds-c-inset-border-width: $spacer-half;
 
     &::before {
       background-color: $color-gray-lighter;
-      border: 1px solid $color-gray-light;
+      border-color: $color-gray-light;
       cursor: not-allowed;
     }
   }
@@ -123,7 +123,6 @@ $ds-c-inset-border-width: $spacer-half;
 
     &::before {
       background-color: rgba($color-muted-inverse, 0.15);
-      box-shadow: 0 0 0 1px $color-muted-inverse;
     }
   }
 }


### PR DESCRIPTION
Disabled checkboxes and radio buttons now have consistent border styling for default and inverse variations.

![Screen Shot 2020-09-10 at 4 38 12 PM](https://user-images.githubusercontent.com/1449852/92801903-0696cc00-f384-11ea-9bbe-f8dac802163a.png)

### How to test
1. run the doc site locally 
1. Go to the choice page and see that the default and inverse disabled choice options have the same border treatment.
1. compare that to the live choice page https://design.cms.gov/components/choice/ where the default disabled choice has a much thinner border.