### PR TITLE
[NO-TICKET] Add clearInputOnBlur prop to Autocomplete

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -22,6 +22,7 @@ import WrapperDiv from './WrapperDiv';
 import classNames from 'classnames';
 import { errorPlacementDefault } from '../flags';
 import get from 'lodash/get';
+import keepInputDownshiftStateReducer from './keepInputDownshiftStateReducer';
 import uniqueId from 'lodash.uniqueid';
 
 export interface AutocompleteItems {
@@ -37,6 +38,7 @@ type PropsNotPassedToDownshift =
   | 'loading'
   | 'children'
   | 'className'
+  | 'clearInputOnBlur'
   | 'clearSearchButton';
 
 export interface AutocompleteProps extends Omit<DownshiftProps<any>, PropsNotPassedToDownshift> {
@@ -57,6 +59,10 @@ export interface AutocompleteProps extends Omit<DownshiftProps<any>, PropsNotPas
    * Useful for adding utility classes.
    */
   className?: string;
+  /**
+   * When set to `false`, do not clear the input when the input element loses focus.
+   */
+  clearInputOnBlur?: boolean;
   /**
    * Text rendered on the page if `clearInput` prop is passed. Default is "Clear search".
    */
@@ -140,6 +146,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, any> {
     autoCompleteLabel: 'off',
     clearInputText: 'Clear search',
     clearSearchButton: true,
+    clearInputOnBlur: true,
     itemToString: (item): string => (item ? item.name : ''),
     loadingMessage: 'Loading...',
     noResultsMessage: 'No results',
@@ -262,11 +269,16 @@ export class Autocomplete extends React.Component<AutocompleteProps, any> {
       loading,
       children,
       className,
+      clearInputOnBlur,
       clearSearchButton,
       ...autocompleteProps
     }: AutocompleteProps = this.props;
 
     const rootClassName = classNames('ds-u-clearfix', 'ds-c-autocomplete', className);
+
+    if (clearInputOnBlur === false) {
+      autocompleteProps.stateReducer = keepInputDownshiftStateReducer;
+    }
 
     return (
       <Downshift {...autocompleteProps}>

--- a/packages/design-system/src/components/Autocomplete/keepInputDownshiftStateReducer.ts
+++ b/packages/design-system/src/components/Autocomplete/keepInputDownshiftStateReducer.ts
@@ -1,0 +1,33 @@
+import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
+
+/**
+ * For some use cases of the Autocomplete component, we do not want the input to
+ * be cleared when the input element loses focus. The default behavior of Downshift
+ * is to clear the input value when the field loses focus. This custom Downshift
+ * state reducer keeps that input value rather than clearing it.
+ */
+export default function keepInputDownshiftStateReducer(
+  state: DownshiftState<any>,
+  changes: StateChangeOptions<any>
+) {
+  switch (changes.type) {
+    case Downshift.stateChangeTypes.touchEnd:
+    case Downshift.stateChangeTypes.blurInput:
+    case Downshift.stateChangeTypes.mouseUp:
+      return {
+        inputValue: state.inputValue,
+        isOpen: false,
+      };
+    // Clear input when `esc` is pressed
+    // Default behavior to reselect the last selected item, but that doesn't
+    // trigger the validations for the change events
+    case Downshift.stateChangeTypes.keyDownEscape:
+      return {
+        inputValue: '',
+        isOpen: false,
+        selectedItem: null,
+      };
+    default:
+      return changes;
+  }
+}


### PR DESCRIPTION
## Summary
All of the instances of Autocomplete that I know of on hc.gov require the behavior implemented in this PR. DM me for details and more context.

### Added
- Added `clearInputOnBlur` default prop to `Autocomplete` that can be set to `false` to keep input after blur, instead of the default behavior which is to clear input if no selections are made.

## How to test
Modify one of the examples by setting `clearInputOnBlur` to false and observe the new behavior.
