### PR TITLE
WNMGDS 814/e2e tool update

### DIFF
--- a/packages/design-system-scripts/helpers/e2e/assertNoAxeViolations.js
+++ b/packages/design-system-scripts/helpers/e2e/assertNoAxeViolations.js
@@ -1,5 +1,4 @@
 /* global driver, AxeBuilder */
-// const AxeBuilder = require('@axe-core/webdriverjs');
 const { RULESET_ALL } = require('./constants');
 const chalk = require('chalk');
 

--- a/packages/design-system-scripts/helpers/e2e/assertNoAxeViolations.js
+++ b/packages/design-system-scripts/helpers/e2e/assertNoAxeViolations.js
@@ -1,4 +1,5 @@
-/* global driver, axeBuilder */
+/* global driver, AxeBuilder */
+// const AxeBuilder = require('@axe-core/webdriverjs');
 const { RULESET_ALL } = require('./constants');
 const chalk = require('chalk');
 
@@ -41,23 +42,25 @@ function printViolations(violations) {
   violations.forEach(printViolation);
 }
 
-module.exports = async function assertNoAxeViolations(url, disabledRules = []) {
+module.exports = function assertNoAxeViolations(url, disabledRules = []) {
   if (url) {
-    await driver.get(url);
+    return driver.get(url)
+    .then(() => {
+      const defaultDisabledRules = ['bypass'];
+      return new AxeBuilder(driver)
+        .withTags(RULESET_ALL)
+        .disableRules(defaultDisabledRules.concat(disabledRules))
+        .analyze((err, results) => {
+          if (results && results.violations.length >= 1) {
+            printViolations(results.violations);
+          }
+          if (err) {
+            // ESLint wants us to handle the error directly, but that's what
+            // our assertion does below.
+          }
+          expect(results.violations.length).toBe(0);
+        });
+    })
+    .catch((err) => { console.log(err)});
   }
-  const defaultDisabledRules = ['bypass'];
-
-  await axeBuilder(driver)
-    .withTags(RULESET_ALL)
-    .disableRules(defaultDisabledRules.concat(disabledRules))
-    .analyze((err, results) => {
-      if (results.violations.length >= 1) {
-        printViolations(results.violations);
-      }
-      if (err) {
-        // ESLint wants us to handle the error directly, but that's what
-        // our assertion does below.
-      }
-      expect(results.violations.length).toBe(0);
-    });
 };

--- a/packages/design-system-scripts/helpers/e2e/constants.js
+++ b/packages/design-system-scripts/helpers/e2e/constants.js
@@ -1,5 +1,5 @@
 const ROOT_URL = 'http://localhost:3001';
-const RULESET_ALL = ['section508', 'wcag2a', 'wcag2aa', 'wcag21aa'];
+const RULESET_ALL = ['section508', 'wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
 const RULESET_BEST_PRACTICE = ['best-practice'];
 const RULESET_WCAG_TWO = ['section508', 'wcag2a', 'wcag2aa'];
 const RULESET_508 = ['section508'];

--- a/packages/design-system-scripts/jest/e2e.environment.js
+++ b/packages/design-system-scripts/jest/e2e.environment.js
@@ -1,5 +1,5 @@
 /* eslint-disable  filenames/match-exported */
-const AxeBuilder = require('axe-webdriverjs');
+const AxeBuilder = require('@axe-core/webdriverjs');
 const NodeEnvironment = require('jest-environment-node');
 const { Builder, By, Key, until } = require('selenium-webdriver');
 const chrome = require('selenium-webdriver/chrome');
@@ -33,7 +33,7 @@ class WebDriverEnvironment extends NodeEnvironment {
     this.global.element.all = (locator) => this.driver.findElements(locator);
     this.global.key = Key;
     this.global.until = until;
-    this.global.axeBuilder = AxeBuilder;
+    this.global.AxeBuilder = AxeBuilder;
   }
 
   async teardown() {

--- a/packages/design-system-scripts/jest/unit.config.js
+++ b/packages/design-system-scripts/jest/unit.config.js
@@ -9,7 +9,6 @@ module.exports = (rootDir, core) => ({
   snapshotSerializers: ['enzyme-to-json/serializer'],
   testPathIgnorePatterns: ['dist/', 'node_modules/', '.+\\.e2e\\.test\\.js$'],
   transformIgnorePatterns: ['node_modules(?!/@cmsgov)'],
-  testTimeout: 30000,
   // Add moduleNameMapper for core CMSDS to resolve imports from @cmsgov/design-system to packages/design-system
   moduleNameMapper: core
     ? {

--- a/packages/design-system-scripts/jest/unit.config.js
+++ b/packages/design-system-scripts/jest/unit.config.js
@@ -9,6 +9,7 @@ module.exports = (rootDir, core) => ({
   snapshotSerializers: ['enzyme-to-json/serializer'],
   testPathIgnorePatterns: ['dist/', 'node_modules/', '.+\\.e2e\\.test\\.js$'],
   transformIgnorePatterns: ['node_modules(?!/@cmsgov)'],
+  testTimeout: 30000,
   // Add moduleNameMapper for core CMSDS to resolve imports from @cmsgov/design-system to packages/design-system
   moduleNameMapper: core
     ? {

--- a/packages/design-system-scripts/package.json
+++ b/packages/design-system-scripts/package.json
@@ -12,6 +12,7 @@
     "cmsds": "./cli.js"
   },
   "dependencies": {
+    "@axe-core/webdriverjs": "^4.2.2",
     "@babel/core": "^7.8.4",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-transform-object-assign": "^7.10.4",
@@ -22,7 +23,6 @@
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^10.3.0",
     "autoprefixer": "9.6.0",
-    "axe-webdriverjs": "^2.3.0",
     "babel-loader": "^8.0.0",
     "babel-plugin-inline-react-svg": "^1.1.2",
     "browser-sync": "2.26.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@axe-core/webdriverjs@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@axe-core/webdriverjs/-/webdriverjs-4.2.2.tgz#430a3caf365e4dfa4314fe4ea644543fd5f868f3"
+  integrity sha512-h3VrFXAHAIinoHQU/u9bmLUET/gAfab3y7VpUt6HOHe4NKsk9wi+6zoM3L8yCZSWriItmK3nuVrn6byeC+/Pcw==
+  dependencies:
+    axe-core "^4.2.3"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -3650,19 +3657,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
-axe-core@^3.3.1:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
-  integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
-
-axe-webdriverjs@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/axe-webdriverjs/-/axe-webdriverjs-2.3.0.tgz#92511fbce38624a57e1aa861dd8a3c73c6a3a972"
-  integrity sha512-AuUsX5OFTXOJ6reIKjtGay4O656n5G+m8MzhfL1SC8MHINBFFFn3Taucckn8+UZYJuTtNEobllSfiuPTHyKnSA==
-  dependencies:
-    axe-core "^3.3.1"
-    babel-runtime "^6.26.0"
-    depd "^2.0.0"
+axe-core@^4.2.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.3.tgz#b55cd8e8ddf659fe89b064680e1c6a4dceab0325"
+  integrity sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
 
 axios@0.19.0:
   version "0.19.0"
@@ -3781,14 +3779,6 @@ babel-preset-jest@^25.5.0:
   dependencies:
     babel-plugin-jest-hoist "^25.5.0"
     babel-preset-current-node-syntax "^0.1.2"
-
-babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
 
 bach@^1.0.0:
   version "1.2.0"
@@ -4888,11 +4878,6 @@ commander@^5.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.0.0.tgz#dbf1909b49e5044f8fdaf0adc809f0c0722bdfd0"
   integrity sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==
 
-commander@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
-
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -5153,11 +5138,6 @@ core-js-pure@^3.0.0:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
-
-core-js@^2.4.0:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
-  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
 core-js@^3.5.0, core-js@^3.6.5:
   version "3.6.5"
@@ -5763,11 +5743,6 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
-depd@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -11649,15 +11624,6 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-nunjucks@>=3.2.0:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.3.tgz#1b33615247290e94e28263b5d855ece765648a31"
-  integrity sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==
-  dependencies:
-    a-sync-waterfall "^1.0.0"
-    asap "^2.0.3"
-    commander "^5.1.0"
-
 nunjucks@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.1.tgz#f229539281e92c6ad25d8c578c9bdb41655caf83"
@@ -13625,11 +13591,6 @@ regenerate@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.1.tgz#cad92ad8e6b591773485fbe05a485caf4f457e6f"
   integrity sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==
-
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.5:
   version "0.13.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4878,6 +4878,11 @@ commander@^5.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.0.0.tgz#dbf1909b49e5044f8fdaf0adc809f0c0722bdfd0"
   integrity sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==
 
+commander@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -11623,6 +11628,15 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+
+nunjucks@>=3.2.0:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.3.tgz#1b33615247290e94e28263b5d855ece765648a31"
+  integrity sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==
+  dependencies:
+    a-sync-waterfall "^1.0.0"
+    asap "^2.0.3"
+    commander "^5.1.0"
 
 nunjucks@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
## Summary
Updating the npm package we use for axe accessibility testing

## How to test
- Pull down branch
- run `yarn install`
- run `yarn test`

_Note: it is expected that the e2e tests will fail. Specifically, one of the spinner tests. This is good! This error was also caught by DK in [this Jira](https://jira.cms.gov/browse/WNMGDS-843) The fix for this test will come in a separate PR and that is a dependency for merging this PR_