### PR TITLE
[WNMGDS-766] Handle bottom placed error in Autocomplete 

### DIFF
--- a/packages/design-system-docs/src/pages/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Autocomplete/Autocomplete.example.jsx
@@ -47,8 +47,6 @@ ReactDOM.render(
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Labeled list"
         name="Downshift_autocomplete"
-        errorMessage="Example error message Bottom placement with extra long message message message message message"
-        errorPlacement="bottom"
       />
     </Autocomplete>
 
@@ -74,7 +72,7 @@ ReactDOM.render(
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Simple list"
         name="Downshift_autocomplete"
-        errorMessage="Example error message Default placement"
+        errorMessage="Example error message"
       />
     </Autocomplete>
 
@@ -83,8 +81,6 @@ ReactDOM.render(
         hint="List should return string Loading to simulate async data call."
         label="Loading message"
         name="Downshift_autocomplete"
-        errorMessage="Example error message Top placement"
-        errorPlacement="top"
       />
     </Autocomplete>
 

--- a/packages/design-system-docs/src/pages/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Autocomplete/Autocomplete.example.jsx
@@ -47,6 +47,8 @@ ReactDOM.render(
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Labeled list"
         name="Downshift_autocomplete"
+        errorMessage="Example error message Bottom placement with extra long message message message message message"
+        errorPlacement="bottom"
       />
     </Autocomplete>
 
@@ -72,6 +74,7 @@ ReactDOM.render(
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Simple list"
         name="Downshift_autocomplete"
+        errorMessage="Example error message Default placement"
       />
     </Autocomplete>
 
@@ -80,6 +83,8 @@ ReactDOM.render(
         hint="List should return string Loading to simulate async data call."
         label="Loading message"
         name="Downshift_autocomplete"
+        errorMessage="Example error message Top placement"
+        errorPlacement="top"
       />
     </Autocomplete>
 

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
@@ -97,7 +97,7 @@ export class Autocomplete extends React.PureComponent {
           ? classNames(
               'ds-c-autocomplete__error-message',
               {
-                'ds-c-autocomplete__error-message-with-clear-search': this.props.clearSearchButton,
+                'ds-c-autocomplete__error-message--clear-btn': this.props.clearSearchButton,
               },
               child.props.errorMessageClassName
             )

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
@@ -97,6 +97,7 @@ export class Autocomplete extends React.PureComponent {
           'aria-labelledby': null,
           'aria-owns': isOpen ? this.listboxId : null,
           autoComplete: this.props.autoCompleteLabel,
+          // Additional class to handle bottom placed errors that breaks the Autocomplete's design
           errorMessageClassName:
             child.props.errorPlacement === 'bottom' ? 'ds-c-autocomplete__error-message' : null,
           focusTrigger: this.props.focusTrigger,

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
@@ -97,6 +97,8 @@ export class Autocomplete extends React.PureComponent {
           'aria-labelledby': null,
           'aria-owns': isOpen ? this.listboxId : null,
           autoComplete: this.props.autoCompleteLabel,
+          errorMessageClassName:
+            child.props.errorPlacement === 'bottom' ? 'ds-c-autocomplete__error-message' : null,
           focusTrigger: this.props.focusTrigger,
           id: this.id,
           inputRef: this.props.inputRef,

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
@@ -208,7 +208,7 @@ export class Autocomplete extends React.PureComponent {
               {clearSearchButton && (
                 <Button
                   aria-label={ariaClearLabel}
-                  className="ds-u-float--right ds-u-margin-right--0"
+                  className="ds-u-margin-right--0"
                   onClick={clearSelection}
                   size="small"
                   variation="transparent"

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
@@ -45,7 +45,6 @@ export class Autocomplete extends React.PureComponent {
     this.listboxId = uniqueId('autocomplete_owned_listbox_');
     this.listboxContainerId = uniqueId('autocomplete_owned_container_');
     this.listboxHeadingId = uniqueId('autocomplete_header_');
-    this.textFieldProps = null;
   }
 
   filterItems(items, inputValue, getInputProps, getItemProps, highlightedIndex) {
@@ -92,11 +91,16 @@ export class Autocomplete extends React.PureComponent {
     return React.Children.map(this.props.children, (child) => {
       if (isTextField(child)) {
         // The display of bottom placed errorMessages in TextField breaks the Autocomplete's UI design.
-        // This fix will add a class to visually hide the bottom placed errors and allow screen readers access only.
-        // A custom bottom placed errors display is handled further down this component.
+        // Add errorMessageClassName to fix the styles for bottom placed errors
         const bottomError = child.props.errorPlacement === 'bottom' && child.props.errorMessage;
         const errorMessageClassName = bottomError
-          ? classNames('ds-u-visibility--screen-reader', child.props.errorMessageClassName)
+          ? classNames(
+              'ds-c-autocomplete__error-message',
+              {
+                'ds-c-autocomplete__error-message-with-clear-search': this.props.clearSearchButton,
+              },
+              child.props.errorMessageClassName
+            )
           : child.props.errorMessageClassName;
         const propOverrides = {
           'aria-autocomplete': 'list',
@@ -115,8 +119,7 @@ export class Autocomplete extends React.PureComponent {
           onKeyDown: child.props.onKeyDown,
           role: 'combobox',
         };
-        // Save TextFieldProps for custom bottom placed errors handling
-        this.textFieldProps = bottomError ? child.props : null;
+
         return React.cloneElement(child, getInputProps(propOverrides));
       }
 
@@ -190,33 +193,18 @@ export class Autocomplete extends React.PureComponent {
                 </ul>
               </div>
             ) : null}
-            <div className="ds-c-autocomplete__bottom-container">
-              {this.textFieldProps && (
-                // Bottom placed errorMessages are visually hidden by TextField.
-                // A custom display of bottom placed error messages after the `clear search` button is handled here.
-                <span
-                  aria-hidden="true"
-                  className={classNames(
-                    'ds-c-field__error-message',
-                    { 'ds-c-field__error-message--inverse': this.textFieldProps.inversed },
-                    this.textFieldProps.errorMessageClassName
-                  )}
-                >
-                  {this.textFieldProps.errorMessage}
-                </span>
-              )}
-              {clearSearchButton && (
-                <Button
-                  aria-label={ariaClearLabel}
-                  className="ds-u-margin-right--0"
-                  onClick={clearSelection}
-                  size="small"
-                  variation="transparent"
-                >
-                  {clearInputText}
-                </Button>
-              )}
-            </div>
+
+            {clearSearchButton && (
+              <Button
+                aria-label={ariaClearLabel}
+                className="ds-u-float--right ds-u-margin-right--0"
+                onClick={clearSelection}
+                size="small"
+                variation="transparent"
+              >
+                {clearInputText}
+              </Button>
+            )}
           </WrapperDiv>
         )}
       </Downshift>

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
@@ -191,17 +191,6 @@ export class Autocomplete extends React.PureComponent {
               </div>
             ) : null}
             <div className="ds-c-autocomplete__error-message">
-              {clearSearchButton && (
-                <Button
-                  aria-label={ariaClearLabel}
-                  className="ds-u-float--right ds-u-margin-right--0"
-                  onClick={clearSelection}
-                  size="small"
-                  variation="transparent"
-                >
-                  {clearInputText}
-                </Button>
-              )}
               {this.textFieldProps && (
                 // Bottom placed errorMessages are visually hidden by TextField.
                 // A custom display of bottom placed error messages after the `clear search` button is handled here.
@@ -215,6 +204,17 @@ export class Autocomplete extends React.PureComponent {
                 >
                   {this.textFieldProps.errorMessage}
                 </span>
+              )}
+              {clearSearchButton && (
+                <Button
+                  aria-label={ariaClearLabel}
+                  className="ds-u-float--right ds-u-margin-right--0"
+                  onClick={clearSelection}
+                  size="small"
+                  variation="transparent"
+                >
+                  {clearInputText}
+                </Button>
               )}
             </div>
           </WrapperDiv>

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
@@ -190,7 +190,7 @@ export class Autocomplete extends React.PureComponent {
                 </ul>
               </div>
             ) : null}
-            <div className="ds-c-autocomplete__error-message">
+            <div className="ds-c-autocomplete__bottom-container">
               {this.textFieldProps && (
                 // Bottom placed errorMessages are visually hidden by TextField.
                 // A custom display of bottom placed error messages after the `clear search` button is handled here.

--- a/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
+++ b/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
@@ -44,13 +44,17 @@ exports[`Autocomplete renders a snapshot 1`] = `
       value=""
     />
   </div>
-  <button
-    aria-label="Clear search to try again"
-    className="ds-c-button ds-c-button--transparent ds-c-button--small ds-u-float--right ds-u-margin-right--0"
-    onClick={[Function]}
-    type="button"
+  <div
+    className="ds-c-autocomplete__error-message"
   >
-    Clear search
-  </button>
+    <button
+      aria-label="Clear search to try again"
+      className="ds-c-button ds-c-button--transparent ds-c-button--small ds-u-float--right ds-u-margin-right--0"
+      onClick={[Function]}
+      type="button"
+    >
+      Clear search
+    </button>
+  </div>
 </div>
 `;

--- a/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
+++ b/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
@@ -45,7 +45,7 @@ exports[`Autocomplete renders a snapshot 1`] = `
     />
   </div>
   <div
-    className="ds-c-autocomplete__error-message"
+    className="ds-c-autocomplete__bottom-container"
   >
     <button
       aria-label="Clear search to try again"

--- a/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
+++ b/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
@@ -49,7 +49,7 @@ exports[`Autocomplete renders a snapshot 1`] = `
   >
     <button
       aria-label="Clear search to try again"
-      className="ds-c-button ds-c-button--transparent ds-c-button--small ds-u-float--right ds-u-margin-right--0"
+      className="ds-c-button ds-c-button--transparent ds-c-button--small ds-u-margin-right--0"
       onClick={[Function]}
       type="button"
     >

--- a/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
+++ b/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
@@ -44,17 +44,13 @@ exports[`Autocomplete renders a snapshot 1`] = `
       value=""
     />
   </div>
-  <div
-    className="ds-c-autocomplete__bottom-container"
+  <button
+    aria-label="Clear search to try again"
+    className="ds-c-button ds-c-button--transparent ds-c-button--small ds-u-float--right ds-u-margin-right--0"
+    onClick={[Function]}
+    type="button"
   >
-    <button
-      aria-label="Clear search to try again"
-      className="ds-c-button ds-c-button--transparent ds-c-button--small ds-u-margin-right--0"
-      onClick={[Function]}
-      type="button"
-    >
-      Clear search
-    </button>
-  </div>
+    Clear search
+  </button>
 </div>
 `;

--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -42,7 +42,18 @@
   padding: $spacer-1;
 }
 
-// Work-around for bottom placed errors that breaks the Autocomplete's design.
-.ds-c-autocomplete__error-message {
-  float: left;
+// Container for the bottom error message and clear search button
+// Using display flex to account for variations in error and clear button text length
+.ds-c-autocomplete__bottom-container {
+  display: flex;
+  justify-content: flex-end;
+  // Error class used to style the bottom error message for autocomplete
+  .ds-c-field__error-message {
+    flex-grow: 1;
+  }
+  // Button class used to style the clear search button
+  .ds-c-button {
+    display: inherit;
+    min-width: 100px;
+  }
 }

--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -3,6 +3,18 @@
 .ds-c-autocomplete {
   max-width: $input-max-width;
   position: relative;
+  // Undoing the clearfix class on the div containing the label element
+  .ds-u-clearfix {
+    &::before {
+      content: none;
+      display: block;
+    }
+    &::after {
+      clear: none;
+      content: none;
+      display: block;
+    }
+  }
 }
 
 .ds-c-autocomplete__list {
@@ -30,11 +42,7 @@
   padding: $spacer-1;
 }
 
-// Work-around for bottom placed errors that breaks the Autocomplete's design
-// Keep in mind: absolutely positioned error message wont take up space and may
-// conflict with designs further down the screen
+// Work-around for bottom placed errors that breaks the Autocomplete's design.
 .ds-c-autocomplete__error-message {
-  position: absolute;
-  // '- 100px' make provision for the "Clear search button"
-  width: calc(100% - 100px);
+  float: left;
 }

--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -57,3 +57,13 @@
     min-width: 100px;
   }
 }
+
+// Need a custom class so the bottom error message does not conflict with the clear search button
+.ds-c-autocomplete__error-message {
+  float: left;
+}
+
+// Need a custom class for bottom error message to make space for the clear search button
+.ds-c-autocomplete__error-message-with-clear-search {
+  width: calc(100% - 100px);
+}

--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -29,3 +29,8 @@
   color: $color-muted;
   padding: $spacer-1;
 }
+
+.ds-c-autocomplete__error-message {
+  position: absolute;
+  width: calc(100% - 100px);
+}

--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -48,6 +48,6 @@
 }
 
 // Need a custom class for bottom error message to make space for the clear search button
-.ds-c-autocomplete__error-message-with-clear-search {
+.ds-c-autocomplete__error-message--clear-btn {
   width: calc(100% - 100px);
 }

--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -42,22 +42,6 @@
   padding: $spacer-1;
 }
 
-// Container for the bottom error message and clear search button
-// Using display flex to account for variations in error and clear button text length
-.ds-c-autocomplete__bottom-container {
-  display: flex;
-  justify-content: flex-end;
-  // Error class used to style the bottom error message for autocomplete
-  .ds-c-field__error-message {
-    flex-grow: 1;
-  }
-  // Button class used to style the clear search button
-  .ds-c-button {
-    display: inherit;
-    min-width: 100px;
-  }
-}
-
 // Need a custom class so the bottom error message does not conflict with the clear search button
 .ds-c-autocomplete__error-message {
   float: left;

--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -30,7 +30,11 @@
   padding: $spacer-1;
 }
 
+// Work-around for bottom placed errors that breaks the Autocomplete's design
+// Keep in mind: absolutely positioned error message wont take up space and may
+// conflict with designs further down the screen
 .ds-c-autocomplete__error-message {
   position: absolute;
+  // '- 100px' make provision for the "Clear search button"
   width: calc(100% - 100px);
 }


### PR DESCRIPTION
## Summary
Bottom placed errors breaks the Autocomplete's design, specifically with the autocomplete list and "clear search" button. 
Context: https://github.com/CMSgov/design-system/pull/914#issuecomment-767837341

### Changed
Updated markup and/or styling to fix these errors

#### Potential design issue:
- hidden bottom error message if the autocomplete list items is being displayed (which is the same as dropdown component). For this example, top error placement is recommended as the bottom placed error message will be hidden by the autocomplete list items:
![Screen Shot 2021-02-05 at 9 14 56 AM](https://user-images.githubusercontent.com/20322880/107056631-8775ba80-67a0-11eb-927b-df6980a3fae4.png)

## How to test
http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-766/Handle-Autocomplete-bottom-placed-error