### PR TITLE
[NO-TICKET] Expose type definitions for analytics modules

### DIFF
--- a/packages/design-system/src/types/index.d.ts
+++ b/packages/design-system/src/types/index.d.ts
@@ -33,4 +33,5 @@ export * from './Table';
 export * from './TextField';
 export * from './Tooltip';
 
+export * from './analytics';
 export * from './flags';


### PR DESCRIPTION
## Summary
Unfortunately in the `dist` copy of our core package the TS typedefs for the `analytics` folder were never exported, so we don't access to them in the child design systems. I don't think this warrants a hotfix release. I was planning on writing my new code for analytics in the header in TypeScript, but I'll just write it in plain JavaScript for now since it's only one helper function.

### Fixed
- TypeScript type definitions are now available for the `analytics` module
