### PR TITLE
[WNMGDS-686] Use aria-invalid attribute in form components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,12 @@ module.exports = {
       files: ['*.ts', '*.tsx'],
       parser: '@typescript-eslint/parser',
       extends: ['plugin:@typescript-eslint/recommended'],
-      rules: {},
+      rules: {
+        // Disabling based off official documentation on
+        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md#how-to-use
+        'no-use-before-define': 'off',
+        '@typescript-eslint/no-use-before-define': ['error'],
+      },
     },
   ],
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 dist: trusty
 addons:	
   chrome: stable
+  apt:
+    packages:
+      - chromium-chromedriver
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.4
   - export PATH="$HOME/.yarn/bin:$PATH"
+  - ln --symbolic /usr/lib/chromium-browser/chromedriver "${HOME}/bin/chromedriver"
   - google-chrome-stable --version
+  - find . -name chromedriver 
   - chromedriver --version
 install:
   - yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 dist: trusty
 addons:	
   chrome: stable
-  apt:
-    packages:
-      - chromium-chromedriver
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.4
   - export PATH="$HOME/.yarn/bin:$PATH"
-  - ln --symbolic /usr/lib/chromium-browser/chromedriver "${HOME}/bin/chromedriver"
   - google-chrome-stable --version
-  - find . -name chromedriver 
   - chromedriver --version
 install:
   - yarn

--- a/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
+++ b/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
@@ -28,6 +28,7 @@ exports[`Autocomplete renders a snapshot 1`] = `
       aria-controls={null}
       aria-describedby=""
       aria-expanded={false}
+      aria-invalid={false}
       aria-labelledby={null}
       aria-owns={null}
       autoComplete="off"

--- a/packages/design-system/src/components/DateField/DateField.jsx
+++ b/packages/design-system/src/components/DateField/DateField.jsx
@@ -22,8 +22,8 @@ export function DateField(props) {
       {...containerProps}
       component="fieldset"
       labelComponent="legend"
-      render={({ labelId, errorId }) => (
-        <DateInput {...inputOnlyProps} {...{ labelId, errorId }} inversed={props.inversed} />
+      render={({ labelId }) => (
+        <DateInput {...inputOnlyProps} {...{ labelId }} inversed={props.inversed} />
       )}
     />
   );

--- a/packages/design-system/src/components/DateField/DateInput.jsx
+++ b/packages/design-system/src/components/DateField/DateInput.jsx
@@ -117,10 +117,6 @@ DateInput.propTypes = {
    * Disables all three input fields.
    */
   disabled: PropTypes.bool,
-  /**	
-   * The ID of the error message applied to this field.	
-   */	
-  errorId: PropTypes.string,
   /**
    * Applies the "inverse" UI theme
    */

--- a/packages/design-system/src/components/DateField/DateInput.jsx
+++ b/packages/design-system/src/components/DateField/DateInput.jsx
@@ -78,6 +78,7 @@ export class DateInput extends React.PureComponent {
         }}
         autoComplete={this.props.autoComplete && `bday-${type}`}
         aria-describedby={this.props.labelId}
+        aria-invalid={this.props[`${type}Invalid`]}
       />
     );
   }

--- a/packages/design-system/src/components/DateField/DateInput.jsx
+++ b/packages/design-system/src/components/DateField/DateInput.jsx
@@ -117,9 +117,9 @@ DateInput.propTypes = {
    * Disables all three input fields.
    */
   disabled: PropTypes.bool,
-  /**
-   * The ID of the error message applied to this field.
-   */
+  /**	
+   * The ID of the error message applied to this field.	
+   */	
   errorId: PropTypes.string,
   /**
    * Applies the "inverse" UI theme

--- a/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -38,6 +38,7 @@ exports[`DateField renders 1`] = `
       </label>
       <input
         aria-describedby="field_1-label"
+        aria-invalid={false}
         className="ds-c-field ds-c-field--month"
         id="field_2"
         inputMode="numeric"
@@ -66,6 +67,7 @@ exports[`DateField renders 1`] = `
       </label>
       <input
         aria-describedby="field_1-label"
+        aria-invalid={false}
         className="ds-c-field ds-c-field--day"
         id="field_3"
         inputMode="numeric"
@@ -94,6 +96,7 @@ exports[`DateField renders 1`] = `
       </label>
       <input
         aria-describedby="field_1-label"
+        aria-invalid={false}
         className="ds-c-field ds-c-field--year"
         id="field_4"
         inputMode="numeric"

--- a/packages/design-system/src/components/Dropdown/Dropdown.jsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.jsx
@@ -3,7 +3,6 @@ import { omit, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Select from './Select';
-import classNames from 'classnames';
 
 export class Dropdown extends React.PureComponent {
   constructor(props) {

--- a/packages/design-system/src/components/Dropdown/Dropdown.jsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.jsx
@@ -38,6 +38,7 @@ export class Dropdown extends React.PureComponent {
           <Select
             {...inputOnlyProps}
             {...{ id, setRef }}
+            aria-invalid={!!this.props.errorMessage}
             aria-describedby={
               // Link input to bottom placed error message
               // eslint-disable-next-line

--- a/packages/design-system/src/components/Dropdown/Dropdown.jsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.jsx
@@ -37,16 +37,9 @@ export class Dropdown extends React.PureComponent {
         render={({ id, errorId, setRef }) => (
           <Select
             {...inputOnlyProps}
-            {...{ id, setRef }}
-            aria-invalid={!!this.props.errorMessage}
-            aria-describedby={
-              // Link input to bottom placed error message
-              // eslint-disable-next-line
-              classNames(this.props['aria-describedby'], {
-                [errorId]: this.props.errorPlacement === 'bottom' && this.props.errorMessage,
-              })
-            }
+            {...{ id, setRef, errorId }}
             errorMessage={this.props.errorMessage}
+            errorPlacement={this.props.errorPlacement}
             inversed={this.props.inversed}
           />
         )}

--- a/packages/design-system/src/components/Dropdown/Select.jsx
+++ b/packages/design-system/src/components/Dropdown/Select.jsx
@@ -50,7 +50,10 @@ export class Select extends React.PureComponent {
     return (
       <select
         aria-label={ariaLabel}
-        aria-invalid={!!errorMessage}
+        aria-invalid={
+          // eslint-disable-next-line
+          this.props['aria-invalid'] ? this.props['aria-invalid'] : !!errorMessage
+        }
         aria-describedby={
           // Link input to bottom placed error message
           // eslint-disable-next-line

--- a/packages/design-system/src/components/Dropdown/Select.jsx
+++ b/packages/design-system/src/components/Dropdown/Select.jsx
@@ -20,7 +20,9 @@ export class Select extends React.PureComponent {
     const {
       ariaLabel,
       children,
+      errorId,
       errorMessage,
+      errorPlacement,
       fieldClassName,
       inversed,
       options,
@@ -46,7 +48,20 @@ export class Select extends React.PureComponent {
     ));
 
     return (
-      <select aria-label={ariaLabel} className={classes} ref={setRef} {...selectProps}>
+      <select
+        aria-label={ariaLabel}
+        aria-invalid={!!errorMessage}
+        aria-describedby={
+          // Link input to bottom placed error message
+          // eslint-disable-next-line
+          classNames(this.props['aria-describedby'], {
+            [errorId]: errorPlacement === 'bottom' && errorMessage,
+          })
+        }
+        className={classes}
+        ref={setRef}
+        {...selectProps}
+      >
         {/* Render custom options if provided */ children || optionElements}
       </select>
     );
@@ -71,7 +86,15 @@ Select.propTypes = {
    * Disables the entire field.
    */
   disabled: PropTypes.bool,
+  /**
+   * The ID of the error message applied to the Select field.
+   */
+  errorId: PropTypes.string,
   errorMessage: PropTypes.node,
+  /**
+   * Location of the error message relative to the field input
+   */
+  errorPlacement: PropTypes.oneOf(['top', 'bottom']).isRequired,
   /**
    * Additional classes to be added to the select element
    */

--- a/packages/design-system/src/components/Dropdown/Select.test.jsx
+++ b/packages/design-system/src/components/Dropdown/Select.test.jsx
@@ -6,6 +6,7 @@ import { generateOptions } from './Dropdown.test';
 const defaultProps = {
   name: 'Select',
   label: 'Select an option',
+  errorPlacement: 'top',
   id: '1',
   setRef: jest.fn(),
   onBlur: jest.fn(),
@@ -26,16 +27,16 @@ describe('Select', () => {
   it('renders a select menu', () => {
     const data = render({ value: '1', label: '', ariaLabel: 'test aria label' });
 
-    expect(data.wrapper.find('select').length).toBe(1);
-    expect(data.wrapper.find('select').children('option').length).toBe(1);
+    expect(data.wrapper.length).toBe(1);
+    expect(data.wrapper.children('option').length).toBe(1);
     expect(data.wrapper).toMatchSnapshot();
   });
 
   it('renders options correctly', () => {
     const data = render({ defaultValue: '1' }, 10);
 
-    expect(data.wrapper.find('select').length).toBe(1);
-    expect(data.wrapper.find('select').children('option').length).toBe(10);
+    expect(data.wrapper.length).toBe(1);
+    expect(data.wrapper.children('option').length).toBe(10);
     expect(data.wrapper).toMatchSnapshot();
   });
 
@@ -43,64 +44,70 @@ describe('Select', () => {
     const controlledData = render({ value: '1' }, 4);
     const uncontrolledData = render({ defaultValue: '2' }, 4);
 
-    expect(controlledData.wrapper.find('select').prop('defaultValue')).toBe(
-      controlledData.props.defaultValue
-    );
-    expect(uncontrolledData.wrapper.find('select').prop('defaultValue')).toBe(
-      uncontrolledData.props.defaultValue
-    );
+    expect(controlledData.wrapper.prop('defaultValue')).toBe(controlledData.props.defaultValue);
+    expect(uncontrolledData.wrapper.prop('defaultValue')).toBe(uncontrolledData.props.defaultValue);
   });
 
   it('has a selected <option>', () => {
     const controlledData = render({ value: '1' }, 4);
     const uncontrolledData = render({ defaultValue: '2' }, 4);
 
-    expect(controlledData.wrapper.find('select').prop('defaultValue')).toBe(
-      controlledData.props.defaultValue
-    );
-    expect(uncontrolledData.wrapper.find('select').prop('defaultValue')).toBe(
-      uncontrolledData.props.defaultValue
-    );
+    expect(controlledData.wrapper.prop('defaultValue')).toBe(controlledData.props.defaultValue);
+    expect(uncontrolledData.wrapper.prop('defaultValue')).toBe(uncontrolledData.props.defaultValue);
   });
 
   it('applies additional classNames to select element', () => {
     const data = render({ fieldClassName: 'foo' });
 
-    expect(data.wrapper.find('select').hasClass(data.props.fieldClassName)).toBe(true);
+    expect(data.wrapper.hasClass(data.props.fieldClassName)).toBe(true);
     // Make sure we're not replacing the other class names
-    expect(data.wrapper.find('select').hasClass('ds-c-field')).toBe(true);
+    expect(data.wrapper.hasClass('ds-c-field')).toBe(true);
   });
 
   it('adds size classes to select element', () => {
     const mediumData = render({ size: 'medium' });
     const smallData = render({ size: 'small' });
 
-    expect(mediumData.wrapper.find('select').hasClass('ds-c-field--medium')).toBe(true);
-    expect(smallData.wrapper.find('select').hasClass('ds-c-field--small')).toBe(true);
+    expect(mediumData.wrapper.hasClass('ds-c-field--medium')).toBe(true);
+    expect(smallData.wrapper.hasClass('ds-c-field--small')).toBe(true);
   });
 
   it('is inversed', () => {
     const data = render({ inversed: true });
 
-    expect(data.wrapper.find('select').hasClass('ds-c-field--inverse')).toBe(true);
+    expect(data.wrapper.hasClass('ds-c-field--inverse')).toBe(true);
   });
 
   it('has error', () => {
     const data = render({ errorMessage: 'Error' });
 
-    expect(data.wrapper.find('select').hasClass('ds-c-field--error')).toBe(true);
+    expect(data.wrapper.prop('aria-invalid')).toBe(true);
+    expect(data.wrapper.hasClass('ds-c-field--error')).toBe(true);
+  });
+
+  it('handles bottom placed error', () => {
+    const data = render({
+      errorMessage: 'Error',
+      errorPlacement: 'bottom',
+      errorId: '1_error',
+    });
+
+    expect(data.wrapper.prop('aria-invalid')).toBe(true);
+    expect(data.wrapper.prop('aria-describedby')).toBe('1_error');
+    expect(data.wrapper.hasClass('ds-c-field--error')).toBe(true);
+    expect(data.wrapper).toMatchSnapshot();
   });
 
   it('is disabled', () => {
     const data = render({ disabled: true });
 
-    expect(data.wrapper.find('select').prop('disabled')).toBe(true);
+    expect(data.wrapper.prop('disabled')).toBe(true);
   });
 
   it('is not disabled', () => {
     const data = render();
 
-    expect(data.wrapper.find('select').prop('disabled')).toBeUndefined();
+    expect(data.wrapper.prop('disabled')).toBeUndefined();
   });
 
   describe('event handlers', () => {
@@ -112,13 +119,13 @@ describe('Select', () => {
     });
 
     it('calls the onChange handler', () => {
-      wrapper.find('select').simulate('change');
+      wrapper.simulate('change');
       expect(defaultProps.onBlur).not.toHaveBeenCalled();
       expect(defaultProps.onChange).toHaveBeenCalled();
     });
 
     it('calls the onBlur handler', () => {
-      wrapper.find('select').simulate('blur');
+      wrapper.simulate('blur');
       expect(defaultProps.onBlur).toHaveBeenCalled();
       expect(defaultProps.onChange).not.toHaveBeenCalled();
     });

--- a/packages/design-system/src/components/Dropdown/__snapshots__/Select.test.jsx.snap
+++ b/packages/design-system/src/components/Dropdown/__snapshots__/Select.test.jsx.snap
@@ -9,8 +9,30 @@ exports[`Dropdown renders 1`] = `
 />
 `;
 
+exports[`Select handles bottom placed error 1`] = `
+<select
+  aria-describedby="1_error"
+  aria-invalid={true}
+  className="ds-c-field ds-c-field--error"
+  id="1"
+  label="Select an option"
+  name="Select"
+  onBlur={[MockFunction]}
+  onChange={[MockFunction]}
+>
+  <option
+    key="1"
+    value="1"
+  >
+    1
+  </option>
+</select>
+`;
+
 exports[`Select renders a select menu 1`] = `
 <select
+  aria-describedby=""
+  aria-invalid={false}
   aria-label="test aria label"
   className="ds-c-field"
   id="1"
@@ -31,6 +53,8 @@ exports[`Select renders a select menu 1`] = `
 
 exports[`Select renders options correctly 1`] = `
 <select
+  aria-describedby=""
+  aria-invalid={false}
   className="ds-c-field"
   defaultValue="1"
   id="1"

--- a/packages/design-system/src/components/FieldContainer/FieldContainer.test.tsx
+++ b/packages/design-system/src/components/FieldContainer/FieldContainer.test.tsx
@@ -6,6 +6,7 @@ const defaultProps = {
   label: 'Foo',
   component: 'div',
   labelComponent: 'label',
+  errorPlacement: 'top',
   /* eslint-disable */
   render: ({ id, labelId, setRef }) => {
     return <input id={id} aria-describedby={labelId} ref={setRef} />;
@@ -25,24 +26,21 @@ function render(customProps = {}, deep = false) {
 
 describe('FieldContainer', function () {
   it('renders default component and labelComponent elements', () => {
-    const data = render({}, true);
+    const data = render({});
 
     expect(data.wrapper.find('div').length).toBe(1);
-    expect(data.wrapper.find('label').length).toBe(1);
+    expect(data.wrapper.find('FormLabel').length).toBe(1);
     expect(data.wrapper).toMatchSnapshot();
   });
 
   it('renders custom component and labelComponent elements', () => {
-    const data = render(
-      {
-        component: 'fieldset',
-        labelComponent: 'legend',
-      },
-      true
-    );
+    const data = render({
+      component: 'fieldset',
+      labelComponent: 'legend',
+    });
 
-    expect(data.wrapper.find(data.props.component).length).toBe(1);
-    expect(data.wrapper.find(data.props.labelComponent).length).toBe(1);
+    expect(data.wrapper.find('fieldset').length).toBe(1);
+    expect(data.wrapper.find('FormLabel').prop('component')).toEqual('legend');
     expect(data.wrapper).toMatchSnapshot();
   });
 
@@ -70,6 +68,21 @@ describe('FieldContainer', function () {
     expect(data.wrapper.find('FormLabel').prop('errorMessage')).toBe(data.props.errorMessage);
   });
 
+  it('renders bottom placed errors ', () => {
+    const data = render({ errorMessage: 'Error', errorPlacement: 'bottom' });
+
+    expect(data.wrapper.find('FormLabel').prop('errorMessage')).toBeUndefined();
+    expect(data.wrapper.find('InlineError').prop('children')).toEqual('Error');
+    expect(data.wrapper).toMatchSnapshot();
+  });
+
+  it('uses aria-invalid for fieldsets with errorMessage', () => {
+    const data = render({ errorMessage: 'Error', component: 'fieldset' });
+
+    expect(data.wrapper.find('fieldset').prop('aria-invalid')).toBe(true);
+    expect(data.wrapper).toMatchSnapshot();
+  });
+
   it('passes inversed to FormLabel', () => {
     const data = render({ inversed: true });
 
@@ -95,13 +108,13 @@ describe('FieldContainer', function () {
   });
 
   it('generates a unique field input id when id is not defined', () => {
-    const data = render({}, true);
+    const data = render({});
 
     expect(data.wrapper.find('input').prop('id')).toBeDefined();
   });
 
   it('passes id to the field input', () => {
-    const data = render({ id: '1' }, true);
+    const data = render({ id: '1' });
 
     expect(data.wrapper.find('input').prop('id')).toBe(data.props.id);
   });

--- a/packages/design-system/src/components/FieldContainer/FieldContainer.test.tsx
+++ b/packages/design-system/src/components/FieldContainer/FieldContainer.test.tsx
@@ -47,7 +47,7 @@ describe('FieldContainer', function () {
   it('passes label to FormLabel', () => {
     const data = render();
 
-    expect(data.wrapper.find('FormLabel').prop('children')).toBe(data.props.label);
+    expect(data.wrapper.find('FormLabel').prop('children')).toContain(data.props.label);
   });
 
   it('passes hint to FormLabel', () => {

--- a/packages/design-system/src/components/FieldContainer/FieldContainer.tsx
+++ b/packages/design-system/src/components/FieldContainer/FieldContainer.tsx
@@ -118,6 +118,10 @@ export class FieldContainer extends React.Component<FieldContainerProps> {
     );
     const bottomError = errorPlacement === 'bottom' && errorMessage;
 
+    // Use `aria-invalid` attribute on errored fieldsets
+    // Errored form components without fieldsets must handle `aria-invalid` in their own component
+    const ariaInvalid = isFieldset && errorMessage ? true : undefined;
+
     // Field input props handled by <FieldContainer>
     const fieldInputProps = {
       id: this.id,
@@ -141,7 +145,7 @@ export class FieldContainer extends React.Component<FieldContainerProps> {
     ) : null;
 
     return (
-      <ComponentType className={classes}>
+      <ComponentType className={classes} aria-invalid={ariaInvalid}>
         <FormLabel
           className={labelClassName}
           component={labelComponent}

--- a/packages/design-system/src/components/FieldContainer/FieldContainer.tsx
+++ b/packages/design-system/src/components/FieldContainer/FieldContainer.tsx
@@ -116,19 +116,12 @@ export class FieldContainer extends React.Component<FieldContainerProps> {
       },
       className
     );
+
     const bottomError = errorPlacement === 'bottom' && errorMessage;
 
     // Use `aria-invalid` attribute on errored fieldsets
     // Errored form components without fieldsets must handle `aria-invalid` in their own component
     const ariaInvalid = isFieldset && errorMessage ? true : undefined;
-
-    // Field input props handled by <FieldContainer>
-    const fieldInputProps = {
-      id: this.id,
-      labelId: this.labelId,
-      errorId: this.errorId,
-      setRef: this.setFieldRef,
-    };
 
     // Bottom placed errors are handled in FieldContainer instead of FormLabel
     const renderBottomError = bottomError ? (
@@ -138,11 +131,19 @@ export class FieldContainer extends React.Component<FieldContainerProps> {
     ) : null;
     
     // Bottom placed errors cannot be linked to Choices in ChoiceList, so we add a hidden error message to the label
-    const hiddenError = isFieldset && bottomError ? (
+    const renderHiddenError = isFieldset && bottomError ? (
       <div className="ds-u-visibility--screen-reader">
         {errorMessage}
       </div>
     ) : null;
+
+    // Field input props handled by <FieldContainer>
+    const fieldInputProps = {
+      id: this.id,
+      labelId: this.labelId,
+      errorId: this.errorId,
+      setRef: this.setFieldRef,
+    };
 
     return (
       <ComponentType className={classes} aria-invalid={ariaInvalid}>
@@ -160,7 +161,7 @@ export class FieldContainer extends React.Component<FieldContainerProps> {
           inversed={inversed}
         >
           {label}
-          {hiddenError}
+          {renderHiddenError}
         </FormLabel>
         {render(fieldInputProps)}
         {renderBottomError}

--- a/packages/design-system/src/components/FieldContainer/FieldContainer.tsx
+++ b/packages/design-system/src/components/FieldContainer/FieldContainer.tsx
@@ -4,6 +4,13 @@ import React from 'react';
 import classNames from 'classnames';
 import { uniqueId } from 'lodash';
 
+interface FieldContainerRenderProps {
+  id: string;
+  labelId: string;
+  errorId: string;
+  setRef: (elem: HTMLDivElement) => void;
+}
+
 interface FieldContainerProps {
   /**
    * Additional classes to be added to the field container.
@@ -37,7 +44,7 @@ interface FieldContainerProps {
   /**
    * Access a reference to the field input
    */
-  inputRef?: (...args: any[]) => any;
+  inputRef?: (elem: HTMLDivElement) => void;
   /**
    * Applies the "inverse" UI theme
    */
@@ -65,7 +72,7 @@ interface FieldContainerProps {
   /**
    * A function that returns a field input element to accept render props
    */
-  render: (...args: any[]) => any;
+  render: (renderProps: FieldContainerRenderProps) => React.ReactNode;
 }
 
 export class FieldContainer extends React.Component<FieldContainerProps> {
@@ -131,9 +138,10 @@ export class FieldContainer extends React.Component<FieldContainerProps> {
     ) : null;
 
     // Bottom placed errors cannot be linked to Choices in ChoiceList, so we add a hidden error message to the label
-    const renderHiddenError = isFieldset && bottomError ? (
-      <div className="ds-u-visibility--screen-reader">{errorMessage}</div>
-    ) : null;
+    const renderHiddenError =
+      isFieldset && bottomError ? (
+        <div className="ds-u-visibility--screen-reader">{errorMessage}</div>
+      ) : null;
 
     // Field input props handled by <FieldContainer>
     const fieldInputProps = {

--- a/packages/design-system/src/components/FieldContainer/FieldContainer.tsx
+++ b/packages/design-system/src/components/FieldContainer/FieldContainer.tsx
@@ -129,12 +129,10 @@ export class FieldContainer extends React.Component<FieldContainerProps> {
         {errorMessage}
       </InlineError>
     ) : null;
-    
+
     // Bottom placed errors cannot be linked to Choices in ChoiceList, so we add a hidden error message to the label
     const renderHiddenError = isFieldset && bottomError ? (
-      <div className="ds-u-visibility--screen-reader">
-        {errorMessage}
-      </div>
+      <div className="ds-u-visibility--screen-reader">{errorMessage}</div>
     ) : null;
 
     // Field input props handled by <FieldContainer>

--- a/packages/design-system/src/components/FieldContainer/InlineError.tsx
+++ b/packages/design-system/src/components/FieldContainer/InlineError.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 interface InlineErrorProps {
   children?: React.ReactNode;
-  id: string;
+  id?: string;
   inversed?: boolean;
 }
 

--- a/packages/design-system/src/components/FieldContainer/__snapshots__/FieldContainer.test.tsx.snap
+++ b/packages/design-system/src/components/FieldContainer/__snapshots__/FieldContainer.test.tsx.snap
@@ -1,71 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FieldContainer renders custom component and labelComponent elements 1`] = `
-<FieldContainer
-  component="fieldset"
-  label="Foo"
-  labelComponent="legend"
-  render={[Function]}
+exports[`FieldContainer renders bottom placed errors  1`] = `
+<div
+  className=""
 >
-  <fieldset
-    className="ds-c-fieldset"
+  <FormLabel
+    component="label"
+    errorId="field_7-error"
+    id="field_7-label"
   >
-    <FormLabel
-      component="legend"
-      errorId="field_2-error"
-      fieldId="field_2"
-      id="field_2-label"
-    >
-      <legend
-        className="ds-c-label"
-        htmlFor="field_2"
-        id="field_2-label"
-      >
-        <span
-          className=""
-        >
-          Foo
-        </span>
-      </legend>
-    </FormLabel>
-    <input
-      aria-describedby="field_2-label"
-      id="field_2"
-    />
-  </fieldset>
-</FieldContainer>
+    Foo
+  </FormLabel>
+  <input
+    aria-describedby="field_7-label"
+    id="field_7"
+  />
+  <InlineError
+    id="field_7-error"
+  >
+    Error
+  </InlineError>
+</div>
+`;
+
+exports[`FieldContainer renders custom component and labelComponent elements 1`] = `
+<fieldset
+  className="ds-c-fieldset"
+>
+  <FormLabel
+    component="legend"
+    errorId="field_2-error"
+    fieldId="field_2"
+    id="field_2-label"
+  >
+    Foo
+  </FormLabel>
+  <input
+    aria-describedby="field_2-label"
+    id="field_2"
+  />
+</fieldset>
 `;
 
 exports[`FieldContainer renders default component and labelComponent elements 1`] = `
-<FieldContainer
-  component="div"
-  label="Foo"
-  labelComponent="label"
-  render={[Function]}
+<div
+  className=""
 >
-  <div
-    className=""
+  <FormLabel
+    component="label"
+    errorId="field_1-error"
+    id="field_1-label"
   >
-    <FormLabel
-      component="label"
-      errorId="field_1-error"
-      id="field_1-label"
-    >
-      <label
-        className="ds-c-label"
-        id="field_1-label"
-      >
-        <span
-          className=""
-        >
-          Foo
-        </span>
-      </label>
-    </FormLabel>
-    <input
-      aria-describedby="field_1-label"
-      id="field_1"
-    />
-  </div>
-</FieldContainer>
+    Foo
+  </FormLabel>
+  <input
+    aria-describedby="field_1-label"
+    id="field_1"
+  />
+</div>
+`;
+
+exports[`FieldContainer uses aria-invalid for fieldsets with errorMessage 1`] = `
+<fieldset
+  aria-invalid={true}
+  className="ds-c-fieldset"
+>
+  <FormLabel
+    component="label"
+    errorId="field_8-error"
+    errorMessage="Error"
+    fieldId="field_8"
+    id="field_8-label"
+  >
+    Foo
+  </FormLabel>
+  <input
+    aria-describedby="field_8-label"
+    id="field_8"
+  />
+</fieldset>
 `;

--- a/packages/design-system/src/components/FormLabel/FormLabel.jsx
+++ b/packages/design-system/src/components/FormLabel/FormLabel.jsx
@@ -39,7 +39,13 @@ export class FormLabel extends React.PureComponent {
   errorMessage() {
     if (this.props.errorMessage) {
       // Include fallback for errorId for usage outside of FieldContainer
-      const errorId = this.props.errorId || `${this.props.fieldId}-error`;
+      let errorId = null;
+      if (this.props.errorId) {
+        errorId = this.props.errorId;
+      } else if (this.props.fieldId) {
+        errorId = `${this.props.fieldId}-error`;
+      }
+
       return (
         <InlineError id={errorId} inversed={this.props.inversed}>
           {this.props.errorMessage}

--- a/packages/design-system/src/components/FormLabel/FormLabel.test.jsx
+++ b/packages/design-system/src/components/FormLabel/FormLabel.test.jsx
@@ -22,7 +22,20 @@ describe('FormLabel', () => {
     };
     const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
 
+    expect(wrapper.find('InlineError').length).toBe(1);
+    expect(wrapper.find('InlineError').prop('id')).toEqual('name-error');
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('uses provided errorId', () => {
+    const props = {
+      errorMessage: 'Nah, try again.',
+      errorId: 'error',
+    };
+    const wrapper = shallow(<FormLabel {...props}>{labelText}</FormLabel>);
+
+    expect(wrapper.find('InlineError').length).toBe(1);
+    expect(wrapper.find('InlineError').prop('id')).toEqual('error');
   });
 
   it('renders hint string', () => {

--- a/packages/design-system/src/components/TextField/TextField.jsx
+++ b/packages/design-system/src/components/TextField/TextField.jsx
@@ -39,16 +39,9 @@ export class TextField extends React.PureComponent {
         render={({ id, errorId, setRef }) => (
           <TextInput
             {...inputOnlyProps}
-            {...{ id, setRef }}
-            aria-invalid={!!this.props.errorMessage}
-            aria-describedby={
-              // Link input to bottom placed error message
-              // eslint-disable-next-line
-              classNames(this.props['aria-describedby'], {
-                [errorId]: this.props.errorPlacement === 'bottom' && this.props.errorMessage,
-              })
-            }
+            {...{ id, setRef, errorId }}
             errorMessage={this.props.errorMessage}
+            errorPlacement={this.props.errorPlacement}
             inversed={this.props.inversed}
           />
         )}

--- a/packages/design-system/src/components/TextField/TextField.jsx
+++ b/packages/design-system/src/components/TextField/TextField.jsx
@@ -40,6 +40,7 @@ export class TextField extends React.PureComponent {
           <TextInput
             {...inputOnlyProps}
             {...{ id, setRef }}
+            aria-invalid={!!this.props.errorMessage}
             aria-describedby={
               // Link input to bottom placed error message
               // eslint-disable-next-line

--- a/packages/design-system/src/components/TextField/TextInput.jsx
+++ b/packages/design-system/src/components/TextField/TextInput.jsx
@@ -6,7 +6,9 @@ import classNames from 'classnames';
 export function TextInput(props) {
   const {
     ariaLabel,
+    errorId,
     errorMessage,
+    errorPlacement,
     fieldClassName,
     inversed,
     mask,
@@ -43,6 +45,17 @@ export function TextInput(props) {
   const field = (
     <ComponentType
       aria-label={ariaLabel}
+      aria-invalid={
+        // eslint-disable-next-line
+        props['aria-invalid'] ? props['aria-invalid'] : !!errorMessage
+      }
+      aria-describedby={
+        // Link input to bottom placed error message
+        // eslint-disable-next-line
+        classNames(props['aria-describedby'], {
+          [errorId]: errorPlacement === 'bottom' && errorMessage,
+        })
+      }
       className={classes}
       ref={setRef}
       rows={multiline && rows ? rows : undefined}
@@ -68,7 +81,15 @@ TextInput.propTypes = {
    */
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   disabled: PropTypes.bool,
+  /**
+   * The ID of the error message applied to the Select field.
+   */
+  errorId: PropTypes.string,
   errorMessage: PropTypes.node,
+  /**
+   * Location of the error message relative to the field input
+   */
+  errorPlacement: PropTypes.oneOf(['top', 'bottom']).isRequired,
   /**
    * Additional classes to be added to the input element
    */

--- a/packages/design-system/src/components/TextField/TextInput.test.jsx
+++ b/packages/design-system/src/components/TextField/TextInput.test.jsx
@@ -7,6 +7,7 @@ const defaultProps = {
   setRef: jest.fn(),
   id: '1',
   type: 'text',
+  errorPlacement: 'top',
 };
 
 function render(customProps = {}, deep = false) {
@@ -22,65 +23,71 @@ function render(customProps = {}, deep = false) {
 describe('TextInput', function () {
   it('is an input field', () => {
     const data = render();
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.is('input')).toBe(true);
-    expect(field.prop('rows')).toBeUndefined();
+    expect(data.wrapper.is('input')).toBe(true);
+    expect(data.wrapper.prop('rows')).toBeUndefined();
     expect(data.wrapper).toMatchSnapshot();
   });
 
   it('is a textarea', () => {
     const data = render({ multiline: true });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.is('textarea')).toBe(true);
-    expect(field.prop('rows')).toBeUndefined();
-    expect(field.prop('type')).toBeUndefined();
+    expect(data.wrapper.is('textarea')).toBe(true);
+    expect(data.wrapper.prop('rows')).toBeUndefined();
+    expect(data.wrapper.prop('type')).toBeUndefined();
     expect(data.wrapper).toMatchSnapshot();
   });
 
   it('is a password field', () => {
     const data = render({ type: 'password' });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.prop('type')).toBe('password');
+    expect(data.wrapper.prop('type')).toBe('password');
   });
 
   it('is disabled', () => {
     const data = render({ disabled: true });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.prop('disabled')).toBe(data.props.disabled);
+    expect(data.wrapper.prop('disabled')).toBe(data.props.disabled);
   });
 
   it('has error', () => {
     const data = render({ errorMessage: 'Error' });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.hasClass('ds-c-field--error')).toBe(true);
+    expect(data.wrapper.prop('aria-invalid')).toBe(true);
+    expect(data.wrapper.hasClass('ds-c-field--error')).toBe(true);
+  });
+
+  it('handles bottom placed error', () => {
+    const data = render({
+      errorMessage: 'Error',
+      errorPlacement: 'bottom',
+      errorId: '1_error',
+    });
+
+    expect(data.wrapper.prop('aria-invalid')).toBe(true);
+    expect(data.wrapper.prop('aria-describedby')).toBe('1_error');
+    expect(data.wrapper.hasClass('ds-c-field--error')).toBe(true);
+    expect(data.wrapper).toMatchSnapshot();
   });
 
   it('has inversed theme', () => {
     const data = render({ inversed: true });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.hasClass('ds-c-field--inverse')).toBe(true);
+    expect(data.wrapper.hasClass('ds-c-field--inverse')).toBe(true);
   });
 
   it('has a defaultValue', () => {
     const data = render({ defaultValue: 'Yay' });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.prop('defaultValue')).toBe(data.props.defaultValue);
-    expect(field.prop('value')).toBeUndefined();
+    expect(data.wrapper.prop('defaultValue')).toBe(data.props.defaultValue);
+    expect(data.wrapper.prop('value')).toBeUndefined();
   });
 
   it('has a value', () => {
     const data = render({ value: 'Yay' });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.prop('value')).toBe(data.props.value);
-    expect(field.prop('defaultValue')).toBeUndefined();
+    expect(data.wrapper.prop('value')).toBe(data.props.value);
+    expect(data.wrapper.prop('defaultValue')).toBeUndefined();
   });
 
   it('shows 5 rows of text', () => {
@@ -88,17 +95,15 @@ describe('TextInput', function () {
       multiline: true,
       rows: 5,
     });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.prop('rows')).toBe(data.props.rows);
+    expect(data.wrapper.prop('rows')).toBe(data.props.rows);
   });
 
   it('adds className to field', () => {
     const data = render({ fieldClassName: 'bar' });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.hasClass('ds-c-field')).toBe(true);
-    expect(field.hasClass('bar')).toBe(true);
+    expect(data.wrapper.hasClass('ds-c-field')).toBe(true);
+    expect(data.wrapper.hasClass('bar')).toBe(true);
   });
 
   it('adds size classes to input', () => {
@@ -116,28 +121,25 @@ describe('TextInput', function () {
       max: 10,
       min: 1,
     });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.prop('max')).toBe(data.props.max);
-    expect(field.prop('min')).toBe(data.props.min);
+    expect(data.wrapper.prop('max')).toBe(data.props.max);
+    expect(data.wrapper.prop('min')).toBe(data.props.min);
   });
 
   it('adds aria-label attribute', () => {
     const data = render({
       ariaLabel: 'Foo',
     });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.prop('aria-label')).toBe(data.props.ariaLabel);
+    expect(data.wrapper.prop('aria-label')).toBe(data.props.ariaLabel);
   });
 
   it('adds undocumented prop to input field', () => {
     const data = render({
       'data-foo': 'bar',
     });
-    const field = data.wrapper.find('.ds-c-field').first();
 
-    expect(field.prop('data-foo')).toBe(data.props['data-foo']);
+    expect(data.wrapper.prop('data-foo')).toBe(data.props['data-foo']);
   });
 
   describe('event handlers', () => {

--- a/packages/design-system/src/components/TextField/__snapshots__/TextInput.test.jsx.snap
+++ b/packages/design-system/src/components/TextField/__snapshots__/TextInput.test.jsx.snap
@@ -1,7 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TextInput handles bottom placed error 1`] = `
+<input
+  aria-describedby="1_error"
+  aria-invalid={true}
+  className="ds-c-field ds-c-field--error"
+  id="1"
+  name="spec-field"
+  type="text"
+/>
+`;
+
 exports[`TextInput is a textarea 1`] = `
 <textarea
+  aria-describedby=""
+  aria-invalid={false}
   className="ds-c-field"
   id="1"
   name="spec-field"
@@ -10,6 +23,8 @@ exports[`TextInput is a textarea 1`] = `
 
 exports[`TextInput is an input field 1`] = `
 <input
+  aria-describedby=""
+  aria-invalid={false}
   className="ds-c-field"
   id="1"
   name="spec-field"
@@ -19,6 +34,8 @@ exports[`TextInput is an input field 1`] = `
 
 exports[`TextInput masks renders TextInput 1`] = `
 <input
+  aria-describedby=""
+  aria-invalid={false}
   className="ds-c-field"
   id="1"
   name="spec-field"
@@ -31,6 +48,8 @@ exports[`TextInput masks renders currency mask 1`] = `
   mask="currency"
 >
   <input
+    aria-describedby=""
+    aria-invalid={false}
     className="ds-c-field ds-c-field--currency"
     id="1"
     name="spec-field"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,3 @@
-// @cmsgov/design-system-scripts uses babel.config.js to compile .ts files, and doesn't use tsconfig.json
-// However, tsconfig.json is used to generate definition files, used by webpack during doc site generation,
-// and should be used by eslint for type checking (@cmsgov/design-system-scripts build scripts do not provide typechecking)
 {
   "compilerOptions": {
     "target": "es2015",


### PR DESCRIPTION
## Summary
- Handle `aria-invalid` in TextField and Dropdown when `errorMessage` prop is provided
- Handle `aria-invalid` in FieldContainer when `fieldset` component type is used and `errorMessage` prop is provided
- Refactor and move aria attribute handling to TextInput and Select
- Add tests and snapshots

## How to test
- http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-686/add-aria-invalid
