### PR TITLE
[NO_TICKET] Update Step List background image to no-repeat

### DIFF
--- a/packages/design-system/src/styles/components/_StepList.scss
+++ b/packages/design-system/src/styles/components/_StepList.scss
@@ -156,6 +156,7 @@ $current-step-color: $color-primary !default;
 
   &::before {
     background-image: url('#{$image-path}/checkmark-green.svg');
+    background-repeat: no-repeat;
     background-size: contain;
     box-sizing: border-box;
     content: '';


### PR DESCRIPTION
### Fix
StepList green checkmark is sometimes printed with an extra marking. 
Add background no-repeat to the green checkmark icon style to remove the extra marking.
