### PR TITLE
[NO_TICKET] Reimplement feature flags with env vars

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -19,6 +19,12 @@ module.exports = function (api) {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-object-assign',
     'inline-react-svg',
+    [
+      'transform-inline-environment-variables',
+      {
+        include: ['CMSDS_FLAGS'],
+      },
+    ],
   ];
 
   return {

--- a/cmsds.config.js
+++ b/cmsds.config.js
@@ -18,8 +18,9 @@ module.exports = {
   githubUrl: 'https://github.com/CMSgov/design-system',
   // The name of your design system NPM package. This replaces the {{npm}} template in documentation content.'
   npmPackage: '@cmsgov/design-system',
+
   // React feature flag variables
   flags: {
-    ERROR_PLACEMENT_DEFAULT: 'bottom',
+    ERROR_PLACEMENT_DEFAULT: 'top',
   },
 };

--- a/cmsds.config.js
+++ b/cmsds.config.js
@@ -18,4 +18,8 @@ module.exports = {
   githubUrl: 'https://github.com/CMSgov/design-system',
   // The name of your design system NPM package. This replaces the {{npm}} template in documentation content.'
   npmPackage: '@cmsgov/design-system',
+  // React feature flag variables
+  flags: {
+    ERROR_PLACEMENT_DEFAULT: 'bottom',
+  },
 };

--- a/examples/child-design-system/cmsds.config.js
+++ b/examples/child-design-system/cmsds.config.js
@@ -16,4 +16,9 @@ module.exports = {
   githubUrl: 'https://github.com/CMSgov/design-system-example',
   // The name of your design system NPM package. This replaces the {{npm}} template in documentation content.'
   npmPackage: '@cmsgov/design-system-example',
+
+  // React feature flag variables
+  flags: {
+    // ERROR_PLACEMENT_DEFAULT: 'bottom',
+  },
 };

--- a/packages/design-system-scripts/cli.js
+++ b/packages/design-system-scripts/cli.js
@@ -7,6 +7,9 @@ const configFile = require(path.resolve(process.cwd(), 'cmsds.config.js'));
 const configDefaults = require('./configDefaults');
 const config = { ...configDefaults, ...configFile };
 
+// Set flag variable inside process.env
+process.env.CMSDS_FLAGS = JSON.stringify(config.flags);
+
 // The yargs library actually made it so you have to access `.argv` at the end
 // or else it won't do anything. Not sure what the reasoning there was.
 // eslint-disable-next-line no-unused-expressions

--- a/packages/design-system-scripts/cli.js
+++ b/packages/design-system-scripts/cli.js
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 const yargs = require('yargs');
+const { merge } = require('lodash');
 const { logIntroduction } = require('./gulp/common/logUtil');
 const path = require('path');
 // TODO, clean up script parameters to use the CMSDS config better
 const configFile = require(path.resolve(process.cwd(), 'cmsds.config.js'));
 const configDefaults = require('./configDefaults');
-const config = { ...configDefaults, ...configFile };
 
-// Set flag variable inside process.env
+// Override default config with cmsds.config.js
+const config = merge(configDefaults, configFile);
+// Set flag variables inside process.env
 process.env.CMSDS_FLAGS = JSON.stringify(config.flags);
 
 // The yargs library actually made it so you have to access `.argv` at the end

--- a/packages/design-system-scripts/configDefaults.js
+++ b/packages/design-system-scripts/configDefaults.js
@@ -9,4 +9,7 @@ module.exports = {
   name: 'CMS Design System',
   githubUrl: 'https://github.com/CMSgov/design-system',
   npmPackage: '@cmsgov/design-system',
+  flags: {
+    ERROR_PLACEMENT_DEFAULT: 'top',
+  },
 };

--- a/packages/design-system-scripts/package.json
+++ b/packages/design-system-scripts/package.json
@@ -25,6 +25,7 @@
     "axe-webdriverjs": "^2.3.0",
     "babel-loader": "^8.0.0",
     "babel-plugin-inline-react-svg": "^1.1.2",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "browser-sync": "2.26.7",
     "bytes": "3.1.0",
     "chalk": "^2.4.2",

--- a/packages/design-system/src/components/flags.js
+++ b/packages/design-system/src/components/flags.js
@@ -1,4 +1,4 @@
-// featureFlags.js
+// flags.js
 
 export function errorPlacementDefault() {
   const flags = JSON.parse(process.env.CMSDS_FLAGS);

--- a/packages/design-system/src/components/flags.js
+++ b/packages/design-system/src/components/flags.js
@@ -1,12 +1,6 @@
 // featureFlags.js
-const flags = {
-  ERROR_PLACEMENT_DEFAULT: 'top',
-};
 
 export function errorPlacementDefault() {
+  const flags = JSON.parse(process.env.CMSDS_FLAGS);
   return flags.ERROR_PLACEMENT_DEFAULT;
-}
-
-export function setErrorPlacementDefault(value) {
-  flags.ERROR_PLACEMENT_DEFAULT = value;
 }

--- a/packages/design-system/src/components/index.js
+++ b/packages/design-system/src/components/index.js
@@ -1,7 +1,6 @@
 /**
  * index.js - JS entry point
  */
-
 export * from './Alert';
 export * from './Autocomplete';
 export * from './Badge';
@@ -25,5 +24,3 @@ export * from './TextField';
 export * from './Tooltip';
 export * from './UsaBanner';
 export * from './VerticalNav';
-
-export * from './flags';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3731,6 +3731,11 @@ babel-plugin-jest-hoist@^25.5.0:
     "@babel/types" "^7.3.3"
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-transform-inline-environment-variables@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.4.3.tgz#a3b09883353be8b5e2336e3ff1ef8a5d93f9c489"
+  integrity sha1-o7CYgzU76LXiM24/8e+KXZP5xIk=
+
 babel-preset-current-node-syntax@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz#b4b547acddbf963cba555ba9f9cbbb70bfd044da"
@@ -11685,15 +11690,13 @@ number-is-nan@^1.0.0:
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 nunjucks@>=3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.2.tgz#45f915fef0f89fbab38c489dc85025f64859f466"
-  integrity sha512-KUi85OoF2NMygwODAy28Lh9qHmq5hO3rBlbkYoC8v377h4l8Pt5qFjILl0LWpMbOrZ18CzfVVUvIHUIrtED3sA==
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.3.tgz#1b33615247290e94e28263b5d855ece765648a31"
+  integrity sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==
   dependencies:
     a-sync-waterfall "^1.0.0"
     asap "^2.0.3"
     commander "^5.1.0"
-  optionalDependencies:
-    chokidar "^3.3.0"
 
 nunjucks@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
## Summary
The old feature flag implementation which was based off a flag variable wasn't working when building for production. This PR replaces that implementation with a `flags` property inside `cmsds.config.js`, which is copied over to `process.env` and used inside the components on build time. This means the HCgov design systems doesnt have to use the `setErrorPlacement` flag helper anymore, and can just set the `flags` property inside `cmsds.config.js`

## How to test
- Build the CMSDS DS with `flags.ERROR_PLACEMENT_DEFAULT` set to `top`, `bottom`, and undefined. Make sure the error placements work as expected, they should default to `top` if the flag is not defined, and use the value if otherwise provided.
- Test the flags when building for production. This can be achieved by running the following scripts:
```
yarn build --ignoreRootPath
npx http-server ./packages/design-system-docs/dist
```
- Test the flags on HCgov DS and product applications
