### PR TITLE
[WNMGDS-850] Fix tooltip trigger link styles

### DIFF
--- a/packages/design-system-docs/src/pages/components/Tooltip/Tooltip.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Tooltip/Tooltip.example.jsx
@@ -21,7 +21,7 @@ ReactDOM.render(
         <Tooltip
           className="ds-c-tooltip__trigger-link"
           component="a"
-          title="Tooltip trigger uses <a> for the trigger, styled with dashed underline"
+          title="Tooltip trigger uses <a> for the trigger, styled with dotted underline"
         >
           inline trigger
         </Tooltip>
@@ -90,7 +90,7 @@ ReactDOM.render(
             className="ds-c-tooltip__trigger-link"
             component="a"
             inversed
-            title="Tooltip trigger uses <a> for the trigger, styled with dashed underline"
+            title="Tooltip trigger uses <a> for the trigger, styled with dotted underline"
           >
             inline trigger
           </Tooltip>

--- a/packages/design-system-docs/src/pages/components/Tooltip/_Tooltip.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Tooltip/_Tooltip.docs.scss
@@ -53,14 +53,14 @@ Style guide: components.tooltip.tooltip-icon
 
 The following Sass variables can be overridden to theme choice fields:
 
-- `$tooltip-icon-size`
-- `$tooltip-arrow-size`
-- `$tooltip-plus-border-size`
-- `$tooltip-border-radius`
-- `$tooltip-color`
-- `$tooltip-background-color`
-- `$tooltip-color-inverse`
-- `$tooltip-background-color-inverse`
+- `$tooltip-icon-size` - Width/height of the icon used to trigger the tooltip
+- `$tooltip-arrow-size` - Width/height of the arrow on the tooltip
+- `$tooltip-icon-container-size` - Width/height of the containing element of the tooltip icon
+- `$tooltip-border-radius` - Border radius for the tooltip dialog
+- `$tooltip-text-color` - Text color for the tooltip content
+- `$tooltip-background-color` - Background color for the tooltip dialog
+- `$tooltip-text-color-inverse` - Text color for inverse tooltip content
+- `$tooltip-background-color-inverse` - Background color for the inverse tooltip dialog
 
 Style guide: components.tooltip.guidance
 */

--- a/packages/design-system/src/styles/base/_link.scss
+++ b/packages/design-system/src/styles/base/_link.scss
@@ -85,7 +85,7 @@
   //
   // Specifically exclude '.ds-c-button' because this is most likely case where
   // a inverse link element will have other styles applied
-  .ds-base--inverse a:not(.ds-c-button) {
+  .ds-base--inverse a:not(.ds-c-button):not(.ds-c-tooltip__trigger-link) {
     @extend %link-inverse;
   }
 }

--- a/packages/design-system/src/styles/base/_link.scss
+++ b/packages/design-system/src/styles/base/_link.scss
@@ -85,6 +85,8 @@
   //
   // Specifically exclude '.ds-c-button' because this is most likely case where
   // a inverse link element will have other styles applied
+  // Also exclude '.ds-c-tooltip__trigger-link' as we need to set
+  // text decoration styles for the tooltip trigger links
   .ds-base--inverse a:not(.ds-c-button):not(.ds-c-tooltip__trigger-link) {
     @extend %link-inverse;
   }

--- a/packages/design-system/src/styles/components/_Tooltip.scss
+++ b/packages/design-system/src/styles/components/_Tooltip.scss
@@ -1,4 +1,5 @@
 @import '../settings/index.scss';
+@import '../base/link.scss';
 
 $tooltip-icon-size: 16px !default;
 $tooltip-arrow-size: 8px !default;
@@ -21,8 +22,16 @@ $tooltip-background-color-inverse: $color-background !default;
 %trigger-underline-styles {
   text-decoration: underline;
   text-decoration-style: dotted;
-  text-underline-offset: 2px;
+  text-underline-position: under;
 }
+/* stylelint-disable media-feature-value-dollar-variable */
+// Chrome needs this offset becasue it handles text-underline-position differently and without this the underline runs into descending letters like g,j,q,p,y.
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  %trigger-underline-styles {
+    text-underline-offset: 2px;
+  }
+}
+/* stylelint-enable media-feature-value-dollar-variable */
 
 // stylelint-disable selector-no-qualifying-type
 // Tooltip trigger style

--- a/packages/design-system/src/styles/components/_Tooltip.scss
+++ b/packages/design-system/src/styles/components/_Tooltip.scss
@@ -3,12 +3,12 @@
 
 $tooltip-icon-size: 16px !default;
 $tooltip-arrow-size: 8px !default;
-$tooltip-plus-border-size: 24px !default;
+$tooltip-icon-container-size: 24px !default;
 
 $tooltip-border-radius: 4px !default;
-$tooltip-color: $color-base-inverse !default;
+$tooltip-text-color: $color-base-inverse !default;
 $tooltip-background-color: $color-background-inverse !default;
-$tooltip-color-inverse: $color-base !default;
+$tooltip-text-color-inverse: $color-base !default;
 $tooltip-background-color-inverse: $color-background !default;
 
 %trigger-reset-styles {
@@ -80,7 +80,7 @@ $tooltip-background-color-inverse: $color-background !default;
 
 // Interior content of tooltip
 .ds-c-tooltip__content {
-  color: $tooltip-color;
+  color: $tooltip-text-color;
   display: block;
   font-size: $small-font-size;
   font-weight: 400;
@@ -190,6 +190,6 @@ $tooltip-background-color-inverse: $color-background !default;
   }
 
   .ds-c-tooltip__content {
-    color: $tooltip-color-inverse;
+    color: $tooltip-text-color-inverse;
   }
 }

--- a/packages/design-system/src/styles/components/_Tooltip.scss
+++ b/packages/design-system/src/styles/components/_Tooltip.scss
@@ -18,6 +18,12 @@ $tooltip-background-color-inverse: $color-background !default;
   margin: 0;
 }
 
+%trigger-underline-styles {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
 // stylelint-disable selector-no-qualifying-type
 // Tooltip trigger style
 .ds-c-tooltip__trigger {
@@ -34,11 +40,17 @@ $tooltip-background-color-inverse: $color-background !default;
 
 .ds-c-tooltip__trigger-link {
   @extend %trigger-reset-styles;
+  @extend %trigger-underline-styles;
   color: $color-primary;
   padding: 0;
-  text-decoration: underline;
-  text-decoration-style: dashed;
 }
+
+// stylelint-disable-next-line selector-class-pattern
+.ds-base--inverse .ds-c-tooltip__trigger-link {
+  @extend %link-inverse;
+  @extend %trigger-underline-styles;
+}
+
 // stylelint-enable selector-no-qualifying-type
 
 // Tooltip arrow

--- a/packages/design-system/src/styles/components/_Tooltip.scss
+++ b/packages/design-system/src/styles/components/_Tooltip.scss
@@ -28,7 +28,7 @@ $tooltip-background-color-inverse: $color-background !default;
 // Chrome needs this offset becasue it handles text-underline-position differently and without this the underline runs into descending letters like g,j,q,p,y.
 @media all and (-webkit-min-device-pixel-ratio: 0) and (min-resolution: 0.001dpcm) {
   %trigger-underline-styles {
-    text-underline-offset: 2px;
+    text-underline-offset: 4px;
   }
 }
 /* stylelint-enable  */

--- a/packages/design-system/src/styles/components/_Tooltip.scss
+++ b/packages/design-system/src/styles/components/_Tooltip.scss
@@ -24,14 +24,14 @@ $tooltip-background-color-inverse: $color-background !default;
   text-decoration-style: dotted;
   text-underline-position: under;
 }
-/* stylelint-disable media-feature-value-dollar-variable */
+/* stylelint-disable  */
 // Chrome needs this offset becasue it handles text-underline-position differently and without this the underline runs into descending letters like g,j,q,p,y.
-@media screen and (-webkit-min-device-pixel-ratio: 0) {
+@media all and (-webkit-min-device-pixel-ratio: 0) and (min-resolution: 0.001dpcm) {
   %trigger-underline-styles {
     text-underline-offset: 2px;
   }
 }
-/* stylelint-enable media-feature-value-dollar-variable */
+/* stylelint-enable  */
 
 // stylelint-disable selector-no-qualifying-type
 // Tooltip trigger style

--- a/packages/design-system/src/styles/components/_TooltipIcon.scss
+++ b/packages/design-system/src/styles/components/_TooltipIcon.scss
@@ -4,10 +4,10 @@
   border-radius: 100%;
   box-sizing: border-box;
   display: inline-block;
-  height: $tooltip-plus-border-size;
+  height: $tooltip-icon-container-size;
   position: relative;
   vertical-align: middle;
-  width: $tooltip-plus-border-size;
+  width: $tooltip-icon-container-size;
 
   &:hover {
     border-color: $color-gray-lighter;


### PR DESCRIPTION
## Summary
[WNGMDS-850](https://jira.cms.gov/browse/WNMGDS-850)

There are two trigger link changes in this PR for trigger link styles.

(1) Based on Bernard's conversation [here](https://github.com/CMSgov/design-system/pull/971#discussion_r594705783) with @LouisFettet , the previous dashed underline made the trigger difficult to read.

**This is the example Louis showed of what a trigger looks like on hc.gov:**
![image](https://user-images.githubusercontent.com/21293083/112369396-86e2a600-8cb2-11eb-8641-b34c9a37651a.png)

**And this is what it looked like in the original Tooltip PR:**
![image](https://user-images.githubusercontent.com/21293083/112369496-9feb5700-8cb2-11eb-8a13-205b95dab2ed.png)

This PR introduces a compromise between changing to `border-bottom` and the issue of the thick dashed underline being hard to read. Instead of using `dashed`, I discussed with Bernard using `dotted`, because it actually looks more like the dashed underline in Louis's example above. 

**Below is dotted:**
![image](https://user-images.githubusercontent.com/21293083/112369551-ac6faf80-8cb2-11eb-965f-f4b2a27d958e.png)

Also, I made use of the text-underline-offset to make the text easier to read. (Note: I don't think IE supports this).

(2) Based on my original review of Bernard's PR (read here), the inverse trigger link was not showing dashed, and was showing a solid underline. This PR attempts to fix this by excluding `.ds-c-tooltip__trigger-link` from the general CSS rule for .ds-base--inverse and explicitly setting the text decoration in the Tooltip SCSS file.

**Before:**
![image](https://user-images.githubusercontent.com/21293083/112369628-c7daba80-8cb2-11eb-9284-92f9f6697beb.png)

**After:**
![image](https://user-images.githubusercontent.com/21293083/112369596-bd202580-8cb2-11eb-8751-b468f8b92cb0.png)

## How to test
View [http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-850/fix-tooltip-trigger-styles](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-850/fix-tooltip-trigger-styles) in multiple browsers. Ensure the dotted underline for the trigger is acceptable, and that the text is easier to read.

Also make sure the inverse trigger is no longer a solid underline.
