### PR TITLE
Review TS types/interfaces for TextField components.

### DIFF
--- a/packages/design-system/src/components/TextField/Mask.tsx
+++ b/packages/design-system/src/components/TextField/Mask.tsx
@@ -1,6 +1,9 @@
 import { maskValue, unmaskValue } from './maskHelpers';
 import React from 'react';
 
+// TODO: Remove `maskValue` and `unmaskValue` exports with next major release (v3.x.x)
+export { maskValue, unmaskValue };
+
 const maskPattern = {
   phone: '[0-9-]*',
   ssn: '[0-9-*]*',

--- a/packages/design-system/src/components/TextField/TextField.tsx
+++ b/packages/design-system/src/components/TextField/TextField.tsx
@@ -10,10 +10,11 @@ import pick from 'lodash/pick';
 export { unmaskValue } from './maskHelpers';
 
 export type TextFieldDefaultValue = string | number;
-
+export type TextFieldMask = 'currency' | 'phone' | 'ssn' | 'zip';
 export type TextFieldRows = number | string;
-
+export type TextFieldSize = 'small' | 'medium';
 export type TextFieldValue = string | number;
+export type TextFieldErrorPlacement = 'top' | 'bottom';
 
 export interface TextFieldProps {
   /**
@@ -39,7 +40,7 @@ export interface TextFieldProps {
   /**
    * Location of the error message relative to the field input
    */
-  errorPlacement?: 'top' | 'bottom';
+  errorPlacement?: TextFieldErrorPlacement;
   /**
    * Additional classes to be added to the field element
    */
@@ -85,7 +86,7 @@ export interface TextFieldProps {
    * you expect to be entered. Depending on the mask, the
    * field's appearance and functionality may be affected.
    */
-  mask?: 'currency' | 'phone' | 'ssn' | 'zip';
+  mask?: TextFieldMask;
   /**
    * Whether or not the text field is a multiline text field
    */
@@ -109,7 +110,7 @@ export interface TextFieldProps {
   /**
    * Set the max-width of the input either to `'small'` or `'medium'`.
    */
-  size?: 'small' | 'medium';
+  size?: TextFieldSize;
   /**
    * HTML `input` [type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#<input>_types) attribute. If you are using `type=number` please use the numeric prop instead.
    */

--- a/packages/design-system/src/components/TextField/TextInput.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.tsx
@@ -3,7 +3,11 @@ import Mask from './Mask';
 import classNames from 'classnames';
 
 export type TextInputDefaultValue = string | number;
+export type TextInputMask = 'currency' | 'phone' | 'ssn' | 'zip';
+export type TextInputRows = number | string;
+export type TextInputSize = 'small' | 'medium';
 export type TextInputValue = string | number;
+export type TextInputErrorPlacement = 'top' | 'bottom';
 
 export interface TextInputProps {
   /**
@@ -25,7 +29,7 @@ export interface TextInputProps {
   /**
    * Location of the error message relative to the field input
    */
-  errorPlacement?: 'top' | 'bottom';
+  errorPlacement?: TextInputErrorPlacement;
   /**
    * Additional classes to be added to the field element
    */
@@ -43,7 +47,7 @@ export interface TextInputProps {
    * you expect to be entered. Depending on the mask, the
    * field's appearance and functionality may be affected.
    */
-  mask?: 'currency' | 'phone' | 'ssn' | 'zip';
+  mask?: TextInputMask;
   /**
    * Whether or not the text field is a multiline text field
    */
@@ -63,12 +67,12 @@ export interface TextInputProps {
    * Optionally specify the number of visible text lines for the field. Only
    * applicable if this is a multiline field.
    */
-  rows?: number | string;
+  rows?: TextInputRows;
   setRef?: (...args: any[]) => any;
   /**
    * Set the max-width of the input either to `'small'` or `'medium'`.
    */
-  size?: 'small' | 'medium';
+  size?: TextInputSize;
   /**
    * HTML `input` [type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#<input>_types) attribute. If you are using `type=number` please use the numeric prop instead.
    */
@@ -80,7 +84,7 @@ export interface TextInputProps {
   value?: TextInputValue;
 }
 
-export type OmitProps = 'size' | 'ref';
+type OmitProps = 'size' | 'ref';
 
 /**
  * <TextInput> is an internal component used by <TextField>, which wraps it and handles shared form UI like labels, error messages, etc


### PR DESCRIPTION
# Summary
Re-refactored `<Mask />`,  `<TextField />`, and `<TextInput />`,  components to include several export types to address any possible breaking API changes.

Referenced the [original TS conversion PR](https://github.com/CMSgov/design-system/commit/c70d77a7903be42868c3725a5d3014a4cc44132f#) to update interface.

## Changed
`export`
- `maskValue` and `unmaskValue` functions (to be removed at next major version release)
- `TextFieldMask`
- `TextFieldSize`
- `TextFieldErrorPlacement`
- `TextInputMask`
- `TextInputRows`
- `TextInputSize`
- `TextInputErrorPlacement`

Referenced new exports in main interface.