### PR TITLE
[NO-TICKET] Remove USWDS link from color doc page

### DIFF
--- a/packages/design-system-docs/src/pages/styles/color-palette/_color-palette.docs.scss
+++ b/packages/design-system-docs/src/pages/styles/color-palette/_color-palette.docs.scss
@@ -1,8 +1,6 @@
 /*
 Color palette
 
-@uswds https://designsystem.digital.gov/components/colors/
-
 <p class="ds-text--lead">The design system provides a flexible, yet distinctly American palette designed to communicate warmth and trustworthiness while meeting the highest standards of 508 color contrast requirements.</p>
 
 The palette is designed to support a range of distinct visual styles that continue to feel connected. The intent of the palette is to convey a warm and open American spirit, with bright saturated tints of blue, grounded in sophisticated deeper shades of cool blues and grays. These colors — combined with clear hierarchy, good information design, and ample white space — should leave users feeling welcomed and in good hands.


### PR DESCRIPTION
We don't really use color in the same way as USWDS does now in their V2.
 I don't think it makes sense to link out to their site on this page.

This PR removes the USWDS link from the color palette page