### PR TITLE
[WNMGDS-876] Only include aria-describedby on non-interactive content Tooltips

### DIFF
--- a/packages/design-system/src/components/Tooltip/Tooltip.jsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.jsx
@@ -161,7 +161,7 @@ export class Tooltip extends React.Component {
       <TriggerComponent
         type={TriggerComponent === 'button' ? 'button' : undefined}
         aria-label={ariaLabel || ''}
-        aria-describedby={this.id}
+        aria-describedby={dialog ? null : this.id}
         className={triggerClasses}
         ref={this.setTriggerElement}
         {...others}

--- a/packages/design-system/src/components/Tooltip/Tooltip.jsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.jsx
@@ -200,7 +200,7 @@ export class Tooltip extends React.Component {
         };
 
     const tooltipContent = () => (
-      <span
+      <div
         id={this.id}
         tabIndex={dialog ? '-1' : null}
         ref={this.setTooltipElement}
@@ -214,11 +214,11 @@ export class Tooltip extends React.Component {
         {...eventHandlers}
       >
         <span className="ds-c-tooltip__arrow" data-popper-arrow />
-        <span className="ds-c-tooltip__content ds-base">{title}</span>
+        <div className="ds-c-tooltip__content ds-base">{title}</div>
         {!dialog && (
           <span className="ds-c-tooltip__interactive-border" style={interactiveBorderStyle} />
         )}
-      </span>
+      </div>
     );
     return (
       <CSSTransition in={this.state.active} classNames="ds-c-tooltip" timeout={transitionDuration}>
@@ -259,10 +259,10 @@ export class Tooltip extends React.Component {
         };
 
     return (
-      <span {...eventHandlers}>
+      <div className="ds-c-tooltip__container" {...eventHandlers}>
         {this.renderTrigger()}
         {this.renderContent()}
-      </span>
+      </div>
     );
   }
 }

--- a/packages/design-system/src/components/Tooltip/Tooltip.jsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.jsx
@@ -160,8 +160,8 @@ export class Tooltip extends React.Component {
     return (
       <TriggerComponent
         type={TriggerComponent === 'button' ? 'button' : undefined}
-        aria-label={ariaLabel || ''}
-        aria-describedby={dialog ? '' : this.id}
+        aria-label={ariaLabel || undefined}
+        aria-describedby={dialog ? undefined : this.id}
         className={triggerClasses}
         ref={this.setTriggerElement}
         {...others}

--- a/packages/design-system/src/components/Tooltip/Tooltip.jsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.jsx
@@ -161,7 +161,7 @@ export class Tooltip extends React.Component {
       <TriggerComponent
         type={TriggerComponent === 'button' ? 'button' : undefined}
         aria-label={ariaLabel || ''}
-        aria-describedby={dialog ? null : this.id}
+        aria-describedby={dialog ? '' : this.id}
         className={triggerClasses}
         ref={this.setTriggerElement}
         {...others}

--- a/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.jsx.snap
+++ b/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.jsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip renders custom trigger component 1`] = `
-<span
+<div
+  className="ds-c-tooltip__container"
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 >
@@ -23,7 +24,7 @@ exports[`Tooltip renders custom trigger component 1`] = `
     in={false}
     timeout={250}
   >
-    <span
+    <div
       aria-hidden={true}
       className="ds-c-tooltip"
       data-placement="top"
@@ -42,11 +43,11 @@ exports[`Tooltip renders custom trigger component 1`] = `
         className="ds-c-tooltip__arrow"
         data-popper-arrow={true}
       />
-      <span
+      <div
         className="ds-c-tooltip__content ds-base"
       >
         Tooltip body content
-      </span>
+      </div>
       <span
         className="ds-c-tooltip__interactive-border"
         style={
@@ -58,13 +59,14 @@ exports[`Tooltip renders custom trigger component 1`] = `
           }
         }
       />
-    </span>
+    </div>
   </CSSTransition>
-</span>
+</div>
 `;
 
 exports[`Tooltip renders default trigger icon 1`] = `
-<span
+<div
+  className="ds-c-tooltip__container"
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 >
@@ -85,7 +87,7 @@ exports[`Tooltip renders default trigger icon 1`] = `
     in={false}
     timeout={250}
   >
-    <span
+    <div
       aria-hidden={true}
       className="ds-c-tooltip"
       data-placement="top"
@@ -104,11 +106,11 @@ exports[`Tooltip renders default trigger icon 1`] = `
         className="ds-c-tooltip__arrow"
         data-popper-arrow={true}
       />
-      <span
+      <div
         className="ds-c-tooltip__content ds-base"
       >
         Tooltip body content
-      </span>
+      </div>
       <span
         className="ds-c-tooltip__interactive-border"
         style={
@@ -120,13 +122,15 @@ exports[`Tooltip renders default trigger icon 1`] = `
           }
         }
       />
-    </span>
+    </div>
   </CSSTransition>
-</span>
+</div>
 `;
 
 exports[`Tooltip renders dialog tooltip 1`] = `
-<span>
+<div
+  className="ds-c-tooltip__container"
+>
   <button
     aria-describedby="trigger_4"
     aria-label=""
@@ -153,7 +157,7 @@ exports[`Tooltip renders dialog tooltip 1`] = `
       }
       paused={false}
     >
-      <span
+      <div
         aria-hidden={true}
         className="ds-c-tooltip"
         data-placement="top"
@@ -171,19 +175,20 @@ exports[`Tooltip renders dialog tooltip 1`] = `
           className="ds-c-tooltip__arrow"
           data-popper-arrow={true}
         />
-        <span
+        <div
           className="ds-c-tooltip__content ds-base"
         >
           Tooltip body content
-        </span>
-      </span>
+        </div>
+      </div>
     </FocusTrap>
   </CSSTransition>
-</span>
+</div>
 `;
 
 exports[`Tooltip renders inverse tooltip 1`] = `
-<span
+<div
+  className="ds-c-tooltip__container"
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 >
@@ -204,7 +209,7 @@ exports[`Tooltip renders inverse tooltip 1`] = `
     in={false}
     timeout={250}
   >
-    <span
+    <div
       aria-hidden={true}
       className="ds-c-tooltip ds-c-tooltip--inverse"
       data-placement="top"
@@ -223,11 +228,11 @@ exports[`Tooltip renders inverse tooltip 1`] = `
         className="ds-c-tooltip__arrow"
         data-popper-arrow={true}
       />
-      <span
+      <div
         className="ds-c-tooltip__content ds-base"
       >
         Tooltip body content
-      </span>
+      </div>
       <span
         className="ds-c-tooltip__interactive-border"
         style={
@@ -239,7 +244,7 @@ exports[`Tooltip renders inverse tooltip 1`] = `
           }
         }
       />
-    </span>
+    </div>
   </CSSTransition>
-</span>
+</div>
 `;

--- a/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.jsx.snap
+++ b/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.jsx.snap
@@ -8,7 +8,6 @@ exports[`Tooltip renders custom trigger component 1`] = `
 >
   <a
     aria-describedby="trigger_3"
-    aria-label=""
     className="ds-base ds-c-tooltip__trigger ds-c-tooltip__trigger-icon"
     onBlur={[Function]}
     onClick={[Function]}
@@ -72,7 +71,6 @@ exports[`Tooltip renders default trigger icon 1`] = `
 >
   <button
     aria-describedby="trigger_1"
-    aria-label=""
     className="ds-base ds-c-tooltip__trigger ds-c-tooltip__trigger-icon"
     onBlur={[Function]}
     onClick={[Function]}
@@ -132,8 +130,6 @@ exports[`Tooltip renders dialog tooltip 1`] = `
   className="ds-c-tooltip__container"
 >
   <button
-    aria-describedby=""
-    aria-label=""
     className="ds-base ds-c-tooltip__trigger ds-c-tooltip__trigger-icon"
     onClick={[Function]}
     onTouchStart={[Function]}
@@ -194,7 +190,6 @@ exports[`Tooltip renders inverse tooltip 1`] = `
 >
   <button
     aria-describedby="trigger_2"
-    aria-label=""
     className="ds-base ds-c-tooltip__trigger ds-c-tooltip__trigger-icon"
     onBlur={[Function]}
     onClick={[Function]}

--- a/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.jsx.snap
+++ b/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.jsx.snap
@@ -132,7 +132,7 @@ exports[`Tooltip renders dialog tooltip 1`] = `
   className="ds-c-tooltip__container"
 >
   <button
-    aria-describedby="trigger_4"
+    aria-describedby={null}
     aria-label=""
     className="ds-base ds-c-tooltip__trigger ds-c-tooltip__trigger-icon"
     onClick={[Function]}

--- a/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.jsx.snap
+++ b/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.jsx.snap
@@ -132,7 +132,7 @@ exports[`Tooltip renders dialog tooltip 1`] = `
   className="ds-c-tooltip__container"
 >
   <button
-    aria-describedby={null}
+    aria-describedby=""
     aria-label=""
     className="ds-base ds-c-tooltip__trigger ds-c-tooltip__trigger-icon"
     onClick={[Function]}

--- a/packages/design-system/src/styles/components/_Tooltip.scss
+++ b/packages/design-system/src/styles/components/_Tooltip.scss
@@ -19,6 +19,10 @@ $tooltip-background-color-inverse: $color-background !default;
   margin: 0;
 }
 
+.ds-c-tooltip__container {
+  display: inline;
+}
+
 %trigger-underline-styles {
   text-decoration: underline;
   text-decoration-style: dotted;


### PR DESCRIPTION
## Summary
There was an issue noted by DK in [this pr](https://github.com/CMSgov/design-system/pull/979#issuecomment-808540772) where the screenreader was announcing the hidden content of interactive tooltips.

This is due to the fact that `aria-describedby` will announce the contents of items, even if they are hidden and have `aria-hidden` = true.

The non-interactive tooltips need `aria-describedby` because as you tab through them, the tooltip appears and we need the content of the tooltip to be read. However, for interactive tooltips, we do not want the content announced until the element is un-hidden, so we do not need `aria-describedby`

### Changed
`aria-describedby` will now only be included on items that do not include the `dialog` prop (non-interactive tooltips)

## How to test
- FIrst view the tooltip locally on master with the screenreader on
- As you tab through, the content of the interactive tooltip is announced, even though the tooltip is not displayed
- View http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNGMDS-876/Tooltip-screenreader-issue
- The content of the non-interactive tooltips should still be announced as you tab through
- The content of the interactive tooltip should not be announced until you hit spacebar to show the tooltip