### PR TITLE
[WNMGDS-823] Update build release files

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -14,8 +14,8 @@
   "types": "dist/types/index.d.ts",
   "files": [
     "dist",
-    "src/components/**/*.?sx",
-    "!src/components/**/*.test.?sx"
+    "src/components/**/*.{jsx,tsx}",
+    "!src/**/*{.test,.spec,.d}.{jsx,tsx}"
   ],
   "dependencies": {
     "@popperjs/core": "^2.4.4",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -14,8 +14,9 @@
   "types": "dist/types/index.d.ts",
   "files": [
     "dist",
-    "src/components/**/*.jsx",
-    "!src/components/**/*.test.jsx"
+    "src/components/**/*.?sx",
+    "src/components/**/*.tsx",
+    "!src/components/**/*.test.?sx"
   ],
   "dependencies": {
     "@popperjs/core": "^2.4.4",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -15,7 +15,6 @@
   "files": [
     "dist",
     "src/components/**/*.?sx",
-    "src/components/**/*.tsx",
     "!src/components/**/*.test.?sx"
   ],
   "dependencies": {

--- a/prerelease.sh
+++ b/prerelease.sh
@@ -16,7 +16,7 @@ yarn install
 
 echo "${GREEN}Building files and running tests...${NC}"
 yarn build
-yarn test
+yarn test:unit
 yarn test:e2e --skipBuild
 
 echo "${GREEN}Bumping version and creating tagged release commit...${NC}"


### PR DESCRIPTION
## Summary
The zipped files generated by 'npm pack' for release does not include typescript source files. 
This PR adds typescript source files to the zipped files for publishing to npm.

## How to test
- Run `npm pack ./packages/design-system/` command on terminal - this will generate a `.tgz` file
- Unzip the `.tgz` file and check that it contains all the files from `dist` folder and all the component files under `src/components` folder 
- Specifically check that it should include the typescript files for FormControl and InlineError

