### PR TITLE
[NO-TICKET] Remove linter rule that hinders productivity

### DIFF
--- a/packages/eslint-config-design-system/index.js
+++ b/packages/eslint-config-design-system/index.js
@@ -38,7 +38,6 @@ module.exports = {
     ],
     'no-unused-vars': ['error', { ignoreRestSiblings: true }],
     'jsx-quotes': 'off',
-    'sort-imports': 'error',
     'react/forbid-prop-types': 'error',
     'react/jsx-closing-bracket-location': 'error',
     'react/jsx-first-prop-new-line': ['error', 'multiline'],


### PR DESCRIPTION

## Summary
This particular rule isn't very helpful to us and ends up costing us time to try to fix. The lack of this rule will not result in choas in our codebase. Particularly the pattern to always include imports with multiple named imports before imports with single named imports seems arbitrary and doesn't help the eye find things when scanning an import list.

### Removed
- Removed linter rule about ordering imports a certain way

## How to test
Change the order of imports somewhere, [like putting this import last in the list](https://github.com/CMSgov/design-system/blob/master/packages/design-system/src/components/ChoiceList/ChoiceList.tsx#L2). On master, `yarn lint` will throw an error. On this branch, it won't care.