### PR TITLE
[WNMGDS-851] Fix build error

### DIFF
--- a/packages/design-system-scripts/gulp/build.js
+++ b/packages/design-system-scripts/gulp/build.js
@@ -161,7 +161,6 @@ async function compileEsmJs(dir, changedPath) {
 function compileJs(dir, options, changedPath) {
   const src = path.join(dir, 'src', 'components');
   const srcGlob = getSrcGlob(src, changedPath);
-  console.log('changedPath', changedPath);
   return streamPromise(
     gulp
       .src(srcGlob, { base: path.join(dir, 'src') })

--- a/packages/design-system-scripts/gulp/build.js
+++ b/packages/design-system-scripts/gulp/build.js
@@ -88,7 +88,7 @@ async function copyAll(dir, options) {
 async function generateTypeDefinitions(dir, changedPath) {
   const src = path.join(dir, 'src', 'components');
   const srcGlob = changedPath
-    ? [changedPath`!${src}/**/*.{js,jsx}`]
+    ? [changedPath]
     : [
         `${src}/**/*.{ts,tsx}`,
         `!${src}/**/*.{js,jsx}`,
@@ -161,7 +161,7 @@ async function compileEsmJs(dir, changedPath) {
 function compileJs(dir, options, changedPath) {
   const src = path.join(dir, 'src', 'components');
   const srcGlob = getSrcGlob(src, changedPath);
-
+  console.log('changedPath', changedPath);
   return streamPromise(
     gulp
       .src(srcGlob, { base: path.join(dir, 'src') })
@@ -183,7 +183,8 @@ function compileJs(dir, options, changedPath) {
     })
     .then(() => {
       // If design system is using typescript, use tsc to generate definition files for tsx files
-      if (options.typescript) {
+      const unknownOrTypescriptPath = !changedPath || changedPath.match(/\.(ts|tsx)$/);
+      if (options.typescript && unknownOrTypescriptPath) {
         return generateTypeDefinitions(dir, changedPath);
       }
     });


### PR DESCRIPTION
## Summary
Fix development so we don't have to constantly manually rebuild! :tada: 

### Fixed
When rebuilding there was an error being thrown that was introduced in #968. Reworked build.js so that error is not thrown.

## How to test
- Run master first to see issue
- `yarn start` on master and load the Tooltip page on localhost
- Go to Tooltip.jsx and add in random text (ex Blah Blah Blah) on Line 172
- Notice that even though gulp attempts to rebuild, the page never refreshes with your text. You'll also see this error in the terminal
```
(node:97074) UnhandledPromiseRejectionWarning: TypeError: changedPath is not a function
```
- Revert your changes
- Check out this branch
- `yarn start` and load the Tooltip page on localhost
- Do the same with Tooltip.jsx. Notice after ~8 seconds, the page refreshes with correct text. The page refreshes twice, and it's on the second time the changes show

**To try with a typescript component**
- Checkout the Filter Chip branch (`WNMGDS-867/dismissible-badge`)
- `yarn start`
- Load the Filter Chip page
- Open FilterChip.tsx and add something beside `{label}` on Line 61
- Notice the page never updates
- Clear your FilterChip.tsx changes
- Merge this branch in (git merge origin WNMGDS-851/fix-recompiling)
- yarn start
- Make changes in FilterChip.tsx, they'll refresh on the page