### PR TITLE
[WNMGDS-524] Fix eslint logging and run linter

### DIFF
--- a/examples/create-react-app/src/components/App.test.js
+++ b/examples/create-react-app/src/components/App.test.js
@@ -1,6 +1,6 @@
+import App from './App';
 import React from 'react';
 import { render } from '@testing-library/react';
-import App from './App';
 
 test('renders learn react link', () => {
   const { getByText } = render(<App />);

--- a/lerna.json
+++ b/lerna.json
@@ -5,9 +5,7 @@
     }
   },
   "npmClient": "yarn",
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "ignoreChanges": [
     "packages/stylelint-config-design-system/**",
     "packages/eslint-config-design-system/**"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:e2e": "yarn cmsds test:e2e ./packages",
     "update-snapshots": "yarn cmsds test ./packages --updateSnapshot",
     "posttest": "yarn lint",
-    "lint": "yarn cmsds lint ./ --ignorePatterns '**/node_modules/**' '**/dist/**' '**/helpers/**' '**/__tests__/**' 'examples/create-react-app-typescript/**'"
+    "lint": "yarn cmsds lint ./ --ignorePatterns '**/node_modules/**' '**/dist/**' '**/helpers/**' '**/__tests__/**' 'tmp/**' '**/types/**' 'examples/create-react-app-typescript/**'"
   },
   "devDependencies": {
     "backstopjs": "^5.0.4",

--- a/packages/design-system-docs/src/pages/components/Badge/Badge.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Badge/Badge.example.jsx
@@ -1,12 +1,12 @@
-import React, { Fragment } from 'react';
 import { Badge } from '@cmsgov/design-system';
+import React from 'react';
 import ReactDOM from 'react-dom';
 
 ReactDOM.render(
-  <Fragment>
+  <>
     <Badge>Default badge</Badge>
     <Badge variation="info">Badge with `variation` prop</Badge>
     <Badge size="big">Badge with `size` prop</Badge>
-  </Fragment>,
+  </>,
   document.getElementById('js-example')
 );

--- a/packages/design-system-docs/src/pages/components/Button/Button.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Button/Button.example.jsx
@@ -1,7 +1,7 @@
 /* eslint no-alert: 0 */
-import React, { Fragment } from 'react';
 import { Button } from '@cmsgov/design-system';
 import PropTypes from 'prop-types';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 
@@ -15,7 +15,7 @@ const Link = ({ className, ...props }) => (
 Link.propTypes = { children: PropTypes.node };
 
 ReactDOM.render(
-  <Fragment>
+  <>
     <Button className="ds-u-margin-right--1">Button</Button>
     <Button className="ds-u-margin-right--1" variation="primary">
       Button with `variation` prop
@@ -33,6 +33,6 @@ ReactDOM.render(
     <Button className="ds-u-margin-right--1" component={Link} href="/">
       Button with `component` prop
     </Button>
-  </Fragment>,
+  </>,
   document.getElementById('js-example')
 );

--- a/packages/design-system-docs/src/scripts/components/ReactExample.jsx
+++ b/packages/design-system-docs/src/scripts/components/ReactExample.jsx
@@ -25,7 +25,7 @@ class ReactExample extends React.PureComponent {
           onLoad={this.handleFrameLoad}
           responsive={this.props.responsive}
           src={iframeURL}
-          title={`React example`}
+          title="React example"
         />
 
         <CodeSnippet>{this.highlightedMarkup()}</CodeSnippet>

--- a/packages/design-system-scripts/cli.js
+++ b/packages/design-system-scripts/cli.js
@@ -178,13 +178,12 @@ yargs
     },
   })
   .command({
-    command: 'lint <directories..>',
-    desc: 'Runs prettier, stylelint and eslint on one or more directories.',
+    command: 'lint <directory>',
+    desc: 'Runs prettier, stylelint and eslint in a directory',
     builder: (yargs) => {
       yargs
-        .positional('directories..', {
-          desc:
-            'The relative paths to one or more directories. Linting will be run on the "src" folder inside the provided directories.',
+        .positional('directory', {
+          desc: 'The relative path to the directory where linters and formatters will be run.',
           type: 'string',
           demandOption: true,
         })
@@ -223,11 +222,11 @@ yargs
         });
     },
     handler: async (argv) => {
-      const { lintDirectories } = require('./gulp/lint');
-      const { directories, fix, ignorePatterns, failAfterError, ...disable } = argv;
+      const { lintDirectory } = require('./gulp/lint');
+      const { directory, fix, ignorePatterns, failAfterError, ...disable } = argv;
 
       process.env.NODE_ENV = 'test';
-      await lintDirectories(directories, fix, ignorePatterns, failAfterError, disable);
+      await lintDirectory(directory, fix, ignorePatterns, failAfterError, disable);
     },
   })
   .demandCommand()

--- a/packages/design-system-scripts/cli.js
+++ b/packages/design-system-scripts/cli.js
@@ -178,12 +178,12 @@ yargs
     },
   })
   .command({
-    command: 'lint <directory>',
-    desc: 'Runs prettier, stylelint and eslint in a directory',
+    command: 'lint <directories..>',
+    desc: 'Runs prettier, stylelint and eslint on one or more directories.',
     builder: (yargs) => {
       yargs
-        .positional('directory', {
-          desc: 'The relative path to the directory where linters and formatters will be run.',
+        .positional('directories..', {
+          desc: 'The relative path to one or more directories that will be linted.',
           type: 'string',
           demandOption: true,
         })
@@ -222,11 +222,11 @@ yargs
         });
     },
     handler: async (argv) => {
-      const { lintDirectory } = require('./gulp/lint');
-      const { directory, fix, ignorePatterns, failAfterError, ...disable } = argv;
+      const { lintDirectories } = require('./gulp/lint');
+      const { directories, fix, ignorePatterns, failAfterError, ...disable } = argv;
 
       process.env.NODE_ENV = 'test';
-      await lintDirectory(directory, fix, ignorePatterns, failAfterError, disable);
+      await lintDirectories(directories, fix, ignorePatterns, failAfterError, disable);
     },
   })
   .demandCommand()

--- a/packages/design-system-scripts/gulp/docs/generatePages/markdownRenderer.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/markdownRenderer.js
@@ -10,7 +10,7 @@ require('prismjs/components/prism-scss');
 
 const markdownRenderer = new marked.Renderer();
 
-Prism.languages.bash['function'].pattern = /(^|\s|;|\||&)(?:npm|yarn|install)(?=$|\s|;|\||&)/;
+Prism.languages.bash.function.pattern = /(^|\s|;|\||&)(?:npm|yarn|install)(?=$|\s|;|\||&)/;
 
 function highlightCode(code, lang) {
   lang = lang === 'html' ? 'markup' : lang;

--- a/packages/design-system-scripts/gulp/docs/generatePages/savePage.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/savePage.js
@@ -19,7 +19,9 @@ function savePage(page, docsPath) {
       return saveToFile(html, pathObj);
     }
 
+    /* eslint-disable promise/no-return-wrap */
     return Promise.resolve(false);
+    /* eslint-enable promise/no-return-wrap */
   });
 }
 
@@ -84,7 +86,11 @@ function saveToFile(html, pathObj, retry = true) {
         return saveToFile(html, pathObj, false).then(resolve);
       }
 
-      fs.writeFile(pathObj.path, html).then(() => resolve(true));
+      fs.writeFile(pathObj.path, html)
+        .then(() => resolve(true))
+        .catch((error) => {
+          console.error(error.message);
+        });
     });
   });
 }

--- a/packages/design-system-scripts/gulp/lint.js
+++ b/packages/design-system-scripts/gulp/lint.js
@@ -33,7 +33,7 @@ async function runPrettier(dir, ignorePatterns, failAfterError) {
   return streamPromise(
     gulp
       .src(getSrcGlob(src, dir, ignorePatterns))
-      .pipe(count(`## Files formatted with Prettier in ${dir}`))
+      .pipe(count(`## Files formatted with Prettier`))
       .pipe(gulpIf(!failAfterError, prettier()))
       .pipe(gulpIf(failAfterError, prettier.check()))
       .pipe(gulp.dest(dir))
@@ -48,7 +48,7 @@ async function runStylelint(dir, fix, ignorePatterns, failAfterError) {
     gulp
       .src(getSrcGlob(src, dir, ignorePatterns))
       .pipe(changedInPlace({ firstPass: true }))
-      .pipe(count(`## Sass files linted in ${dir}`))
+      .pipe(count(`## Sass files linted`))
       .pipe(
         stylelint({
           fix,
@@ -65,45 +65,35 @@ async function runStylelint(dir, fix, ignorePatterns, failAfterError) {
 async function runEslint(dir, fix, ignorePatterns, failAfterError) {
   const src = [path.join(dir, '**/*.{js,jsx,ts,tsx}')];
 
-  // Taken from gulp-eslint example
-  // https://github.com/adametry/gulp-eslint/blob/master/example/fix.js
-  const isFixed = (file) => {
-    return file.eslint != null && file.eslint.fixed;
-  };
-
   return streamPromise(
     gulp
       .src(getSrcGlob(src, dir, ignorePatterns))
-      .pipe(count(`## JS files linted in ${dir}`))
+      .pipe(count(`## JS files linted`))
       .pipe(eslint({ fix }))
       .pipe(eslint.format())
       .pipe(gulpIf(failAfterError, eslint.failAfterError()))
-      .pipe(gulpIf(isFixed, gulp.dest(dir)))
+      .pipe(gulp.dest(dir))
   );
 }
 
 module.exports = {
-  async lintDirectories(directories, fix, ignorePatterns, failAfterError, disable) {
+  async lintDirectory(directory, fix, ignorePatterns, failAfterError, disable) {
     logTask(
       '🔎 ',
-      `Linting files in: ${directories.join(', ')} and ignoring paths: ${ignorePatterns.join(', ')}`
+      `Linting files in: ${directory} and ignoring paths: ${ignorePatterns.join(', ')}`
     );
 
-    await Promise.all(
-      directories.map(async (dir) => {
-        if (!disable.disablePrettier) {
-          prettier = require('gulp-prettier');
-          await runPrettier(dir, ignorePatterns, failAfterError);
-        }
-        if (!disable.disableStylelint) {
-          stylelint = require('gulp-stylelint');
-          await runStylelint(dir, fix, ignorePatterns, failAfterError);
-        }
-        if (!disable.disableEslint) {
-          eslint = require('gulp-eslint');
-          await runEslint(dir, fix, ignorePatterns, failAfterError);
-        }
-      })
-    );
+    if (!disable.disablePrettier) {
+      prettier = require('gulp-prettier');
+      await runPrettier(directory, ignorePatterns, failAfterError);
+    }
+    if (!disable.disableStylelint) {
+      stylelint = require('gulp-stylelint');
+      await runStylelint(directory, fix, ignorePatterns, failAfterError);
+    }
+    if (!disable.disableEslint) {
+      eslint = require('gulp-eslint');
+      await runEslint(directory, fix, ignorePatterns, failAfterError);
+    }
   },
 };

--- a/packages/design-system-scripts/gulp/lint.js
+++ b/packages/design-system-scripts/gulp/lint.js
@@ -77,23 +77,27 @@ async function runEslint(dir, fix, ignorePatterns, failAfterError) {
 }
 
 module.exports = {
-  async lintDirectory(directory, fix, ignorePatterns, failAfterError, disable) {
+  async lintDirectories(directories, fix, ignorePatterns, failAfterError, disable) {
     logTask(
       '🔎 ',
-      `Linting files in: ${directory} and ignoring paths: ${ignorePatterns.join(', ')}`
+      `Linting files in: ${directories.join(', ')} and ignoring paths: ${ignorePatterns.join(', ')}`
     );
 
-    if (!disable.disablePrettier) {
-      prettier = require('gulp-prettier');
-      await runPrettier(directory, ignorePatterns, failAfterError);
-    }
-    if (!disable.disableStylelint) {
-      stylelint = require('gulp-stylelint');
-      await runStylelint(directory, fix, ignorePatterns, failAfterError);
-    }
-    if (!disable.disableEslint) {
-      eslint = require('gulp-eslint');
-      await runEslint(directory, fix, ignorePatterns, failAfterError);
-    }
+    await Promise.all(
+      directories.map(async (dir) => {
+        if (!disable.disablePrettier) {
+          prettier = require('gulp-prettier');
+          await runPrettier(dir, ignorePatterns, failAfterError);
+        }
+        if (!disable.disableStylelint) {
+          stylelint = require('gulp-stylelint');
+          await runStylelint(dir, fix, ignorePatterns, failAfterError);
+        }
+        if (!disable.disableEslint) {
+          eslint = require('gulp-eslint');
+          await runEslint(dir, fix, ignorePatterns, failAfterError);
+        }
+      })
+    );
   },
 };

--- a/packages/design-system/src/types/ChoiceList/ChoiceList.d.ts
+++ b/packages/design-system/src/types/ChoiceList/ChoiceList.d.ts
@@ -6,14 +6,7 @@ export type ChoiceListSize = 'small';
 export type ChoiceListType = 'checkbox' | 'radio';
 
 // Omit props that we override with values from the ChoiceList
-type OmitChoiceProp =
-  | 'inversed'
-  | 'name'
-  | 'onBlur'
-  | 'onChange'
-  | 'size'
-  | 'type'
-  | 'inputRef';
+type OmitChoiceProp = 'inversed' | 'name' | 'onBlur' | 'onChange' | 'size' | 'type' | 'inputRef';
 export type ChoiceProps = Omit<ChoiceComponentProps, OmitChoiceProp>;
 
 export interface ChoiceListProps {


### PR DESCRIPTION
### Summary
- This PR ensures that eslint is run and reported for all files in the provided directory. Previously only some errors would show.
- It also fixes the logging to accurately display how many JS files were linted
- It runs eslint and fixes many linter errors

### How to test
- Run `yarn lint` on different directories
- Create linter errors to see if they are reported
- Use the `--fix` flag to see if automatically fixable linter errors are fixed
- Ensure the documentation around the CMSDS scripts are updated

