### PR TITLE
[No Ticket] - Fix HelpDrawerToggle React Warning

### DIFF
--- a/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
@@ -14,7 +14,7 @@ export class HelpDrawerToggle extends React.PureComponent {
   }
 
   render() {
-    const { className, children, inline, showDrawer, ...others } = this.props;
+    const { className, children, inline, showDrawer, helpDrawerOpen, ...others } = this.props;
     const classes = classNames(
       'ds-c-help-drawer__toggle',
       inline && 'ds-u-display--inline',

--- a/packages/design-system/src/components/HelpDrawer/__snapshots__/HelpDrawerToggle.test.jsx.snap
+++ b/packages/design-system/src/components/HelpDrawer/__snapshots__/HelpDrawerToggle.test.jsx.snap
@@ -4,7 +4,6 @@ exports[`HelpDrawerToggle renders a button 1`] = `
 <Button
   className="ds-c-help-drawer__toggle"
   component="button"
-  helpDrawerOpen={false}
   inputRef={[Function]}
   onClick={[Function]}
   type="button"

--- a/packages/design-system/src/types/HelpDrawer/HelpDrawerToggle.d.ts
+++ b/packages/design-system/src/types/HelpDrawer/HelpDrawerToggle.d.ts
@@ -25,6 +25,9 @@ export interface HelpDrawerToggleProps {
   showDrawer: (...args: any[]) => any;
 }
 
-export default class HelpDrawerToggle extends React.Component<HelpDrawerToggleProps, any> {
+export default class HelpDrawerToggle extends React.Component<
+React.HTMLProps<HTMLButtonElement> & HelpDrawerToggleProps,
+  any
+> {
   render(): JSX.Element;
 }


### PR DESCRIPTION
### Fixed
There is a React warning happening for the HelpDrawerToggle:
```
Warning: React does not recognize the `helpDrawerOpen` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `helpdraweropen` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          in button (created by Button)
          in Button (created by HelpDrawerToggle)
          in HelpDrawerToggle (at HelpDrawerWrapper.tsx:69)
```
The `helpDrawerOpen` prop was being applied to the Button component which it shouldn't be, so I added it to line 17 to pull it out from the others variable before others is applied to the Button

