### PR TITLE
[WNMGDS-733] Add `rootPath` parameter to cli.js

### DIFF
--- a/packages/design-system-scripts/cli.js
+++ b/packages/design-system-scripts/cli.js
@@ -60,12 +60,21 @@ yargs
         type: 'boolean',
         default: false,
       });
+      yargs.option('rootPath', {
+        desc: 'The URL root path for the published docs site.',
+        type: 'string',
+        default: '',
+      });
     },
     handler: async (argv) => {
       const { buildSrc } = require('./gulp/build');
       const { buildDocs } = require('./gulp/docs');
 
       process.env.NODE_ENV = 'production';
+      if (argv.rootPath !== '') {
+        config.rootPath = argv.rootPath;
+      }
+
       if (argv.ignoreRootPath) {
         config.rootPath = '';
       }


### PR DESCRIPTION
### Changes
Update the domain path for design system docs site where the initial default `rootPath` is configured under `cmsds.config.js`. 

To support "build-a-branch" option for CBJ to build testing docs site for the branch name, a different `rootPath` can be  set via command line args as follows: 
`yarn build --rootPath="release-2.2.1"`

### How to test
- Run `yarn build --rootPath="test-branch"` and note that `rootPath` is set to `test-branch`

![Screen Shot 2021-01-07 at 9 35 41 AM](https://user-images.githubusercontent.com/20322880/103905645-dca0ac80-50cc-11eb-98ed-8125cd28d367.png)
