### PR TITLE
[WNMGDS-659] Remove default currency ariaLabel

### DIFF
--- a/packages/design-system/src/components/TextField/TextField.jsx
+++ b/packages/design-system/src/components/TextField/TextField.jsx
@@ -28,14 +28,6 @@ export class TextField extends React.PureComponent {
     }
   }
 
-  ariaLabel() {
-    if (this.props.ariaLabel) {
-      return this.props.ariaLabel;
-    } else if (this.props.mask === 'currency') {
-      return `${this.props.label}. Enter amount in dollars.`;
-    }
-  }
-
   /**
    * @param {React.Component} field
    * @returns {React.Component} The input field, optionally including mask
@@ -97,7 +89,7 @@ export class TextField extends React.PureComponent {
 
     const field = (
       <FieldComponent
-        aria-label={this.ariaLabel()}
+        aria-label={this.props.ariaLabel}
         className={fieldClasses}
         id={this.id}
         /* eslint-disable no-return-assign */

--- a/packages/design-system/src/components/TextField/TextField.test.jsx
+++ b/packages/design-system/src/components/TextField/TextField.test.jsx
@@ -154,15 +154,6 @@ describe('TextField', function () {
     expect(field.prop('aria-label')).toBe(data.props.ariaLabel);
   });
 
-  it('adds default aria-label for currency mask', () => {
-    const data = render({
-      mask: 'currency',
-    });
-    const field = data.wrapper.find('.ds-c-field').first();
-
-    expect(field.prop('aria-label')).toBe(`${data.props.label}. Enter amount in dollars.`);
-  });
-
   it('adds overrides default aria-label with defined prop', () => {
     const data = render({
       ariaLabel: 'Foo',

--- a/packages/design-system/src/components/TextField/__snapshots__/TextField.test.jsx.snap
+++ b/packages/design-system/src/components/TextField/__snapshots__/TextField.test.jsx.snap
@@ -6,14 +6,14 @@ exports[`TextField masks renders TextField 1`] = `
 >
   <FormLabel
     component="label"
-    fieldId="textfield_58"
-    id="textfield_label_59"
+    fieldId="textfield_56"
+    id="textfield_label_57"
   >
     Foo
   </FormLabel>
   <input
     className="ds-c-field"
-    id="textfield_58"
+    id="textfield_56"
     name="spec-field"
     type="text"
   />
@@ -26,8 +26,8 @@ exports[`TextField masks renders currency mask 1`] = `
 >
   <FormLabel
     component="label"
-    fieldId="textfield_60"
-    id="textfield_label_61"
+    fieldId="textfield_58"
+    id="textfield_label_59"
   >
     Foo
   </FormLabel>
@@ -35,9 +35,8 @@ exports[`TextField masks renders currency mask 1`] = `
     mask="currency"
   >
     <input
-      aria-label="Foo. Enter amount in dollars."
       className="ds-c-field ds-c-field--currency"
-      id="textfield_60"
+      id="textfield_58"
       name="spec-field"
       type="text"
     />


### PR DESCRIPTION
### Summary
This PR fixes https://github.com/CMSgov/design-system/issues/838
A default `ariaLabel` was added to currency masks originally to give screen reader users more contexts, but this prevents users from defining their own `ariaLabel` for currency fields.

Instead of requiring a hardcoded `ariaLabel`, we want the `ariaLabel` as a normal prop.

### How to test
- Ensure `ariaLabel` isnt defaulted for currency mask