### PR TITLE
Revert dateformatter in datefield interface to previous type.

### DIFF
--- a/packages/design-system/src/components/DateField/DateField.tsx
+++ b/packages/design-system/src/components/DateField/DateField.tsx
@@ -30,7 +30,7 @@ export interface DateFieldProps {
    *
    * By default `dateFormatter` will be set to the `defaultDateFormatter` function, which prevents days/months more than 2 digits & years more than 4 digits.
    */
-  dateFormatter?: typeof defaultDateFormatter;
+  dateFormatter?: (...args: any[]) => any;
   disabled?: boolean;
   errorMessage?: React.ReactNode;
   /**


### PR DESCRIPTION
Duplicating fix from #1119 to go into `master` for a hotfix.

Review that PR for more details.