### PR TITLE
[WNMGDS-833] ga tracking for alert and modal

### DIFF
--- a/packages/design-system/src/components/Alert/Alert.jsx
+++ b/packages/design-system/src/components/Alert/Alert.jsx
@@ -10,7 +10,7 @@ const defaultAnalytics = (heading = '', variation = 'information') => ({
   onComponentDidMount: {
     event_name: 'alert_impression',
     event_type: EVENT_CATEGORY.uiInteraction,
-    ga_eventAction: 'alert',
+    ga_eventAction: 'alert impression',
     ga_eventCategory: EVENT_CATEGORY.uiComponents,
     ga_eventLabel: heading,
     heading: heading,

--- a/packages/design-system/src/components/Alert/Alert.jsx
+++ b/packages/design-system/src/components/Alert/Alert.jsx
@@ -1,8 +1,10 @@
 import { EVENT_CATEGORY, sendAnalyticsEvent } from '../analytics/SendAnalytics';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import classNames from 'classnames';
 import get from 'lodash/get';
+import { htmlToText } from 'html-to-text';
 import uniqueId from 'lodash.uniqueid';
 
 // Default analytics object
@@ -21,9 +23,12 @@ const defaultAnalytics = (heading = '', variation = 'information') => ({
 export class Alert extends React.PureComponent {
   constructor(props) {
     super(props);
-
-    this.headingId = this.props.headingId || uniqueId('alert_');
-
+    this.headingId = props.headingId || uniqueId('alert_');
+    this.eventHeading = props.heading || props.children;
+    this.eventHeadingText =
+      typeof this.eventHeading === 'string'
+        ? this.eventHeading
+        : htmlToText(ReactDOMServer.renderToString(this.eventHeading));
     if (process.env.NODE_ENV !== 'production') {
       if (!props.heading && !props.children) {
         console.warn(
@@ -35,10 +40,10 @@ export class Alert extends React.PureComponent {
 
   componentDidMount() {
     const eventAction = 'onComponentDidMount';
-    /* Send analytics event for helpdrawer open */
+    /* Send analytics event for alert */
     sendAnalyticsEvent(
       get(this.props.analytics, eventAction),
-      get(defaultAnalytics(this.props.heading, this.props.variation), eventAction)
+      get(defaultAnalytics(this.eventHeadingText, this.props.variation), eventAction)
     );
   }
 

--- a/packages/design-system/src/components/Alert/Alert.jsx
+++ b/packages/design-system/src/components/Alert/Alert.jsx
@@ -1,7 +1,22 @@
+import { EVENT_CATEGORY, sendAnalyticsEvent } from '../analytics/SendAnalytics';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import get from 'lodash/get';
 import uniqueId from 'lodash.uniqueid';
+
+// Default analytics object
+const defaultAnalytics = (heading = '', variation = 'information') => ({
+  onComponentDidMount: {
+    event_name: 'alert_impression',
+    event_type: EVENT_CATEGORY.uiInteraction,
+    ga_eventAction: 'alert',
+    ga_eventCategory: EVENT_CATEGORY.uiComponents,
+    ga_eventLabel: heading,
+    heading: heading,
+    type: variation,
+  },
+});
 
 export class Alert extends React.PureComponent {
   constructor(props) {
@@ -16,6 +31,15 @@ export class Alert extends React.PureComponent {
         );
       }
     }
+  }
+
+  componentDidMount() {
+    const eventAction = 'onComponentDidMount';
+    /* Send analytics event for helpdrawer open */
+    sendAnalyticsEvent(
+      get(this.props.analytics, eventAction),
+      get(defaultAnalytics(this.props.heading, this.props.variation), eventAction)
+    );
   }
 
   heading() {
@@ -51,11 +75,39 @@ export class Alert extends React.PureComponent {
     );
   }
 }
+
 Alert.defaultProps = {
   role: 'region',
   headingLevel: '3',
 };
+
+/**
+ * Defines the shape of an analytics event for tracking that is an object with key-value pairs
+ */
+const AnalyticsEventShape = PropTypes.shape({
+  event_name: PropTypes.string,
+  event_type: PropTypes.string,
+  ga_eventAction: PropTypes.string,
+  ga_eventCategory: PropTypes.string,
+  ga_eventLabel: PropTypes.string,
+  ga_eventType: PropTypes.string,
+  ga_eventValue: PropTypes.string,
+  heading: PropTypes.string,
+  type: PropTypes.string,
+});
+
 Alert.propTypes = {
+  /**
+   * Analytics events tracking is enabled by default.
+   * The `analytics` prop is an object of events that is either a nested `objects` with key-value
+   * pairs, or `boolean` for disabling the event tracking. To disable an event tracking, set the
+   * event object value to `false`.
+   * When an event is triggered, the object value is populated and sent to google analytics
+   * if `window.utag` instance is loaded.
+   */
+  analytics: PropTypes.shape({
+    onComponentDidMount: PropTypes.oneOfType([PropTypes.bool, AnalyticsEventShape]),
+  }),
   /**
    * The alert's body content
    */

--- a/packages/design-system/src/components/Dialog/Dialog.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.jsx
@@ -1,107 +1,153 @@
+import { EVENT_CATEGORY, sendAnalyticsEvent } from '../analytics/SendAnalytics';
 import AriaModal from 'react-aria-modal';
 import Button from '../Button/Button';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import get from 'lodash/get';
 
-export const Dialog = function (props) {
-  const {
-    actions,
-    actionsClassName,
-    ariaCloseLabel,
-    children,
-    className,
-    closeButtonSize,
-    closeButtonText,
-    closeButtonVariation,
-    closeText,
-    escapeExits,
-    escapeExitDisabled,
-    headerClassName,
-    heading,
-    onExit,
-    size,
-    title,
-    ...modalProps
-  } = props;
+// Default analytics object
+const defaultAnalytics = (heading) => ({
+  onComponentDidMount: {
+    event_name: 'modal_impression',
+    event_type: EVENT_CATEGORY.uiInteraction,
+    ga_eventAction: 'modal impression',
+    ga_eventCategory: EVENT_CATEGORY.uiComponents,
+    ga_eventLabel: heading,
+    heading: heading,
+  },
+  onComponentWillUnmount: {
+    event_name: 'modal_closed',
+    event_type: EVENT_CATEGORY.uiInteraction,
+    ga_eventAction: 'closed modal',
+    ga_eventCategory: EVENT_CATEGORY.uiComponents,
+    ga_eventLabel: heading,
+    heading: heading,
+  },
+});
 
-  if (process.env.NODE_ENV !== 'production') {
-    if (props.title) {
-      console.warn(
-        `[Deprecated]: Please remove the 'title' prop in <Dialog>, use 'heading' instead. This prop has been renamed and will be removed in a future release.`
-      );
-    }
-    if (props.escapeExitDisabled) {
-      console.warn(
-        `[Deprecated]: Please remove the 'escapeExitDisabled' prop in <Dialog>, use 'escapeExits' instead. This prop has been renamed and will be removed in a future release.`
-      );
-    }
-    if (props.closeText) {
-      console.warn(
-        `[Deprecated]: Please remove the 'closeText' prop in <Dialog>, use 'closeButtonText' instead. This prop has been renamed and will be removed in a future release.`
-      );
+export class Dialog extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    if (process.env.NODE_ENV !== 'production') {
+      if (props.title) {
+        console.warn(
+          `[Deprecated]: Please remove the 'title' prop in <Dialog>, use 'heading' instead. This prop has been renamed and will be removed in a future release.`
+        );
+      }
+      if (props.escapeExitDisabled) {
+        console.warn(
+          `[Deprecated]: Please remove the 'escapeExitDisabled' prop in <Dialog>, use 'escapeExits' instead. This prop has been renamed and will be removed in a future release.`
+        );
+      }
+      if (props.closeText) {
+        console.warn(
+          `[Deprecated]: Please remove the 'closeText' prop in <Dialog>, use 'closeButtonText' instead. This prop has been renamed and will be removed in a future release.`
+        );
+      }
     }
   }
 
-  const dialogClassNames = classNames(
-    'ds-c-dialog',
-    'ds-base',
-    className,
-    size && `ds-c-dialog--${size}`
-  );
-  const headerClassNames = classNames('ds-c-dialog__header', headerClassName);
-  const actionsClassNames = classNames('ds-c-dialog__actions', actionsClassName);
-  // TODO: remove after deprecating 'escapeExitDiabled' prop
-  const escapeExitsProp = escapeExitDisabled ? !escapeExitDisabled : escapeExits;
+  componentDidMount() {
+    if (this.headingRef) this.headingRef.focus();
+    const eventAction = 'onComponentDidMount';
+    /* Send analytics event for helpdrawer open */
+    sendAnalyticsEvent(
+      get(this.props.analytics, eventAction),
+      get(defaultAnalytics(this.props.title || this.props.heading), eventAction)
+    );
+  }
 
-  /* eslint-disable jsx-a11y/no-redundant-roles */
-  return (
-    <AriaModal
-      dialogClass={dialogClassNames}
-      // TODO: remove 'escapeExits' after deprecating 'escapeExitDiabled' prop so that 'escapeExits' will pass via the 'modalProps' spread operator
-      escapeExits={escapeExitsProp}
-      focusDialog
-      includeDefaultStyles={false}
-      onExit={onExit}
-      titleId="dialog-title dialog-content"
-      underlayClass="ds-c-dialog-wrap"
-      {...modalProps}
-    >
-      <div role="document">
-        <header className={headerClassNames} role="banner">
-          {
-            // TODO: make heading required after removing title
-            (title || heading) && (
-              <h1 className="ds-h2" id="dialog-title">
-                {heading}
-              </h1>
-            )
-          }
-          <Button
-            aria-label={ariaCloseLabel}
-            className="ds-c-dialog__close"
-            onClick={onExit}
-            size={closeButtonSize}
-            variation={closeButtonVariation}
-          >
+  componentWillUnmount() {
+    const eventAction = 'onComponentWillUnmount';
+    /* Send analytics event for helpdrawer close */
+    sendAnalyticsEvent(
+      get(this.props.analytics, eventAction),
+      get(defaultAnalytics(this.props.title || this.props.heading), eventAction)
+    );
+  }
+
+  render() {
+    const {
+      actions,
+      actionsClassName,
+      ariaCloseLabel,
+      children,
+      className,
+      closeButtonSize,
+      closeButtonText,
+      closeButtonVariation,
+      closeText,
+      escapeExits,
+      escapeExitDisabled,
+      headerClassName,
+      heading,
+      onExit,
+      size,
+      title,
+      ...modalProps
+    } = this.props;
+
+    const dialogClassNames = classNames(
+      'ds-c-dialog',
+      'ds-base',
+      className,
+      size && `ds-c-dialog--${size}`
+    );
+    const headerClassNames = classNames('ds-c-dialog__header', headerClassName);
+    const actionsClassNames = classNames('ds-c-dialog__actions', actionsClassName);
+    // TODO: remove after deprecating 'escapeExitDiabled' prop
+    const escapeExitsProp = escapeExitDisabled ? !escapeExitDisabled : escapeExits;
+
+    /* eslint-disable jsx-a11y/no-redundant-roles */
+    return (
+      <AriaModal
+        dialogClass={dialogClassNames}
+        // TODO: remove 'escapeExits' after deprecating 'escapeExitDiabled' prop so that 'escapeExits' will pass via the 'modalProps' spread operator
+        escapeExits={escapeExitsProp}
+        focusDialog
+        includeDefaultStyles={false}
+        onExit={onExit}
+        titleId="dialog-title dialog-content"
+        underlayClass="ds-c-dialog-wrap"
+        {...modalProps}
+      >
+        <div role="document">
+          <header className={headerClassNames} role="banner">
             {
-              // TODO: remove closeText support once fully deprecated
-              closeText || closeButtonText
+              // TODO: make heading required after removing title
+              (title || heading) && (
+                <h1 className="ds-h2" id="dialog-title">
+                  {heading}
+                </h1>
+              )
             }
-          </Button>
-        </header>
-        <main role="main">
-          <div id="dialog-content">{children}</div>
-        </main>
-        {actions && (
-          <aside className={actionsClassNames} role="complementary">
-            {actions}
-          </aside>
-        )}
-      </div>
-    </AriaModal>
-  );
-};
+            <Button
+              aria-label={ariaCloseLabel}
+              className="ds-c-dialog__close"
+              onClick={onExit}
+              size={closeButtonSize}
+              variation={closeButtonVariation}
+            >
+              {
+                // TODO: remove closeText support once fully deprecated
+                closeText || closeButtonText
+              }
+            </Button>
+          </header>
+          <main role="main">
+            <div id="dialog-content">{children}</div>
+          </main>
+          {actions && (
+            <aside className={actionsClassNames} role="complementary">
+              {actions}
+            </aside>
+          )}
+        </div>
+      </AriaModal>
+    );
+  }
+}
 
 Dialog.defaultProps = {
   ariaCloseLabel: 'Close modal dialog',
@@ -112,6 +158,20 @@ Dialog.defaultProps = {
   underlayClickExits: false,
 };
 
+/**
+ * Defines the shape of an analytics event for tracking that is an object with key-value pairs
+ */
+const AnalyticsEventShape = PropTypes.shape({
+  event_name: PropTypes.string,
+  event_type: PropTypes.string,
+  ga_eventAction: PropTypes.string,
+  ga_eventCategory: PropTypes.string,
+  ga_eventLabel: PropTypes.string,
+  ga_eventType: PropTypes.string,
+  ga_eventValue: PropTypes.string,
+  heading: PropTypes.string,
+});
+
 // TODO: closeButtonText should be a string, but it is being used as a node in MCT,
 // until we provide a better solution for customization, we type it as a node.
 Dialog.propTypes = {
@@ -121,6 +181,18 @@ Dialog.propTypes = {
    * alert, error, or warning occurs.
    */
   alert: PropTypes.bool,
+  /**
+   * Analytics events tracking is enabled by default.
+   * The `analytics` prop is an object of events that is either a nested `objects` with key-value
+   * pairs, or `boolean` for disabling the event tracking. To disable an event tracking, set the
+   * event object value to `false`.
+   * When an event is triggered, the object value is populated and sent to google analytics
+   * if `window.utag` instance is loaded.
+   */
+  analytics: PropTypes.shape({
+    onComponentDidMount: PropTypes.oneOfType([PropTypes.bool, AnalyticsEventShape]),
+    onComponentWillUnmount: PropTypes.oneOfType([PropTypes.bool, AnalyticsEventShape]),
+  }),
   /**
    * Provide a **DOM node** which contains your page's content (which the modal should render
    * outside of). When the modal is open this node will receive `aria-hidden="true"`.

--- a/packages/design-system/src/components/Dialog/Dialog.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.jsx
@@ -3,8 +3,10 @@ import AriaModal from 'react-aria-modal';
 import Button from '../Button/Button';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import classNames from 'classnames';
 import get from 'lodash/get';
+import { htmlToText } from 'html-to-text';
 
 // Default analytics object
 const defaultAnalytics = (heading) => ({
@@ -29,6 +31,11 @@ const defaultAnalytics = (heading) => ({
 export class Dialog extends React.PureComponent {
   constructor(props) {
     super(props);
+    this.eventHeading = props.title || props.heading;
+    this.eventHeadingText =
+      typeof this.eventHeading === 'string'
+        ? this.eventHeading
+        : htmlToText(ReactDOMServer.renderToString(this.eventHeading));
     if (process.env.NODE_ENV !== 'production') {
       if (props.title) {
         console.warn(
@@ -49,21 +56,20 @@ export class Dialog extends React.PureComponent {
   }
 
   componentDidMount() {
-    if (this.headingRef) this.headingRef.focus();
     const eventAction = 'onComponentDidMount';
-    /* Send analytics event for helpdrawer open */
+    /* Send analytics event for dialog open */
     sendAnalyticsEvent(
       get(this.props.analytics, eventAction),
-      get(defaultAnalytics(this.props.title || this.props.heading), eventAction)
+      get(defaultAnalytics(this.eventHeadingText), eventAction)
     );
   }
 
   componentWillUnmount() {
     const eventAction = 'onComponentWillUnmount';
-    /* Send analytics event for helpdrawer close */
+    /* Send analytics event for dialog close */
     sendAnalyticsEvent(
       get(this.props.analytics, eventAction),
-      get(defaultAnalytics(this.props.title || this.props.heading), eventAction)
+      get(defaultAnalytics(this.eventHeadingText), eventAction)
     );
   }
 

--- a/packages/design-system/src/types/Alert/Alert.d.ts
+++ b/packages/design-system/src/types/Alert/Alert.d.ts
@@ -6,7 +6,35 @@ export type AlertRole = 'alert' | 'alertdialog' | 'region' | 'status';
 
 export type AlertVariation = 'error' | 'warn' | 'success';
 
+export interface AnalyticsEventShape {
+  event_name: string;
+  event_type: string;
+  ga_eventAction: string;
+  ga_eventCategory: string;
+  ga_eventLabel: string;
+  ga_eventType?: string;
+  ga_eventValue?: string;
+  heading: string;
+  type: string;
+  [additional_props: string]: unknown;
+}
+// additional_props?: Record<string, unknown>;
+
+export interface AnalyticsObjectShape {
+  onComponentDidMount?: boolean | AnalyticsEventShape;
+  onComponentWillUnmount?: boolean | AnalyticsEventShape;
+}
+
 export interface AlertProps {
+  /**
+   * Analytics events tracking is enabled by default.
+   * The `analytics` prop is an object of events that is either a nested `objects` with key-value
+   * pairs, or `boolean` for disabling the event tracking. To disable an event tracking, set the
+   * event object value to `false`.
+   * When an event is triggered, the object value is populated and sent to google analytics
+   * if `window.utag` instance is loaded.
+   */
+  analytics?: AnalyticsObjectShape;
   /**
    * The alert's body content
    */

--- a/packages/design-system/src/types/Dialog/Dialog.d.ts
+++ b/packages/design-system/src/types/Dialog/Dialog.d.ts
@@ -4,6 +4,24 @@ export type DialogCloseButtonSize = 'small' | 'big';
 
 export type DialogSize = 'narrow' | 'wide' | 'full';
 
+export interface AnalyticsEventShape {
+  event_name: string;
+  event_type: string;
+  ga_eventAction: string;
+  ga_eventCategory: string;
+  ga_eventLabel: string;
+  ga_eventType?: string;
+  ga_eventValue?: string;
+  heading: string;
+  [additional_props: string]: unknown;
+}
+// additional_props?: Record<string, unknown>;
+
+export interface AnalyticsObjectShape {
+  onComponentDidMount?: boolean | AnalyticsEventShape;
+  onComponentWillUnmount?: boolean | AnalyticsEventShape;
+}
+
 export interface DialogProps {
   /**
    * If `true`, the modal will receive a role of `alertdialog`, instead of its
@@ -11,6 +29,15 @@ export interface DialogProps {
    * alert, error, or warning occurs.
    */
   alert?: boolean;
+  /**
+   * Analytics events tracking is enabled by default.
+   * The `analytics` prop is an object of events that is either a nested `objects` with key-value
+   * pairs, or `boolean` for disabling the event tracking. To disable an event tracking, set the
+   * event object value to `false`.
+   * When an event is triggered, the object value is populated and sent to google analytics
+   * if `window.utag` instance is loaded.
+   */
+  analytics?: AnalyticsObjectShape;
   /**
    * Provide a **DOM node** which contains your page's content (which the modal should render
    * outside of). When the modal is open this node will receive `aria-hidden="true"`.


### PR DESCRIPTION
## Summary
Add GA event tracking to `<Alert>` and `<Dialog>` as [per Blast's requirements](https://confluence.cms.gov/display/HCDSG/Design+System+Component+GA+Event+Tracking%3A+Data+format): 

## How to test
http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-833/ga-tracking-for-alert-and-modal/

Test locally:
- Test that `Alert` and `Modal Dialog` components work as per normal. Then proceed to test GA event tracking.

Alert:
- Go to `Alert` component.
- Inspect DevTools network tab and filter for `collect` to view the analytics data or view using Chrome's extension `Omnibug`: there should be GA events captured for the 3 React examples

Modal Dialog:
- Go to `Modal Dialog` component, the React example and click `Click to show modal` to open modal dialog.
- Inspect DevTools network tab and filter for `collect` to view the analytics data or view using Chrome's extension `Omnibug`
- `Close` modal dialog and inspect DevTools network tab to view the analytics data again

**note that the network data only shows the 3 values for each of the event captured. Other values on the code are there to support other items/future GA4 implementation
   
   