### PR TITLE
[WNMGDS-719] Update Dialog to expose 'AriaModal' props

### DIFF
--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -35,7 +35,7 @@ Style guide: components.dialog.react
 ---
 
 ### When to use
-- Use when you require an immediate response from the user.  
+- Use when you require an immediate response from the user.
 - Use to request information that is preventing the system from continuing a user-initiated process.
 - Use to notify the user of urgent information concerning their current work. Modal dialogs are commonly used to report system errors or convey a consequence of a user’s action.
 - Use to confirm a user decision. Clearly describe the action being confirmed and explain any potential consequences that it may cause. Both the title and the button should reflect the action that will occur. If the action is destructive or irreversible then use a transactional danger modal.
@@ -48,12 +48,16 @@ Style guide: components.dialog.react
 - `<Dialog>` makes use of the `<AriaModal>` component maintained by [react-aria-modal docs on Github](https://github.com/davidtheclark/react-aria-modal). The above documented props are only those directly exposed by the `<Dialog>` component, but you can pass props specific to `<AriaModal>` here as well, e.g. you can set the [`scrollDisabled`](https://github.com/davidtheclark/react-aria-modal#scrolldisabled) prop if you'd like to enable scrolling behind the modal window.
 
 ### Accessibility
+- Modal dialog should support keyboard navigation.
+    - `Enter` and `Space` to select the highlighted item.
+    - `Tab` to move the focus sequentially through the list of focusable items
+    - `Shift + Tab` to move the focus sequentially through the list of focusable items in reversed order
 
 ### Focus Management
 - When the modal is opened, the entire modal is the default focus state. Most screen readers will announce the entire dialog content.
 - Focus is trapped within the modal and users can then navigate through the dialog actions with the keyboard.
 - Escape will close the modal. To disable exiting when users press the Escape key, set the `escapeExits` prop to `false`
-- When the modal closes, focus returns to the element that was focused just before the modal if activated
+- When the modal closes, focus returns to the element that was focused just before the modal is activated
 - To place the focus inside of the dialog on activating the modal, set the dialog focus using the `initialFocus` prop with boolean prop `focusDialog` set to `false`
 
 ### Related patterns

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -42,7 +42,7 @@ Style guide: components.dialog.react
 
 ### When to consider alternatives
 - Every time! Before using a modal, consider whether there’s another component that might be less disruptive for the user. Modals should be a last resort.
-- Multi-step process. Avoid complicated user flows in a modal that may take the user away from the original page. A multi-step process is better suited to an individual page, guiding the user and accommodating complexities in the user flow.
+- If you have a multi-step process. Avoid complicated user flows in a modal that may take the user away from the original page. A multi-step process is better suited to an individual page, guiding the user and accommodating complexities in the user flow.
 
 ### Usage
 - `<Dialog>` makes use of the `<AriaModal>` component maintained by [react-aria-modal docs on Github](https://github.com/davidtheclark/react-aria-modal). The above documented props are only those directly exposed by the `<Dialog>` component, but you can pass props specific to `<AriaModal>` here as well, e.g. you can set the [`scrollDisabled`](https://github.com/davidtheclark/react-aria-modal#scrolldisabled) prop if you'd like to enable scrolling behind the modal window.

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -34,6 +34,27 @@ Style guide: components.dialog.react
 /*
 ---
 
+### When to use
+- Require an immediate response from the user. Use a dialog to request information that is preventing the system from continuing a user-initiated process.
+- Notify the user of urgent information. Use a modal dialog to notify the user of urgent information concerning their current work. Modal dialogs are commonly used to report system errors or convey a consequence of a user’s action.
+- Confirm a user decision. Use a modal dialog to confirm user decisions. Clearly describe the action being confirmed and explain any potential consequences that it may cause. Both the title and the button should reflect the action that will occur. If the action is destructive or irreversible then use a transactional danger modal.
+
+### When to consider alternatives
+- Every time! Before using a modal, consider whether there’s another component that might be less disruptive for the user. Modals should be a last resort.
+- Multi-step process. Avoid complicated user flows in a modal that may take the user away from the original page. A multi-step process is better suited to an individual page, guiding the user and accommodating complexities in the user flow.
+
+### Usage
+- `<Dialog>` makes use of the `<AriaModal>` component maintained by [react-aria-modal docs on Github](https://github.com/davidtheclark/react-aria-modal). The above documented props are only those directly exposed by the `<Dialog>` component, but you can pass props specific to `<AriaModal>` here as well, e.g. you can set the [`scrollDisabled`](https://github.com/davidtheclark/react-aria-modal#scrolldisabled) prop if you'd like to enable scrolling behind the modal window.
+
+### Accessibility
+
+### Focus Management
+- When the modal is opened, the entire modal is the default focus state. Most screen readers will announce the entire dialog content.
+- Focus is trapped within the modal and users can then navigate through the dialog actions with the keyboard.
+- Escape will close the modal. To disable exiting when users press the Escape key, set the `escapeExits` prop to `false`
+- When the modal closes, focus returns to the element that was focused just before the modal if activated
+- To place the focus inside of the dialog on activating the modal, set the dialog focus using the `initialFocus` prop with boolean prop `focusDialog` set to `false`
+
 ### Related patterns
 
 - [Alert]({{root}}/components/alert)

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -38,7 +38,7 @@ Style guide: components.dialog.react
 - Use when you require an immediate response from the user.  
 - Use to request information that is preventing the system from continuing a user-initiated process.
 - Use to notify the user of urgent information concerning their current work. Modal dialogs are commonly used to report system errors or convey a consequence of a user’s action.
-- Confirm a user decision. Use a modal dialog to confirm user decisions. Clearly describe the action being confirmed and explain any potential consequences that it may cause. Both the title and the button should reflect the action that will occur. If the action is destructive or irreversible then use a transactional danger modal.
+- Use to confirm a user decision. Clearly describe the action being confirmed and explain any potential consequences that it may cause. Both the title and the button should reflect the action that will occur. If the action is destructive or irreversible then use a transactional danger modal.
 
 ### When to consider alternatives
 - Every time! Before using a modal, consider whether there’s another component that might be less disruptive for the user. Modals should be a last resort.

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -48,7 +48,7 @@ Style guide: components.dialog.react
 - `<Dialog>` makes use of the `<AriaModal>` component maintained by [react-aria-modal docs on Github](https://github.com/davidtheclark/react-aria-modal). The above documented props are only those directly exposed by the `<Dialog>` component, but you can pass props specific to `<AriaModal>` here as well, e.g. you can set the [`scrollDisabled`](https://github.com/davidtheclark/react-aria-modal#scrolldisabled) prop if you'd like to enable scrolling behind the modal window.
 
 ### Accessibility
-- Modal dialog should support keyboard navigation.
+#### Keyboard support
     - `Enter` and `Space` to select the highlighted item.
     - `Tab` to move the focus sequentially through the list of focusable items
     - `Shift + Tab` to move the focus sequentially through the list of focusable items in reversed order

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -53,7 +53,7 @@ Style guide: components.dialog.react
     - `Tab` to move the focus sequentially through the list of focusable items
     - `Shift + Tab` to move the focus sequentially through the list of focusable items in reversed order
 
-### Focus Management
+#### Focus Management
 - When the modal is opened, the entire modal is the default focus state. Most screen readers will announce the entire dialog content.
 - Focus is trapped within the modal and users can then navigate through the dialog actions with the keyboard.
 - Escape will close the modal. To disable exiting when users press the Escape key, set the `escapeExits` prop to `false`

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -49,9 +49,9 @@ Style guide: components.dialog.react
 
 ### Accessibility
 #### Keyboard support
-    - `Enter` and `Space` to select the highlighted item.
-    - `Tab` to move the focus sequentially through the list of focusable items
-    - `Shift + Tab` to move the focus sequentially through the list of focusable items in reversed order
+- `Enter` or `Space` to select the highlighted item.
+- `Tab` to move the focus sequentially through the list of focusable items.
+- `Shift + Tab` to move the focus sequentially through the list of focusable items in reversed order.
 
 #### Focus Management
 - When the modal is opened, the entire modal is the default focus state. Most screen readers will announce the entire dialog content.

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -35,7 +35,8 @@ Style guide: components.dialog.react
 ---
 
 ### When to use
-- Require an immediate response from the user. Use a dialog to request information that is preventing the system from continuing a user-initiated process.
+- Use when you require an immediate response from the user.  
+- Use to request information that is preventing the system from continuing a user-initiated process.
 - Notify the user of urgent information. Use a modal dialog to notify the user of urgent information concerning their current work. Modal dialogs are commonly used to report system errors or convey a consequence of a user’s action.
 - Confirm a user decision. Use a modal dialog to confirm user decisions. Clearly describe the action being confirmed and explain any potential consequences that it may cause. Both the title and the button should reflect the action that will occur. If the action is destructive or irreversible then use a transactional danger modal.
 

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -37,7 +37,7 @@ Style guide: components.dialog.react
 ### When to use
 - Use when you require an immediate response from the user.  
 - Use to request information that is preventing the system from continuing a user-initiated process.
-- Notify the user of urgent information. Use a modal dialog to notify the user of urgent information concerning their current work. Modal dialogs are commonly used to report system errors or convey a consequence of a user’s action.
+- Use to notify the user of urgent information concerning their current work. Modal dialogs are commonly used to report system errors or convey a consequence of a user’s action.
 - Confirm a user decision. Use a modal dialog to confirm user decisions. Clearly describe the action being confirmed and explain any potential consequences that it may cause. Both the title and the button should reflect the action that will occur. If the action is destructive or irreversible then use a transactional danger modal.
 
 ### When to consider alternatives

--- a/packages/design-system/src/components/Dialog/Dialog.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.jsx
@@ -14,6 +14,7 @@ export const Dialog = function (props) {
     closeButtonSize,
     closeButtonVariation,
     closeText,
+    escapeExits,
     escapeExitDisabled,
     headerClassName,
     heading,
@@ -29,6 +30,11 @@ export const Dialog = function (props) {
         `[Deprecated]: Please remove the 'title' prop in <Dialog>, use 'heading' instead. This prop has been renamed and will be removed in a future release.`
       );
     }
+    if (props.escapeExitDisabled) {
+      console.warn(
+        `[Deprecated]: Please remove the 'escapeExitDisabled' prop in <Dialog>, use AriaModal props 'escapeExits' instead. This prop has been renamed and will be removed in a future release.`
+      );
+    }
   }
 
   const dialogClassNames = classNames(
@@ -39,13 +45,16 @@ export const Dialog = function (props) {
   );
   const headerClassNames = classNames('ds-c-dialog__header', headerClassName);
   const actionsClassNames = classNames('ds-c-dialog__actions', actionsClassName);
+  // TODO: remove after deprecating 'escapeExitDiabled' prop
+  const escapeExitsProp = escapeExitDisabled ? !escapeExitDisabled : escapeExits;
 
   /* eslint-disable jsx-a11y/no-redundant-roles */
   return (
     <AriaModal
       dialogClass={dialogClassNames}
+      // TODO: remove 'escapeExits' after deprecating 'escapeExitDiabled' prop so that 'escapeExits' will pass via the 'modalProps' spread operator
+      escapeExits={escapeExitsProp}
       focusDialog
-      escapeExits={!escapeExitDisabled}
       includeDefaultStyles={false}
       onExit={onExit}
       titleId="dialog-title dialog-content"
@@ -89,6 +98,7 @@ Dialog.defaultProps = {
   ariaCloseLabel: 'Close modal dialog',
   closeButtonVariation: 'transparent',
   closeText: 'Close',
+  escapeExits: true,
   escapeExitDisabled: false,
   underlayClickExits: false,
 };
@@ -150,7 +160,13 @@ Dialog.propTypes = {
    */
   closeText: PropTypes.node,
   /**
-   * Disable exiting the dialog when a user presses the Escape key.
+   * Enable exiting the dialog when a user presses the Escape key.
+   * [Read more on react-aria-modal docs.](https://github.com/davidtheclark/react-aria-modal#escapeexits)
+   */
+  escapeExits: PropTypes.bool,
+  /**
+   * @hide-prop [Deprecated] This prop has been renamed to `escapeExits`.
+   * @hide-prop Disable exiting the dialog when a user presses the Escape key.
    */
   escapeExitDisabled: PropTypes.bool,
   /**
@@ -182,6 +198,7 @@ Dialog.propTypes = {
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
    * Enable exiting the dialog when a user clicks the underlay.
+   * [Read more on react-aria-modal docs.](https://github.com/davidtheclark/react-aria-modal#underlayclickexits)
    */
   underlayClickExits: PropTypes.bool,
 };

--- a/packages/design-system/src/components/Dialog/Dialog.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.jsx
@@ -186,6 +186,11 @@ Dialog.propTypes = {
    */
   heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
+   * Set focus to a specific element that should receive initial focus (if `focusDialog={false}`).
+   * [Read more on react-aria-modal docs.](https://github.com/davidtheclark/react-aria-modal#initialfocus)
+   */
+  initialFocus: PropTypes.string,
+  /**
    * A method to handle the state change of exiting (or deactivating)
    * the modal. It will be invoked when the user presses Escape, or clicks outside
    * the dialog (if `underlayClickExits=true`).

--- a/packages/design-system/src/components/Dialog/Dialog.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.jsx
@@ -32,7 +32,7 @@ export const Dialog = function (props) {
     }
     if (props.escapeExitDisabled) {
       console.warn(
-        `[Deprecated]: Please remove the 'escapeExitDisabled' prop in <Dialog>, use AriaModal props 'escapeExits' instead. This prop has been renamed and will be removed in a future release.`
+        `[Deprecated]: Please remove the 'escapeExitDisabled' prop in <Dialog>, use 'escapeExits' instead. This prop has been renamed and will be removed in a future release.`
       );
     }
   }

--- a/packages/design-system/src/components/Dialog/__snapshots__/Dialog.test.jsx.snap
+++ b/packages/design-system/src/components/Dialog/__snapshots__/Dialog.test.jsx.snap
@@ -54,6 +54,7 @@ exports[`Dialog renders react-aria-modal 1`] = `
   closeButtonVariation="transparent"
   closeText="Close"
   escapeExitDisabled={false}
+  escapeExits={true}
   getApplicationNode={
     [MockFunction] {
       "calls": Array [

--- a/packages/design-system/src/types/Dialog/Dialog.d.ts
+++ b/packages/design-system/src/types/Dialog/Dialog.d.ts
@@ -53,8 +53,14 @@ export interface DialogProps {
    */
   closeText?: React.ReactNode;
   /**
-   * Disable exiting the dialog when a user presses the Escape key.
+   * Enable exiting the dialog when a user presses the Escape key.
+   * [Read more on react-aria-modal docs.](https://github.com/davidtheclark/react-aria-modal#escapeexits)
    */
+  escapeExits?: boolean;
+  /**
+    * @hide-prop [Deprecated] This prop has been renamed to `escapeExits`.
+    * @hide-prop Disable exiting the dialog when a user presses the Escape key.
+    */
   escapeExitDisabled?: boolean;
   /**
    * Same as `applicationNode`, but a function that returns the node instead of
@@ -73,9 +79,10 @@ export interface DialogProps {
    */
   heading?: React.ReactNode;
   /**
-   * @hide-prop
+   * Set focus to a specific element that should receive initial focus (if `focusDialog={false}`).
+   * [Read more on react-aria-modal docs.](https://github.com/davidtheclark/react-aria-modal#initialfocus)
    */
-  id?: string;
+  initialFocus?: string;
   /**
    * A method to handle the state change of exiting (or deactivating)
    * the modal. It will be invoked when the user presses Escape, or clicks outside

--- a/packages/design-system/src/types/Dialog/Dialog.d.ts
+++ b/packages/design-system/src/types/Dialog/Dialog.d.ts
@@ -101,7 +101,7 @@ export interface DialogProps {
   /**
    * Allow additional AriaModal props to be passed to Dialog
    */
-  additional_props?: Record<string, unknown>;
+  [additional_props: string]: unknown;
 }
 
 type OmitProps = 'size' | 'title';

--- a/packages/design-system/src/types/Dialog/Dialog.d.ts
+++ b/packages/design-system/src/types/Dialog/Dialog.d.ts
@@ -98,6 +98,10 @@ export interface DialogProps {
    * Enable exiting the dialog when a user clicks the underlay.
    */
   underlayClickExits?: boolean;
+  /**
+   * Allow additional AriaModal props to be passed to Dialog
+   */
+  additional_props?: Record<string, unknown>;
 }
 
 type OmitProps = 'size' | 'title';


### PR DESCRIPTION
## Summary
Update `<Dialog>` to better document and expose options for customizing `<AriaModal>`, namely the focus behavior.

- Update `<AriaModal>` prop documentation to link to `react-aria-modal` documentation
- Add prop documentation for other common <AriaModal> props like `initialFocus`
- Deprecate `escapeExitDisabled` in favor of using `escapeExits` directly. `escapeExits` would be documented similarly to `initialFocus` and other AriaModal props
- Add UI and accessibility guidance to the Dialog on managing focus
- Ensure typescript defs are updated

Fixes: #901

## How to test
- Go to demo test site: http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-719/update-dialog-props-focus-behavior
- Test that `Dialog` component and `Third party external link` pattern works
- Test using create-react-app-typescript and ensure that the typescript definition for `AriaModal` props that are not surfaced by `Dialog` are working (eg. the `scrollDisabled` prop)

