### PR TITLE
[WNMGDS-830] Update icon for success alert

### DIFF
--- a/packages/design-system-docs/src/pages/components/Alert/_Alert.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Alert/_Alert.docs.scss
@@ -64,6 +64,13 @@ Style guide: components.alert.react
 - Alerts should give users adequate time to review and comprehend the provided information. Avoid hiding alerts using a timer.
 - Include a mechanism like a button to dismiss alerts where appropriate.
 
+### Customization
+The following Sass variables can be overridden to theme alerts:
+
+- `$alert-padding` - Used to provide padding for the alert element
+- `$alert-bar-size` - Used to control the width of the left bar on the alert
+- `$alert-icon-size` - Used to control the size of the alert icon
+
 ### Learn more
 
 - [18F Content Guide \- Active voice](https://content-guide.18f.gov/active-voice/)

--- a/packages/design-system/src/styles/components/_Alert.scss
+++ b/packages/design-system/src/styles/components/_Alert.scss
@@ -1,5 +1,9 @@
 @import '../settings/index.scss';
 
+$alert-padding: $spacer-2;
+$alert-bar-size: $spacer-1;
+$alert-icon-size: $spacer-5;
+
 // Links on darker backgrounds that aren't quite dark as inverse
 %link-darker {
   color: $color-primary-darker;
@@ -40,10 +44,6 @@
     }
   }
 }
-
-$alert-padding: $spacer-2;
-$alert-bar-size: $spacer-1;
-$alert-icon-size: $spacer-5;
 
 .ds-c-alert {
   background-color: $color-primary-alt-lightest;
@@ -116,6 +116,6 @@ $alert-icon-size: $spacer-5;
 
 .ds-c-alert--success {
   background-color: $color-success-lightest;
-  background-image: url('#{$image-path}/success.svg');
+  background-image: url('#{$image-path}/success-fill.svg');
   border-color: $color-success;
 }


### PR DESCRIPTION
## Summary
Updating the icon used for the success alert to be more consistent with the the icons being used 

### Added
- Added alert variables to the documentation page for theming

### Changed
- Changed the success alerts icon to used the checkmark that's filled

## How to test
View the alert page and see that the success alert is using the filled check icon and matches the style of the others
**You'll need to run the site locally because icons don't show on the demo URLs**
