### PR TITLE
[WNMGDS-615] Set inverse choice bg to transparent

### DIFF
--- a/packages/design-system/src/styles/components/_Choice.scss
+++ b/packages/design-system/src/styles/components/_Choice.scss
@@ -58,7 +58,7 @@ $ds-c-inset-border-width: $spacer-half;
 }
 
 .ds-c-choice--inverse + label::before {
-  background-color: $color-background-inverse;
+  background-color: transparent;
   border-color: $choice-border-color-inverse;
 }
 


### PR DESCRIPTION
### Changed
- Changed background color for inverse choice items to be transparent instead of dark blue 

### How to test
- Run the doc site locally
- Go to the choice page and change the inerse background color to another color
- See that the inverse choice items are set to transparent and not dark blue

#### Before fix background was always set to dark blue (see choice 2) 
![Screen Shot 2020-09-21 at 10 23 59 AM](https://user-images.githubusercontent.com/1449852/93779165-acec9800-fbf4-11ea-866a-877d21b41909.png)

#### After fix background is transparent so background shows through (see choice 2) 
![Screen Shot 2020-09-21 at 10 23 40 AM](https://user-images.githubusercontent.com/1449852/93779162-ac540180-fbf4-11ea-80ed-1a3818340fb4.png)