### PR TITLE
[WNMGDS-568] Add styles for field error message class

### DIFF
--- a/packages/design-system-docs/src/pages/components/ChoiceList/checkbox-radio.example.html
+++ b/packages/design-system-docs/src/pages/components/ChoiceList/checkbox-radio.example.html
@@ -37,7 +37,7 @@
   </fieldset>
   <fieldset class="ds-c-fieldset">
     <legend class="ds-c-label"><span>Radio example</span></legend>
-    <span class="ds-c-field__error" role="alert">
+    <span class="ds-c-field__error-message" role="alert">
       Example error message
     </span>
     <input
@@ -88,7 +88,9 @@
     <fieldset class="ds-c-fieldset">
       <legend class="ds-c-label"><span>Inverse example</span></legend>
       <span class="ds-c-field__hint ds-c-field__hint--inverse">Helpful hint text</span>
-      <span class="ds-c-field__error ds-c-field__error--inverse">Example error message</span>
+      <span class="ds-c-field__error-message ds-c-field__error-message--inverse"
+        >Example error message</span
+      >
       <input
         class="ds-c-choice ds-c-choice--inverse ds-c-choice--error"
         id="inverse-1"

--- a/packages/design-system-docs/src/pages/components/ChoiceList/checkbox-radio.example.html
+++ b/packages/design-system-docs/src/pages/components/ChoiceList/checkbox-radio.example.html
@@ -37,7 +37,7 @@
   </fieldset>
   <fieldset class="ds-c-fieldset">
     <legend class="ds-c-label"><span>Radio example</span></legend>
-    <span class="ds-c-field__hint ds-u-color--error" role="alert">
+    <span class="ds-c-field__error" role="alert">
       Example error message
     </span>
     <input
@@ -88,7 +88,7 @@
     <fieldset class="ds-c-fieldset">
       <legend class="ds-c-label"><span>Inverse example</span></legend>
       <span class="ds-c-field__hint ds-c-field__hint--inverse">Helpful hint text</span>
-      <span class="ds-c-field__hint ds-u-color--error-light">Example error message</span>
+      <span class="ds-c-field__error ds-c-field__error--inverse">Example error message</span>
       <input
         class="ds-c-choice ds-c-choice--inverse ds-c-choice--error"
         id="inverse-1"

--- a/packages/design-system-docs/src/pages/components/DateField/datefield.example.html
+++ b/packages/design-system-docs/src/pages/components/DateField/datefield.example.html
@@ -3,7 +3,7 @@
     <legend class="ds-c-label" id="dob-datefield">
       <span class="ds-u-font-weight--bold">Date of birth</span>
       <span class="ds-c-field__hint">For example: 4 / 28 / 1986</span>
-      <span class="ds-c-field__error ds-c-field__error" inverse="alert">
+      <span class="ds-c-field__error-message" role="alert">
         Please enter a year in the past
       </span>
     </legend>
@@ -65,7 +65,7 @@
       <legend class="ds-c-label" id="dob-datefield">
         <span class="ds-u-font-weight--bold">Inverse example</span>
         <span class="ds-c-field__hint ds-c-field__hint--inverse">For example: 4 / 28 / 1986</span>
-        <span class="ds-c-field__error ds-c-field__error--inverse" role="alert">
+        <span class="ds-c-field__error-message ds-c-field__error-message--inverse" role="alert">
           Please enter a year in the past
         </span>
       </legend>

--- a/packages/design-system-docs/src/pages/components/DateField/datefield.example.html
+++ b/packages/design-system-docs/src/pages/components/DateField/datefield.example.html
@@ -3,7 +3,7 @@
     <legend class="ds-c-label" id="dob-datefield">
       <span class="ds-u-font-weight--bold">Date of birth</span>
       <span class="ds-c-field__hint">For example: 4 / 28 / 1986</span>
-      <span class="ds-c-field__hint ds-u-color--error" role="alert">
+      <span class="ds-c-field__error ds-c-field__error" inverse="alert">
         Please enter a year in the past
       </span>
     </legend>
@@ -65,7 +65,7 @@
       <legend class="ds-c-label" id="dob-datefield">
         <span class="ds-u-font-weight--bold">Inverse example</span>
         <span class="ds-c-field__hint ds-c-field__hint--inverse">For example: 4 / 28 / 1986</span>
-        <span class="ds-c-field__hint ds-u-color--error-light" role="alert">
+        <span class="ds-c-field__error ds-c-field__error--inverse" role="alert">
           Please enter a year in the past
         </span>
       </legend>

--- a/packages/design-system-docs/src/pages/components/Dropdown/dropdown.example.html
+++ b/packages/design-system-docs/src/pages/components/Dropdown/dropdown.example.html
@@ -17,7 +17,7 @@
       <span class="ds-c-field__hint ds-c-field__hint--inverse">
         Helpful hint text
       </span>
-      <span class="ds-c-field__hint ds-u-color--error-light" role="alert">
+      <span class="ds-c-field__error-message ds-c-field__error-message--inverse" role="alert">
         Example error message
       </span>
     </label>

--- a/packages/design-system-docs/src/pages/components/FormLabel/_FormLabel.docs.scss
+++ b/packages/design-system-docs/src/pages/components/FormLabel/_FormLabel.docs.scss
@@ -58,6 +58,7 @@ Style guide: components.form-label.react
 #### Validation
 
 - Place inline validation messages within the field's `<label>` element.
+- Apply the `.ds-c-field__error-message` class to error text.
 - Visually align inline validation messages with the input fields, so people using screen magnifiers can read them quickly.
 - Either place an icon next to the error, labeling the icon as error with ARIA or off-screen text, or use text in front of the message itself. Like: "Error: The email address is not a valid email address." The use of the icon or text not only clearly labels the following text as an error, but allows users to know that the message is an error without relying on color alone.
 - The form field receives an `aria-describedby` attribute that references the `id` of the error message.

--- a/packages/design-system-docs/src/pages/components/FormLabel/form-label.example.html
+++ b/packages/design-system-docs/src/pages/components/FormLabel/form-label.example.html
@@ -4,7 +4,7 @@
     <span class="ds-c-field__hint">
       Optional. We'll use this number as a backup if we need to contact you about your application.
     </span>
-    <span class="ds-c-field__error" role="alert">
+    <span class="ds-c-field__error-message" role="alert">
       Please enter a valid phone number.
     </span>
   </label>
@@ -14,7 +14,7 @@
       <span class="ds-c-field__hint ds-c-field__hint--inverse">
         Helpful hint text
       </span>
-      <span class="ds-c-field__error ds-c-field__error--inverse" role="alert">
+      <span class="ds-c-field__error-message ds-c-field__error-message--inverse" role="alert">
         Example error message
       </span>
     </label>

--- a/packages/design-system-docs/src/pages/components/FormLabel/form-label.example.html
+++ b/packages/design-system-docs/src/pages/components/FormLabel/form-label.example.html
@@ -4,7 +4,7 @@
     <span class="ds-c-field__hint">
       Optional. We'll use this number as a backup if we need to contact you about your application.
     </span>
-    <span class="ds-c-field__hint ds-u-color--error" role="alert">
+    <span class="ds-c-field__error" role="alert">
       Please enter a valid phone number.
     </span>
   </label>
@@ -14,7 +14,7 @@
       <span class="ds-c-field__hint ds-c-field__hint--inverse">
         Helpful hint text
       </span>
-      <span class="ds-c-field__hint ds-u-color--error-light" role="alert">
+      <span class="ds-c-field__error ds-c-field__error--inverse" role="alert">
         Example error message
       </span>
     </label>

--- a/packages/design-system-docs/src/pages/components/TextField/textfield.example.html
+++ b/packages/design-system-docs/src/pages/components/TextField/textfield.example.html
@@ -54,7 +54,7 @@
   <label class="ds-c-label" for="input-error">
     <span>Error field</span>
     <span class="ds-c-field__hint">Helpful hint text</span>
-    <span class="ds-c-field__hint ds-u-color--error" role="alert">
+    <span class="ds-c-field__error-message" role="alert">
       Example error message
     </span>
   </label>
@@ -81,7 +81,9 @@
     <label class="ds-c-label ds-u-margin-top--0" for="input-inverse">
       <span>Inverse field</span>
       <span class="ds-c-field__hint ds-c-field__hint--inverse">Helpful hint text</span>
-      <span class="ds-c-field__hint ds-u-color--error-light">Example error message</span>
+      <span class="ds-c-field__error-message ds-c-field__error-message--inverse"
+        >Example error message</span
+      >
     </label>
     <input
       class="ds-c-field ds-c-field--inverse ds-c-field--error"

--- a/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -127,7 +127,7 @@ exports[`DateField has errorMessage 1`] = `
       For example: 4 / 28 / 1986
     </span>
     <span
-      className="ds-c-field__hint ds-u-color--error"
+      className="ds-c-field__error"
       role="alert"
     >
       This is required.

--- a/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -127,7 +127,7 @@ exports[`DateField has errorMessage 1`] = `
       For example: 4 / 28 / 1986
     </span>
     <span
-      className="ds-c-field__error"
+      className="ds-c-field__error-message"
       role="alert"
     >
       This is required.

--- a/packages/design-system/src/components/FormLabel/FormLabel.jsx
+++ b/packages/design-system/src/components/FormLabel/FormLabel.jsx
@@ -5,8 +5,8 @@ import classNames from 'classnames';
 export class FormLabel extends React.PureComponent {
   errorMessage() {
     if (this.props.errorMessage) {
-      const classes = classNames('ds-c-field__hint', 'ds-u-color--error', {
-        'ds-u-color--error-light': this.props.inversed,
+      const classes = classNames('ds-c-field__error', {
+        'ds-c-field__error--inverse': this.props.inversed,
       });
 
       const id = this.props.fieldId ? `${this.props.fieldId}-message` : undefined;

--- a/packages/design-system/src/components/FormLabel/FormLabel.jsx
+++ b/packages/design-system/src/components/FormLabel/FormLabel.jsx
@@ -5,8 +5,8 @@ import classNames from 'classnames';
 export class FormLabel extends React.PureComponent {
   errorMessage() {
     if (this.props.errorMessage) {
-      const classes = classNames('ds-c-field__error', {
-        'ds-c-field__error--inverse': this.props.inversed,
+      const classes = classNames('ds-c-field__error-message', {
+        'ds-c-field__error-message--inverse': this.props.inversed,
       });
 
       const id = this.props.fieldId ? `${this.props.fieldId}-message` : undefined;

--- a/packages/design-system/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
+++ b/packages/design-system/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
@@ -89,7 +89,7 @@ exports[`FormLabel renders error state 1`] = `
     Hello world
   </span>
   <span
-    className="ds-c-field__hint ds-u-color--error"
+    className="ds-c-field__error"
     id="name-message"
     role="alert"
   >

--- a/packages/design-system/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
+++ b/packages/design-system/src/components/FormLabel/__snapshots__/FormLabel.test.jsx.snap
@@ -89,7 +89,7 @@ exports[`FormLabel renders error state 1`] = `
     Hello world
   </span>
   <span
-    className="ds-c-field__error"
+    className="ds-c-field__error-message"
     id="name-message"
     role="alert"
   >

--- a/packages/design-system/src/styles/components/_FormLabel.scss
+++ b/packages/design-system/src/styles/components/_FormLabel.scss
@@ -41,6 +41,16 @@
   color: $color-muted-inverse;
 }
 
+.ds-c-field__error {
+  color: $color-error;
+  display: block;
+  font-weight: $font-normal;
+}
+
+.ds-c-field__error--inverse {
+  color: $color-error-light;
+}
+
 .ds-c-choice + label .ds-c-field__hint {
   flex-basis: 100%;
 }

--- a/packages/design-system/src/styles/components/_FormLabel.scss
+++ b/packages/design-system/src/styles/components/_FormLabel.scss
@@ -41,13 +41,13 @@
   color: $color-muted-inverse;
 }
 
-.ds-c-field__error {
+.ds-c-field__error-message {
   color: $color-error;
   display: block;
   font-weight: $font-normal;
 }
 
-.ds-c-field__error--inverse {
+.ds-c-field__error-message--inverse {
   color: $color-error-light;
 }
 


### PR DESCRIPTION
Add class `ds-c-field__error-message` and use in-place of `.ds-c-field__hint .ds-u-color--error` for handling the display of error message by the `FormLabel` component that currently has this error message handling.

### Changed
- Add classes `ds-c-field__error-message` and ` ds-c-field__error-message--inverse`.
- Use these classes for display of field error message instead of the current usage of `ds-c-field__hint .ds-u-color--error`

### How to test
- Run the design system site locally
- Check dev console log to make sure the new classes is applied for the following examples `Date field`, `Checkbox & Radio`  and `Form Label & Legend`

