### PR TITLE
WNMGDS-1064 - Fix text-underline bug 

### DIFF
--- a/packages/design-system/src/styles/base/_link.scss
+++ b/packages/design-system/src/styles/base/_link.scss
@@ -1,5 +1,5 @@
 /* stylelint-disable selector-class-pattern */
-@import '../settings/index.scss';
+@import '../settings/index.scss'; 
 
 // Links
 // Default link

--- a/packages/design-system/src/styles/base/_link.scss
+++ b/packages/design-system/src/styles/base/_link.scss
@@ -17,7 +17,7 @@ $link-inverse-active-color: $color-muted-inverse !default;
 // Link underline
 $link-underline-height: 1px !default;
 $link-underline-height-hover: 1px !default;
-$link-underline-offset: 0 !default;
+$link-underline-offset: auto !default;
 
 %link {
   color: $link-color;


### PR DESCRIPTION

## Summary
ISSUE: Mobile view: Underlines in various texts seems to be broken 

DESCRIPTION: When PCII is open in mobile view, texts which are underlined, there seems to be line that is broken in pieces instead of continuous line.
https://jira.cms.gov/browse/WNMGPCII-1515 


### Fixed
changed value of text-underline-offset from `0` to `auto` where the browser chooses the appropriate offset for underlines.
https://developer.mozilla.org/en-US/docs/Web/CSS/text-underline-offset

## How to test
take a look at the demo url on an iOS device to ensure that the links are not looking broken
 http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1064-text-underline-fix 