### PR TITLE
[NO_TICKET] Allow react-docgen-typescript to find tsconfig.json with path.resolve

### DIFF
--- a/packages/design-system-scripts/gulp/docs/extractReactData/parseReactFile.js
+++ b/packages/design-system-scripts/gulp/docs/extractReactData/parseReactFile.js
@@ -107,10 +107,16 @@ function getRelativePath(file, options) {
  */
 function parseComponent(file, options) {
   let docs;
+
   if (file.extname === '.tsx') {
-    // Use `react-docgen-typescript` for `tsx` files
-    docs = tsDocgen.withCustomConfig('./tsconfig.json').parse(file.path);
-    processDocgenTemplates(docs[0], options);
+    // Avoid processing .tsx files unless typescript config is enabled
+    if (!options.typescript) {
+      docs = [{}];
+    } else {
+      // Use `react-docgen-typescript` for `tsx` files
+      docs = tsDocgen.withCustomConfig(path.resolve('tsconfig.json')).parse(file.path);
+      processDocgenTemplates(docs[0], options);
+    }
   } else {
     // Use `react-docgen` for normal `jsx` files
     docs = reactDocgen.parse(

--- a/packages/design-system-scripts/gulp/docs/webpack/createWebpackConfig.js
+++ b/packages/design-system-scripts/gulp/docs/webpack/createWebpackConfig.js
@@ -7,11 +7,10 @@ module.exports = async function createWebpackConfig(sourceDir, docsDir, options)
   const distPath = path.resolve(docsDir, 'dist');
   const docs = await getDocsDirs(docsDir);
 
-  // Entry and include paths are set to `design-system` and `design-system-docs`
-  // packages in `node_modules` for child design systems
-  // This is the first element in the dirs array from `getDirsToProcess`
   const entry = {
+    // Default doc site JS located in @cmsgov/design-system-docs/src/index.jsx
     index: [path.resolve(docs[0], 'src/index.jsx')],
+    // Doc site example page JS located in @cmsgov/design-system-docs/src/example.js
     example: [path.resolve(docs[0], 'src/example.js')],
   };
 


### PR DESCRIPTION
### Summary 
Prevents react-docgen error in HCgov Child DS
 
### How to test
Run this branch on HCgov child ds and ensure there isnt any errors