### PR TITLE
[WNMGDS-893] Remove success/danger button variations from modal examples

### DIFF
--- a/packages/design-system-docs/src/pages/components/Dialog/Dialog.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Dialog/Dialog.example.jsx
@@ -22,7 +22,7 @@ class Example extends React.PureComponent {
   render() {
     return (
       <div id="App" style={{ minHeight: 300 }}>
-        <Button onClick={() => this.showModal()} size="big" variation="success">
+        <Button onClick={() => this.showModal()} size="big" variation="primary">
           Click to show modal
         </Button>
 

--- a/packages/design-system-docs/src/pages/components/Dialog/dialog-size.example.html
+++ b/packages/design-system-docs/src/pages/components/Dialog/dialog-size.example.html
@@ -2,21 +2,21 @@
   <button
     data-type="ds-c-dialog--narrow"
     data-heading="Narrow dialog"
-    class="dialog-open-btn ds-c-button ds-c-button--success ds-c-button--big ds-u-display--block"
+    class="dialog-open-btn ds-c-button ds-c-button--primary ds-c-button--big ds-u-display--block"
   >
     Click to show narrow dialog
   </button>
   <button
     data-type="ds-c-dialog--wide"
     data-heading="Wide dialog"
-    class="dialog-open-btn ds-c-button ds-c-button--success ds-c-button--big ds-u-display--block ds-u-margin-top--2"
+    class="dialog-open-btn ds-c-button ds-c-button--primary ds-c-button--big ds-u-display--block ds-u-margin-top--2"
   >
     Click to show wide dialog
   </button>
   <button
     data-type="ds-c-dialog--full"
     data-heading="Full page dialog"
-    class="dialog-open-btn ds-c-button ds-c-button--success ds-c-button--big ds-u-display--block ds-u-margin-top--2"
+    class="dialog-open-btn ds-c-button ds-c-button--primary ds-c-button--big ds-u-display--block ds-u-margin-top--2"
   >
     Click to show full page dialog
   </button>

--- a/packages/design-system-docs/src/pages/components/Dialog/dialog.example.html
+++ b/packages/design-system-docs/src/pages/components/Dialog/dialog.example.html
@@ -14,7 +14,7 @@
         <p class="ds-text"><strong>Dialog body text. </strong> {{lorem-m}}</p>
       </main>
       <aside class="ds-c-dialog__actions" role="complementary">
-        <button class="ds-c-button ds-c-button--danger">Dialog action</button>
+        <button class="ds-c-button ds-c-button--primary">Dialog action</button>
         <button class="ds-c-button ds-c-button--transparent">Cancel</button>
       </aside>
     </div>

--- a/packages/design-system/src/components/Dialog/Dialog.e2e.test.js
+++ b/packages/design-system/src/components/Dialog/Dialog.e2e.test.js
@@ -16,7 +16,7 @@ describe('Modal Dialog component', () => {
   it('Should open the modal dialog on click', async () => {
     await driver.get(rootURL);
 
-    let el = await getElementByClassName('ds-c-button--success');
+    let el = await getElementByClassName('ds-c-button--primary');
     el.click();
 
     el = await getElementByClassName('ds-c-dialog');
@@ -26,7 +26,7 @@ describe('Modal Dialog component', () => {
   it('Should have no accessibility violations', async () => {
     await driver.get(rootURL);
 
-    let el = await getElementByClassName('ds-c-button--success');
+    let el = await getElementByClassName('ds-c-button--primary');
     el.click();
 
     el = await getElementByClassName('ds-c-dialog');


### PR DESCRIPTION
## Summary
Remove success/danger button variations from modal examples and replace with the primary button variation

## How to test
Go to demo site: http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-893/remove-button-variations-from-modal-examples/components/dialog/
- check that the examples are all using the 'primary' button variation (which is blue) instead of the previous success (green) and danger (red) button variations