### PR TITLE
[NO-TICKET] Update table example to fix right aligned header

### DIFF
--- a/packages/design-system-docs/src/pages/components/Table/table.example.html
+++ b/packages/design-system-docs/src/pages/components/Table/table.example.html
@@ -10,19 +10,19 @@
   <thead>
     <tr>
       <th scope="col">Name</th>
-      <th class="ds-u-text-align--right" scope="col">Rate</th>
+      <th scope="col">Rate</th>
       <th scope="col">Favorite fruit</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Fred</td>
-      <td class="ds-u-text-align--right">51.25%</td>
+      <td>51.25%</td>
       <td>Apples</td>
     </tr>
     <tr>
       <td>Tamara</td>
-      <td class="ds-u-text-align--right">98.70%</td>
+      <td>98.70%</td>
       <td>Strawberries</td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Summary
This was brought up in Slack as something to fix about the plain HTML table example. The header is right aligned and it looks off. 

### Changed
Removed the right align class from the table headers and cells. I think a better right aligned example would be needed to show when and why to align table content to the right.

## How to test
Go to the demo site table page and see that the html table header for `Rate` is no longer right aligned. 
http://design-system-demo.s3-website-us-east-1.amazonaws.com/sw-remove-table-alignment