### PR TITLE
[NO-TICKET] Update chromedriver from version 91 to 93

### DIFF
--- a/packages/design-system-scripts/package.json
+++ b/packages/design-system-scripts/package.json
@@ -28,7 +28,7 @@
     "browser-sync": "2.26.7",
     "bytes": "3.1.0",
     "chalk": "^2.4.2",
-    "chromedriver": "91.0.0",
+    "chromedriver": "93.0.0",
     "cli-table2": "^0.2.0",
     "colors": "1.3.3",
     "cssnano": "4.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4557,10 +4557,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@91.0.0:
-  version "91.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-91.0.0.tgz#b8c07d715c1bde2ed5817757e923bd65565c8f94"
-  integrity sha512-0eQGLDWvfVd1apkqQpt4452bCATrsj50whhVzMqPiazNSfCXXwfYWRonYxx3DVFCG3+RwSCLvsk8/vpuojCyJA==
+chromedriver@93.0.0:
+  version "93.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-93.0.0.tgz#6c136a074248b88efe5851bca7e41110aff5aeb9"
+  integrity sha512-WHntgiZf13rds6SjeFRgH02prad8k+wWrQSaj5QPi0kaNJUukdJNDJG7pn8OshWTKTJZ6oqgvMQ1mvnIIBY5GQ==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.1"


### PR DESCRIPTION

## Summary
Updated chrome driver version used in the e2e tests because the chromium version in our CI stack changed and e2e tests were failing.