### PR TITLE
[WNMGDS-745] Fix HCgov Header/Footer displaying empty screen

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
@@ -14,7 +14,6 @@
  * an unacceptable regression of the user experience.
  */
 
-import { get, uniqueId } from 'lodash';
 import Button from '../Button/Button';
 import Downshift from 'downshift';
 import PropTypes from 'prop-types';
@@ -22,6 +21,8 @@ import React from 'react';
 import TextField from '../TextField/TextField';
 import WrapperDiv from './WrapperDiv';
 import classNames from 'classnames';
+import get from 'lodash/get';
+import uniqueId from 'lodash.uniqueid';
 
 /**
  * Determine if a React component is a TextField

--- a/packages/design-system/src/components/Table/Table.jsx
+++ b/packages/design-system/src/components/Table/Table.jsx
@@ -1,9 +1,10 @@
-import { get, uniqueId } from 'lodash';
 import Alert from '../Alert/Alert';
 import PropTypes from 'prop-types';
 import React from 'react';
 import TableCaption from './TableCaption';
 import classNames from 'classnames';
+import get from 'lodash/get';
+import uniqueId from 'lodash.uniqueid';
 
 // TODO: Revert out of this 'PR update to use lifecycle methods'
 // (https://github.com/CMSgov/design-system/pull/777)


### PR DESCRIPTION
## Summary
Fix HCgov Header/Footer component page not displaying correctly on local testing of HCgov design system document site (note: odd that it does work on github pages though)

This issue was introduced in [PR Autocomplete component not rendering](https://github.com/CMSgov/design-system/pull/881)

### How to test
- Run the doc site locally with `yarn start`
- Setup HCgov child design system in the package.json to reference this branch with `file:../design-system/package/design-system/`
- Run `git clean -fdx` and then `yarn install` to Install the local DS branch
- Test that the Header and Footer component pages are displaying correctly