### PR TITLE
[WNMGDS-880] Tooltip examples displaying warning message

### DIFF
--- a/packages/design-system-docs/src/pages/components/Tooltip/Tooltip.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Tooltip/Tooltip.example.jsx
@@ -16,7 +16,7 @@ ReactDOM.render(
       </Tooltip>
     </div>
     <div className="ds-u-display--flex ds-u-align-items--center ds-u-margin-y--2">
-      <p className="ds-u-margin--0">
+      <div className="ds-u-margin--0">
         {'Tooltip with '}
         <Tooltip
           className="ds-c-tooltip__trigger-link"
@@ -25,7 +25,7 @@ ReactDOM.render(
         >
           inline trigger
         </Tooltip>
-      </p>
+      </div>
     </div>
     <div className="ds-u-display--flex ds-u-align-items--center ds-u-margin-y--2">
       <Tooltip placement="right" className="ds-c-button" title="Tooltip positioned on the right">
@@ -84,7 +84,7 @@ ReactDOM.render(
         </Tooltip>
       </div>
       <div className="">
-        <p className="ds-u-margin--0">
+        <div className="ds-u-margin--0">
           {'Inverse tooltip with '}
           <Tooltip
             className="ds-c-tooltip__trigger-link"
@@ -94,7 +94,7 @@ ReactDOM.render(
           >
             inline trigger
           </Tooltip>
-        </p>
+        </div>
       </div>
     </div>
   </>,


### PR DESCRIPTION
## Summary
When viewing the Tooltip component on localhost, a warning message of `<div> cannot appear as a descendant of <p>` is showing up on developer console. `<div> inside of <p>` is not valid HTML and should be avoided.

### Changed
Changed tooltip examples to be wrapped by `<div>` instead of `<p>`

## How to test
Test design system document site on local system (localhost) and view Tooltip component examples to ensure that there's no warning messages shown on the developer console.
