### PR TITLE
Export several types and interfaces from <Dropdown />.

### DIFF
--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -5,6 +5,14 @@ import { errorPlacementDefault } from '../flags';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 
+export type DropdownDefaultValue = number | string;
+export interface DropdownOptions {
+  label: React.ReactNode;
+  value: number | string;
+}
+export type DropdownSize = 'small' | 'medium';
+export type DropdownValue = number | string;
+export type DropdownErrorPlacement = 'top' | 'bottom';
 export interface DropdownProps {
   /**
    * Adds `aria-label` attribute. When using `aria-label`, `label` should be empty string.
@@ -22,7 +30,7 @@ export interface DropdownProps {
    * Sets the initial selected state. Use this for an uncontrolled component;
    * otherwise, use the `value` property.
    */
-  defaultValue?: number | string;
+  defaultValue?: DropdownDefaultValue;
   /**
    * Disables the entire field.
    */
@@ -35,7 +43,7 @@ export interface DropdownProps {
   /**
    * Location of the error message relative to the field input
    */
-  errorPlacement?: 'top' | 'bottom';
+  errorPlacement?: DropdownErrorPlacement;
   /**
    * Additional classes to be added to the select element
    */
@@ -75,10 +83,7 @@ export interface DropdownProps {
   /**
    * The list of options to be rendered. Provide an empty list if using custom options via the `children` prop.
    */
-  options: {
-    label: React.ReactNode;
-    value: number | string;
-  }[];
+  options: DropdownOptions[];
   onBlur?: (...args: any[]) => any;
   onChange?: (...args: any[]) => any;
   /**
@@ -88,12 +93,12 @@ export interface DropdownProps {
   /**
    * If the component renders a select, set the max-width of the input either to `'small'` or `'medium'`.
    */
-  size?: 'small' | 'medium';
+  size?: DropdownSize;
   /**
    * Sets the field's `value`. Use this in combination with `onChange`
    * for a controlled component; otherwise, set `defaultValue`.
    */
-  value?: number | string;
+  value?: DropdownValue;
 }
 
 type OmitProps =


### PR DESCRIPTION
## Summary
Re-refactored `<Dropdown />` component to include several `export` types/interfaces to address any possible breaking API changes.

Referenced the [original TS conversion PR](https://github.com/CMSgov/design-system/commit/c70d77a7903be42868c3725a5d3014a4cc44132f#diff-c132558c7ba0b4e130880148a65be06ed0cb42a950020183fb88bc11a899a351) to update interface.

### Changed
`export`
- `DropdownDefaultValue`
- `DropdownOptions`
- `DropdownSize`
- `DropdownValue`
- `DropdownErrorPlacement`

Referenced new exports in main interface.