### PR TITLE
Autocomplete bottom error message styling 

### DIFF
--- a/packages/design-system-docs/src/pages/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Autocomplete/Autocomplete.example.jsx
@@ -47,6 +47,8 @@ ReactDOM.render(
         hint="Type c then use ARROW keys to change options, ENTER key to make a selection, ESC to dismiss."
         label="Labeled list"
         name="Downshift_autocomplete"
+        errorMessage="This field is incorrect This field is incorrect This field is incorrect This field is incorrect This field is incorrect"
+        errorPlacement="bottom"
       />
     </Autocomplete>
 

--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -3,6 +3,18 @@
 .ds-c-autocomplete {
   max-width: $input-max-width;
   position: relative;
+  // Undoing the clearfix class on the div containing the label element
+  .ds-u-clearfix {
+    &::before {
+      content: none;
+      display: block;
+    }
+    &::after {
+      clear: none;
+      content: none;
+      display: block;
+    }
+  }
 }
 
 .ds-c-autocomplete__list {
@@ -34,7 +46,8 @@
 // Keep in mind: absolutely positioned error message wont take up space and may
 // conflict with designs further down the screen
 .ds-c-autocomplete__error-message {
-  position: absolute;
+  // position: absolute;
+  float: left;
   // '- 100px' make provision for the "Clear search button"
   width: calc(100% - 100px);
 }

--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -42,12 +42,9 @@
   padding: $spacer-1;
 }
 
-// Work-around for bottom placed errors that breaks the Autocomplete's design
-// Keep in mind: absolutely positioned error message wont take up space and may
-// conflict with designs further down the screen
+// Need a custom class so the error message does not conflict with the clear search button
 .ds-c-autocomplete__error-message {
-  // position: absolute;
   float: left;
-  // '- 100px' make provision for the "Clear search button"
+  // '- 100px' make space for the clear search button
   width: calc(100% - 100px);
 }


### PR DESCRIPTION
**Note:** 
- Updating the CSS for the autocomplete component to remove the clearfix functionality from the nested div in the component


## How to test
go to autocomplete page and see the error message and dropdown for the autocomplete do not conflict 
http://design-system-demo.s3-website-us-east-1.amazonaws.com/sw-autocomplete-fix-css/components/autocomplete/