### PR TITLE
[NO-TICKET] Reduce OS notifications for build process

### DIFF
--- a/packages/design-system-scripts/gulp/build.js
+++ b/packages/design-system-scripts/gulp/build.js
@@ -202,7 +202,7 @@ module.exports = {
     if (process.env.NODE_ENV === 'production') {
       await printStats(sourceDir, options);
     }
-    logTask('✅ ', 'Build succeeded');
+    logTask('✅ ', 'Build succeeded', true);
     log('');
   },
   copyAssets,

--- a/packages/design-system-scripts/gulp/common/logUtil.js
+++ b/packages/design-system-scripts/gulp/common/logUtil.js
@@ -77,8 +77,10 @@ module.exports = {
     notify(name, message, true);
   },
 
-  logTask: function (name, message) {
+  logTask: function (name, message, showNotification = false) {
     log(chalk.magenta(name), chalk.green(message));
-    notify(name, message, false);
+    if (showNotification) {
+      notify(name, message, false);
+    }
   },
 };

--- a/packages/design-system-scripts/gulp/docs/docs.js
+++ b/packages/design-system-scripts/gulp/docs/docs.js
@@ -32,7 +32,7 @@ module.exports = {
     await generatePages(sourceDir, docsDir, options);
     await compileDocsSass(docsDir, options);
     await runWebpackStatically(sourceDir, docsDir, options);
-    logTask('✅ ', 'Docs generation succeeded');
+    logTask('✅ ', 'Docs generation succeeded', true);
     log('');
   },
   generatePages,


### PR DESCRIPTION
## Summary
There are many steps in the build process, and they each have an OS-level popup notification associated with them. This is actually really obnoxious during development, so let's only use the notification for success messages. Even that has questionable utility.

### Changed
- (Internal) Restrict the OS notifications for the build process to only show for success messages

## How to test
Run `yarn start` or `yarn build`
