### PR TITLE
[WNMGDS-817] Remove unnecessary aria-describedby

### DIFF
--- a/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
+++ b/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.jsx.snap
@@ -27,7 +27,6 @@ exports[`Autocomplete renders a snapshot 1`] = `
       aria-activedescendant={null}
       aria-autocomplete="list"
       aria-controls={null}
-      aria-describedby=""
       aria-expanded={false}
       aria-invalid={false}
       aria-labelledby={null}

--- a/packages/design-system/src/components/Button/Button.test.jsx
+++ b/packages/design-system/src/components/Button/Button.test.jsx
@@ -2,8 +2,8 @@ import Button from './Button.jsx';
 import React from 'react';
 import { shallow } from 'enzyme';
 
-/* eslint-disable react/prop-types */
 const Link = (props) => {
+  /* eslint-disable-next-line react/prop-types */
   return <div {...props}>{props.children}</div>;
 };
 

--- a/packages/design-system/src/components/Dropdown/Select.jsx
+++ b/packages/design-system/src/components/Dropdown/Select.jsx
@@ -47,24 +47,21 @@ export class Select extends React.PureComponent {
       </option>
     ));
 
+    /* eslint-disable react/prop-types */
+    const ariaAttributes = {
+      'aria-label': ariaLabel,
+      // Use set `aria-invalid` based off errorMessage unless manually specified
+      'aria-invalid': this.props['aria-invalid'] ? this.props['aria-invalid'] : !!errorMessage,
+      // Link input to bottom placed error message
+      'aria-describedby':
+        errorPlacement === 'bottom' && errorMessage
+          ? classNames(this.props['aria-describedby'], errorId)
+          : undefined,
+    };
+    /* eslint-enable react/prop-types */
+
     return (
-      <select
-        aria-label={ariaLabel}
-        aria-invalid={
-          // eslint-disable-next-line
-          this.props['aria-invalid'] ? this.props['aria-invalid'] : !!errorMessage
-        }
-        aria-describedby={
-          // Link input to bottom placed error message
-          // eslint-disable-next-line
-          classNames(this.props['aria-describedby'], {
-            [errorId]: errorPlacement === 'bottom' && errorMessage,
-          })
-        }
-        className={classes}
-        ref={setRef}
-        {...selectProps}
-      >
+      <select {...ariaAttributes} className={classes} ref={setRef} {...selectProps}>
         {/* Render custom options if provided */ children || optionElements}
       </select>
     );

--- a/packages/design-system/src/components/Dropdown/__snapshots__/Select.test.jsx.snap
+++ b/packages/design-system/src/components/Dropdown/__snapshots__/Select.test.jsx.snap
@@ -31,7 +31,6 @@ exports[`Select handles bottom placed error 1`] = `
 
 exports[`Select renders a select menu 1`] = `
 <select
-  aria-describedby=""
   aria-invalid={false}
   aria-label="test aria label"
   className="ds-c-field"
@@ -53,7 +52,6 @@ exports[`Select renders a select menu 1`] = `
 
 exports[`Select renders options correctly 1`] = `
 <select
-  aria-describedby=""
   aria-invalid={false}
   className="ds-c-field"
   defaultValue="1"

--- a/packages/design-system/src/components/TextField/TextInput.jsx
+++ b/packages/design-system/src/components/TextField/TextInput.jsx
@@ -42,20 +42,22 @@ export function TextInput(props) {
 
   const ComponentType = multiline ? 'textarea' : 'input';
 
+  /* eslint-disable react/prop-types */
+  const ariaAttributes = {
+    'aria-label': ariaLabel,
+    // Use set `aria-invalid` based off errorMessage unless manually specified
+    'aria-invalid': props['aria-invalid'] ? props['aria-invalid'] : !!errorMessage,
+    // Link input to bottom placed error message
+    'aria-describedby':
+      errorPlacement === 'bottom' && errorMessage
+        ? classNames(props['aria-describedby'], errorId)
+        : undefined,
+  };
+  /* eslint-enable react/prop-types */
+
   const field = (
     <ComponentType
-      aria-label={ariaLabel}
-      aria-invalid={
-        // eslint-disable-next-line
-        props['aria-invalid'] ? props['aria-invalid'] : !!errorMessage
-      }
-      aria-describedby={
-        // Link input to bottom placed error message
-        // eslint-disable-next-line
-        classNames(props['aria-describedby'], {
-          [errorId]: errorPlacement === 'bottom' && errorMessage,
-        })
-      }
+      {...ariaAttributes}
       className={classes}
       ref={setRef}
       rows={multiline && rows ? rows : undefined}

--- a/packages/design-system/src/components/TextField/__snapshots__/TextInput.test.jsx.snap
+++ b/packages/design-system/src/components/TextField/__snapshots__/TextInput.test.jsx.snap
@@ -13,7 +13,6 @@ exports[`TextInput handles bottom placed error 1`] = `
 
 exports[`TextInput is a textarea 1`] = `
 <textarea
-  aria-describedby=""
   aria-invalid={false}
   className="ds-c-field"
   id="1"
@@ -23,7 +22,6 @@ exports[`TextInput is a textarea 1`] = `
 
 exports[`TextInput is an input field 1`] = `
 <input
-  aria-describedby=""
   aria-invalid={false}
   className="ds-c-field"
   id="1"
@@ -34,7 +32,6 @@ exports[`TextInput is an input field 1`] = `
 
 exports[`TextInput masks renders TextInput 1`] = `
 <input
-  aria-describedby=""
   aria-invalid={false}
   className="ds-c-field"
   id="1"
@@ -48,7 +45,6 @@ exports[`TextInput masks renders currency mask 1`] = `
   mask="currency"
 >
   <input
-    aria-describedby=""
     aria-invalid={false}
     className="ds-c-field ds-c-field--currency"
     id="1"


### PR DESCRIPTION
## Summary
- Update TextField, Dropdown, and DateField components to avoid providing empty `aria-describedby` attributes.

## How to test
- Ensure aria attributes are correct for both top and bottom placed errors
- `http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-10/feature