### PR TITLE
[WNMGDS-888] Update beta analytics help drawer

### DIFF
--- a/packages/design-system-docs/src/pages/components/Alert/_Alert.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Alert/_Alert.docs.scss
@@ -31,6 +31,114 @@ Style guide: components.alert.react
 */
 
 /*
+Analytics events
+
+<table class="ds-c-table ds-c-table--compact">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">onComponentDidMount</code></td>
+      <td><code>bool, or object</code></td>
+      <td>
+        <p>Track alert opened event</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<h4>Analytics event object</h4>
+
+<table class="ds-c-table ds-c-table--compact">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">event_name</code></td>
+      <td><code>string</code></td>
+      <td>onComponentDidMount: <code>'alert_impression'</code></td>
+      <td>
+        <p>When provided, override text to display as the event name</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">event_type</code></td>
+      <td><code>string</code></td>
+      <td><code>'ui interaction'</code></td>
+      <td>
+        <p>When provided, override text to display as the event type</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">ga_eventAction</code></td>
+      <td><code>string</code></td>
+      <td>onComponentDidMount: <code>'alert impression'</code></td>
+      <td>
+        <p>When provided, override text to display as the event action</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">ga_eventCategory</code></td>
+      <td><code>string</code></td>
+      <td><code>'ui components'</code></td>
+      <td>
+        <p>When provided, override text to display as the event category</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">ga_eventLabel</code></td>
+      <td><code>string</code></td>
+      <td>Alert prop: <code>heading or children</code></td>
+      <td>
+        <p>When provided, override text to display as the event label</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code class="ds-u-font-weight--bold">ga_eventType</code>
+      </td>
+      <td><code>string</code></td>
+      <td>cmsds</td>
+      <td>
+        <p>When provided, override text to display as the event type</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code class="ds-u-font-weight--bold">ga_eventValue</code>
+      </td>
+      <td><code>string</code></td>
+      <td></td>
+      <td>
+        <p>When provided, override text to display as the event value</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">heading</code></td>
+      <td><code>string</code></td>
+      <td>Alert prop: <code>heading or children</code></td>
+      <td>
+        <p>When provided, override text to display as the heading</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+Style guide: components.alert.analytics-object
+*/
+
+/*
 ---
 
 ### When to use

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -32,6 +32,121 @@ Style guide: components.dialog.react
 */
 
 /*
+Analytics events
+
+<table class="ds-c-table ds-c-table--compact">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">onComponentDidMount</code></td>
+      <td><code>bool, or object</code></td>
+      <td>
+        <p>Track modal dialog opened event</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">onComponentWillUnmount</code></td>
+      <td><code>bool, or object</code></td>
+      <td>
+        <p>Track modal dialog closed event</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<h4>Analytics event object</h4>
+
+<table class="ds-c-table ds-c-table--compact">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">event_name</code></td>
+      <td><code>string</code></td>
+      <td>onComponentDidMount: <code>'modal_impression'</code>, or onComponentWillUnmount: <code>'modal_closed'</code></td>
+      <td>
+        <p>When provided, override text to display as the event name</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">event_type</code></td>
+      <td><code>string</code></td>
+      <td><code>'ui interaction'</code></td>
+      <td>
+        <p>When provided, override text to display as the event type</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">ga_eventAction</code></td>
+      <td><code>string</code></td>
+      <td>onComponentDidMount: <code>'modal impression'</code>, or onComponentWillUnmount: <code>'closed modal'</code></td>
+      <td>
+        <p>When provided, override text to display as the event action</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">ga_eventCategory</code></td>
+      <td><code>string</code></td>
+      <td><code>'ui components'</code></td>
+      <td>
+        <p>When provided, override text to display as the event category</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">ga_eventLabel</code></td>
+      <td><code>string</code></td>
+      <td>Dialog prop: <code>heading or title</code></td>
+      <td>
+        <p>When provided, override text to display as the event label</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code class="ds-u-font-weight--bold">ga_eventType</code>
+      </td>
+      <td><code>string</code></td>
+      <td>cmsds</td>
+      <td>
+        <p>When provided, override text to display as the event type</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code class="ds-u-font-weight--bold">ga_eventValue</code>
+      </td>
+      <td><code>string</code></td>
+      <td></td>
+      <td>
+        <p>When provided, override text to display as the event value</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">heading</code></td>
+      <td><code>string</code></td>
+      <td>Dialog prop: <code>heading or title</code></td>
+      <td>
+        <p>When provided, override text to display as the heading</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+Style guide: components.dialog.analytics-object
+*/
+
+/*
 ---
 
 ### Related patterns

--- a/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
@@ -17,6 +17,14 @@ Style guide: patterns.external-link.react
 */
 
 /*
+Analytics events
+
+- Refer to [Modal Dialog]({{root}}/components/dialog) for details of the Analytics props
+
+Style guide: patterns.external-link.analytics-object
+*/
+
+/*
 ---
 
 Use this pattern when the user is in the middle of a task or application to let them know that the action they are taking will move them away from the current site and or process. This serves as a warning where the user can then decide to remain where they are in the application or process.

--- a/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
+++ b/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
@@ -37,7 +37,7 @@ Style guide: components.help-drawer.react-help-drawer-toggle
 /*
 Analytics events
 
-<table class="ds-c-table">
+<table class="ds-c-table ds-c-table--compact">
   <thead>
     <tr>
       <th>Name</th>
@@ -65,7 +65,7 @@ Analytics events
 
 <h4>Analytics event object</h4>
 
-<table class="ds-c-table">
+<table class="ds-c-table ds-c-table--compact">
   <thead>
     <tr>
       <th>Name</th>

--- a/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
+++ b/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
@@ -76,11 +76,19 @@ Analytics events
   </thead>
   <tbody>
     <tr>
-      <td><code class="ds-u-font-weight--bold">ga_eventCategory</code></td>
+      <td><code class="ds-u-font-weight--bold">event_name</code></td>
       <td><code>string</code></td>
-      <td><code>'content tools'</code></td>
+      <td><code>'help_drawer_opened'</code></td>
       <td>
-        <p>When provided, override text to display as the event category</p>
+        <p>When provided, override text to display as the event name</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">event_type</code></td>
+      <td><code>string</code></td>
+      <td><code>'ui interaction'</code></td>
+      <td>
+        <p>When provided, override text to display as the event type</p>
       </td>
     </tr>
     <tr>
@@ -89,6 +97,14 @@ Analytics events
       <td>onComponentDidMount: <code>'opened help drawer'</code>, or onComponentWillUnmount: <code>'closed help drawer'</code></td>
       <td>
         <p>When provided, override text to display as the event action</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">ga_eventCategory</code></td>
+      <td><code>string</code></td>
+      <td><code>'ui components'</code></td>
+      <td>
+        <p>When provided, override text to display as the event category</p>
       </td>
     </tr>
     <tr>
@@ -103,12 +119,32 @@ Analytics events
     </tr>
     <tr>
       <td>
+        <code class="ds-u-font-weight--bold">ga_eventType</code>
+      </td>
+      <td><code>string</code></td>
+      <td>cmsds</td>
+      <td>
+        <p>When provided, override text to display as the event type</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code class="ds-u-font-weight--bold">ga_eventValue</code>
       </td>
       <td><code>string</code></td>
       <td></td>
       <td>
         <p>When provided, override text to display as the event value</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code class="ds-u-font-weight--bold">heading</code></td>
+      <td><code>string</code></td>
+      <td>
+        HelpDrawer prop: <code>heading or title</code>
+      </td>
+      <td>
+        <p>When provided, override text to display as the heading</p>
       </td>
     </tr>
   </tbody>

--- a/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
+++ b/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
@@ -78,7 +78,7 @@ Analytics events
     <tr>
       <td><code class="ds-u-font-weight--bold">event_name</code></td>
       <td><code>string</code></td>
-      <td><code>'help_drawer_opened'</code></td>
+      <td>onComponentDidMount: <code>'help_drawer_opened'</code>, or onComponentWillUnmount: <code>'help_drawer_closed'</code></td>
       <td>
         <p>When provided, override text to display as the event name</p>
       </td>
@@ -110,9 +110,7 @@ Analytics events
     <tr>
       <td><code class="ds-u-font-weight--bold">ga_eventLabel</code></td>
       <td><code>string</code></td>
-      <td>
-        HelpDrawer prop: <code>heading or title</code>
-      </td>
+      <td>HelpDrawer prop: <code>heading or title</code></td>
       <td>
         <p>When provided, override text to display as the event label</p>
       </td>
@@ -140,9 +138,7 @@ Analytics events
     <tr>
       <td><code class="ds-u-font-weight--bold">heading</code></td>
       <td><code>string</code></td>
-      <td>
-        HelpDrawer prop: <code>heading or title</code>
-      </td>
+      <td>HelpDrawer prop: <code>heading or title</code></td>
       <td>
         <p>When provided, override text to display as the heading</p>
       </td>

--- a/packages/design-system-scripts/gulp/docs/__tests__/__snapshots__/generateHtmlExample.test.js.snap
+++ b/packages/design-system-scripts/gulp/docs/__tests__/__snapshots__/generateHtmlExample.test.js.snap
@@ -5,10 +5,8 @@ Object {
   "body": "<button>Foo</button>
   <script type=\\"text/javascript\\" src=\\"/example.js\\"></script>",
   "head": "<title>Example: components.button</title>
-    <link rel=\\"stylesheet\\" href=\\"/example.css\\" />
-    <link href=\\"https://fonts.googleapis.com/css?family=Roboto+Mono:400,700\\" rel=\\"stylesheet\\" />
-    
-  ",
+  <link rel=\\"stylesheet\\" href=\\"/example.css\\" />
+  <link href=\\"https://fonts.googleapis.com/css?family=Roboto+Mono:400,700\\" rel=\\"stylesheet\\" />",
   "uri": "example/components.button.primary",
 }
 `;
@@ -18,10 +16,8 @@ Object {
   "body": "<button>Foo</button>
   <script type=\\"text/javascript\\" src=\\"/example.js\\"></script>",
   "head": "<title>Example: components.button</title>
-    <link rel=\\"stylesheet\\" href=\\"/example.css\\" />
-    <link href=\\"https://fonts.googleapis.com/css?family=Roboto+Mono:400,700\\" rel=\\"stylesheet\\" />
-    
-  ",
+  <link rel=\\"stylesheet\\" href=\\"/example.css\\" />
+  <link href=\\"https://fonts.googleapis.com/css?family=Roboto+Mono:400,700\\" rel=\\"stylesheet\\" />",
   "uri": "example/components.button",
 }
 `;

--- a/packages/design-system-scripts/gulp/docs/generatePages/generateHtmlExample.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/generateHtmlExample.js
@@ -1,5 +1,4 @@
 const savePage = require('./savePage');
-const createAnalyticsTag = require('./createAnalyticsTag');
 
 /**
  * Process template tags in KSS markup
@@ -42,10 +41,8 @@ function generateHtmlExample(page, modifier, docsPath, options) {
   if (modifier) id += `.${modifier.name}`;
 
   const head = `<title>Example: ${page.reference}</title>
-    <link rel="stylesheet" href="/${rootPath}example.css" />
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,700" rel="stylesheet" />
-    ${options.core ? createAnalyticsTag() : ''}
-  `;
+  <link rel="stylesheet" href="/${rootPath}example.css" />
+  <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,700" rel="stylesheet" />`;
 
   const body = `${processMarkup(page.markup, modifier)}
   <script type="text/javascript" src="/${rootPath}example.js"></script>`;

--- a/packages/design-system-scripts/gulp/docs/generatePages/generateReactExample.js
+++ b/packages/design-system-scripts/gulp/docs/generatePages/generateReactExample.js
@@ -45,6 +45,8 @@ async function generateReactExample(
 
       const exampleScripts = stats.compilation.assets['bundle.js'].source();
 
+      // TODO: Remove line `${core ? createAnalyticsTag() : ''}` before merging to master
+      // Purpose if for localhost testing of Tealium event tracking
       const head = `
         <title>Example: ${page.reference}</title>
         <link rel="stylesheet" href="/${path.join(rootPath, 'example.css')}" />

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -24,6 +24,7 @@
     "downshift": "^3.2.10",
     "ev-emitter": "^1.1.1",
     "focus-trap-react": "^6.0.0",
+    "html-to-text": "^7.1.1",
     "lodash.uniqueid": "^4.0.1",
     "prop-types": "^15.7.2",
     "react-aria-modal": "^2.11.1",

--- a/packages/design-system/src/components/Alert/Alert.jsx
+++ b/packages/design-system/src/components/Alert/Alert.jsx
@@ -1,14 +1,34 @@
+import { EVENT_CATEGORY, sendAnalyticsEvent } from '../analytics/SendAnalytics';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import classNames from 'classnames';
+import get from 'lodash/get';
+import { htmlToText } from 'html-to-text';
 import uniqueId from 'lodash.uniqueid';
+
+// Default analytics object
+const defaultAnalytics = (heading = '', variation = 'information') => ({
+  onComponentDidMount: {
+    event_name: 'alert_impression',
+    event_type: EVENT_CATEGORY.uiInteraction,
+    ga_eventAction: 'alert impression',
+    ga_eventCategory: EVENT_CATEGORY.uiComponents,
+    ga_eventLabel: heading,
+    heading: heading,
+    type: variation,
+  },
+});
 
 export class Alert extends React.PureComponent {
   constructor(props) {
     super(props);
-
-    this.headingId = this.props.headingId || uniqueId('alert_');
-
+    this.headingId = props.headingId || uniqueId('alert_');
+    this.eventHeading = props.heading || props.children;
+    this.eventHeadingText =
+      typeof this.eventHeading === 'string'
+        ? this.eventHeading
+        : htmlToText(ReactDOMServer.renderToString(this.eventHeading));
     if (process.env.NODE_ENV !== 'production') {
       if (!props.heading && !props.children) {
         console.warn(
@@ -16,6 +36,15 @@ export class Alert extends React.PureComponent {
         );
       }
     }
+  }
+
+  componentDidMount() {
+    const eventAction = 'onComponentDidMount';
+    /* Send analytics event for alert */
+    sendAnalyticsEvent(
+      get(this.props.analytics, eventAction),
+      get(defaultAnalytics(this.eventHeadingText, this.props.variation), eventAction)
+    );
   }
 
   heading() {
@@ -51,11 +80,39 @@ export class Alert extends React.PureComponent {
     );
   }
 }
+
 Alert.defaultProps = {
   role: 'region',
   headingLevel: '3',
 };
+
+/**
+ * Defines the shape of an analytics event for tracking that is an object with key-value pairs
+ */
+const AnalyticsEventShape = PropTypes.shape({
+  event_name: PropTypes.string,
+  event_type: PropTypes.string,
+  ga_eventAction: PropTypes.string,
+  ga_eventCategory: PropTypes.string,
+  ga_eventLabel: PropTypes.string,
+  ga_eventType: PropTypes.string,
+  ga_eventValue: PropTypes.string,
+  heading: PropTypes.string,
+  type: PropTypes.string,
+});
+
 Alert.propTypes = {
+  /**
+   * Analytics events tracking is enabled by default.
+   * The `analytics` prop is an object of events that is either a nested `objects` with key-value
+   * pairs, or `boolean` for disabling the event tracking. To disable an event tracking, set the
+   * event object value to `false`.
+   * When an event is triggered, the object value is populated and sent to google analytics
+   * if `window.utag` instance is loaded.
+   */
+  analytics: PropTypes.shape({
+    onComponentDidMount: PropTypes.oneOfType([PropTypes.bool, AnalyticsEventShape]),
+  }),
   /**
    * The alert's body content
    */

--- a/packages/design-system/src/components/Alert/Alert.test.jsx
+++ b/packages/design-system/src/components/Alert/Alert.test.jsx
@@ -59,4 +59,69 @@ describe('Alert', function () {
 
     expect(wrapper.hasClass('ds-c-alert--hide-icon')).toBe(true);
   });
+
+  describe('Analytics event tracking', () => {
+    let tealiumMock;
+    const defaultEvent = {
+      event_name: 'alert_impression',
+      event_type: 'ui interaction',
+      ga_eventCategory: 'ui components',
+      ga_eventAction: 'alert impression',
+      ga_eventLabel: text,
+      heading: text,
+      type: 'information',
+    };
+
+    beforeEach(() => {
+      tealiumMock = jest.fn();
+      window.utag = {
+        link: tealiumMock,
+      };
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('sends analytics event tracking', () => {
+      render({ tealiumMock });
+      expect(tealiumMock).toBeCalledWith({
+        ga_eventType: 'cmsds',
+        ga_eventValue: '',
+        ...defaultEvent,
+      });
+    });
+
+    it('disables analytics event tracking', () => {
+      const analyticsProps = {
+        analytics: {
+          onComponentDidMount: false,
+        },
+      };
+      render({ tealiumMock, heading: 'dialog heading', ...analyticsProps });
+      expect(tealiumMock).not.toBeCalledWith(defaultEvent);
+    });
+
+    it('overrides analytics event tracking', () => {
+      const analyticsProps = {
+        analytics: {
+          onComponentDidMount: {
+            event_name: 'event name',
+            event_type: 'event type',
+            ga_eventCategory: 'event category',
+            ga_eventAction: 'event action',
+            ga_eventLabel: 'event label',
+            ga_eventValue: 'event value',
+            ga_other: 'other one',
+            ga_other2: 'other two',
+            ga_eventType: 'other type',
+            heading: 'other heading',
+            type: 'other type',
+          },
+        },
+      };
+      render({ tealiumMock, ...analyticsProps });
+      expect(tealiumMock).toBeCalledWith(analyticsProps.analytics.onComponentDidMount);
+    });
+  });
 });

--- a/packages/design-system/src/components/Dialog/Dialog.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.jsx
@@ -9,7 +9,7 @@ import get from 'lodash/get';
 import { htmlToText } from 'html-to-text';
 
 // Default analytics object
-const defaultAnalytics = (heading) => ({
+const defaultAnalytics = (heading = '') => ({
   onComponentDidMount: {
     event_name: 'modal_impression',
     event_type: EVENT_CATEGORY.uiInteraction,

--- a/packages/design-system/src/components/Dialog/Dialog.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.jsx
@@ -1,107 +1,159 @@
+import { EVENT_CATEGORY, sendAnalyticsEvent } from '../analytics/SendAnalytics';
 import AriaModal from 'react-aria-modal';
 import Button from '../Button/Button';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import classNames from 'classnames';
+import get from 'lodash/get';
+import { htmlToText } from 'html-to-text';
 
-export const Dialog = function (props) {
-  const {
-    actions,
-    actionsClassName,
-    ariaCloseLabel,
-    children,
-    className,
-    closeButtonSize,
-    closeButtonText,
-    closeButtonVariation,
-    closeText,
-    escapeExits,
-    escapeExitDisabled,
-    headerClassName,
-    heading,
-    onExit,
-    size,
-    title,
-    ...modalProps
-  } = props;
+// Default analytics object
+const defaultAnalytics = (heading) => ({
+  onComponentDidMount: {
+    event_name: 'modal_impression',
+    event_type: EVENT_CATEGORY.uiInteraction,
+    ga_eventAction: 'modal impression',
+    ga_eventCategory: EVENT_CATEGORY.uiComponents,
+    ga_eventLabel: heading,
+    heading: heading,
+  },
+  onComponentWillUnmount: {
+    event_name: 'modal_closed',
+    event_type: EVENT_CATEGORY.uiInteraction,
+    ga_eventAction: 'closed modal',
+    ga_eventCategory: EVENT_CATEGORY.uiComponents,
+    ga_eventLabel: heading,
+    heading: heading,
+  },
+});
 
-  if (process.env.NODE_ENV !== 'production') {
-    if (props.title) {
-      console.warn(
-        `[Deprecated]: Please remove the 'title' prop in <Dialog>, use 'heading' instead. This prop has been renamed and will be removed in a future release.`
-      );
-    }
-    if (props.escapeExitDisabled) {
-      console.warn(
-        `[Deprecated]: Please remove the 'escapeExitDisabled' prop in <Dialog>, use 'escapeExits' instead. This prop has been renamed and will be removed in a future release.`
-      );
-    }
-    if (props.closeText) {
-      console.warn(
-        `[Deprecated]: Please remove the 'closeText' prop in <Dialog>, use 'closeButtonText' instead. This prop has been renamed and will be removed in a future release.`
-      );
+export class Dialog extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.eventHeading = props.title || props.heading;
+    this.eventHeadingText =
+      typeof this.eventHeading === 'string'
+        ? this.eventHeading
+        : htmlToText(ReactDOMServer.renderToString(this.eventHeading));
+    if (process.env.NODE_ENV !== 'production') {
+      if (props.title) {
+        console.warn(
+          `[Deprecated]: Please remove the 'title' prop in <Dialog>, use 'heading' instead. This prop has been renamed and will be removed in a future release.`
+        );
+      }
+      if (props.escapeExitDisabled) {
+        console.warn(
+          `[Deprecated]: Please remove the 'escapeExitDisabled' prop in <Dialog>, use 'escapeExits' instead. This prop has been renamed and will be removed in a future release.`
+        );
+      }
+      if (props.closeText) {
+        console.warn(
+          `[Deprecated]: Please remove the 'closeText' prop in <Dialog>, use 'closeButtonText' instead. This prop has been renamed and will be removed in a future release.`
+        );
+      }
     }
   }
 
-  const dialogClassNames = classNames(
-    'ds-c-dialog',
-    'ds-base',
-    className,
-    size && `ds-c-dialog--${size}`
-  );
-  const headerClassNames = classNames('ds-c-dialog__header', headerClassName);
-  const actionsClassNames = classNames('ds-c-dialog__actions', actionsClassName);
-  // TODO: remove after deprecating 'escapeExitDiabled' prop
-  const escapeExitsProp = escapeExitDisabled ? !escapeExitDisabled : escapeExits;
+  componentDidMount() {
+    const eventAction = 'onComponentDidMount';
+    /* Send analytics event for dialog open */
+    sendAnalyticsEvent(
+      get(this.props.analytics, eventAction),
+      get(defaultAnalytics(this.eventHeadingText), eventAction)
+    );
+  }
 
-  /* eslint-disable jsx-a11y/no-redundant-roles */
-  return (
-    <AriaModal
-      dialogClass={dialogClassNames}
-      // TODO: remove 'escapeExits' after deprecating 'escapeExitDiabled' prop so that 'escapeExits' will pass via the 'modalProps' spread operator
-      escapeExits={escapeExitsProp}
-      focusDialog
-      includeDefaultStyles={false}
-      onExit={onExit}
-      titleId="dialog-title dialog-content"
-      underlayClass="ds-c-dialog-wrap"
-      {...modalProps}
-    >
-      <div role="document">
-        <header className={headerClassNames} role="banner">
-          {
-            // TODO: make heading required after removing title
-            (title || heading) && (
-              <h1 className="ds-h2" id="dialog-title">
-                {heading}
-              </h1>
-            )
-          }
-          <Button
-            aria-label={ariaCloseLabel}
-            className="ds-c-dialog__close"
-            onClick={onExit}
-            size={closeButtonSize}
-            variation={closeButtonVariation}
-          >
+  componentWillUnmount() {
+    const eventAction = 'onComponentWillUnmount';
+    /* Send analytics event for dialog close */
+    sendAnalyticsEvent(
+      get(this.props.analytics, eventAction),
+      get(defaultAnalytics(this.eventHeadingText), eventAction)
+    );
+  }
+
+  render() {
+    const {
+      actions,
+      actionsClassName,
+      ariaCloseLabel,
+      children,
+      className,
+      closeButtonSize,
+      closeButtonText,
+      closeButtonVariation,
+      closeText,
+      escapeExits,
+      escapeExitDisabled,
+      headerClassName,
+      heading,
+      onExit,
+      size,
+      title,
+      ...modalProps
+    } = this.props;
+
+    const dialogClassNames = classNames(
+      'ds-c-dialog',
+      'ds-base',
+      className,
+      size && `ds-c-dialog--${size}`
+    );
+    const headerClassNames = classNames('ds-c-dialog__header', headerClassName);
+    const actionsClassNames = classNames('ds-c-dialog__actions', actionsClassName);
+    // TODO: remove after deprecating 'escapeExitDiabled' prop
+    const escapeExitsProp = escapeExitDisabled ? !escapeExitDisabled : escapeExits;
+
+    /* eslint-disable jsx-a11y/no-redundant-roles */
+    return (
+      <AriaModal
+        dialogClass={dialogClassNames}
+        // TODO: remove 'escapeExits' after deprecating 'escapeExitDiabled' prop so that 'escapeExits' will pass via the 'modalProps' spread operator
+        escapeExits={escapeExitsProp}
+        focusDialog
+        includeDefaultStyles={false}
+        onExit={onExit}
+        titleId="dialog-title dialog-content"
+        underlayClass="ds-c-dialog-wrap"
+        {...modalProps}
+      >
+        <div role="document">
+          <header className={headerClassNames} role="banner">
             {
-              // TODO: remove closeText support once fully deprecated
-              closeText || closeButtonText
+              // TODO: make heading required after removing title
+              (title || heading) && (
+                <h1 className="ds-h2" id="dialog-title">
+                  {heading}
+                </h1>
+              )
             }
-          </Button>
-        </header>
-        <main role="main">
-          <div id="dialog-content">{children}</div>
-        </main>
-        {actions && (
-          <aside className={actionsClassNames} role="complementary">
-            {actions}
-          </aside>
-        )}
-      </div>
-    </AriaModal>
-  );
-};
+            <Button
+              aria-label={ariaCloseLabel}
+              className="ds-c-dialog__close"
+              onClick={onExit}
+              size={closeButtonSize}
+              variation={closeButtonVariation}
+            >
+              {
+                // TODO: remove closeText support once fully deprecated
+                closeText || closeButtonText
+              }
+            </Button>
+          </header>
+          <main role="main">
+            <div id="dialog-content">{children}</div>
+          </main>
+          {actions && (
+            <aside className={actionsClassNames} role="complementary">
+              {actions}
+            </aside>
+          )}
+        </div>
+      </AriaModal>
+    );
+  }
+}
 
 Dialog.defaultProps = {
   ariaCloseLabel: 'Close modal dialog',
@@ -112,6 +164,20 @@ Dialog.defaultProps = {
   underlayClickExits: false,
 };
 
+/**
+ * Defines the shape of an analytics event for tracking that is an object with key-value pairs
+ */
+const AnalyticsEventShape = PropTypes.shape({
+  event_name: PropTypes.string,
+  event_type: PropTypes.string,
+  ga_eventAction: PropTypes.string,
+  ga_eventCategory: PropTypes.string,
+  ga_eventLabel: PropTypes.string,
+  ga_eventType: PropTypes.string,
+  ga_eventValue: PropTypes.string,
+  heading: PropTypes.string,
+});
+
 // TODO: closeButtonText should be a string, but it is being used as a node in MCT,
 // until we provide a better solution for customization, we type it as a node.
 Dialog.propTypes = {
@@ -121,6 +187,18 @@ Dialog.propTypes = {
    * alert, error, or warning occurs.
    */
   alert: PropTypes.bool,
+  /**
+   * Analytics events tracking is enabled by default.
+   * The `analytics` prop is an object of events that is either a nested `objects` with key-value
+   * pairs, or `boolean` for disabling the event tracking. To disable an event tracking, set the
+   * event object value to `false`.
+   * When an event is triggered, the object value is populated and sent to google analytics
+   * if `window.utag` instance is loaded.
+   */
+  analytics: PropTypes.shape({
+    onComponentDidMount: PropTypes.oneOfType([PropTypes.bool, AnalyticsEventShape]),
+    onComponentWillUnmount: PropTypes.oneOfType([PropTypes.bool, AnalyticsEventShape]),
+  }),
   /**
    * Provide a **DOM node** which contains your page's content (which the modal should render
    * outside of). When the modal is open this node will receive `aria-hidden="true"`.

--- a/packages/design-system/src/components/Dialog/Dialog.test.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.test.jsx
@@ -63,4 +63,67 @@ describe('Dialog', function () {
 
     expect(props.onExit.mock.calls.length).toBe(1);
   });
+
+  describe('Analytics event tracking', () => {
+    let tealiumMock;
+    const defaultEvent = {
+      event_name: 'modal_impression',
+      event_type: 'ui interaction',
+      ga_eventCategory: 'ui components',
+      ga_eventAction: 'modal impression',
+      ga_eventLabel: 'dialog heading',
+      heading: 'dialog heading',
+    };
+
+    beforeEach(() => {
+      tealiumMock = jest.fn();
+      window.utag = {
+        link: tealiumMock,
+      };
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('sends analytics event tracking on open dialog', () => {
+      render({ tealiumMock, heading: 'dialog heading' });
+      expect(tealiumMock).toBeCalledWith({
+        ga_eventType: 'cmsds',
+        ga_eventValue: '',
+        ...defaultEvent,
+      });
+    });
+
+    it('disables analytics event tracking on open', () => {
+      const analyticsProps = {
+        analytics: {
+          onComponentDidMount: false,
+        },
+      };
+      render({ tealiumMock, heading: 'dialog heading', ...analyticsProps });
+      expect(tealiumMock).not.toBeCalledWith(defaultEvent);
+    });
+
+    it('overrides analytics event tracking on open', () => {
+      const analyticsProps = {
+        analytics: {
+          onComponentDidMount: {
+            event_name: 'event name',
+            event_type: 'event type',
+            ga_eventCategory: 'event category',
+            ga_eventAction: 'event action',
+            ga_eventLabel: 'event label',
+            ga_eventValue: 'event value',
+            ga_other: 'other one',
+            ga_other2: 'other two',
+            ga_eventType: 'other type',
+            heading: 'other heading',
+          },
+        },
+      };
+      render({ tealiumMock, ...analyticsProps });
+      expect(tealiumMock).toBeCalledWith(analyticsProps.analytics.onComponentDidMount);
+    });
+  });
 });

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
@@ -1,4 +1,4 @@
-import { EVENT_ACTION, EVENT_CATEGORY, sendAnalyticsEvent } from '../analytics/Analytics';
+import { EVENT_CATEGORY, sendAnalyticsEvent } from '../analytics/Analytics';
 import Button from '../Button/Button';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -8,14 +8,20 @@ import get from 'lodash/get';
 // Default analytics object
 const defaultAnalytics = (heading) => ({
   onComponentDidMount: {
-    ga_eventCategory: EVENT_CATEGORY.contentTools,
-    ga_eventAction: EVENT_ACTION.helpDrawerOpen,
+    event_name: 'help_drawer_opened',
+    event_type: 'ui interaction',
+    ga_eventAction: 'opened help drawer',
+    ga_eventCategory: EVENT_CATEGORY.uiComponents,
     ga_eventLabel: heading,
+    heading: heading,
   },
   onComponentWillUnmount: {
-    ga_eventCategory: EVENT_CATEGORY.contentTools,
-    ga_eventAction: EVENT_ACTION.helpDrawerClose,
+    event_name: 'help_drawer_closed',
+    event_type: 'ui interaction',
+    ga_eventAction: 'closed help drawer',
+    ga_eventCategory: EVENT_CATEGORY.uiComponents,
     ga_eventLabel: heading,
+    heading: heading,
   },
 });
 

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
@@ -9,7 +9,7 @@ import get from 'lodash/get';
 const defaultAnalytics = (heading) => ({
   onComponentDidMount: {
     event_name: 'help_drawer_opened',
-    event_type: 'ui interaction',
+    event_type: EVENT_CATEGORY.uiInteraction,
     ga_eventAction: 'opened help drawer',
     ga_eventCategory: EVENT_CATEGORY.uiComponents,
     ga_eventLabel: heading,
@@ -17,7 +17,7 @@ const defaultAnalytics = (heading) => ({
   },
   onComponentWillUnmount: {
     event_name: 'help_drawer_closed',
-    event_type: 'ui interaction',
+    event_type: EVENT_CATEGORY.uiInteraction,
     ga_eventAction: 'closed help drawer',
     ga_eventCategory: EVENT_CATEGORY.uiComponents,
     ga_eventLabel: heading,
@@ -132,10 +132,14 @@ HelpDrawer.defaultProps = {
  * Defines the shape of an analytics event for tracking that is an object with key-value pairs
  */
 const AnalyticsEventShape = PropTypes.shape({
-  ga_eventCategory: PropTypes.string,
+  event_name: PropTypes.string,
+  event_type: PropTypes.string,
   ga_eventAction: PropTypes.string,
+  ga_eventCategory: PropTypes.string,
   ga_eventLabel: PropTypes.string,
+  ga_eventType: PropTypes.string,
   ga_eventValue: PropTypes.string,
+  heading: PropTypes.string,
 });
 
 // TODO: closeButtonText, title/heading should be a string, but it is being used as a node in MCT,

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
@@ -1,4 +1,4 @@
-import { EVENT_CATEGORY, sendAnalyticsEvent } from '../analytics/Analytics';
+import { EVENT_CATEGORY, sendAnalyticsEvent } from '../analytics/SendAnalytics';
 import Button from '../Button/Button';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
@@ -2,8 +2,10 @@ import { EVENT_CATEGORY, sendAnalyticsEvent } from '../analytics/SendAnalytics';
 import Button from '../Button/Button';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import classNames from 'classnames';
 import get from 'lodash/get';
+import { htmlToText } from 'html-to-text';
 
 // Default analytics object
 const defaultAnalytics = (heading) => ({
@@ -29,6 +31,11 @@ export class HelpDrawer extends React.PureComponent {
   constructor(props) {
     super(props);
     this.headingRef = null;
+    this.eventHeading = props.title || props.heading;
+    this.eventHeadingText =
+      typeof this.eventHeading === 'string'
+        ? this.eventHeading
+        : htmlToText(ReactDOMServer.renderToString(this.eventHeading));
     if (process.env.NODE_ENV !== 'production') {
       if (props.title) {
         console.warn(
@@ -45,23 +52,20 @@ export class HelpDrawer extends React.PureComponent {
 
   componentDidMount() {
     if (this.headingRef) this.headingRef.focus();
-
     const eventAction = 'onComponentDidMount';
-
     /* Send analytics event for helpdrawer open */
     sendAnalyticsEvent(
       get(this.props.analytics, eventAction),
-      get(defaultAnalytics(this.props.title || this.props.heading), eventAction)
+      get(defaultAnalytics(this.eventHeadingText), eventAction)
     );
   }
 
   componentWillUnmount() {
     const eventAction = 'onComponentWillUnmount';
-
     /* Send analytics event for helpdrawer close */
     sendAnalyticsEvent(
       get(this.props.analytics, eventAction),
-      get(defaultAnalytics(this.props.title || this.props.heading), eventAction)
+      get(defaultAnalytics(this.eventHeadingText), eventAction)
     );
   }
 

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
@@ -8,7 +8,7 @@ import get from 'lodash/get';
 import { htmlToText } from 'html-to-text';
 
 // Default analytics object
-const defaultAnalytics = (heading) => ({
+const defaultAnalytics = (heading = '') => ({
   onComponentDidMount: {
     event_name: 'help_drawer_opened',
     event_type: EVENT_CATEGORY.uiInteraction,

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.test.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.test.jsx
@@ -47,6 +47,14 @@ describe('HelpDrawer', () => {
 
   describe('Analytics event tracking', () => {
     let tealiumMock;
+    const defaultEvent = {
+      event_name: 'help_drawer_opened',
+      event_type: 'ui interaction',
+      ga_eventCategory: 'ui components',
+      ga_eventAction: 'opened help drawer',
+      ga_eventLabel: defaultProps.heading,
+      heading: defaultProps.heading,
+    };
 
     beforeEach(() => {
       tealiumMock = jest.fn();
@@ -62,15 +70,13 @@ describe('HelpDrawer', () => {
     it('sends analytics event tracking on open help drawer', () => {
       renderHelpDrawer({ tealiumMock });
       expect(tealiumMock).toBeCalledWith({
-        ga_eventCategory: 'content tools',
-        ga_eventAction: 'opened help drawer',
-        ga_eventLabel: defaultProps.heading,
         ga_eventType: 'cmsds',
         ga_eventValue: '',
+        ...defaultEvent,
       });
     });
 
-    it('disables analytics event tracking', () => {
+    it('disables analytics event tracking on open', () => {
       const analyticsProps = {
         analytics: {
           // disables on open help drawer
@@ -89,30 +95,28 @@ describe('HelpDrawer', () => {
         return { props, wrapper };
       }
       renderDrawer({ tealiumMock });
-      expect(tealiumMock).not.toBeCalledWith({
-        ga_eventCategory: 'content tools',
-        ga_eventAction: 'opened help drawer',
-        ga_eventLabel: analyticsProps.heading,
-        ga_eventType: 'cmsds',
-        ga_eventValue: '',
-      });
+      expect(tealiumMock).not.toBeCalledWith(defaultEvent);
     });
 
-    it('overrides analytics event tracking', () => {
+    it('overrides analytics event tracking on open', () => {
       const analyticsProps = {
         analytics: {
           // override default analytics on open help drawer
           onComponentDidMount: {
+            event_name: 'event name',
+            event_type: 'event type',
             ga_eventCategory: 'event category',
             ga_eventAction: 'event action',
             ga_eventLabel: 'event label',
             ga_eventValue: 'event value',
             ga_other: 'other one',
             ga_other2: 'other two',
+            ga_eventType: 'other type',
+            heading: 'other heading',
           },
         },
         onCloseClick: () => {},
-        heading: 'HelpDrawer yy',
+        heading: 'HelpDrawer title',
       };
       function renderDrawer(props) {
         props = Object.assign({}, analyticsProps, props);
@@ -124,16 +128,7 @@ describe('HelpDrawer', () => {
         return { props, wrapper };
       }
       renderDrawer({ tealiumMock });
-
-      expect(tealiumMock).toBeCalledWith({
-        ga_eventCategory: 'event category',
-        ga_eventAction: 'event action',
-        ga_eventLabel: 'event label',
-        ga_eventValue: 'event value',
-        ga_other: 'other one',
-        ga_other2: 'other two',
-        ga_eventType: 'cmsds',
-      });
+      expect(tealiumMock).toBeCalledWith(analyticsProps.analytics.onComponentDidMount);
     });
   });
 });

--- a/packages/design-system/src/components/analytics/Analytics.ts
+++ b/packages/design-system/src/components/analytics/Analytics.ts
@@ -27,21 +27,22 @@ export interface AnalyticsPayload {
   ga_eventLabel: string;
   ga_eventType: string;
   ga_eventValue: string;
-  additional_props?: Record<string, unknown>;
+  [additional_props: string]: unknown;
 }
 
 export const EVENT_CATEGORY = {
   contentTools: 'content tools',
   uiComponents: 'ui components',
+  uiInteraction: 'ui interaction',
 };
 
 interface AnalyticsEventProps {
   ga_eventAction: string;
   ga_eventCategory: string;
   ga_eventLabel: string;
-  ga_eventType: string;
+  ga_eventType?: string;
   ga_eventValue?: string;
-  additional_props?: Record<string, unknown>;
+  [additional_props: string]: unknown;
 }
 
 export function sendEvent(event: EventType, props: AnalyticsPayload, retry = 0): string {
@@ -66,7 +67,6 @@ export function sendAnalyticsEvent(
   defaultPayload: AnalyticsEventProps
 ): string {
   const analyticsDisabled = overrides === false;
-
   if (window.utag && !analyticsDisabled) {
     const mergedPayload = merge(defaultPayload, overrides);
     const {
@@ -74,7 +74,7 @@ export function sendAnalyticsEvent(
       ga_eventCategory,
       ga_eventLabel,
       ga_eventType = 'cmsds', // default value
-      ga_eventValue = '',     // default value
+      ga_eventValue = '', // default value
       ...other_props
     } = mergedPayload;
     const payload: AnalyticsPayload = {
@@ -85,7 +85,6 @@ export function sendAnalyticsEvent(
       ga_eventValue,
       ...other_props,
     };
-
     return sendEvent('link', payload);
   } else {
     return '';

--- a/packages/design-system/src/components/analytics/Analytics.ts
+++ b/packages/design-system/src/components/analytics/Analytics.ts
@@ -22,28 +22,24 @@ const TIMEOUT = 300;
 
 /* eslint-disable camelcase */
 export interface AnalyticsPayload {
-  ga_eventType: string;
-  ga_eventCategory: string;
   ga_eventAction: string;
+  ga_eventCategory: string;
   ga_eventLabel: string;
+  ga_eventType: string;
   ga_eventValue: string;
   additional_props?: Record<string, unknown>;
 }
 
 export const EVENT_CATEGORY = {
   contentTools: 'content tools',
-};
-
-export const EVENT_ACTION = {
-  helpDrawerOpen: 'opened help drawer',
-  helpDrawerClose: 'closed help drawer',
+  uiComponents: 'ui components',
 };
 
 interface AnalyticsEventProps {
-  ga_eventType: string;
-  ga_eventCategory: string;
   ga_eventAction: string;
+  ga_eventCategory: string;
   ga_eventLabel: string;
+  ga_eventType: string;
   ga_eventValue?: string;
   additional_props?: Record<string, unknown>;
 }
@@ -74,18 +70,18 @@ export function sendAnalyticsEvent(
   if (window.utag && !analyticsDisabled) {
     const mergedPayload = merge(defaultPayload, overrides);
     const {
-      ga_eventType = 'cmsds', // default value
-      ga_eventCategory,
       ga_eventAction,
+      ga_eventCategory,
       ga_eventLabel,
-      ga_eventValue = '', // default value
+      ga_eventType = 'cmsds', // default value
+      ga_eventValue = '',     // default value
       ...other_props
     } = mergedPayload;
     const payload: AnalyticsPayload = {
-      ga_eventType,
-      ga_eventCategory,
       ga_eventAction,
+      ga_eventCategory,
       ga_eventLabel,
+      ga_eventType,
       ga_eventValue,
       ...other_props,
     };

--- a/packages/design-system/src/components/analytics/SendAnalytics.test.ts
+++ b/packages/design-system/src/components/analytics/SendAnalytics.test.ts
@@ -1,4 +1,4 @@
-import { sendAnalyticsEvent } from './Analytics';
+import { sendAnalyticsEvent } from './SendAnalytics';
 
 describe('sendAnalyticsEvent', () => {
   const gaEventProps = {

--- a/packages/design-system/src/components/analytics/SendAnalytics.ts
+++ b/packages/design-system/src/components/analytics/SendAnalytics.ts
@@ -45,7 +45,7 @@ interface AnalyticsEventProps {
   [additional_props: string]: unknown;
 }
 
-export function sendEvent(event: EventType, props: AnalyticsPayload, retry = 0): string {
+export function sendAnalytics(event: EventType, props: AnalyticsPayload, retry = 0): string {
   if (window.utag && window.utag[event]) {
     try {
       window.utag[event](props);
@@ -55,7 +55,7 @@ export function sendEvent(event: EventType, props: AnalyticsPayload, retry = 0):
     }
   } else {
     if (++retry <= MAX_RETRIES) {
-      setTimeout(() => sendEvent(event, props, retry), retry * TIMEOUT);
+      setTimeout(() => sendAnalytics(event, props, retry), retry * TIMEOUT);
     } else {
       return `Tealium event max retries reached`;
     }
@@ -85,11 +85,11 @@ export function sendAnalyticsEvent(
       ga_eventValue,
       ...other_props,
     };
-    return sendEvent('link', payload);
+    return sendAnalytics('link', payload);
   } else {
     return '';
   }
 }
 /* eslint-enable camelcase */
 
-export default sendEvent;
+export default sendAnalytics;

--- a/packages/design-system/src/components/analytics/index.js
+++ b/packages/design-system/src/components/analytics/index.js
@@ -1,1 +1,1 @@
-export { default as sendEvent } from './Analytics';
+export { default as sendAnalytics } from './SendAnalytics';

--- a/packages/design-system/src/types/Alert/Alert.d.ts
+++ b/packages/design-system/src/types/Alert/Alert.d.ts
@@ -6,7 +6,35 @@ export type AlertRole = 'alert' | 'alertdialog' | 'region' | 'status';
 
 export type AlertVariation = 'error' | 'warn' | 'success';
 
+export interface AnalyticsEventShape {
+  event_name: string;
+  event_type: string;
+  ga_eventAction: string;
+  ga_eventCategory: string;
+  ga_eventLabel: string;
+  ga_eventType?: string;
+  ga_eventValue?: string;
+  heading: string;
+  type: string;
+  [additional_props: string]: unknown;
+}
+// additional_props?: Record<string, unknown>;
+
+export interface AnalyticsObjectShape {
+  onComponentDidMount?: boolean | AnalyticsEventShape;
+  onComponentWillUnmount?: boolean | AnalyticsEventShape;
+}
+
 export interface AlertProps {
+  /**
+   * Analytics events tracking is enabled by default.
+   * The `analytics` prop is an object of events that is either a nested `objects` with key-value
+   * pairs, or `boolean` for disabling the event tracking. To disable an event tracking, set the
+   * event object value to `false`.
+   * When an event is triggered, the object value is populated and sent to google analytics
+   * if `window.utag` instance is loaded.
+   */
+  analytics?: AnalyticsObjectShape;
   /**
    * The alert's body content
    */

--- a/packages/design-system/src/types/Alert/Alert.d.ts
+++ b/packages/design-system/src/types/Alert/Alert.d.ts
@@ -22,7 +22,6 @@ export interface AnalyticsEventShape {
 
 export interface AnalyticsObjectShape {
   onComponentDidMount?: boolean | AnalyticsEventShape;
-  onComponentWillUnmount?: boolean | AnalyticsEventShape;
 }
 
 export interface AlertProps {

--- a/packages/design-system/src/types/Dialog/Dialog.d.ts
+++ b/packages/design-system/src/types/Dialog/Dialog.d.ts
@@ -4,6 +4,24 @@ export type DialogCloseButtonSize = 'small' | 'big';
 
 export type DialogSize = 'narrow' | 'wide' | 'full';
 
+export interface AnalyticsEventShape {
+  event_name: string;
+  event_type: string;
+  ga_eventAction: string;
+  ga_eventCategory: string;
+  ga_eventLabel: string;
+  ga_eventType?: string;
+  ga_eventValue?: string;
+  heading: string;
+  [additional_props: string]: unknown;
+}
+// additional_props?: Record<string, unknown>;
+
+export interface AnalyticsObjectShape {
+  onComponentDidMount?: boolean | AnalyticsEventShape;
+  onComponentWillUnmount?: boolean | AnalyticsEventShape;
+}
+
 export interface DialogProps {
   /**
    * If `true`, the modal will receive a role of `alertdialog`, instead of its
@@ -11,6 +29,15 @@ export interface DialogProps {
    * alert, error, or warning occurs.
    */
   alert?: boolean;
+  /**
+   * Analytics events tracking is enabled by default.
+   * The `analytics` prop is an object of events that is either a nested `objects` with key-value
+   * pairs, or `boolean` for disabling the event tracking. To disable an event tracking, set the
+   * event object value to `false`.
+   * When an event is triggered, the object value is populated and sent to google analytics
+   * if `window.utag` instance is loaded.
+   */
+  analytics?: AnalyticsObjectShape;
   /**
    * Provide a **DOM node** which contains your page's content (which the modal should render
    * outside of). When the modal is open this node will receive `aria-hidden="true"`.

--- a/packages/design-system/src/types/HelpDrawer/HelpDrawer.d.ts
+++ b/packages/design-system/src/types/HelpDrawer/HelpDrawer.d.ts
@@ -1,8 +1,37 @@
 import * as React from 'react';
 
 export type HelpDrawerHeadingLevel = '1' | '2' | '3' | '4' | '5';
+/**
+ * Defines the shape of an analytics event for tracking that is an object with key-value pairs
+ */
+ export interface AnalyticsEventShape {
+    event_name: string;
+    event_type: string;
+    ga_eventAction: string;
+    ga_eventCategory: string;
+    ga_eventLabel: string;
+    ga_eventType?: string;
+    ga_eventValue?: string;
+    heading: string;
+    [additional_props: string]: unknown;
+  }
+  // additional_props?: Record<string, unknown>;
+
+export interface AnalyticsObjectShape {
+  onComponentDidMount?: boolean | AnalyticsEventShape;
+  onComponentWillUnmount?: boolean | AnalyticsEventShape;
+}
 
 export interface HelpDrawerProps {
+  /**
+   * Analytics events tracking is enabled by default.
+   * The `analytics` prop is an object of events that is either a nested `objects` with key-value
+   * pairs, or `boolean` for disabling the event tracking. To disable an event tracking, set the
+   * event object value to `false`.
+   * When an event is triggered, the object value is populated and sent to google analytics
+   * if `window.utag` instance is loaded.
+   */
+  analytics?: AnalyticsObjectShape;
   /**
    * Helps give more context to screen readers on the button that closes the Help Drawer
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,6 +5939,15 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
+dom-serializer@^1.0.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.1.tgz#d845a1565d7c041a95e5dab62184ab41e3a519be"
+  integrity sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    entities "^2.0.0"
+
 dom-serializer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
@@ -5967,6 +5976,11 @@ domelementtype@^2.0.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
   integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
 
+domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
@@ -5980,6 +5994,13 @@ domhandler@^2.3.0:
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
+
+domhandler@^4.0.0, domhandler@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.0.tgz#f9768a5f034be60a89a27c2e4d0f74eba0d8b059"
+  integrity sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==
+  dependencies:
+    domelementtype "^2.2.0"
 
 domutils@1.5.1:
   version "1.5.1"
@@ -5996,6 +6017,15 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.5.2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.6.0.tgz#2e15c04185d43fb16ae7057cb76433c6edb938b7"
+  integrity sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -8315,6 +8345,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hex-color-regex@^1.0.1, hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
@@ -8390,6 +8425,16 @@ html-tags@^3.1.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
   integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
 
+html-to-text@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/html-to-text/-/html-to-text-7.1.1.tgz#69de8d85b91646b4bc14fdf4f850e9e046efff15"
+  integrity sha512-c9QWysrfnRZevVpS8MlE7PyOdSuIOjg8Bt8ZE10jMU/BEngA6j3llj4GRfAmtQzcd1FjKE0sWu5IHXRUH9YxIQ==
+  dependencies:
+    deepmerge "^4.2.2"
+    he "^1.2.0"
+    htmlparser2 "^6.1.0"
+    minimist "^1.2.5"
+
 htmlparser2@^3.10.0, htmlparser2@^3.9.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
@@ -8401,6 +8446,16 @@ htmlparser2@^3.10.0, htmlparser2@^3.9.1:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
 
 http-cache-semantics@^3.8.1:
   version "3.8.1"


### PR DESCRIPTION
## Summary
To prepare for a release of the beta Help drawer component with GA event tracking as a POC, Blast suggested these key-value pairs changes.
```
Open help drawer event:
    event_name: 'help_drawer_opened',
    event_type: 'ui interaction',
    ga_eventAction: 'opened help drawer',
    ga_eventCategory: 'ui components',
    ga_eventLabel: heading,
    ga_eventType: 'cmsds',
    ga_eventValue: '', 
    heading: heading,

Close help drawer event:
    event_name: 'help_drawer_closed',
    event_type: 'ui interaction',
    ga_eventAction: 'closed help drawer',
    ga_eventCategory: 'ui components',
    ga_eventLabel: heading,
    ga_eventType: 'cmsds',
    ga_eventValue: '', 
    heading: heading
```

## How to test
http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-888/update-beta-analytics-helpdrawer/components/help-drawer/

Test locally:
Test that Help drawer component works as per normal. Then proceed to test GA event tracking.

- Go to `Help Drawer` component, the React example and click `Toggle the helpdrawer` to open help drawer.
- Inspect DevTools network tab and filter for `collect` to view the analytics data or view using Chrome's extension `Omnibug`
- `Close` help drawer and inspect DevTools network tab to view the analytics data again
   -  note that the network data only shows the 3 values. Other values are there to support other items/future GA4 implementation
   
![Screen Shot 2021-04-20 at 4 42 30 PM](https://user-images.githubusercontent.com/20322880/115586182-520a4480-a29a-11eb-8e44-3f75a7d46ce7.png)

   