### PR TITLE
[NO-TICKET] Set prop tables on the doc site to be compact

### DIFF
--- a/packages/design-system-docs/src/scripts/components/ReactPropDocs.jsx
+++ b/packages/design-system-docs/src/scripts/components/ReactPropDocs.jsx
@@ -29,7 +29,7 @@ class ReactPropDocs extends React.PureComponent {
   render() {
     return [
       <h3 key="propDocsHeader">Props</h3>,
-      <Table key="propDocsTable" stackable scrollable>
+      <Table key="propDocsTable" stackable scrollable compact>
         <TableCaption>
           <span className="ds-u-visibility--screen-reader">React Properties Documentation</span>
         </TableCaption>


### PR DESCRIPTION
This PR adds the compact table styling to the React property tables 

DEMO URL 
http://design-system-demo.s3-website-us-east-1.amazonaws.com/NO-TICKET-compact-table-for-props