### PR TITLE
[WNMGDS-819] Allow doc site to use the feature flag

### DIFF
--- a/examples/child-design-system/docs/src/pages/components/Button/Button.example.jsx
+++ b/examples/child-design-system/docs/src/pages/components/Button/Button.example.jsx
@@ -4,9 +4,9 @@
 // https://webpack.js.org/configuration/resolve/#resolvealias
 //
 // Because the react example files are located separately from the design system source directory (`sourceDir` in `cmsds.config.js`),
-// We provide the `@src` alias to allow for easy imports from `sourceDir`
+// We provide the `@design-system` alias to allow for easy imports from `sourceDir`
 // This is also possible in typescript child design systems via the `paths` compiler option in the `tsconfig.json`
-import Button from '@src/components/Button/Button';
+import { Button } from '@design-system';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/examples/child-design-system/docs/src/pages/components/Card/Card.example.jsx
+++ b/examples/child-design-system/docs/src/pages/components/Card/Card.example.jsx
@@ -2,9 +2,9 @@
 // https://webpack.js.org/configuration/resolve/#resolvealias
 //
 // Because the react example files are located separately from the design system source directory (`sourceDir` in `cmsds.config.js`),
-// We provide the `@src` alias to allow for easy imports from `sourceDir`
+// We provide the `@design-sysytem` alias to allow for easy imports from `sourceDir`
 // This is also possible in typescript child design systems via the `paths` compiler option in the `tsconfig.json`
-import Card from '@src/components/Card/Card';
+import { Card } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/examples/child-design-system/tsconfig.json
+++ b/examples/child-design-system/tsconfig.json
@@ -6,7 +6,7 @@
     // Equivalent to `alias` in webpack's resolve config. https://webpack.js.org/configuration/resolve/#resolvealias
     "baseUrl": ".",
     "paths": {
-      "@src/*": ["src/*"]
+      "@design-system/*": ["*"],
     }
   }
 }

--- a/packages/design-system-docs/src/pages/components/Alert/Alert.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Alert/Alert.example.jsx
@@ -1,4 +1,4 @@
-import { Alert } from '@cmsgov/design-system';
+import { Alert } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/Autocomplete/Autocomplete.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Autocomplete/Autocomplete.example.jsx
@@ -1,4 +1,4 @@
-import { Autocomplete, TextField } from '@cmsgov/design-system';
+import { Autocomplete, TextField } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/Badge/Badge.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Badge/Badge.example.jsx
@@ -1,4 +1,4 @@
-import { Badge } from '@cmsgov/design-system';
+import { Badge } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/Button/Button.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Button/Button.example.jsx
@@ -1,5 +1,5 @@
 /* eslint no-alert: 0 */
-import { Button } from '@cmsgov/design-system';
+import { Button } from '@design-system';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/packages/design-system-docs/src/pages/components/ChoiceList/Choice.example.jsx
+++ b/packages/design-system-docs/src/pages/components/ChoiceList/Choice.example.jsx
@@ -1,4 +1,4 @@
-import { Choice, TextField } from '@cmsgov/design-system';
+import { Choice, TextField } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/ChoiceList/ChoiceList.example.jsx
+++ b/packages/design-system-docs/src/pages/components/ChoiceList/ChoiceList.example.jsx
@@ -1,4 +1,4 @@
-import { ChoiceList } from '@cmsgov/design-system';
+import { ChoiceList } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/DateField/DateField.example.jsx
+++ b/packages/design-system-docs/src/pages/components/DateField/DateField.example.jsx
@@ -1,4 +1,4 @@
-import { DateField } from '@cmsgov/design-system';
+import { DateField } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/Dialog/Dialog.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Dialog/Dialog.example.jsx
@@ -1,4 +1,4 @@
-import { Button, Dialog } from '@cmsgov/design-system';
+import { Button, Dialog } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/Dialog/ThirdPartyLink.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Dialog/ThirdPartyLink.example.jsx
@@ -1,4 +1,4 @@
-import { Button, Dialog } from '@cmsgov/design-system';
+import { Button, Dialog } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/Dropdown/Dropdown.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Dropdown/Dropdown.example.jsx
@@ -1,4 +1,4 @@
-import { Dropdown } from '@cmsgov/design-system';
+import { Dropdown } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/FormLabel/FormLabel.example.jsx
+++ b/packages/design-system-docs/src/pages/components/FormLabel/FormLabel.example.jsx
@@ -1,4 +1,4 @@
-import { FormLabel } from '@cmsgov/design-system';
+import { FormLabel } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/HelpDrawer/HelpDrawer.example.jsx
+++ b/packages/design-system-docs/src/pages/components/HelpDrawer/HelpDrawer.example.jsx
@@ -1,4 +1,4 @@
-import { HelpDrawer, HelpDrawerToggle } from '@cmsgov/design-system';
+import { HelpDrawer, HelpDrawerToggle } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/MonthPicker/MonthPicker.example.jsx
+++ b/packages/design-system-docs/src/pages/components/MonthPicker/MonthPicker.example.jsx
@@ -1,4 +1,4 @@
-import { MonthPicker } from '@cmsgov/design-system';
+import { MonthPicker } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/Review/Review.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Review/Review.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Review } from '@cmsgov/design-system';
+import { Review } from '@design-system';
 
 const editButtonHref = 'javascript:void(0);';
 ReactDOM.render(

--- a/packages/design-system-docs/src/pages/components/SkipNav/SkipNav.example.jsx
+++ b/packages/design-system-docs/src/pages/components/SkipNav/SkipNav.example.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { SkipNav } from '@cmsgov/design-system';
+import { SkipNav } from '@design-system';
 
 ReactDOM.render(
   <div>

--- a/packages/design-system-docs/src/pages/components/Spinner/Spinner.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Spinner/Spinner.example.jsx
@@ -1,4 +1,4 @@
-import { Button, Spinner } from '@cmsgov/design-system';
+import { Button, Spinner } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/StepList/StepList.example.jsx
+++ b/packages/design-system-docs/src/pages/components/StepList/StepList.example.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { StepList } from '@cmsgov/design-system';
+import { StepList } from '@design-system';
 import classNames from 'classnames';
 
 // Mock react-router example

--- a/packages/design-system-docs/src/pages/components/Table/Table.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Table/Table.example.jsx
@@ -1,11 +1,4 @@
-import {
-  Table,
-  TableBody,
-  TableCaption,
-  TableCell,
-  TableHead,
-  TableRow,
-} from '@cmsgov/design-system';
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableRow } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/Tabs/Tab.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Tabs/Tab.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Tab } from '@cmsgov/design-system';
+import { Tab } from '@design-system';
 
 ReactDOM.render(
   <div className="ds-c-tabs" role="tablist">

--- a/packages/design-system-docs/src/pages/components/Tabs/Tabs.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Tabs/Tabs.example.jsx
@@ -1,4 +1,4 @@
-import { TabPanel, Tabs } from '@cmsgov/design-system';
+import { TabPanel, Tabs } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/TextField/Mask.example.jsx
+++ b/packages/design-system-docs/src/pages/components/TextField/Mask.example.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-multi-comp */
-import { Button, TextField, unmaskValue } from '@cmsgov/design-system';
+import { Button, TextField, unmaskValue } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/TextField/TextField.example.jsx
+++ b/packages/design-system-docs/src/pages/components/TextField/TextField.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { TextField } from '@cmsgov/design-system';
+import { TextField } from '@design-system';
 
 ReactDOM.render(
   <div>

--- a/packages/design-system-docs/src/pages/components/Tooltip/Tooltip.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Tooltip/Tooltip.example.jsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip, TooltipIcon } from '@cmsgov/design-system';
+import { Button, Tooltip, TooltipIcon } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/packages/design-system-docs/src/pages/components/Tooltip/TooltipIcon.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Tooltip/TooltipIcon.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { TooltipIcon } from '@cmsgov/design-system';
+import { TooltipIcon } from '@design-system';
 
 ReactDOM.render(
   <>

--- a/packages/design-system-docs/src/pages/components/VerticalNav/VerticalNav.example.jsx
+++ b/packages/design-system-docs/src/pages/components/VerticalNav/VerticalNav.example.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { VerticalNav } from '@cmsgov/design-system';
+import { VerticalNav } from '@design-system';
 import classNames from 'classnames';
 
 // Mock react-router example

--- a/packages/design-system-scripts/gulp/docs/webpack/createReactExampleWebpackConfig.js
+++ b/packages/design-system-scripts/gulp/docs/webpack/createReactExampleWebpackConfig.js
@@ -33,13 +33,10 @@ module.exports = (sourceDir, reactExampleEntry, typescript) => {
         },
       ],
     },
-    plugins: [
-      new webpack.EnvironmentPlugin(['NODE_ENV'])
-    ],
+    plugins: [new webpack.EnvironmentPlugin(['NODE_ENV'])],
     resolve: {
       modules: ['node_modules'],
       alias: {
-        '@src': path.resolve(sourceDir, 'src'),
         '@design-system': path.resolve(sourceDir),
       },
       extensions: ['.js', '.jsx', '.tsx'],

--- a/packages/design-system-scripts/gulp/docs/webpack/createReactExampleWebpackConfig.js
+++ b/packages/design-system-scripts/gulp/docs/webpack/createReactExampleWebpackConfig.js
@@ -40,8 +40,9 @@ module.exports = (sourceDir, reactExampleEntry, typescript) => {
       modules: ['node_modules'],
       alias: {
         '@src': path.resolve(sourceDir, 'src'),
+        '@design-system': path.resolve(sourceDir),
       },
-      extensions: ['.js', '.jsx'],
+      extensions: ['.js', '.jsx', '.tsx'],
       plugins: [],
     },
     performance: {

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.jsx
@@ -21,6 +21,7 @@ import React from 'react';
 import TextField from '../TextField/TextField';
 import WrapperDiv from './WrapperDiv';
 import classNames from 'classnames';
+import { errorPlacementDefault } from '../flags';
 import get from 'lodash/get';
 import uniqueId from 'lodash.uniqueid';
 
@@ -92,7 +93,9 @@ export class Autocomplete extends React.PureComponent {
       if (isTextField(child)) {
         // The display of bottom placed errorMessages in TextField breaks the Autocomplete's UI design.
         // Add errorMessageClassName to fix the styles for bottom placed errors
-        const bottomError = child.props.errorPlacement === 'bottom' && child.props.errorMessage;
+        const bottomError =
+          (child.props.errorPlacement === 'bottom' || errorPlacementDefault() === 'bottom') &&
+          child.props.errorMessage;
         const errorMessageClassName = bottomError
           ? classNames(
               'ds-c-autocomplete__error-message',

--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -49,5 +49,5 @@
 
 // Need a custom class for bottom error message to make space for the clear search button
 .ds-c-autocomplete__error-message--clear-btn {
-  width: calc(100% - 100px);
+  width: calc(100% - 110px);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,10 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    // Allows `*.example.tsx` files in `docs` to import directly from `src`
     "baseUrl": ".",
+    // Allows `*.example.tsx` files in `docs` to import directly from the design system source root
     "paths": {
       "@design-system/*": ["*"],
-      "@src/*": ["src/*"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     // Allows `*.example.tsx` files in `docs` to import directly from `src`
     "baseUrl": ".",
     "paths": {
+      "@design-system/*": ["*"],
       "@src/*": ["src/*"]
     }
   }


### PR DESCRIPTION
## Summary
- The doc site was previously not working with the feature flag because the example files (imported from `@cmsgov/design-system-docs`) were importing from `@cmsgov/design-system`, rather than the local source directory in the case of the child DS doc site. 
- To solve this I added a new `@design-system` webpack alias to be used in the example files, so when the example files are used in a child DS doc site, they import from the child DS source (which is using the error placement feature flag).
- The old `@src` alias was also removed 

### How to test 
- Setup and build the HC.gov child DS using the `bernard/feature-flag-test` branch, make sure to install from your local CMSDS branch
- Test usage of the HC.gov child DS form components in the CRA example and in a product app
- Test the child design system example 
