### PR TITLE
Update build script to include development branch.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,13 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: 
+      - master
+      - development
   pull_request:
-    branches: [ master ]
+    branches: 
+      - master
+      - development
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
We recently adopted the Gitflow workflow, meaning all new development will branch off/into a newly created `development` branch. However, doing adding this new branch resulted in the build script failing. I've added `development` to a list of branches to fix this.

Followed [guidance from GitHub](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags) to do this fix.

## How to test
Creating this PR should kick off a build check. Once it's merged, we'll see the other PRs builds run.