### PR TITLE
[WNMGDS-1084] adjusting skip link placement for new focus styles

### DIFF
--- a/packages/design-system/src/styles/components/_SkipNav.scss
+++ b/packages/design-system/src/styles/components/_SkipNav.scss
@@ -9,7 +9,7 @@
 
   &:focus {
     background-color: $color-white;
-    left: 0;
-    top: 0;
+    left: 12px;
+    top: 12px;
   }
 }


### PR DESCRIPTION
## Summary
Adjusting SkipNav link to account for new focus styles

### Changed
Moved the skip nav link a little down and a little to the right. This was identified on Hgov, but mgov could also benefit especially with the implementation of the new focus styles.

## How to test
1. Run doc site and navigate to http://localhost:3002/example/components.skip-nav.react/
2. Tab through the screen until the Skip Nav link is focused
3. Confirm that skip link's entire focus outline is in frame

Before:
<img width="589" alt="Screen Shot 2021-09-22 at 9 52 38 AM" src="https://user-images.githubusercontent.com/33579665/134378984-f810b6f6-b8a4-4417-b85c-7fb8b2e451b6.png">

After
<img width="589" alt="Screen Shot 2021-09-22 at 9 52 25 AM" src="https://user-images.githubusercontent.com/33579665/134379010-61ee93ac-3bed-45d3-9382-3a4bfa75cd01.png">
:
