### PR TITLE
[NO-TICKET] Direct import of lodash

### DIFF
--- a/packages/design-system/src/components/ChoiceList/ChoiceList.jsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.jsx
@@ -3,7 +3,7 @@ import Choice from './Choice';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { pick } from 'lodash';
+import pick from 'lodash/pick';
 
 export class ChoiceList extends React.PureComponent {
   constructor(props) {

--- a/packages/design-system/src/components/ChoiceList/__snapshots__/ChoiceList.test.jsx.snap
+++ b/packages/design-system/src/components/ChoiceList/__snapshots__/ChoiceList.test.jsx.snap
@@ -79,18 +79,18 @@ exports[`ChoiceList Radio buttons and Checkboxes is a radio button group 1`] = `
         >
           <input
             className="ds-c-choice"
-            id="radio_spec-field_1"
+            id="radio_spec-field_2"
             name="spec-field"
             type="radio"
             value="1"
           />
           <FormLabel
             component="label"
-            fieldId="radio_spec-field_1"
+            fieldId="radio_spec-field_2"
           >
             <label
               className="ds-c-label"
-              htmlFor="radio_spec-field_1"
+              htmlFor="radio_spec-field_2"
             >
               <span
                 className=""
@@ -117,18 +117,18 @@ exports[`ChoiceList Radio buttons and Checkboxes is a radio button group 1`] = `
         >
           <input
             className="ds-c-choice"
-            id="radio_spec-field_2"
+            id="radio_spec-field_3"
             name="spec-field"
             type="radio"
             value="2"
           />
           <FormLabel
             component="label"
-            fieldId="radio_spec-field_2"
+            fieldId="radio_spec-field_3"
           >
             <label
               className="ds-c-label"
-              htmlFor="radio_spec-field_2"
+              htmlFor="radio_spec-field_3"
             >
               <span
                 className=""

--- a/packages/design-system/src/components/DateField/DateField.jsx
+++ b/packages/design-system/src/components/DateField/DateField.jsx
@@ -1,8 +1,9 @@
 import { FieldContainer, FieldContainerPropKeys } from '../FieldContainer/FieldContainer';
-import { omit, pick } from 'lodash';
 import DateInput from './DateInput';
 import PropTypes from 'prop-types';
 import React from 'react';
+import omit from 'lodash/omit';
+import pick from 'lodash/pick';
 
 // Prevents day/month greater than 2 digits and year greater than 4 digits
 const standardLengthFormatter = ({ day, month, year }) => ({

--- a/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
+++ b/packages/design-system/src/components/DateField/__snapshots__/DateField.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`DateField renders 1`] = `
 >
   <legend
     className="ds-c-label"
-    id="field_1-label"
+    id="field_snapshot-label"
   >
     <span
       className=""
@@ -27,8 +27,8 @@ exports[`DateField renders 1`] = `
     >
       <label
         className="ds-c-label ds-c-datefield__label"
-        htmlFor="field_2"
-        id="field_2-label"
+        htmlFor="field_snapshot"
+        id="field_snapshot-label"
       >
         <span
           className=""
@@ -37,9 +37,9 @@ exports[`DateField renders 1`] = `
         </span>
       </label>
       <input
-        aria-describedby="field_1-label"
+        aria-describedby="field_snapshot-label"
         className="ds-c-field ds-c-field--month"
-        id="field_2"
+        id="field_snapshot"
         inputMode="numeric"
         name="month"
         pattern="[0-9]*"
@@ -56,8 +56,8 @@ exports[`DateField renders 1`] = `
     >
       <label
         className="ds-c-label ds-c-datefield__label"
-        htmlFor="field_3"
-        id="field_3-label"
+        htmlFor="field_snapshot"
+        id="field_snapshot-label"
       >
         <span
           className=""
@@ -66,9 +66,9 @@ exports[`DateField renders 1`] = `
         </span>
       </label>
       <input
-        aria-describedby="field_1-label"
+        aria-describedby="field_snapshot-label"
         className="ds-c-field ds-c-field--day"
-        id="field_3"
+        id="field_snapshot"
         inputMode="numeric"
         name="day"
         pattern="[0-9]*"
@@ -85,8 +85,8 @@ exports[`DateField renders 1`] = `
     >
       <label
         className="ds-c-label ds-c-datefield__label"
-        htmlFor="field_4"
-        id="field_4-label"
+        htmlFor="field_snapshot"
+        id="field_snapshot-label"
       >
         <span
           className=""
@@ -95,9 +95,9 @@ exports[`DateField renders 1`] = `
         </span>
       </label>
       <input
-        aria-describedby="field_1-label"
+        aria-describedby="field_snapshot-label"
         className="ds-c-field ds-c-field--year"
-        id="field_4"
+        id="field_snapshot"
         inputMode="numeric"
         name="year"
         pattern="[0-9]*"

--- a/packages/design-system/src/components/Dropdown/Dropdown.jsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.jsx
@@ -1,8 +1,9 @@
 import { FieldContainer, FieldContainerPropKeys } from '../FieldContainer/FieldContainer';
-import { omit, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Select from './Select';
+import omit from 'lodash/omit';
+import pick from 'lodash/pick';
 
 export class Dropdown extends React.PureComponent {
   constructor(props) {

--- a/packages/design-system/src/components/FieldContainer/FieldContainer.tsx
+++ b/packages/design-system/src/components/FieldContainer/FieldContainer.tsx
@@ -2,7 +2,7 @@ import FormLabel from '../FormLabel/FormLabel';
 import InlineError from './InlineError';
 import React from 'react';
 import classNames from 'classnames';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash.uniqueid';
 
 interface FieldContainerRenderProps {
   id: string;

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.jsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.jsx
@@ -6,7 +6,7 @@ import Choice from '../ChoiceList/Choice';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { pick } from 'lodash';
+import pick from 'lodash/pick';
 
 const NUM_MONTHS = 12;
 const monthNumbers = (() => {

--- a/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.jsx.snap
+++ b/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.jsx.snap
@@ -52,7 +52,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_1"
+            id="checkbox_months_2"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -60,7 +60,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_1"
+            htmlFor="checkbox_months_2"
           >
             <span
               className=""
@@ -82,7 +82,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_2"
+            id="checkbox_months_3"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -90,7 +90,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_2"
+            htmlFor="checkbox_months_3"
           >
             <span
               className=""
@@ -112,7 +112,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_3"
+            id="checkbox_months_4"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -120,7 +120,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_3"
+            htmlFor="checkbox_months_4"
           >
             <span
               className=""
@@ -142,7 +142,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_4"
+            id="checkbox_months_5"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -150,7 +150,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_4"
+            htmlFor="checkbox_months_5"
           >
             <span
               className=""
@@ -172,7 +172,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_5"
+            id="checkbox_months_6"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -180,7 +180,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_5"
+            htmlFor="checkbox_months_6"
           >
             <span
               className=""
@@ -202,7 +202,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_6"
+            id="checkbox_months_7"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -210,7 +210,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_6"
+            htmlFor="checkbox_months_7"
           >
             <span
               className=""
@@ -232,7 +232,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_7"
+            id="checkbox_months_8"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -240,7 +240,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_7"
+            htmlFor="checkbox_months_8"
           >
             <span
               className=""
@@ -262,7 +262,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_8"
+            id="checkbox_months_9"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -270,7 +270,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_8"
+            htmlFor="checkbox_months_9"
           >
             <span
               className=""
@@ -292,7 +292,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_9"
+            id="checkbox_months_10"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -300,7 +300,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_9"
+            htmlFor="checkbox_months_10"
           >
             <span
               className=""
@@ -322,7 +322,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_10"
+            id="checkbox_months_11"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -330,7 +330,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_10"
+            htmlFor="checkbox_months_11"
           >
             <span
               className=""
@@ -352,7 +352,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_11"
+            id="checkbox_months_12"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -360,7 +360,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_11"
+            htmlFor="checkbox_months_12"
           >
             <span
               className=""
@@ -382,7 +382,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
             checked={false}
             className="ds-c-choice"
             disabled={false}
-            id="checkbox_months_12"
+            id="checkbox_months_13"
             name="months"
             onChange={[Function]}
             type="checkbox"
@@ -390,7 +390,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
           />
           <label
             className="ds-c-label"
-            htmlFor="checkbox_months_12"
+            htmlFor="checkbox_months_13"
           >
             <span
               className=""

--- a/packages/design-system/src/components/TextField/TextField.jsx
+++ b/packages/design-system/src/components/TextField/TextField.jsx
@@ -1,9 +1,10 @@
 import { FieldContainer, FieldContainerPropKeys } from '../FieldContainer/FieldContainer';
-import { omit, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import TextInput from './TextInput';
 import classNames from 'classnames';
+import omit from 'lodash/omit';
+import pick from 'lodash/pick';
 
 export { unmaskValue } from './Mask';
 


### PR DESCRIPTION
## Summary
HCgov DS docs site displays blank screen for Header and Footer when we don't use the direct import of lodash.

See [this PR](https://github.com/CMSgov/design-system/pull/917) for similar fix.

### How to test
- Run the doc site locally with `yarn start`
- Setup HCgov child design system in the package.json to reference this branch with `file:../design-system/package/design-system/`
- Run `git clean -fdx` and then `yarn install` to Install the local DS branch
- Test that the Header and Footer component pages are displaying correctly
