### PR TITLE
[WNMGTAXTOOLS-95] Add Downshift props to Autocomplete props' type def

### DIFF
--- a/packages/design-system/src/types/Autocomplete/Autocomplete.d.ts
+++ b/packages/design-system/src/types/Autocomplete/Autocomplete.d.ts
@@ -1,11 +1,12 @@
 import * as React from 'react';
+import { DownshiftProps } from 'downshift';
 
 export interface AutocompleteItems {
   id?: string;
   name?: string;
 }
 
-export interface AutocompleteProps {
+export interface AutocompleteProps extends DownshiftProps<any> {
   /**
    * Screenreader-specific label for the Clear search `<button>`. Intended to provide a longer, more descriptive explanation of the button's behavior.
    */


### PR DESCRIPTION
https://jira.cms.gov/browse/WNMGTAXTOOLS-95

After upgrading to the latest version of the design system and migrating to TypeScript, we started getting errors for passing props to `Autocomplete` that were defined for `Downshift` but not listed explicitly in the `Autocomplete` props' type definition. We had to ignore the line where we passed `defaultInputValue`, but it turns out that prop was incorrect as of Downshift v3 (changed to `initialInputValue`). I've tested that these typedef changes allow me to uncomment my `initialInputValue={text}` line without errors.

### Fixed
- Since downshift props can be passed down through `Autocomplete`, add it to TypeScript definition so we don't get errors when passing those props.