### PR TITLE
[WNMGDS-1047] Revert `dateFormatter` to original type (DEV)

### DIFF
--- a/packages/design-system/src/components/DateField/DateField.tsx
+++ b/packages/design-system/src/components/DateField/DateField.tsx
@@ -30,7 +30,7 @@ export interface DateFieldProps {
    *
    * By default `dateFormatter` will be set to the `defaultDateFormatter` function, which prevents days/months more than 2 digits & years more than 4 digits.
    */
-  dateFormatter?: typeof defaultDateFormatter;
+  dateFormatter?: (...args: any[]) => any;
   disabled?: boolean;
   errorMessage?: React.ReactNode;
   /**


### PR DESCRIPTION
## Summary
Tyler Gould reported a breaking change in `DateField` component where the `dateFormatter` was no longer accepting a type of `any` - instead enforcing a strict `DateObject` type. Since this is a breaking change to the API, I've reverted this type back to its original definition.

You can see when [the changes were introduced in this commit](https://github.com/CMSgov/design-system/commit/38d69fa924c8af6f1c86da30b6136971871b9270#diff-a16e93d3d7e200cf3e3dce44ef2986d07b25c4fc8b9367e88ac2060ee3d25080L33-R32). I tried highlighting the specific line, but if the link doesn't correctly display, the change was made to file `DateField.tsx` (component) and line 32.

I also noticed as part of that refactor, the `defaultDateFormatter` is now being imported, but appears to be needed for this prop's default value, so I've kept it in this file. I'm guessing because this was the default value, the dev assumed this was the type we wanted to enforce on this prop.

http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1047/fix-datefield-interface