### PR TITLE
[NO-TICKET]Update focus bg colors to utility use

### DIFF
--- a/packages/design-system-docs/src/pages/utilities/background-color/background-color.example.html
+++ b/packages/design-system-docs/src/pages/utilities/background-color/background-color.example.html
@@ -8,12 +8,19 @@
   'warn' , 'warn-dark' , 'warn-darker' , 'warn-darkest' , 'warn-light' , 'warn-lighter' ,
   'warn-lightest' , 'error' , 'error-dark' , 'error-darker' , 'error-darkest' , 'error-light' ,
   'error-lighter' ,'error-lightest'], 'Focus colors' : ['focus-color-light' , 'focus-color-dark' ],
-  'Additional colors' : ['muted-inverse', 'transparent' ], }; -%> <%
+  'Additional colors' : ['muted-inverse', 'transparent' ], 'Focus colors - Deprecated' : ['focus-color', 'focus-color-inverse', 'focus-border-inverse'], }; -%> <%
   Object.keys(groups).forEach(function(fill){ -%>
   <section>
     <h1 class="preview__label">
       <%= fill%>
     </h1>
+    <% if (fill === 'Focus colors - Deprecated') { %>
+      <div class="ds-c-alert ds-c-alert--error ds-u-margin-bottom--2" role="region">
+        <div class="ds-c-alert__body">
+          <p class="ds-c-alert__text"><strong>Deprecated</strong> - Do not use.</p>
+        </div>
+      </div>
+    <% } %>
     <% groups[fill].forEach(function(color){ -%>
     <article class="ds-u-margin-bottom--1">
       <div
@@ -25,41 +32,4 @@
     <% }) -%>
   </section>
   <% }) %>
-  <section>
-    <h1 class="preview__label">
-      Focus colors - Deprecated
-    </h1>
-    <div class="ds-c-alert ds-c-alert--error ds-u-margin-bottom--2" role="region">
-      <div class="ds-c-alert__body">
-        <p class="ds-c-alert__text"><strong>Deprecated</strong> - Do not use.</p>
-      </div>
-    </div>
-    <article class="ds-u-margin-bottom--1">
-      <div
-        class="c-swatch__preview c-swatch__preview--condensed ds-u-radius--circle ds-u-fill--focus-color"
-      ></div>
-      <code>.ds-u-fill--focus-color</code>
-      <code class="c-swatch__label js-swatch-hex ds-u-color--gray ds-u-fill--transparent"
-        >#FFDE11</code
-      >
-    </article>
-    <article class="ds-u-margin-bottom--1">
-      <div
-        class="c-swatch__preview c-swatch__preview--condensed ds-u-radius--circle ds-u-fill--focus-color-inverse"
-      ></div>
-      <code>.ds-u-fill--focus-color-inverse</code>
-      <code class="c-swatch__label js-swatch-hex ds-u-color--gray ds-u-fill--transparent"
-        >#FFDE11</code
-      >
-    </article>
-    <article class="ds-u-margin-bottom--1">
-      <div
-        class="c-swatch__preview c-swatch__preview--condensed ds-u-radius--circle ds-u-fill--focus-border-inverse"
-      ></div>
-      <code>.ds-u-fill--focus-border-inverse</code>
-      <code class="c-swatch__label js-swatch-hex ds-u-color--gray ds-u-fill--transparent"
-        >#8F7C00</code
-      >
-    </article>
-  </section>
 </div>

--- a/packages/design-system-docs/src/pages/utilities/background-color/background-color.example.html
+++ b/packages/design-system-docs/src/pages/utilities/background-color/background-color.example.html
@@ -1,16 +1,19 @@
 <div class="example--list">
-  <% var groups = { 'Primary colors': ['primary', 'primary-darker', 'primary-darkest', 'black',
-  'base', 'gray-dark', 'gray-light', 'white'], 'Secondary colors': ['primary-alt',
-  'primary-alt-dark', 'primary-alt-darkest', 'primary-alt-light', 'primary-alt-lightest'],
-  'Background colors': ['background', 'background-inverse','gray-dark', 'gray', 'gray-light',
-  'gray-lighter', 'gray-lightest'], 'Status colors': ['success', 'success-dark', 'success-darker',
-  'success-darkest', 'success-light', 'success-lighter','success-lightest', 'warn', 'warn-dark',
-  'warn-darker', 'warn-darkest', 'warn-light', 'warn-lighter', 'warn-lightest', 'error',
-  'error-dark', 'error-darker', 'error-darkest', 'error-light', 'error-lighter','error-lightest'],
-  'Additional colors': ['focus-color', 'focus-color-inverse', 'focus-border-inverse',
-  'muted-inverse', 'transparent'], }; -%> <% Object.keys(groups).forEach(function(fill){ -%>
+  <% var groups={ 'Primary colors' : ['primary', 'primary-darker' , 'primary-darkest' , 'black' ,
+  'base' , 'gray-dark' , 'gray-light' , 'white' ], 'Secondary colors' : ['primary-alt',
+  'primary-alt-dark' , 'primary-alt-darkest' , 'primary-alt-light' , 'primary-alt-lightest' ],
+  'Background colors' : ['background', 'background-inverse' ,'gray-dark', 'gray' , 'gray-light' ,
+  'gray-lighter' , 'gray-lightest' ], 'Status colors' : ['success', 'success-dark' ,
+  'success-darker' , 'success-darkest' , 'success-light' , 'success-lighter' ,'success-lightest',
+  'warn' , 'warn-dark' , 'warn-darker' , 'warn-darkest' , 'warn-light' , 'warn-lighter' ,
+  'warn-lightest' , 'error' , 'error-dark' , 'error-darker' , 'error-darkest' , 'error-light' ,
+  'error-lighter' ,'error-lightest'], 'Focus colors' : ['focus-color-light' , 'focus-color-dark' ],
+  'Additional colors' : ['muted-inverse', 'transparent' ], }; -%> <%
+  Object.keys(groups).forEach(function(fill){ -%>
   <section>
-    <h1 class="preview__label"><%= fill%></h1>
+    <h1 class="preview__label">
+      <%= fill%>
+    </h1>
     <% groups[fill].forEach(function(color){ -%>
     <article class="ds-u-margin-bottom--1">
       <div
@@ -22,4 +25,41 @@
     <% }) -%>
   </section>
   <% }) %>
+  <section>
+    <h1 class="preview__label">
+      Focus colors - Deprecated
+    </h1>
+    <div class="ds-c-alert ds-c-alert--error ds-u-margin-bottom--2" role="region">
+      <div class="ds-c-alert__body">
+        <p class="ds-c-alert__text"><strong>Deprecated</strong> - Do not use.</p>
+      </div>
+    </div>
+    <article class="ds-u-margin-bottom--1">
+      <div
+        class="c-swatch__preview c-swatch__preview--condensed ds-u-radius--circle ds-u-fill--focus-color"
+      ></div>
+      <code>.ds-u-fill--focus-color</code>
+      <code class="c-swatch__label js-swatch-hex ds-u-color--gray ds-u-fill--transparent"
+        >#FFDE11</code
+      >
+    </article>
+    <article class="ds-u-margin-bottom--1">
+      <div
+        class="c-swatch__preview c-swatch__preview--condensed ds-u-radius--circle ds-u-fill--focus-color-inverse"
+      ></div>
+      <code>.ds-u-fill--focus-color-inverse</code>
+      <code class="c-swatch__label js-swatch-hex ds-u-color--gray ds-u-fill--transparent"
+        >#FFDE11</code
+      >
+    </article>
+    <article class="ds-u-margin-bottom--1">
+      <div
+        class="c-swatch__preview c-swatch__preview--condensed ds-u-radius--circle ds-u-fill--focus-border-inverse"
+      ></div>
+      <code>.ds-u-fill--focus-border-inverse</code>
+      <code class="c-swatch__label js-swatch-hex ds-u-color--gray ds-u-fill--transparent"
+        >#8F7C00</code
+      >
+    </article>
+  </section>
 </div>

--- a/packages/design-system/src/styles/settings/variables/_color.scss
+++ b/packages/design-system/src/styles/settings/variables/_color.scss
@@ -87,6 +87,15 @@ $color-muted-inverse: #bac5cf !default;
 $color-focus: #3e94cf !default;
 $color-focus-inverse: #59bcff !default;
 
+// More robust focus styles - To deprecate
+$focus-color: #ffde11 !default;
+$focus-color-inverse: #ffde11 !default;
+$focus-border-inverse: #8f7c00 !default;
+$focus-shadow: inset 0 0 0 1px $color-base;
+$focus-shadow-inverse: inset 0 0 0 1px $color-base !default;
+$focus-shadow-link: 0 3px $color-base !default;
+$focus-shadow-link-inverse: 0 3px $focus-border-inverse !default;
+
 // Focus colors
 $color-focus-light: #fff !default;
 $color-focus-dark: #bd13b8 !default;

--- a/packages/design-system/src/styles/utilities/_background-color.scss
+++ b/packages/design-system/src/styles/utilities/_background-color.scss
@@ -270,3 +270,15 @@
 .ds-u-fill--focus-color-dark {
   background-color: $color-focus-dark !important;
 }
+// Deprecated Focus colors
+.ds-u-fill--focus-color {
+  background-color: $focus-color !important;
+}
+
+.ds-u-fill--focus-color-inverse {
+  background-color: $focus-color-inverse !important;
+}
+
+.ds-u-fill--focus-border-inverse {
+  background-color: $focus-border-inverse !important;
+}


### PR DESCRIPTION
## Summary
Updated bg colors to mark old focus styles as deprecated while still supporting use 

### Deprecated
Marked old focus styles as deprecated 

## How to test
http://design-system-demo.s3-website-us-east-1.amazonaws.com/sw-focus-color-fix
Take a look at the bg color utility page to see that the old (gold) focus styles are present and marked as deprecated 
