### PR TITLE
[WNMGDS-664] Update DateField markup

### DIFF
--- a/packages/design-system-docs/src/pages/components/DateField/datefield.example.html
+++ b/packages/design-system-docs/src/pages/components/DateField/datefield.example.html
@@ -1,7 +1,7 @@
 <div class="example--wrapper">
   <fieldset class="ds-c-fieldset">
-    <legend class="ds-c-label" id="dob-datefield">
-      <span class="ds-u-font-weight--bold">Date of birth</span>
+    <legend class="ds-c-label" id="datefield_label_1">
+      <span>Date of birth</span>
       <span class="ds-c-field__hint">For example: 4 / 28 / 1986</span>
       <span class="ds-c-field__error-message" role="alert">
         Please enter a year in the past
@@ -20,7 +20,7 @@
           id="month"
           name="birthdate[month]"
           autocomplete="bday-month"
-          aria-describedby="dob-datefield"
+          aria-describedby="datefield_label_1"
           value="10"
         />
       </div>
@@ -37,7 +37,7 @@
           id="day"
           name="birthdate[day]"
           autocomplete="bday-day"
-          aria-describedby="dob-datefield"
+          aria-describedby="datefield_label_1"
           value="31"
         />
       </div>
@@ -54,7 +54,7 @@
           id="year"
           name="birthdate[year]"
           autocomplete="bday-year"
-          aria-describedby="dob-datefield"
+          aria-describedby="datefield_label_1"
           value="2050"
         />
       </div>
@@ -62,8 +62,8 @@
   </fieldset>
   <div class="example--wrapper example--inverse">
     <fieldset class="ds-c-fieldset">
-      <legend class="ds-c-label" id="dob-datefield">
-        <span class="ds-u-font-weight--bold">Inverse example</span>
+      <legend class="ds-c-label" id="datefield_label_2">
+        <span>Inverse example</span>
         <span class="ds-c-field__hint ds-c-field__hint--inverse">For example: 4 / 28 / 1986</span>
         <span class="ds-c-field__error-message ds-c-field__error-message--inverse" role="alert">
           Please enter a year in the past
@@ -82,7 +82,7 @@
             id="month"
             name="birthdate[month]"
             autocomplete="bday-month"
-            aria-describedby="dob-datefield"
+            aria-describedby="datefield_label_2"
             value="10"
           />
         </div>
@@ -99,7 +99,7 @@
             id="day"
             name="birthdate[day]"
             autocomplete="bday-day"
-            aria-describedby="dob-datefield"
+            aria-describedby="datefield_label_2"
             value="31"
           />
         </div>
@@ -116,7 +116,7 @@
             id="year"
             name="birthdate[year]"
             autocomplete="bday-year"
-            aria-describedby="dob-datefield"
+            aria-describedby="datefield_label_2"
             value="2050"
           />
         </div>

--- a/packages/design-system-docs/src/pages/components/DateField/datefield.example.html
+++ b/packages/design-system-docs/src/pages/components/DateField/datefield.example.html
@@ -9,9 +9,7 @@
     </legend>
     <div class="ds-l-form-row ds-u-align-items--end">
       <div class="ds-l-col--auto">
-        <label class="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1" for="month"
-          ><span>Month</span></label
-        >
+        <label class="ds-c-label ds-c-datefield__label" for="month"><span>Month</span></label>
         <input
           class="ds-c-field ds-c-field--month"
           type="text"
@@ -26,9 +24,7 @@
       </div>
       <span class="ds-c-datefield__separator">/</span>
       <div class="ds-l-col--auto">
-        <label class="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1" for="day"
-          ><span>Day</span></label
-        >
+        <label class="ds-c-label ds-c-datefield__label" for="day"><span>Day</span></label>
         <input
           class="ds-c-field ds-c-field--day"
           type="text"
@@ -43,9 +39,7 @@
       </div>
       <span class="ds-c-datefield__separator">/</span>
       <div class="ds-l-col--auto">
-        <label class="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1" for="year"
-          ><span>Year</span></label
-        >
+        <label class="ds-c-label ds-c-datefield__label" for="year"><span>Year</span></label>
         <input
           class="ds-c-field ds-c-field--error ds-c-field--year"
           type="text"
@@ -71,9 +65,7 @@
       </legend>
       <div class="ds-l-form-row ds-u-align-items--end">
         <div class="ds-l-col--auto">
-          <label class="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1" for="month"
-            ><span>Month</span></label
-          >
+          <label class="ds-c-label ds-c-datefield__label" for="month"><span>Month</span></label>
           <input
             class="ds-c-field ds-c-field--month"
             type="text"
@@ -88,9 +80,7 @@
         </div>
         <span class="ds-c-datefield__separator">/</span>
         <div class="ds-l-col--auto">
-          <label class="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1" for="day"
-            ><span>Day</span></label
-          >
+          <label class="ds-c-label ds-c-datefield__label" for="day"><span>Day</span></label>
           <input
             class="ds-c-field ds-c-field--day"
             type="text"
@@ -105,9 +95,7 @@
         </div>
         <span class="ds-c-datefield__separator">/</span>
         <div class="ds-l-col--auto">
-          <label class="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1" for="year"
-            ><span>Year</span></label
-          >
+          <label class="ds-c-label ds-c-datefield__label" for="year"><span>Year</span></label>
           <input
             class="ds-c-field ds-c-field--error ds-c-field--year"
             type="text"

--- a/packages/design-system/src/components/DateField/DateField.jsx
+++ b/packages/design-system/src/components/DateField/DateField.jsx
@@ -78,7 +78,7 @@ export class DateField extends React.PureComponent {
   render() {
     const sharedDateFieldProps = {
       className: 'ds-l-col--auto',
-      labelClassName: 'ds-u-font-weight--normal ds-u-margin-top--1',
+      labelClassName: 'ds-c-datefield__label',
       inversed: this.props.inversed,
       onBlur: (this.props.onBlur || this.props.onComponentBlur) && this.handleBlur,
       onChange: this.props.onChange && this.handleChange,

--- a/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -55,7 +55,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -84,7 +84,7 @@ exports[`DateField has custom yearMax and yearMin 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -140,7 +140,7 @@ exports[`DateField has errorMessage 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -169,7 +169,7 @@ exports[`DateField has errorMessage 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -198,7 +198,7 @@ exports[`DateField has errorMessage 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -248,7 +248,7 @@ exports[`DateField has invalid day 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -277,7 +277,7 @@ exports[`DateField has invalid day 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -306,7 +306,7 @@ exports[`DateField has invalid day 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -356,7 +356,7 @@ exports[`DateField has invalid month 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -385,7 +385,7 @@ exports[`DateField has invalid month 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -414,7 +414,7 @@ exports[`DateField has invalid month 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -464,7 +464,7 @@ exports[`DateField has invalid year 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -493,7 +493,7 @@ exports[`DateField has invalid year 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -522,7 +522,7 @@ exports[`DateField has invalid year 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -574,7 +574,7 @@ exports[`DateField has requirementLabel 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -603,7 +603,7 @@ exports[`DateField has requirementLabel 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -632,7 +632,7 @@ exports[`DateField has requirementLabel 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -682,7 +682,7 @@ exports[`DateField is disabled 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -712,7 +712,7 @@ exports[`DateField is disabled 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -742,7 +742,7 @@ exports[`DateField is disabled 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -793,7 +793,7 @@ exports[`DateField is inversed 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1 ds-c-label--inverse"
+        className="ds-c-label ds-c-datefield__label ds-c-label--inverse"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -822,7 +822,7 @@ exports[`DateField is inversed 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1 ds-c-label--inverse"
+        className="ds-c-label ds-c-datefield__label ds-c-label--inverse"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -851,7 +851,7 @@ exports[`DateField is inversed 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1 ds-c-label--inverse"
+        className="ds-c-label ds-c-datefield__label ds-c-label--inverse"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -901,7 +901,7 @@ exports[`DateField renders with all defaultProps 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -930,7 +930,7 @@ exports[`DateField renders with all defaultProps 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >
@@ -959,7 +959,7 @@ exports[`DateField renders with all defaultProps 1`] = `
       className="ds-u-clearfix ds-l-col--auto"
     >
       <label
-        className="ds-c-label ds-u-font-weight--normal ds-u-margin-top--1"
+        className="ds-c-label ds-c-datefield__label"
         htmlFor="textfield_snapshot"
         id="textfield_label_snapshot"
       >

--- a/packages/design-system/src/styles/components/_DateField.scss
+++ b/packages/design-system/src/styles/components/_DateField.scss
@@ -21,3 +21,8 @@
   margin: ($input-border-width + $spacer-half) 0;
   padding: $input-padding 0;
 }
+
+.ds-c-datefield__label {
+  font-weight: $font-normal;
+  margin-top: $spacer-1;
+}

--- a/packages/design-system/src/styles/components/_Review.scss
+++ b/packages/design-system/src/styles/components/_Review.scss
@@ -10,8 +10,8 @@
 
 .ds-c-review__heading {
   display: inline-block;
-  font-weight: $font-bold;
   font-size: $base-font-size;
+  font-weight: $font-bold;
   margin-bottom: 0;
   margin-top: 0;
 }


### PR DESCRIPTION
### Summary 
- The `Datefield` HTML example in the Mgov DS doc site was looking weird because of inconsistencies between React and HTML example markup
- This PR fixes those inconsistencies by removing an unnecessary utility class and updating the `id`.
- This PR also introduces a new classname `ds-c-datefield__label` to apply to m/d/y labels, reducing the amount of utilities used and making it easier to override those styles (as is the case in Mgov)

### How to test
- Ensure no visual changes in the core CMSDS
- Run this branch in the Mgov DS and ensure the HTML and React examples for form elements are correct, especially DateField and ChoiceList