### PR TITLE
[WNMGWINSHOP-934] Revert one prop type change for Autocomplete

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -99,7 +99,7 @@ export interface AutocompleteProps extends Omit<DownshiftProps<any>, PropsNotPas
   /**
    * Customize the default status messages announced to screenreader users via aria-live when autocomplete results are populated. [Read more on downshift docs.](https://github.com/paypal/downshift#geta11ystatusmessage)
    */
-  getA11yStatusMessage?: (options: A11yStatusMessageOptions<AutocompleteItems>) => string;
+  getA11yStatusMessage?: DownshiftProps<any>['getA11yStatusMessage'];
   /**
    * Access a reference to the child `TextField`'s `input` element
    */


### PR DESCRIPTION
### Fixed
- Revert change (#1133) to `getA11yStatusMessage` type so we aren't enforcing strict compliance to our `AutocompleteItems` interface. This was causing one hc.gov app to fail its build.