### PR TITLE
[WNMGDS-565] - Update skip nav docs and examples

### DIFF
--- a/packages/design-system-docs/src/pages/components/SkipNav/SkipNav.example.jsx
+++ b/packages/design-system-docs/src/pages/components/SkipNav/SkipNav.example.jsx
@@ -1,0 +1,27 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { SkipNav } from '@cmsgov/design-system';
+
+ReactDOM.render(
+  <div>
+    <SkipNav href="#main" />
+    <nav className="ds-u-padding--3">
+      <h1 className="ds-u-margin--0">Navigation</h1>
+      <p className="ds-u-margin--0">Clicking on the Skip Nav will skip over this section.</p>
+      <ul>
+        <li>
+          <a href="javascript:void(0);">Navigation link 1</a>
+        </li>
+        <li>
+          <a href="javascript:void(0);">Navigation link 2</a>
+        </li>
+      </ul>
+    </nav>
+    <main id="main" className="ds-u-padding--3 ds-u-fill--gray-lightest" tabIndex="-1">
+      <h1 className="ds-u-margin--0">Main content</h1>
+      <p className="ds-u-margin--0">Clicking on the Skip Nav will focus this element.</p>
+    </main>
+  </div>,
+  document.getElementById('js-example')
+);

--- a/packages/design-system-docs/src/pages/components/SkipNav/_SkipNav.docs.scss
+++ b/packages/design-system-docs/src/pages/components/SkipNav/_SkipNav.docs.scss
@@ -11,6 +11,8 @@ Style guide: components.skip-nav
 /*
 `<SkipNav>`
 
+@react-example SkipNav.example.jsx
+
 @react-props SkipNav.jsx
 
 Style guide: components.skip-nav.react

--- a/packages/design-system-docs/src/pages/components/SkipNav/_SkipNav.docs.scss
+++ b/packages/design-system-docs/src/pages/components/SkipNav/_SkipNav.docs.scss
@@ -1,7 +1,7 @@
 /*
 Skip Nav
 
-Skip navigation links allow users with screen readers to bypass long navigation lists. Make sure you include an `id` at the beginning of your main content and that it matches the skipnav link. Find more information here: [webaim.org/techniques/skipnav](http://webaim.org/techniques/skipnav/)
+Skip navigation links allow users with screen readers to bypass long navigation lists. Make sure you include an `id` at the beginning of your main content and that it matches the skipnav link.
 
 Markup: skipnav.example.html
 
@@ -14,4 +14,26 @@ Style guide: components.skip-nav
 @react-props SkipNav.jsx
 
 Style guide: components.skip-nav.react
+*/
+
+/*
+---
+
+### When to use
+
+- Skip navigation links should come before a long list of navigation links. Most commonly, this occurs before a site's main navigation.
+
+### Usage
+
+- Skip navigation can be visually hidden at first or displayed visually at all times, depending on user needs and design requirements.
+- Skip navigation should appear visually on focus.
+- The link should skip the user to the main content of the page.
+- More than one skip link can be on a page, but be mindful of creating too many.
+- Adding a `tabindex="-1"` on the container being skipped to allows older browsers to programmatically move focus properly.
+
+### Learn More
+
+- [Skip Navigation Links on WebAIM](http://webaim.org/techniques/skipnav/)
+
+Style guide: components.skip-nav.guidance
 */

--- a/packages/design-system-docs/src/pages/components/SkipNav/skipnav.example.html
+++ b/packages/design-system-docs/src/pages/components/SkipNav/skipnav.example.html
@@ -1,5 +1,5 @@
 <a class="ds-c-skip-nav" href="#main">Skip to main content</a>
 <a href="javascript:void(0);">Navigation link</a>
-<main id="main" class="ds-u-padding--4 ds-u-fill--gray-lightest" tabindex="0">
+<main id="main" class="ds-u-padding--4 ds-u-fill--gray-lightest" tabindex="-1">
   Main content
 </main>

--- a/packages/design-system-docs/src/pages/components/SkipNav/skipnav.example.html
+++ b/packages/design-system-docs/src/pages/components/SkipNav/skipnav.example.html
@@ -1,5 +1,23 @@
 <a class="ds-c-skip-nav" href="#main">Skip to main content</a>
-<a href="javascript:void(0);">Navigation link</a>
-<main id="main" class="ds-u-padding--4 ds-u-fill--gray-lightest" tabindex="-1">
-  Main content
+<nav class="ds-u-padding--3">
+  <h1 class="ds-u-margin--0">
+    Navigation
+  </h1>
+  <p class="ds-u-margin--0">Clicking on the Skip Nav will skip over this section.</p>
+  <ul>
+    <li>
+      <a href="javascript:void(0);">Navigation link 1</a>
+    </li>
+    <li>
+      <a href="javascript:void(0);">Navigation link 2</a>
+    </li>
+  </ul>
+</nav>
+<main id="main" class="ds-u-padding--3 ds-u-fill--gray-lightest" tabindex="-1">
+  <h1 class="ds-u-margin--0">
+    Main content
+  </h1>
+  <p class="ds-u-margin--0">
+    Clicking on the Skip Nav will focus this element.
+  </p>
 </main>


### PR DESCRIPTION
## Changed
- Adds more detailed docs for skip links.
- Changes `tabindex` in example to `-1` so that the main container isn't in the flow for keyboard accessibility, but still focusable programmatically.