### PR TITLE
Omit props for choices that we override with values from ChoiceList

### DIFF
--- a/packages/design-system/src/types/ChoiceList/ChoiceList.d.ts
+++ b/packages/design-system/src/types/ChoiceList/ChoiceList.d.ts
@@ -6,16 +6,15 @@ export type ChoiceListSize = 'small';
 export type ChoiceListType = 'checkbox' | 'radio';
 
 // Omit props that we override with values from the ChoiceList
-export type ChoiceProps = Omit<
-  ChoiceComponentProps,
-  'inversed',
-  'name',
-  'onBlur',
-  'onChange',
-  'size',
-  'type',
-  'inputRef'
->;
+type OverridenChoiceProp =
+  | 'inversed'
+  | 'name'
+  | 'onBlur'
+  | 'onChange'
+  | 'size'
+  | 'type'
+  | 'inputRef';
+export type ChoiceProps = Omit<ChoiceComponentProps, OverridenChoiceProp>;
 
 export interface ChoiceListProps {
   /**

--- a/packages/design-system/src/types/ChoiceList/ChoiceList.d.ts
+++ b/packages/design-system/src/types/ChoiceList/ChoiceList.d.ts
@@ -1,9 +1,21 @@
 import * as React from 'react';
-import { ChoiceProps } from './Choice';
+import { ChoiceProps as ChoiceComponentProps } from './Choice';
 
 export type ChoiceListSize = 'small';
 
 export type ChoiceListType = 'checkbox' | 'radio';
+
+// Omit props that we override with values from the ChoiceList
+export type ChoiceProps = Omit<
+  ChoiceComponentProps,
+  'inversed',
+  'name',
+  'onBlur',
+  'onChange',
+  'size',
+  'type',
+  'inputRef'
+>;
 
 export interface ChoiceListProps {
   /**


### PR DESCRIPTION
For the ChoiceList `choices` prop, omit the props that we override with values from ChoiceList. Without this fix, ChoiceList choice objects would all require a `name` and `type`. I'm omitting all of the props here that are overridden by https://github.com/CMSgov/design-system/blob/master/packages/design-system/src/components/ChoiceList/ChoiceList.jsx#L34-L43 because they don't get passed down to the Choice component.

I'm putting this PR up so we have something to talk about, but maybe part of it should be some kind of internal tests to protect against these kinds of regressions.

### Fixed
- TypeScript: Fix ChoiceList props' type definition requiring that members of `choices` array have `name` and `type` defined. These come from the parent `ChoiceList` component.

