### PR TITLE
[WNMGDS-1094] Remove development branch from CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,9 @@ name: build
 
 on:
   push:
-    branches: 
-      - master
-      - development
+    branches: [ master ]
   pull_request:
-    branches: 
-      - master
-      - development
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
https://jira.cms.gov/browse/WNMGDS-1094

## Summary
We're switching back to using `master` as our development and release branch. The `development` branch will be retired, so stop running CI tests for PRs against it.

- [x] Rebase this after https://github.com/CMSgov/design-system/pull/1155 is merged