### PR TITLE
[WNMGDS-632] Apply Review classes

### DIFF
--- a/packages/design-system-docs/src/pages/components/Review/review.example.html
+++ b/packages/design-system-docs/src/pages/components/Review/review.example.html
@@ -1,6 +1,6 @@
 <div class="ds-c-review">
   <div class="ds-u-margin-right--2">
-    <h3 class="ds-c-review__heading ds-text">
+    <h3 class="ds-c-review__heading">
       Name
     </h3>
     <div>Jane Doe</div>
@@ -11,7 +11,7 @@
 </div>
 <div class="ds-c-review">
   <div class="ds-u-margin-right--2">
-    <h3 class="ds-c-review__heading ds-text">
+    <h3 class="ds-c-review__heading">
       Date of Birth
     </h3>
     <div>December 3, 1981</div>
@@ -22,7 +22,7 @@
 </div>
 <div class="ds-c-review">
   <div class="ds-u-margin-right--2">
-    <h3 class="ds-c-review__heading ds-text">
+    <h3 class="ds-c-review__heading">
       States Lived
     </h3>
     <div>

--- a/packages/design-system-docs/src/pages/components/Review/review.example.html
+++ b/packages/design-system-docs/src/pages/components/Review/review.example.html
@@ -1,8 +1,6 @@
-<div
-  class="ds-u-border-bottom--2 ds-u-padding-y--2 ds-u-justify-content--between ds-u-display--flex"
->
+<div class="ds-c-review">
   <div class="ds-u-margin-right--2">
-    <h3 class="ds-text ds-u-margin-bottom--0 ds-u-font-weight--bold ds-u-display--inline-block">
+    <h3 class="ds-c-review__heading ds-text">
       Name
     </h3>
     <div>Jane Doe</div>
@@ -11,11 +9,9 @@
     <a href="javascript:void(0);">Edit</a>
   </div>
 </div>
-<div
-  class="ds-u-border-bottom--2 ds-u-padding-y--2 ds-u-justify-content--between ds-u-display--flex"
->
+<div class="ds-c-review">
   <div class="ds-u-margin-right--2">
-    <h3 class="ds-text ds-u-margin-bottom--0 ds-u-font-weight--bold ds-u-display--inline-block">
+    <h3 class="ds-c-review__heading ds-text">
       Date of Birth
     </h3>
     <div>December 3, 1981</div>
@@ -24,11 +20,9 @@
     <a href="javascript:void(0);">Edit</a>
   </div>
 </div>
-<div
-  class="ds-u-border-bottom--2 ds-u-padding-y--2 ds-u-justify-content--between ds-u-display--flex"
->
+<div class="ds-c-review">
   <div class="ds-u-margin-right--2">
-    <h3 class="ds-text ds-u-margin-bottom--0 ds-u-font-weight--bold ds-u-display--inline-block">
+    <h3 class="ds-c-review__heading ds-text">
       States Lived
     </h3>
     <div>

--- a/packages/design-system/src/components/Review/Review.jsx
+++ b/packages/design-system/src/components/Review/Review.jsx
@@ -7,11 +7,7 @@ export class Review extends React.PureComponent {
   heading() {
     const Heading = `h${this.props.headingLevel}` || `h3`;
     if (this.props.heading) {
-      return (
-        <Heading className="ds-c-review__heading ds-text ds-u-margin-bottom--0 ds-u-font-weight--bold ds-u-display--inline-block">
-          {this.props.heading}
-        </Heading>
-      );
+      return <Heading className="ds-c-review__heading ds-text">{this.props.heading}</Heading>;
     }
   }
 
@@ -25,10 +21,7 @@ export class Review extends React.PureComponent {
       onEditClick,
       editContent,
     } = this.props;
-    const classes = classNames(
-      'ds-c-review ds-u-border-bottom--2 ds-u-padding-y--2 ds-u-justify-content--between ds-u-display--flex',
-      className && className
-    );
+    const classes = classNames('ds-c-review', className && className);
     return (
       <div className={classes}>
         <div className="ds-u-margin-right--2">

--- a/packages/design-system/src/components/Review/Review.jsx
+++ b/packages/design-system/src/components/Review/Review.jsx
@@ -21,7 +21,7 @@ export class Review extends React.PureComponent {
       onEditClick,
       editContent,
     } = this.props;
-    const classes = classNames('ds-c-review', className && className);
+    const classes = classNames('ds-c-review', className);
     return (
       <div className={classes}>
         <div className="ds-u-margin-right--2">

--- a/packages/design-system/src/components/Review/Review.jsx
+++ b/packages/design-system/src/components/Review/Review.jsx
@@ -7,7 +7,7 @@ export class Review extends React.PureComponent {
   heading() {
     const Heading = `h${this.props.headingLevel}` || `h3`;
     if (this.props.heading) {
-      return <Heading className="ds-c-review__heading ds-text">{this.props.heading}</Heading>;
+      return <Heading className="ds-c-review__heading">{this.props.heading}</Heading>;
     }
   }
 

--- a/packages/design-system/src/components/Review/__snapshots__/Review.test.jsx.snap
+++ b/packages/design-system/src/components/Review/__snapshots__/Review.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`Review renders review 1`] = `
     className="ds-u-margin-right--2"
   >
     <h3
-      className="ds-c-review__heading ds-text"
+      className="ds-c-review__heading"
     >
       review heading
     </h3>

--- a/packages/design-system/src/components/Review/__snapshots__/Review.test.jsx.snap
+++ b/packages/design-system/src/components/Review/__snapshots__/Review.test.jsx.snap
@@ -2,13 +2,13 @@
 
 exports[`Review renders review 1`] = `
 <div
-  className="ds-c-review ds-u-border-bottom--2 ds-u-padding-y--2 ds-u-justify-content--between ds-u-display--flex"
+  className="ds-c-review"
 >
   <div
     className="ds-u-margin-right--2"
   >
     <h3
-      className="ds-c-review__heading ds-text ds-u-margin-bottom--0 ds-u-font-weight--bold ds-u-display--inline-block"
+      className="ds-c-review__heading ds-text"
     >
       review heading
     </h3>

--- a/packages/design-system/src/styles/components/_Review.scss
+++ b/packages/design-system/src/styles/components/_Review.scss
@@ -11,6 +11,7 @@
 .ds-c-review__heading {
   display: inline-block;
   font-weight: $font-bold;
+  font-size: $base-font-size;
   margin-bottom: 0;
   margin-top: 0;
 }

--- a/packages/design-system/src/styles/components/_Review.scss
+++ b/packages/design-system/src/styles/components/_Review.scss
@@ -1,0 +1,15 @@
+@import '../settings/index.scss';
+
+.ds-c-review {
+  border-bottom: 2px solid $border-color;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 16px;
+  padding-top: 16px;
+}
+
+.ds-c-review__heading {
+  display: inline-block;
+  font-weight: $font-bold;
+  margin-bottom: 2px;
+}

--- a/packages/design-system/src/styles/components/_Review.scss
+++ b/packages/design-system/src/styles/components/_Review.scss
@@ -11,5 +11,6 @@
 .ds-c-review__heading {
   display: inline-block;
   font-weight: $font-bold;
-  margin-bottom: 2px;
+  margin-bottom: 0;
+  margin-top: 0;
 }

--- a/packages/design-system/src/styles/components/index.scss
+++ b/packages/design-system/src/styles/components/index.scss
@@ -10,6 +10,7 @@
 @import 'HelpDrawer.scss';
 @import 'List.scss';
 @import 'MonthPicker.scss';
+@import 'Review.scss';
 @import 'SkipNav.scss';
 @import 'Spinner.scss';
 @import 'StepList.scss';


### PR DESCRIPTION
This fixes the issue of Review component classes cannot be overridden because the component applies utility styles which uses `!important`.

### Changed
- Update Review component to apply it's component styling instead of using utility classes.

### Added 
- `ds-c-review` and `ds-c-review__heading` classes 

### How to test
- Run the design system site locally
- Update Review example to [override classes](https://github.com/CMSgov/design-system/issues/817) and check that the styles applied correctly
