### PR TITLE
[NO_TICKET] Prevent copying setupJs and "styles" build folder

### DIFF
--- a/packages/design-system-scripts/gulp/build.js
+++ b/packages/design-system-scripts/gulp/build.js
@@ -61,10 +61,11 @@ function copyMiscFiles(dir) {
     gulp
       .src([
         `${src}/**/*`,
-        `!${src}/components/**/*`,
-        `!${src}/fonts/**/*`,
-        `!${src}/images/**/*`,
-        `!${src}/styles/**/*`,
+        `!${src}/components/**`,
+        `!${src}/fonts/**`,
+        `!${src}/images/**`,
+        `!${src}/styles/**`,
+        `!${src}/setupTests.{js,jsx,ts,tsx}`,
       ])
       .pipe(gulp.dest(path.join(dir, 'dist')))
   );

--- a/packages/design-system-scripts/gulp/build.js
+++ b/packages/design-system-scripts/gulp/build.js
@@ -53,7 +53,7 @@ function copySass(dir) {
 }
 
 /**
- * Copy any files not processed by the build scripts
+ * Generically copy any non test files that arent already processed by the build scripts
  */
 function copyMiscFiles(dir) {
   const src = path.join(dir, 'src');

--- a/packages/design-system-scripts/gulp/build.js
+++ b/packages/design-system-scripts/gulp/build.js
@@ -66,6 +66,8 @@ function copyMiscFiles(dir) {
         `!${src}/images/**`,
         `!${src}/styles/**`,
         `!${src}/setupTests.{js,jsx,ts,tsx}`,
+        `!${src}/**/*{.test,.spec}.{js,jsx,ts,tsx}`,
+        `!${src}/**/{__mocks__,__tests__,helpers}/**/*`,
       ])
       .pipe(gulp.dest(path.join(dir, 'dist')))
   );

--- a/packages/design-system/src/types/ChoiceList/ChoiceList.d.ts
+++ b/packages/design-system/src/types/ChoiceList/ChoiceList.d.ts
@@ -6,7 +6,7 @@ export type ChoiceListSize = 'small';
 export type ChoiceListType = 'checkbox' | 'radio';
 
 // Omit props that we override with values from the ChoiceList
-type OverridenChoiceProp =
+type OmitChoiceProp =
   | 'inversed'
   | 'name'
   | 'onBlur'
@@ -14,7 +14,7 @@ type OverridenChoiceProp =
   | 'size'
   | 'type'
   | 'inputRef';
-export type ChoiceProps = Omit<ChoiceComponentProps, OverridenChoiceProp>;
+export type ChoiceProps = Omit<ChoiceComponentProps, OmitChoiceProp>;
 
 export interface ChoiceListProps {
   /**


### PR DESCRIPTION
### How to test
- Build Child Design system with this branch, ensure only new folders (i.e. `types`, `locales`) are copied over to dist