### PR TITLE
[WNMGDS-995] autocomplete aria attribute update

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -230,7 +230,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, any> {
           : child.props.errorMessageClassName;
         const propOverrides = {
           'aria-autocomplete': 'list',
-          'aria-controls': isOpen ? this.listboxId : null,
+          'aria-controls': this.listboxId,
           'aria-expanded': isOpen,
           'aria-labelledby': null,
           'aria-owns': isOpen ? this.listboxId : null,

--- a/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Autocomplete renders a snapshot 1`] = `
     <input
       aria-activedescendant={null}
       aria-autocomplete="list"
-      aria-controls={null}
+      aria-controls="autocomplete_owned_listbox_43"
       aria-expanded={false}
       aria-invalid={false}
       aria-labelledby={null}


### PR DESCRIPTION
## Summary
Updated the Autocomplete component so that `aria-controls` attribute is present always.

### Fixed
Updated the Autocomplete component so that `aria-controls` attribute is always present.

## How to test
* Pull up the demo site http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-995/autocomplete-accessibility-bugfix
* Navigate to the Autocomplete component
* Run AXE extension, confirm that `Required ARIA attributes must be provided` issue is resolved
<img width="1792" alt="Screen Shot 2021-08-05 at 11 48 51 AM" src="https://user-images.githubusercontent.com/33579665/128399196-8d9188dc-8dca-465f-820f-359aaa58a598.png"> 