### PR TITLE
[WNMGDS-718] Add responsive styling to USA banner component

### DIFF
--- a/packages/design-system-docs/src/pages/components/UsaBanner/usabanner.example.html
+++ b/packages/design-system-docs/src/pages/components/UsaBanner/usabanner.example.html
@@ -15,13 +15,13 @@
       <p class="ds-c-usa-banner__header-text">
         <span>An official website of the United States government</span>
         <span class="ds-c-usa-banner__header-action" aria-hidden="true">Here’s how you know</span>
-        <button class="ds-c-usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
+        <button class="ds-c-usa-banner__button" aria-expanded="true" aria-controls="gov-banner">
           <span class="ds-c-usa-banner__button-text">Here’s how you know</span>
         </button>
       </p>
     </div>
   </header>
-  <div class="ds-c-usa-banner__content" id="gov-banner" hidden="">
+  <div class="ds-c-usa-banner__content" id="gov-banner">
     <div
       class="ds-u-display--flex ds-u-flex-direction--column ds-u-sm-flex-direction--row ds-u-flex-wrap--nowrap"
     >
@@ -84,13 +84,13 @@
         <span class="ds-c-usa-banner__header-action" aria-hidden="true"
           >Así es como usted puede verificarlo</span
         >
-        <button class="ds-c-usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
+        <button class="ds-c-usa-banner__button" aria-expanded="true" aria-controls="gov-banner">
           <span class="ds-c-usa-banner__button-text">Así es como usted puede verificarlo</span>
         </button>
       </p>
     </div>
   </header>
-  <div class="ds-c-usa-banner__content" id="gov-banner" hidden="">
+  <div class="ds-c-usa-banner__content" id="gov-banner">
     <div
       class="ds-u-display--flex ds-u-flex-direction--column ds-u-sm-flex-direction--row ds-u-flex-wrap--nowrap"
     >

--- a/packages/design-system-docs/src/pages/components/UsaBanner/usabanner.example.html
+++ b/packages/design-system-docs/src/pages/components/UsaBanner/usabanner.example.html
@@ -15,7 +15,7 @@
       <p class="ds-c-usa-banner__header-text">
         <span>An official website of the United States government</span>
         <span class="ds-c-usa-banner__header-action" aria-hidden="true">Here’s how you know</span>
-        <button class="ds-c-usa-banner__button" aria-expanded="true" aria-controls="gov-banner">
+        <button class="ds-c-usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
           <span class="ds-c-usa-banner__button-text">Here’s how you know</span>
         </button>
       </p>
@@ -84,7 +84,7 @@
         <span class="ds-c-usa-banner__header-action" aria-hidden="true"
           >Así es como usted puede verificarlo</span
         >
-        <button class="ds-c-usa-banner__button" aria-expanded="true" aria-controls="gov-banner">
+        <button class="ds-c-usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
           <span class="ds-c-usa-banner__button-text">Así es como usted puede verificarlo</span>
         </button>
       </p>

--- a/packages/design-system-docs/src/pages/components/UsaBanner/usabanner.example.html
+++ b/packages/design-system-docs/src/pages/components/UsaBanner/usabanner.example.html
@@ -1,20 +1,25 @@
 <h6 class="preview__label">English banner</h6>
-<div class="ds-c-usa-banner">
+<section class="ds-c-usa-banner" aria-label="Official government website">
   <header class="ds-c-usa-banner__header">
-    <svg
-      width="16"
-      height="11"
-      class="ds-c-usa-banner__header-flag"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <use href="{{root}}/images/usa-banner-flag.svg#svg"></use>
-    </svg>
-    <p class="ds-c-usa-banner__header-text">
-      <span>An official website of the United States government</span>
-      <button class="ds-c-usa-banner__button" aria-expanded="true" aria-controls="gov-banner">
-        Here’s how you know
-      </button>
-    </p>
+    <div class="ds-c-usa-banner__inner">
+      <p class="ds-c-usa-banner__header-text">
+        <svg
+          width="16"
+          height="11"
+          class="ds-c-usa-banner__header-flag"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use href="{{root}}/images/usa-banner-flag.svg#svg"></use>
+        </svg>
+      </p>
+      <p class="ds-c-usa-banner__header-text">
+        <span>An official website of the United States government</span>
+        <span class="ds-c-usa-banner__header-action" aria-hidden="true">Here’s how you know</span>
+        <button class="ds-c-usa-banner__button" aria-expanded="true" aria-controls="gov-banner">
+          <span class="ds-c-usa-banner__button-text">Here’s how you know</span>
+        </button>
+      </p>
+    </div>
   </header>
   <div class="ds-c-usa-banner__content" id="gov-banner" hidden="">
     <div
@@ -59,24 +64,31 @@
       </div>
     </div>
   </div>
-</div>
+</section>
 <h6 class="preview__label">Spanish banner</h6>
-<div class="ds-c-usa-banner">
+<section class="ds-c-usa-banner" aria-label="Official government website">
   <header class="ds-c-usa-banner__header">
-    <svg
-      width="16"
-      height="11"
-      class="ds-c-usa-banner__header-flag"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <use href="{{root}}/images/usa-banner-flag.svg#svg"></use>
-    </svg>
-    <p class="ds-c-usa-banner__header-text">
-      <span>Un sitio oficial del Gobierno de Estados Unidos</span>
-      <button class="ds-c-usa-banner__button" aria-expanded="true" aria-controls="gov-banner">
-        Así es como usted puede verificarlo
-      </button>
-    </p>
+    <div class="ds-c-usa-banner__inner">
+      <p class="ds-c-usa-banner__header-text">
+        <svg
+          width="16"
+          height="11"
+          class="ds-c-usa-banner__header-flag"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use href="{{root}}/images/usa-banner-flag.svg#svg"></use>
+        </svg>
+      </p>
+      <p class="ds-c-usa-banner__header-text">
+        <span>Un sitio oficial del Gobierno de Estados Unidos</span>
+        <span class="ds-c-usa-banner__header-action" aria-hidden="true"
+          >Así es como usted puede verificarlo</span
+        >
+        <button class="ds-c-usa-banner__button" aria-expanded="true" aria-controls="gov-banner">
+          <span class="ds-c-usa-banner__button-text">Así es como usted puede verificarlo</span>
+        </button>
+      </p>
+    </div>
   </header>
   <div class="ds-c-usa-banner__content" id="gov-banner" hidden="">
     <div
@@ -121,4 +133,4 @@
       </div>
     </div>
   </div>
-</div>
+</section>

--- a/packages/design-system/src/components/UsaBanner/UsaBanner.jsx
+++ b/packages/design-system/src/components/UsaBanner/UsaBanner.jsx
@@ -30,7 +30,9 @@ export class UsaBanner extends React.PureComponent {
           }`}
         >
           <div className="ds-c-usa-banner__inner">
-            <UsaFlagIcon className="ds-c-usa-banner__header-flag" />
+            <p className="ds-c-usa-banner__header-text">
+              <UsaFlagIcon className="ds-c-usa-banner__header-flag" />
+            </p>
             <p className="ds-c-usa-banner__header-text">
               <span>{t.bannerText}</span>
               <p className="ds-c-usa-banner__header-action" aria-hidden="true">

--- a/packages/design-system/src/components/UsaBanner/UsaBanner.jsx
+++ b/packages/design-system/src/components/UsaBanner/UsaBanner.jsx
@@ -23,24 +23,29 @@ export class UsaBanner extends React.PureComponent {
       this.props.locale === 'es' ? SpanishTranslations.usaBanner : EnglishTranslations.usaBanner;
 
     return (
-      <div className="ds-c-usa-banner">
+      <section className="ds-c-usa-banner" aria-label="Official government website">
         <header
           className={`ds-c-usa-banner__header ${
             this.state.isBannerOpen ? 'ds-c-usa-banner__header--expanded' : ''
           }`}
         >
-          <UsaFlagIcon className="ds-c-usa-banner__header-flag" />
-          <p className="ds-c-usa-banner__header-text">
-            <span>{t.bannerText}</span>
-            <button
-              onClick={this.handleToggleBanner}
-              className="ds-c-usa-banner__button"
-              aria-expanded={this.state.isBannerOpen}
-              aria-controls="gov-banner"
-            >
-              {t.bannerActionText}
-            </button>
-          </p>
+          <div className="ds-c-usa-banner__inner">
+            <UsaFlagIcon className="ds-c-usa-banner__header-flag" />
+            <p className="ds-c-usa-banner__header-text">
+              <span>{t.bannerText}</span>
+              <p className="ds-c-usa-banner__header-action" aria-hidden="true">
+                {t.bannerActionText}
+              </p>
+              <button
+                onClick={this.handleToggleBanner}
+                className="ds-c-usa-banner__button"
+                aria-expanded={this.state.isBannerOpen}
+                aria-controls="gov-banner"
+              >
+                <span className="ds-c-usa-banner__button-text">{t.bannerActionText}</span>
+              </button>
+            </p>
+          </div>
         </header>
         <div className="ds-c-usa-banner__content" id="gov-banner" hidden={!this.state.isBannerOpen}>
           <div className="ds-u-display--flex ds-u-flex-direction--column ds-u-sm-flex-direction--row ds-u-flex-wrap--nowrap">
@@ -67,7 +72,7 @@ export class UsaBanner extends React.PureComponent {
             </div>
           </div>
         </div>
-      </div>
+      </section>
     );
   }
 }

--- a/packages/design-system/src/components/UsaBanner/UsaBanner.jsx
+++ b/packages/design-system/src/components/UsaBanner/UsaBanner.jsx
@@ -35,9 +35,9 @@ export class UsaBanner extends React.PureComponent {
             </p>
             <p className="ds-c-usa-banner__header-text">
               <span>{t.bannerText}</span>
-              <p className="ds-c-usa-banner__header-action" aria-hidden="true">
+              <span className="ds-c-usa-banner__header-action" aria-hidden="true">
                 {t.bannerActionText}
-              </p>
+              </span>
               <button
                 onClick={this.handleToggleBanner}
                 className="ds-c-usa-banner__button"

--- a/packages/design-system/src/components/UsaBanner/__snapshots__/UsaBanner.test.jsx.snap
+++ b/packages/design-system/src/components/UsaBanner/__snapshots__/UsaBanner.test.jsx.snap
@@ -1,59 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`applies Spanish translation 1`] = `
-<div
+<section
+  aria-label="Official government website"
   className="ds-c-usa-banner"
 >
   <header
     className="ds-c-usa-banner__header "
   >
-    <svg
-      className="ds-c-usa-banner__header-flag"
-      height="11"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      className="ds-c-usa-banner__inner"
     >
-      <g
-        fill="none"
-        fillRule="evenodd"
+      <p
+        className="ds-c-usa-banner__header-text"
       >
-        <path
-          d="M0 0h16v11H0z"
-          fill="#FFF"
-        />
-        <path
-          d="M8 0h8v1H8z"
-          fill="#DB3E1F"
-        />
-        <path
-          d="M0 0h8v7H0z"
-          fill="#1E33B1"
-        />
-        <path
-          d="M8 2h8v1H8zm0 2h8v1H8zm0 2h8v1H8zM0 8h16v1H0zm0 2h16v1H0z"
-          fill="#DB3E1F"
-        />
-        <path
-          d="M1 1h1v1H1zm1 2h1v1H2zM1 5h1v1H1zm2-4h1v1H3zm1 2h1v1H4zM3 5h1v1H3zm2-4h1v1H5zm1 2h1v1H6zM5 5h1v1H5z"
-          fill="#FFF"
-        />
-      </g>
-    </svg>
-    <p
-      className="ds-c-usa-banner__header-text"
-    >
-      <span>
-        Un sitio oficial del Gobierno de Estados Unidos
-      </span>
-      <button
-        aria-controls="gov-banner"
-        aria-expanded={false}
-        className="ds-c-usa-banner__button"
-        onClick={[Function]}
+        <svg
+          className="ds-c-usa-banner__header-flag"
+          height="11"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fillRule="evenodd"
+          >
+            <path
+              d="M0 0h16v11H0z"
+              fill="#FFF"
+            />
+            <path
+              d="M8 0h8v1H8z"
+              fill="#DB3E1F"
+            />
+            <path
+              d="M0 0h8v7H0z"
+              fill="#1E33B1"
+            />
+            <path
+              d="M8 2h8v1H8zm0 2h8v1H8zm0 2h8v1H8zM0 8h16v1H0zm0 2h16v1H0z"
+              fill="#DB3E1F"
+            />
+            <path
+              d="M1 1h1v1H1zm1 2h1v1H2zM1 5h1v1H1zm2-4h1v1H3zm1 2h1v1H4zM3 5h1v1H3zm2-4h1v1H5zm1 2h1v1H6zM5 5h1v1H5z"
+              fill="#FFF"
+            />
+          </g>
+        </svg>
+      </p>
+      <p
+        className="ds-c-usa-banner__header-text"
       >
-        Así es como usted puede verificarlo
-      </button>
-    </p>
+        <span>
+          Un sitio oficial del Gobierno de Estados Unidos
+        </span>
+        <span
+          aria-hidden="true"
+          className="ds-c-usa-banner__header-action"
+        >
+          Así es como usted puede verificarlo
+        </span>
+        <button
+          aria-controls="gov-banner"
+          aria-expanded={false}
+          className="ds-c-usa-banner__button"
+          onClick={[Function]}
+        >
+          <span
+            className="ds-c-usa-banner__button-text"
+          >
+            Así es como usted puede verificarlo
+          </span>
+        </button>
+      </p>
+    </div>
   </header>
   <div
     className="ds-c-usa-banner__content"
@@ -157,37 +176,56 @@ exports[`applies Spanish translation 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`applies additional class names to expanded banner 1`] = `
-<div
+<section
+  aria-label="Official government website"
   className="ds-c-usa-banner"
 >
   <header
     className="ds-c-usa-banner__header ds-c-usa-banner__header--expanded"
   >
-    <UsaFlagIcon
-      className="ds-c-usa-banner__header-flag"
-      height="11"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    />
-    <p
-      className="ds-c-usa-banner__header-text"
+    <div
+      className="ds-c-usa-banner__inner"
     >
-      <span>
-        An official website of the United States government
-      </span>
-      <button
-        aria-controls="gov-banner"
-        aria-expanded={true}
-        className="ds-c-usa-banner__button"
-        onClick={[Function]}
+      <p
+        className="ds-c-usa-banner__header-text"
       >
-        Here’s how you know
-      </button>
-    </p>
+        <UsaFlagIcon
+          className="ds-c-usa-banner__header-flag"
+          height="11"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </p>
+      <p
+        className="ds-c-usa-banner__header-text"
+      >
+        <span>
+          An official website of the United States government
+        </span>
+        <span
+          aria-hidden="true"
+          className="ds-c-usa-banner__header-action"
+        >
+          Here’s how you know
+        </span>
+        <button
+          aria-controls="gov-banner"
+          aria-expanded={true}
+          className="ds-c-usa-banner__button"
+          onClick={[Function]}
+        >
+          <span
+            className="ds-c-usa-banner__button-text"
+          >
+            Here’s how you know
+          </span>
+        </button>
+      </p>
+    </div>
   </header>
   <div
     className="ds-c-usa-banner__content"
@@ -260,63 +298,82 @@ exports[`applies additional class names to expanded banner 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`renders correctly 1`] = `
-<div
+<section
+  aria-label="Official government website"
   className="ds-c-usa-banner"
 >
   <header
     className="ds-c-usa-banner__header "
   >
-    <svg
-      className="ds-c-usa-banner__header-flag"
-      height="11"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      className="ds-c-usa-banner__inner"
     >
-      <g
-        fill="none"
-        fillRule="evenodd"
+      <p
+        className="ds-c-usa-banner__header-text"
       >
-        <path
-          d="M0 0h16v11H0z"
-          fill="#FFF"
-        />
-        <path
-          d="M8 0h8v1H8z"
-          fill="#DB3E1F"
-        />
-        <path
-          d="M0 0h8v7H0z"
-          fill="#1E33B1"
-        />
-        <path
-          d="M8 2h8v1H8zm0 2h8v1H8zm0 2h8v1H8zM0 8h16v1H0zm0 2h16v1H0z"
-          fill="#DB3E1F"
-        />
-        <path
-          d="M1 1h1v1H1zm1 2h1v1H2zM1 5h1v1H1zm2-4h1v1H3zm1 2h1v1H4zM3 5h1v1H3zm2-4h1v1H5zm1 2h1v1H6zM5 5h1v1H5z"
-          fill="#FFF"
-        />
-      </g>
-    </svg>
-    <p
-      className="ds-c-usa-banner__header-text"
-    >
-      <span>
-        An official website of the United States government
-      </span>
-      <button
-        aria-controls="gov-banner"
-        aria-expanded={false}
-        className="ds-c-usa-banner__button"
-        onClick={[Function]}
+        <svg
+          className="ds-c-usa-banner__header-flag"
+          height="11"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fill="none"
+            fillRule="evenodd"
+          >
+            <path
+              d="M0 0h16v11H0z"
+              fill="#FFF"
+            />
+            <path
+              d="M8 0h8v1H8z"
+              fill="#DB3E1F"
+            />
+            <path
+              d="M0 0h8v7H0z"
+              fill="#1E33B1"
+            />
+            <path
+              d="M8 2h8v1H8zm0 2h8v1H8zm0 2h8v1H8zM0 8h16v1H0zm0 2h16v1H0z"
+              fill="#DB3E1F"
+            />
+            <path
+              d="M1 1h1v1H1zm1 2h1v1H2zM1 5h1v1H1zm2-4h1v1H3zm1 2h1v1H4zM3 5h1v1H3zm2-4h1v1H5zm1 2h1v1H6zM5 5h1v1H5z"
+              fill="#FFF"
+            />
+          </g>
+        </svg>
+      </p>
+      <p
+        className="ds-c-usa-banner__header-text"
       >
-        Here’s how you know
-      </button>
-    </p>
+        <span>
+          An official website of the United States government
+        </span>
+        <span
+          aria-hidden="true"
+          className="ds-c-usa-banner__header-action"
+        >
+          Here’s how you know
+        </span>
+        <button
+          aria-controls="gov-banner"
+          aria-expanded={false}
+          className="ds-c-usa-banner__button"
+          onClick={[Function]}
+        >
+          <span
+            className="ds-c-usa-banner__button-text"
+          >
+            Here’s how you know
+          </span>
+        </button>
+      </p>
+    </div>
   </header>
   <div
     className="ds-c-usa-banner__content"
@@ -420,5 +477,5 @@ exports[`renders correctly 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;

--- a/packages/design-system/src/images/close-alt.svg
+++ b/packages/design-system/src/images/close-alt.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 15 15">
+  <path fill="none" stroke="#000" stroke-linecap="round" stroke-width="2" d="M0 13.0332964L13.0332964 0M13.0332964 13.0332964L0 0" transform="translate(1 1)"/>
+</svg>

--- a/packages/design-system/src/styles/components/_UsaBanner.scss
+++ b/packages/design-system/src/styles/components/_UsaBanner.scss
@@ -129,7 +129,7 @@ $usa-banner-text-color: #1b1b1b;
 
   // Display close icon on smaller viewport
   // stylelint-disable scss/media-feature-value-dollar-variable
-  @media (max-width: #{$width-sm - 1px}) {
+  @media (max-width: $width-sm - 1px) {
     &[aria-expanded='true']::before {
       background-color: #e6e6e6;
       bottom: 0;

--- a/packages/design-system/src/styles/components/_UsaBanner.scss
+++ b/packages/design-system/src/styles/components/_UsaBanner.scss
@@ -1,5 +1,7 @@
 $usa-banner-background-color: #f0f0f0;
 $usa-banner-text-color: #1b1b1b;
+$usa-banner-close-image-background-color: #e6e6e6;
+$usa-banner-header-action-color: #005ea2;
 
 .ds-c-usa-banner {
   background-color: $usa-banner-background-color;
@@ -43,7 +45,7 @@ $usa-banner-text-color: #1b1b1b;
 }
 
 .ds-c-usa-banner__header-action {
-  color: #005ea2;
+  color: $usa-banner-header-action-color;
   display: block;
   line-height: 1.1;
   margin-bottom: 0;
@@ -92,12 +94,8 @@ $usa-banner-text-color: #1b1b1b;
   border-radius: 0;
   bottom: 0;
   box-shadow: none;
-  color: #005ea2;
   display: block;
   font-size: 0.8rem;
-  -moz-osx-font-smoothing: auto;
-  -webkit-font-smoothing: subpixel-antialiased;
-  font-weight: 400;
   height: auto;
   left: 0;
   line-height: 1.2;
@@ -113,14 +111,9 @@ $usa-banner-text-color: #1b1b1b;
   @extend .ds-c-link;
   /* stylelint-enable scss/at-extend-no-missing-placeholder */
   @media (min-width: $width-sm) {
-    background-color: transparent;
-    border: 0;
     bottom: auto;
-    box-shadow: none;
     display: inline;
     left: auto;
-    margin: 0;
-    padding: 0;
     position: relative;
     right: auto;
     top: auto;
@@ -131,7 +124,7 @@ $usa-banner-text-color: #1b1b1b;
   // stylelint-disable scss/media-feature-value-dollar-variable
   @media (max-width: $width-sm - 1px) {
     &[aria-expanded='true']::before {
-      background-color: #e6e6e6;
+      background-color: $usa-banner-close-image-background-color;
       bottom: 0;
       content: '';
       display: block;
@@ -160,6 +153,7 @@ $usa-banner-text-color: #1b1b1b;
 }
 
 .ds-c-usa-banner__button-text {
+  // Hide the button-text on narrow viewport as header-action will display the action text
   left: -999em;
   position: absolute;
 
@@ -232,9 +226,6 @@ $usa-banner-text-color: #1b1b1b;
   @media (min-width: $width-sm) {
     background-color: transparent;
     display: block;
-    font-size: 0.8rem;
-    font-weight: 400;
-    min-height: 0;
     padding-right: 0;
     .ds-c-usa-banner__button-text::after {
       transform: rotate(180deg);

--- a/packages/design-system/src/styles/components/_UsaBanner.scss
+++ b/packages/design-system/src/styles/components/_UsaBanner.scss
@@ -74,9 +74,15 @@ $usa-banner-text-color: #1b1b1b;
 
 .ds-c-usa-banner__content {
   font-size: 0.99816rem;
+  margin-left: auto;
+  margin-right: auto;
   overflow: hidden;
-  padding: $spacer-3 0;
-  width: 100%;
+  padding: 0.25rem 1rem 1rem 0.5rem;
+
+  @media (min-width: $width-sm) {
+    padding-bottom: 1.5rem;
+    padding-top: 1.5rem;
+  }
 }
 
 .ds-c-usa-banner__button {

--- a/packages/design-system/src/styles/components/_UsaBanner.scss
+++ b/packages/design-system/src/styles/components/_UsaBanner.scss
@@ -7,7 +7,7 @@ $usa-banner-text-color: #1b1b1b;
   font-family: 'Source Sans Pro Web', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
   font-size: 1.06471rem;
   line-height: 1.52155;
-  padding: 0 $spacer-3;
+  padding: 0;
 }
 
 .ds-c-usa-banner__header {
@@ -17,10 +17,16 @@ $usa-banner-text-color: #1b1b1b;
   font-size: 0.79853rem;
   font-weight: 400;
   line-height: 1.12707;
-  min-height: 0;
-  padding-bottom: 0.25rem;
-  padding-top: 0.25rem;
+  min-height: 2rem;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
   position: relative;
+
+  @media (min-width: $width-sm) {
+    min-height: 0;
+    padding-bottom: 0.25rem;
+    padding-top: 0.25rem;
+  }
 }
 
 .ds-c-usa-banner__header-flag {
@@ -36,24 +42,12 @@ $usa-banner-text-color: #1b1b1b;
   }
 }
 
-.ds-c-usa-banner__content {
-  font-size: 0.99816rem;
-  overflow: hidden;
-  padding: $spacer-3 0;
-  width: 100%;
-}
-
-.ds-c-usa-banner__button {
-  /* stylelint-disable scss/at-extend-no-missing-placeholder */
-  @extend .ds-c-link;
-  /* stylelint-enable scss/at-extend-no-missing-placeholder */
-  background-color: transparent;
-  border: 0;
-  box-shadow: none;
-  font-size: inherit;
-  line-height: inherit;
-  margin: 0;
-  padding: 0;
+.ds-c-usa-banner__header-action {
+  color: #005ea2;
+  line-height: 1.1;
+  margin-bottom: 0;
+  margin-top: 2px;
+  text-decoration: underline;
 
   &::after {
     background-image: url('#{$image-path}/arrow-down.svg'),
@@ -68,11 +62,133 @@ $usa-banner-text-color: #1b1b1b;
     padding-right: 2px;
     width: 0.5rem;
   }
+
+  // Hide header-action text for large viewport and when expanded
+  @media (min-width: $width-sm) {
+    display: none;
+  }
+  .ds-c-usa-banner__header--expanded & {
+    display: none;
+  }
+}
+
+.ds-c-usa-banner__content {
+  font-size: 0.99816rem;
+  overflow: hidden;
+  padding: $spacer-3 0;
+  width: 100%;
+}
+
+.ds-c-usa-banner__button {
+  background-color: transparent;
+  border: 0;
+  border-radius: 0;
+  bottom: 0;
+  box-shadow: none;
+  color: #005ea2;
+  display: block;
+  font-size: 0.8rem;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: subpixel-antialiased;
+  font-weight: 400;
+  height: auto;
+  left: 0;
+  line-height: 1.2;
+  margin: 0;
+  overflow: visible;
+  padding: 0;
+  position: absolute;
+  text-align: left;
+  top: 0;
+  width: 100%;
+
+  /* stylelint-disable scss/at-extend-no-missing-placeholder */
+  @extend .ds-c-link;
+  /* stylelint-enable scss/at-extend-no-missing-placeholder */
+  @media (min-width: $width-sm) {
+    background-color: transparent;
+    border: 0;
+    bottom: auto;
+    box-shadow: none;
+    display: inline;
+    font-size: inherit;
+    left: auto;
+    line-height: inherit;
+    margin: 0;
+    margin-left: 0.5rem;
+    padding: 0;
+    right: auto;
+    top: auto;
+    width: auto;
+  }
+
+  // Display close icon on smaller viewport
+  @media (max-width: $width-sm) {
+    &[aria-expanded='true']::before {
+      background-color: #e6e6e6;
+      bottom: 0;
+      content: '';
+      display: block;
+      height: 3rem;
+      position: absolute;
+      right: 0;
+      top: 0;
+      width: 3rem;
+    }
+
+    &[aria-expanded='true']::after {
+      background: 0 0;
+      background-color: #005ea2;
+      bottom: 0;
+      content: '';
+      display: inline-block;
+      height: 3rem;
+      margin-left: 0;
+      // -webkit-mask: url('#{$image-path}/close-alt.svg') no-repeat center/1rem 1rem;
+      mask: url('#{$image-path}/close-alt.svg') no-repeat center/1rem 1rem;
+      position: absolute;
+      right: 0;
+      top: 0;
+      vertical-align: middle;
+      width: 3rem;
+    }
+  }
+}
+
+.ds-c-usa-banner__button-text {
+  left: -999em;
+  position: absolute;
+
+  &::after {
+    display: none;
+  }
+
+  @media (min-width: $width-sm) {
+    display: inline;
+    position: static;
+
+    &::after {
+      background-image: url('#{$image-path}/arrow-down.svg'),
+        linear-gradient(transparent, transparent);
+      background-position: 50%;
+      background-repeat: no-repeat;
+      background-size: 0.5rem;
+      content: '';
+      display: inline-block;
+      height: 0.5rem;
+      margin-left: 2px;
+      padding-right: 2px;
+      width: 0.5rem;
+    }
+  }
 }
 
 .ds-c-usa-banner__guidance {
   align-items: flex-start;
   display: flex;
+  max-width: 64ex;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   padding-top: $spacer-2;
 
   @media (min-width: $width-sm) {
@@ -108,8 +224,35 @@ $usa-banner-text-color: #1b1b1b;
 
 // stylelint-disable no-duplicate-selectors
 .ds-c-usa-banner__header--expanded {
-  .ds-c-usa-banner__button::after {
-    transform: rotate(180deg);
+  padding-right: 3.5rem;
+
+  @media (min-width: $width-sm) {
+    background-color: transparent;
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 400;
+    min-height: 0;
+    padding-right: 0;
+    .ds-c-usa-banner__button-text::after {
+      transform: rotate(180deg);
+    }
+  }
+
+  .ds-c-usa-banner__header-action {
+    display: none;
   }
 }
 // stylelint-enable no-duplicate-selectors
+
+.ds-c-usa-banner__inner {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  line-height: 1;
+  margin-left: 0;
+  margin-right: auto;
+  max-width: 64rem;
+  padding-left: 1rem;
+  padding-right: 0;
+  padding-right: 0;
+}

--- a/packages/design-system/src/styles/components/_UsaBanner.scss
+++ b/packages/design-system/src/styles/components/_UsaBanner.scss
@@ -123,6 +123,7 @@ $usa-banner-text-color: #1b1b1b;
     margin: 0;
     margin-left: 0.5rem;
     padding: 0;
+    position: relative;
     right: auto;
     top: auto;
     width: auto;
@@ -143,15 +144,12 @@ $usa-banner-text-color: #1b1b1b;
     }
 
     &[aria-expanded='true']::after {
-      background: 0 0;
-      background-color: #005ea2;
+      background: url('#{$image-path}/close-alt.svg') no-repeat center/1rem 1rem;
       bottom: 0;
       content: '';
       display: inline-block;
       height: 3rem;
       margin-left: 0;
-      // -webkit-mask: url('#{$image-path}/close-alt.svg') no-repeat center/1rem 1rem;
-      mask: url('#{$image-path}/close-alt.svg') no-repeat center/1rem 1rem;
       position: absolute;
       right: 0;
       top: 0;

--- a/packages/design-system/src/styles/components/_UsaBanner.scss
+++ b/packages/design-system/src/styles/components/_UsaBanner.scss
@@ -137,7 +137,10 @@ $usa-banner-header-action-color: #005ea2;
     // stylelint-enable scss/media-feature-value-dollar-variable
 
     &[aria-expanded='true']::after {
-      background: url('#{$image-path}/close-alt.svg') no-repeat center/1rem 1rem;
+      background-image: url('#{$image-path}/close-alt.svg');
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: 1rem 1rem;
       bottom: 0;
       content: '';
       display: inline-block;

--- a/packages/design-system/src/styles/components/_UsaBanner.scss
+++ b/packages/design-system/src/styles/components/_UsaBanner.scss
@@ -44,6 +44,7 @@ $usa-banner-text-color: #1b1b1b;
 
 .ds-c-usa-banner__header-action {
   color: #005ea2;
+  display: block;
   line-height: 1.1;
   margin-bottom: 0;
   margin-top: 2px;
@@ -117,11 +118,8 @@ $usa-banner-text-color: #1b1b1b;
     bottom: auto;
     box-shadow: none;
     display: inline;
-    font-size: inherit;
     left: auto;
-    line-height: inherit;
     margin: 0;
-    margin-left: 0.5rem;
     padding: 0;
     position: relative;
     right: auto;
@@ -130,7 +128,8 @@ $usa-banner-text-color: #1b1b1b;
   }
 
   // Display close icon on smaller viewport
-  @media (max-width: $width-sm) {
+  // stylelint-disable scss/media-feature-value-dollar-variable
+  @media (max-width: #{$width-sm - 1px}) {
     &[aria-expanded='true']::before {
       background-color: #e6e6e6;
       bottom: 0;
@@ -142,6 +141,7 @@ $usa-banner-text-color: #1b1b1b;
       top: 0;
       width: 3rem;
     }
+    // stylelint-enable scss/media-feature-value-dollar-variable
 
     &[aria-expanded='true']::after {
       background: url('#{$image-path}/close-alt.svg') no-repeat center/1rem 1rem;
@@ -223,7 +223,6 @@ $usa-banner-text-color: #1b1b1b;
 
 .ds-c-usa-banner__media-body {
   margin: 0;
-  // overflow: hidden;
 }
 
 // stylelint-disable no-duplicate-selectors
@@ -251,12 +250,9 @@ $usa-banner-text-color: #1b1b1b;
 .ds-c-usa-banner__inner {
   align-items: flex-start;
   display: flex;
-  flex-wrap: wrap;
   line-height: 1;
   margin-left: 0;
   margin-right: auto;
-  max-width: 64rem;
   padding-left: 1rem;
-  padding-right: 0;
   padding-right: 0;
 }


### PR DESCRIPTION
### Changed
- Add responsive feature to USA banner component on small viewport.
![Screen Shot 2020-12-17 at 9 26 20 AM](https://user-images.githubusercontent.com/20322880/102500096-eee97680-4049-11eb-81fb-7af841c1ec88.png)

### How To test
- Run the doc site locally with `yarn start`
- Then visit the USA Banner component page and ensure the USA banner displays correctly on resizing of the viewport
