### PR TITLE
Add export for DateFieldYearValue in <DateField />.

### DIFF
--- a/packages/design-system/src/components/DateField/DateField.tsx
+++ b/packages/design-system/src/components/DateField/DateField.tsx
@@ -11,6 +11,7 @@ export type DateFieldMonthDefaultValue = string | number;
 export type DateFieldMonthValue = string | number;
 export type DateFieldYearDefaultValue = string | number;
 export type DateFieldYearValue = string | number;
+export type DateFieldErrorPlacement = 'top' | 'bottom';
 
 export interface DateFieldProps {
   /**
@@ -39,7 +40,7 @@ export interface DateFieldProps {
   /**
    * Location of the error message relative to the field input
    */
-  errorPlacement?: 'top' | 'bottom';
+  errorPlacement?: DateFieldErrorPlacement;
   /**
    * Additional hint text to display above the individual month/day/year fields
    */


### PR DESCRIPTION
## Summary
Re-refactored `<DateInput />` component to include `export` type to address any possible breaking API changes.

Referenced the [original TS conversion PR](https://github.com/CMSgov/design-system/commit/38d69fa924c8af6f1c86da30b6136971871b9270#diff-b3894434effaa75461ba8dcb9438ad92764a4b9bb71fa6a04ce652baa877a692) to update interface. 

### Changed
- `DateFieldErrorPlacement` is now an exported type.
