### PR TITLE
[WNMGDS-801] Fix rootPath on docs site

### DIFF
--- a/packages/design-system-scripts/cli.js
+++ b/packages/design-system-scripts/cli.js
@@ -63,7 +63,7 @@ yargs
       yargs.option('rootPath', {
         desc: 'The URL root path for the published docs site.',
         type: 'string',
-        default: '',
+        default: config.rootPath,
       });
     },
     handler: async (argv) => {
@@ -71,10 +71,10 @@ yargs
       const { buildDocs } = require('./gulp/docs');
 
       process.env.NODE_ENV = 'production';
-      if (argv.rootPath !== '') {
+
+      if (argv.rootPath) {
         config.rootPath = argv.rootPath;
       }
-
       if (argv.ignoreRootPath) {
         config.rootPath = '';
       }

--- a/packages/design-system-scripts/cli.js
+++ b/packages/design-system-scripts/cli.js
@@ -72,9 +72,8 @@ yargs
 
       process.env.NODE_ENV = 'production';
 
-      if (argv.rootPath) {
-        config.rootPath = argv.rootPath;
-      }
+      // Allow cli args to override or ignore default rootPath defined in cmsds.config.js
+      config.rootPath = argv.rootPath;
       if (argv.ignoreRootPath) {
         config.rootPath = '';
       }


### PR DESCRIPTION
### Fixed
Fix rootPath on child ds docs site not picking up the default value set on cmsds.config.js

## How to test
- Run `yarn build` and verify that `design-system-docs/dist/index.html` contains the default path:
    -  `<link rel="stylesheet" href="/index.css" />`
    -  `<script src="/index.js"></script>`
- Run `yarn build --rootPath="test-branch"` and verify that `design-system-docs/dist/index.html` contains the correct path:
    -  `<link rel="stylesheet" href="/test-branch/index.css" />`
    -  `<script src="/test-branch/index.js"></script>`

- On Child ds, run `yarn build` and verify that `docs/dist/index.html` contains the correct default path: eg
    -  `<link rel="stylesheet" href="/hcgov-design-system/index.css" />`
    -  `<script src="/hcgov-design-systemh/index.js"></script>`
