### PR TITLE
[NO_TICKET] Update Tooltip e2e test

### DIFF
--- a/packages/design-system/src/components/Tooltip/Tooltip.e2e.test.js
+++ b/packages/design-system/src/components/Tooltip/Tooltip.e2e.test.js
@@ -2,17 +2,15 @@
 import { ROOT_URL } from '../helpers/e2e/constants';
 
 import assertNoAxeViolations from '../helpers/e2e/assertNoAxeViolations';
-import { getElementById } from '../helpers/e2e';
+import { getElementByClassName } from '../helpers/e2e';
 
-const rootURL = `${ROOT_URL}/example/components.tooltip.react/`;
+const rootURL = `${ROOT_URL}/example/components.tooltip.tooltip/`;
 
 describe('Tooltip component', () => {
   it('Should render', async () => {
     await driver.get(rootURL);
 
-    expect(await getElementById('tooltip-1-id')).toBeTruthy();
-    expect(await getElementById('tooltip-2-id')).toBeTruthy();
-    expect(await getElementById('tooltip-3-id')).toBeTruthy();
+    expect(await getElementByClassName('ds-c-tooltip__trigger')).toBeTruthy();
   });
 
   it('Should have no accessibility violations', async () => {


### PR DESCRIPTION
### Summary
Currently, the `yarn test:e2e` ends with timeout error for Tooltip component.

Found that testing for any of these will timeout.
- expect(await getElementByClassName('ds-c-tooltip')).toBeTruthy();
- expect(await getElementByClassName('ds-c-tooltip__content')).toBeTruthy();
- expect(await getElementById(‘trigger_1)).toBeTruthy();
``` : Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Error:```

### Update
- Update the Tooltip e2e test to look for another classname
