### PR TITLE
[WNMGDS-896] Update tooltip test

### DIFF
--- a/packages/design-system/src/components/Tooltip/Tooltip.test.jsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.test.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import Tooltip from './Tooltip';
 import TooltipIcon from './TooltipIcon';
 
+jest.mock('@popperjs/core');
+
 const defaultProps = {
   children: <TooltipIcon />,
   className: 'ds-c-tooltip__trigger-icon',


### PR DESCRIPTION
## Summary
Tooltip unit test is displaying a console.error `Popper: Invalid reference or popper argument provided. They must be either a DOM element or virtual element.`. 

### Added
Mocked the popper module in the Tooltip test to avoid error

## How to test
Run yarn test on master, see console errors pop up.

Run yarn test on this branch, no errors.