### PR TITLE
[NO-TICKET] Put analytics behind feature flags

### DIFF
--- a/packages/design-system-docs/src/pages/components/Alert/_Alert.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Alert/_Alert.docs.scss
@@ -191,13 +191,20 @@ Style guide: components.alert.guidance
 /*
 Google Analytics
 
-Analytics event tracking is disabled by default. To enable this feature, import and set the feature flag in your application's entry file:
+**Analytics event tracking is disabled by default.**
+
+### Enable event tracking
+
+- Import and set the `setAlertSendsAnalytics` feature flag to `true` in your application's entry file:
 ```
 import { setAlertSendsAnalytics } from "@cmsgov/<design-system-package>";
 setAlertSendsAnalytics(true);
 ```
-On application where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
-- To disable the automatic event tracking on certain cases, pass this prop to the component
+On applications where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
+
+### Disable event tracking
+
+- Pass the `onComponentDidMount` prop set to `false` to the component:
 ```
 analytics={
   {
@@ -205,7 +212,9 @@ analytics={
   }
 }
 ```
-- To override the event tracking, pass changes via the analytics prop
+### Override  event tracking
+
+- Pass changes via any of the [available analytics props](#components.alert.analytics).
 
 Style guide: components.alert.guidance-analytics
 */

--- a/packages/design-system-docs/src/pages/components/Alert/_Alert.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Alert/_Alert.docs.scss
@@ -196,7 +196,8 @@ Google Analytics
 ### Enable event tracking
 
 - Import and set the `setAlertSendsAnalytics` feature flag to `true` in your application's entry file:
-```
+
+```JSX
 import { setAlertSendsAnalytics } from "@cmsgov/<design-system-package>";
 setAlertSendsAnalytics(true);
 ```
@@ -205,7 +206,8 @@ On applications where the page has `utag` loaded, the data goes to Tealium which
 ### Disable event tracking
 
 - Pass the `onComponentDidMount` prop set to `false` to the component:
-```
+
+```JSX
 analytics={
   {
     onComponentDidMount: {false}

--- a/packages/design-system-docs/src/pages/components/Alert/_Alert.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Alert/_Alert.docs.scss
@@ -191,8 +191,13 @@ Style guide: components.alert.guidance
 /*
 Google Analytics
 
-On application where the page has `utag` loaded, analytics event tracking is enabled by default. The data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
-- To disable the automatic event tracking, pass this prop to the component
+Analytics event tracking is disabled by default. To enable this feature, import and set the feature flag in your application's entry file:
+```
+import { setAlertSendsAnalytics } from "@cmsgov/<design-system-package>";
+setAlertSendsAnalytics(true);
+```
+On application where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
+- To disable the automatic event tracking on certain cases, pass this prop to the component
 ```
 analytics={
   {

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -188,8 +188,13 @@ Style guide: components.dialog.guidance
 /*
 Google Analytics
 
-On application where the page has `utag` loaded, analytics event tracking is enabled by default. The data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
-- To disable the automatic event tracking, pass this prop to the component
+Analytics event tracking is disabled by default. To enable this feature, import and set the feature flag in your application's entry file:
+```
+import { setDialogSendsAnalytics } from "@cmsgov/<design-system-package>";
+setDialogSendsAnalytics(true);
+```
+On application where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
+- To disable the automatic event tracking on certain cases, pass this prop to the component
 ```
 analytics={
   {

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -193,7 +193,8 @@ Google Analytics
 ### Enable event tracking
 
 - Import and set the `setDialogSendsAnalytics` feature flag to `true` in your application's entry file:
-```
+
+```JSX
 import { setDialogSendsAnalytics } from "@cmsgov/<design-system-package>";
 setDialogSendsAnalytics(true);
 ```
@@ -204,7 +205,7 @@ On applications where the page has `utag` loaded, the data goes to Tealium which
 - Pass the `onComponentDidMount` prop set to `false` to the component:
 - Pass the `onComponentWillUnmount` prop set to `false` to the component:
 
-```
+```JSX
 analytics={
   {
     onComponentDidMount: {false},

--- a/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_Dialog.docs.scss
@@ -188,13 +188,22 @@ Style guide: components.dialog.guidance
 /*
 Google Analytics
 
-Analytics event tracking is disabled by default. To enable this feature, import and set the feature flag in your application's entry file:
+**Analytics event tracking is disabled by default.**
+
+### Enable event tracking
+
+- Import and set the `setDialogSendsAnalytics` feature flag to `true` in your application's entry file:
 ```
 import { setDialogSendsAnalytics } from "@cmsgov/<design-system-package>";
 setDialogSendsAnalytics(true);
 ```
-On application where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
-- To disable the automatic event tracking on certain cases, pass this prop to the component
+On applications where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
+
+### Disable event tracking
+
+- Pass the `onComponentDidMount` prop set to `false` to the component:
+- Pass the `onComponentWillUnmount` prop set to `false` to the component:
+
 ```
 analytics={
   {
@@ -203,7 +212,9 @@ analytics={
   }
 }
 ```
-- To override the event tracking, pass changes via the analytics prop
+### Override  event tracking
+
+- Pass changes via any of the [available analytics props](#components.alert.analytics).
 
 Style guide: components.dialog.guidance-analytics
 */

--- a/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
@@ -55,7 +55,8 @@ Google Analytics
 ### Enable event tracking
 
 - Import and set the `setDialogSendsAnalytics` feature flag to `true` in your application's entry file:
-```
+
+```JSX
 import { setDialogSendsAnalytics } from "@cmsgov/<design-system-package>";
 setDialogSendsAnalytics(true);
 ```
@@ -66,7 +67,7 @@ On applications where the page has `utag` loaded, the data goes to Tealium which
 - Pass the `onComponentDidMount` prop set to `false` to the component:
 - Pass the `onComponentWillUnmount` prop set to `false` to the component:
 
-```
+```JSX
 analytics={
   {
     onComponentDidMount: {false},

--- a/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
@@ -50,13 +50,22 @@ Style guide: patterns.external-link.guidance
 /*
 Google Analytics
 
-Analytics event tracking is disabled by default. To enable this feature, import and set the feature flag in your application's entry file:
+**Analytics event tracking is disabled by default.**
+
+### Enable event tracking
+
+- Import and set the `setDialogSendsAnalytics` feature flag to `true` in your application's entry file:
 ```
 import { setDialogSendsAnalytics } from "@cmsgov/<design-system-package>";
 setDialogSendsAnalytics(true);
 ```
-On application where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
-- To disable the automatic event tracking on certain cases, pass this prop to the component
+On applications where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
+
+### Disable event tracking
+
+- Pass the `onComponentDidMount` prop set to `false` to the component:
+- Pass the `onComponentWillUnmount` prop set to `false` to the component:
+
 ```
 analytics={
   {
@@ -65,7 +74,9 @@ analytics={
   }
 }
 ```
-- To override the event tracking, pass changes via the analytics prop
+### Override  event tracking
+
+- Pass changes via any of the [available analytics props](#components.alert.analytics).
 
 Style guide: patterns.external-link.guidance-analytics
 */

--- a/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
@@ -50,8 +50,13 @@ Style guide: patterns.external-link.guidance
 /*
 Google Analytics
 
-On application where the page has `utag` loaded, analytics event tracking is enabled by default. The data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
-- To disable the automatic event tracking, pass this prop to the component
+Analytics event tracking is disabled by default. To enable this feature, import and set the feature flag in your application's entry file:
+```
+import { setDialogSendsAnalytics } from "@cmsgov/<design-system-package>";
+setDialogSendsAnalytics(true);
+```
+On application where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
+- To disable the automatic event tracking on certain cases, pass this prop to the component
 ```
 analytics={
   {

--- a/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
+++ b/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
@@ -200,7 +200,7 @@ Google Analytics
 
 - Import and set the `setHelpDrawerSendsAnalytics` feature flag to `true` in your application's entry file:
 
-```
+```JSX
 import { setHelpDrawerSendsAnalytics } from "@cmsgov/<design-system-package>";
 setHelpDrawerSendsAnalytics(true);
 ```
@@ -211,7 +211,7 @@ On application where the page has `utag` loaded, the data goes to Tealium which 
 - Pass the `onComponentDidMount` prop set to `false` to the component:
 - Pass the `onComponentWillUnmount` prop set to `false` to the component:
 
-```
+```JSX
 analytics={
   {
     onComponentDidMount: {false},

--- a/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
+++ b/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
@@ -194,8 +194,13 @@ Style guide: components.help-drawer.guidance
 /*
 Google Analytics
 
-On application where the page has `utag` loaded, analytics event tracking is enabled by default. The data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
-- To disable the automatic event tracking, pass this prop to the component
+Analytics event tracking is disabled by default. To enable this feature, import and set the feature flag in your application's entry file:
+```
+import { setHelpDrawerSendsAnalytics } from "@cmsgov/<design-system-package>";
+setHelpDrawerSendsAnalytics(true);
+```
+On application where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
+- To disable the automatic event tracking on certain cases, pass this prop to the component
 ```
 analytics={
   {

--- a/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
+++ b/packages/design-system-docs/src/pages/components/HelpDrawer/_HelpDrawer.docs.scss
@@ -194,13 +194,23 @@ Style guide: components.help-drawer.guidance
 /*
 Google Analytics
 
-Analytics event tracking is disabled by default. To enable this feature, import and set the feature flag in your application's entry file:
+**Analytics event tracking is disabled by default.**
+
+### Enable event tracking
+
+- Import and set the `setHelpDrawerSendsAnalytics` feature flag to `true` in your application's entry file:
+
 ```
 import { setHelpDrawerSendsAnalytics } from "@cmsgov/<design-system-package>";
 setHelpDrawerSendsAnalytics(true);
 ```
 On application where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
-- To disable the automatic event tracking on certain cases, pass this prop to the component
+
+### Disable event tracking
+
+- Pass the `onComponentDidMount` prop set to `false` to the component:
+- Pass the `onComponentWillUnmount` prop set to `false` to the component:
+
 ```
 analytics={
   {
@@ -209,7 +219,10 @@ analytics={
   }
 }
 ```
-- To override the event tracking, pass changes via the analytics prop
+
+### Override  event tracking
+
+- Pass changes via any of the [available analytics props](#components.alert.analytics).
 
 Style guide: components.help-drawer.guidance-analytics
 */

--- a/packages/design-system/src/components/Alert/Alert.jsx
+++ b/packages/design-system/src/components/Alert/Alert.jsx
@@ -1,6 +1,7 @@
 import { EVENT_CATEGORY, MAX_LENGTH, sendAnalyticsEvent } from '../analytics/SendAnalytics';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { alertSendsAnalytics } from '../flags';
 import classNames from 'classnames';
 import get from 'lodash/get';
 import uniqueId from 'lodash.uniqueid';
@@ -51,10 +52,12 @@ export class Alert extends React.PureComponent {
             : '';
       }
 
-      sendAnalyticsEvent(
-        get(this.props.analytics, eventAction),
-        get(defaultAnalytics(this.eventHeadingText, this.props.variation), eventAction)
-      );
+      if (alertSendsAnalytics()) {
+        sendAnalyticsEvent(
+          get(this.props.analytics, eventAction),
+          get(defaultAnalytics(this.eventHeadingText, this.props.variation), eventAction)
+        );
+      }
     }
   }
 

--- a/packages/design-system/src/components/Alert/Alert.jsx
+++ b/packages/design-system/src/components/Alert/Alert.jsx
@@ -35,24 +35,24 @@ export class Alert extends React.PureComponent {
   }
 
   componentDidMount() {
-    const eventAction = 'onComponentDidMount';
-    const eventHeading = this.props.heading || this.props.children;
+    if (alertSendsAnalytics()) {
+      const eventAction = 'onComponentDidMount';
+      const eventHeading = this.props.heading || this.props.children;
 
-    /* Send analytics event for `error`, `warn`, `success` alert variations */
-    if (this.props.variation) {
-      if (typeof eventHeading === 'string') {
-        this.eventHeadingText = eventHeading.substring(0, MAX_LENGTH);
-      } else {
-        const eventHeadingTextElement =
-          (this.alertRef && this.alertRef.getElementsByClassName('ds-c-alert__heading')[0]) ||
-          (this.alertRef && this.alertRef.getElementsByClassName('ds-c-alert__body')[0]);
-        this.eventHeadingText =
-          eventHeadingTextElement && eventHeadingTextElement.textContent
-            ? eventHeadingTextElement.textContent.substring(0, MAX_LENGTH)
-            : '';
-      }
+      /* Send analytics event for `error`, `warn`, `success` alert variations */
+      if (this.props.variation) {
+        if (typeof eventHeading === 'string') {
+          this.eventHeadingText = eventHeading.substring(0, MAX_LENGTH);
+        } else {
+          const eventHeadingTextElement =
+            (this.alertRef && this.alertRef.getElementsByClassName('ds-c-alert__heading')[0]) ||
+            (this.alertRef && this.alertRef.getElementsByClassName('ds-c-alert__body')[0]);
+          this.eventHeadingText =
+            eventHeadingTextElement && eventHeadingTextElement.textContent
+              ? eventHeadingTextElement.textContent.substring(0, MAX_LENGTH)
+              : '';
+        }
 
-      if (alertSendsAnalytics()) {
         sendAnalyticsEvent(
           get(this.props.analytics, eventAction),
           get(defaultAnalytics(this.eventHeadingText, this.props.variation), eventAction)

--- a/packages/design-system/src/components/Alert/Alert.test.jsx
+++ b/packages/design-system/src/components/Alert/Alert.test.jsx
@@ -1,5 +1,6 @@
 import Alert from './Alert';
 import React from 'react';
+import { setAlertSendsAnalytics } from '../flags';
 import { shallow } from 'enzyme';
 
 const text = 'Ruhroh';
@@ -73,6 +74,7 @@ describe('Alert', function () {
     };
 
     beforeEach(() => {
+      setAlertSendsAnalytics(true);
       tealiumMock = jest.fn();
       window.utag = {
         link: tealiumMock,
@@ -80,6 +82,7 @@ describe('Alert', function () {
     });
 
     afterEach(() => {
+      setAlertSendsAnalytics(false);
       jest.resetAllMocks();
     });
 

--- a/packages/design-system/src/components/Dialog/Dialog.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.jsx
@@ -53,19 +53,19 @@ export class Dialog extends React.PureComponent {
   }
 
   componentDidMount() {
-    const eventAction = 'onComponentDidMount';
-    const eventHeading = this.props.title || this.props.heading;
-
-    if (typeof eventHeading === 'string') {
-      this.eventHeadingText = eventHeading.substring(0, MAX_LENGTH);
-    } else {
-      this.eventHeadingText =
-        this.headingRef && this.headingRef.textContent
-          ? this.headingRef.textContent.substring(0, MAX_LENGTH)
-          : '';
-    }
-
     if (dialogSendsAnalytics()) {
+      const eventAction = 'onComponentDidMount';
+      const eventHeading = this.props.title || this.props.heading;
+
+      if (typeof eventHeading === 'string') {
+        this.eventHeadingText = eventHeading.substring(0, MAX_LENGTH);
+      } else {
+        this.eventHeadingText =
+          this.headingRef && this.headingRef.textContent
+            ? this.headingRef.textContent.substring(0, MAX_LENGTH)
+            : '';
+      }
+
       /* Send analytics event for dialog open */
       sendAnalyticsEvent(
         get(this.props.analytics, eventAction),

--- a/packages/design-system/src/components/Dialog/Dialog.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.jsx
@@ -4,6 +4,7 @@ import Button from '../Button/Button';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import { dialogSendsAnalytics } from '../flags';
 import get from 'lodash/get';
 
 // Default analytics object
@@ -64,20 +65,24 @@ export class Dialog extends React.PureComponent {
           : '';
     }
 
-    /* Send analytics event for dialog open */
-    sendAnalyticsEvent(
-      get(this.props.analytics, eventAction),
-      get(defaultAnalytics(this.eventHeadingText), eventAction)
-    );
+    if (dialogSendsAnalytics()) {
+      /* Send analytics event for dialog open */
+      sendAnalyticsEvent(
+        get(this.props.analytics, eventAction),
+        get(defaultAnalytics(this.eventHeadingText), eventAction)
+      );
+    }
   }
 
   componentWillUnmount() {
-    const eventAction = 'onComponentWillUnmount';
-    /* Send analytics event for dialog close */
-    sendAnalyticsEvent(
-      get(this.props.analytics, eventAction),
-      get(defaultAnalytics(this.eventHeadingText), eventAction)
-    );
+    if (dialogSendsAnalytics()) {
+      const eventAction = 'onComponentWillUnmount';
+      /* Send analytics event for dialog close */
+      sendAnalyticsEvent(
+        get(this.props.analytics, eventAction),
+        get(defaultAnalytics(this.eventHeadingText), eventAction)
+      );
+    }
   }
 
   render() {

--- a/packages/design-system/src/components/Dialog/Dialog.test.jsx
+++ b/packages/design-system/src/components/Dialog/Dialog.test.jsx
@@ -1,6 +1,7 @@
 import { mount, shallow } from 'enzyme';
 import Dialog from './Dialog';
 import React from 'react';
+import { setDialogSendsAnalytics } from '../flags';
 
 function render(customProps = {}, deep = false) {
   const props = Object.assign(
@@ -76,6 +77,7 @@ describe('Dialog', function () {
     };
 
     beforeEach(() => {
+      setDialogSendsAnalytics(true);
       tealiumMock = jest.fn();
       window.utag = {
         link: tealiumMock,
@@ -83,6 +85,7 @@ describe('Dialog', function () {
     });
 
     afterEach(() => {
+      setDialogSendsAnalytics(false);
       jest.resetAllMocks();
     });
 

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import get from 'lodash/get';
+import { helpDrawerSendsAnalytics } from '../flags';
 
 // Default analytics object
 const defaultAnalytics = (heading = '') => ({
@@ -60,20 +61,24 @@ export class HelpDrawer extends React.PureComponent {
           : '';
     }
 
-    /* Send analytics event for helpdrawer open */
-    sendAnalyticsEvent(
-      get(this.props.analytics, eventAction),
-      get(defaultAnalytics(this.eventHeadingText), eventAction)
-    );
+    if (helpDrawerSendsAnalytics()) {
+      /* Send analytics event for helpdrawer open */
+      sendAnalyticsEvent(
+        get(this.props.analytics, eventAction),
+        get(defaultAnalytics(this.eventHeadingText), eventAction)
+      );
+    }
   }
 
   componentWillUnmount() {
-    const eventAction = 'onComponentWillUnmount';
-    /* Send analytics event for helpdrawer close */
-    sendAnalyticsEvent(
-      get(this.props.analytics, eventAction),
-      get(defaultAnalytics(this.eventHeadingText), eventAction)
-    );
+    if (helpDrawerSendsAnalytics()) {
+      const eventAction = 'onComponentWillUnmount';
+      /* Send analytics event for helpdrawer close */
+      sendAnalyticsEvent(
+        get(this.props.analytics, eventAction),
+        get(defaultAnalytics(this.eventHeadingText), eventAction)
+      );
+    }
   }
 
   render() {

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
@@ -49,19 +49,19 @@ export class HelpDrawer extends React.PureComponent {
   componentDidMount() {
     if (this.headingRef) this.headingRef.focus();
 
-    const eventAction = 'onComponentDidMount';
-    const eventHeading = this.props.title || this.props.heading;
-
-    if (typeof eventHeading === 'string') {
-      this.eventHeadingText = eventHeading.substring(0, MAX_LENGTH);
-    } else {
-      this.eventHeadingText =
-        this.headingRef && this.headingRef.textContent
-          ? this.headingRef.textContent.substring(0, MAX_LENGTH)
-          : '';
-    }
-
     if (helpDrawerSendsAnalytics()) {
+      const eventAction = 'onComponentDidMount';
+      const eventHeading = this.props.title || this.props.heading;
+
+      if (typeof eventHeading === 'string') {
+        this.eventHeadingText = eventHeading.substring(0, MAX_LENGTH);
+      } else {
+        this.eventHeadingText =
+          this.headingRef && this.headingRef.textContent
+            ? this.headingRef.textContent.substring(0, MAX_LENGTH)
+            : '';
+      }
+
       /* Send analytics event for helpdrawer open */
       sendAnalyticsEvent(
         get(this.props.analytics, eventAction),

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.test.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.test.jsx
@@ -1,6 +1,7 @@
 import HelpDrawer from './HelpDrawer.jsx';
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { setHelpDrawerSendsAnalytics } from '../flags';
 import { shallow } from 'enzyme';
 
 const defaultProps = {
@@ -57,6 +58,7 @@ describe('HelpDrawer', () => {
     };
 
     beforeEach(() => {
+      setHelpDrawerSendsAnalytics(true);
       tealiumMock = jest.fn();
       window.utag = {
         link: tealiumMock,
@@ -64,6 +66,7 @@ describe('HelpDrawer', () => {
     });
 
     afterEach(() => {
+      setHelpDrawerSendsAnalytics(false);
       jest.resetAllMocks();
     });
 

--- a/packages/design-system/src/components/flags.ts
+++ b/packages/design-system/src/components/flags.ts
@@ -12,7 +12,7 @@ const flags: flagsType = {
   ERROR_PLACEMENT_DEFAULT: 'top',
   ALERT_SENDS_ANALYTICS: false,
   DIALOG_SENDS_ANALYTICS: false,
-  HELP_DRAWER_SENDS_ANALYTICS: true,
+  HELP_DRAWER_SENDS_ANALYTICS: false,
 };
 
 export function errorPlacementDefault(): errorPlacementValue {

--- a/packages/design-system/src/components/flags.ts
+++ b/packages/design-system/src/components/flags.ts
@@ -1,11 +1,18 @@
 type errorPlacementValue = 'top' | 'bottom';
+
 interface flagsType {
   ERROR_PLACEMENT_DEFAULT: errorPlacementValue;
+  ALERT_SENDS_ANALYTICS: boolean;
+  DIALOG_SENDS_ANALYTICS: boolean;
+  HELP_DRAWER_SENDS_ANALYTICS: boolean;
 }
 
 // featureFlags.js
 const flags: flagsType = {
   ERROR_PLACEMENT_DEFAULT: 'top',
+  ALERT_SENDS_ANALYTICS: false,
+  DIALOG_SENDS_ANALYTICS: false,
+  HELP_DRAWER_SENDS_ANALYTICS: true,
 };
 
 export function errorPlacementDefault(): errorPlacementValue {
@@ -14,4 +21,28 @@ export function errorPlacementDefault(): errorPlacementValue {
 
 export function setErrorPlacementDefault(value: errorPlacementValue): void {
   flags.ERROR_PLACEMENT_DEFAULT = value;
+}
+
+export function alertSendsAnalytics(): boolean {
+  return flags.ALERT_SENDS_ANALYTICS;
+}
+
+export function setAlertSendsAnalytics(value: boolean): void {
+  flags.ALERT_SENDS_ANALYTICS = value;
+}
+
+export function dialogSendsAnalytics(): boolean {
+  return flags.DIALOG_SENDS_ANALYTICS;
+}
+
+export function setDialogSendsAnalytics(value: boolean): void {
+  flags.DIALOG_SENDS_ANALYTICS = value;
+}
+
+export function helpDrawerSendsAnalytics(): boolean {
+  return flags.HELP_DRAWER_SENDS_ANALYTICS;
+}
+
+export function setHelpDrawerSendsAnalytics(value: boolean): void {
+  flags.HELP_DRAWER_SENDS_ANALYTICS = value;
 }


### PR DESCRIPTION
## Summary
Put sending of analytics behind separate feature flags for each component that sends them while we get the issues worked out on the application side.

### Changed
- Analytics-sending is now behind feature flags for each component that sends them. They all OFF by default for now.