### PR TITLE
Wnmgds 1105 helpdrawer util classes

### DIFF
--- a/packages/design-system-docs/src/pages/components/HelpDrawer/help-drawer.example.html
+++ b/packages/design-system-docs/src/pages/components/HelpDrawer/help-drawer.example.html
@@ -15,37 +15,34 @@
   </button>
   <div class="ds-c-help-drawer">
     <div class="ds-c-help-drawer__header">
-      <div
-        class="ds-u-fill--gray-lightest ds-u-padding--2 ds-u-display--flex ds-u-align-items--start"
-      >
-        <h3 tabindex="0" class="ds-u-text--lead ds-u-margin-y--0 ds-u-margin-right--2">
+      <div class="ds-c-help-drawer__header-container">
+        <h3 tabindex="0" class="ds-c-help-drawer__header-heading">
           Help Drawer Heading
         </h3>
         <button
-          class="ds-c-button ds-c-button--secondary ds-c-button--small ds-u-margin-left--auto"
+          class="ds-c-button ds-c-button--secondary ds-c-button--small ds-c-help-drawer__header-button ds-c-help-drawer__close-button"
           type="button"
         >
           Close
         </button>
       </div>
     </div>
-    <div
-      class="ds-c-help-drawer__body ds-u-md-font-size--small ds-u-lg-font-size--base ds-u-padding--2"
-    >
-      <strong>An Explanation</strong>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-        cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
-    </div>
-    <div
-      class="ds-c-help-drawer__footer ds-u-fill--primary-alt-lightest ds-u-md-font-size--small ds-u-lg-font-size--base ds-u-padding--2"
-    >
-      <h4 class="ds-text ds-u-margin--0">Footer title</h4>
-      <p class="ds-text ds-u-margin--0">Footer content</p>
+    <div class="ds-c-help-drawer__body">
+      <div class="ds-c-help-drawer__content">
+        <strong>An Explanation</strong>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+          ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+          ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+          sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+      </div>
+      <div class="ds-c-help-drawer__footer">
+        <h4 class="ds-text ds-c-help-drawer__footer-title">Footer title</h4>
+        <p class="ds-text ds-c-help-drawer__footer-body">Footer content</p>
+      </div>
     </div>
   </div>
   <p>

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.jsx
@@ -90,11 +90,11 @@ export class HelpDrawer extends React.PureComponent {
            * separation between our sticky header, and the flex container
            * so things display as expected when the body content overflows
            */}
-          <div className="ds-u-fill--gray-lightest ds-u-padding--2 ds-u-display--flex ds-u-align-items--start">
+          <div className="ds-c-help-drawer__header-container">
             <Heading
               ref={(el) => (this.headingRef = el)}
               tabIndex="0"
-              className="ds-u-text--lead ds-u-margin-y--0 ds-u-margin-right--2"
+              className="ds-c-help-drawer__header-heading"
             >
               {
                 // TODO: make heading required after removing title
@@ -103,7 +103,7 @@ export class HelpDrawer extends React.PureComponent {
             </Heading>
             <Button
               aria-label={ariaLabel}
-              className="ds-u-margin-left--auto ds-c-help-drawer__close-button"
+              className="ds-c-help-drawer__header-button ds-c-help-drawer__close-button"
               size="small"
               onClick={onCloseClick}
             >
@@ -112,12 +112,10 @@ export class HelpDrawer extends React.PureComponent {
           </div>
         </div>
         <div className="ds-c-help-drawer__body">
-          <div className="ds-c-help-drawer__content ds-u-md-font-size--small ds-u-lg-font-size--base ds-u-padding--2">
-            {children}
-          </div>
-          <div className="ds-c-help-drawer__footer ds-u-fill--primary-alt-lightest ds-u-md-font-size--small ds-u-lg-font-size--base ds-u-padding--2">
-            <h4 className="ds-text ds-u-margin--0">{footerTitle}</h4>
-            <div className="ds-text ds-u-margin--0">{footerBody}</div>
+          <div className="ds-c-help-drawer__content">{children}</div>
+          <div className="ds-c-help-drawer__footer">
+            <h4 className="ds-c-help-drawer__footer-title">{footerTitle}</h4>
+            <div className="ds-c-help-drawer__footer-body">{footerBody}</div>
           </div>
         </div>
       </div>

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.jsx
@@ -17,7 +17,7 @@ export class HelpDrawerToggle extends React.PureComponent {
     const { className, children, inline, showDrawer, helpDrawerOpen, ...others } = this.props;
     const classes = classNames(
       'ds-c-help-drawer__toggle',
-      inline && 'ds-u-display--inline',
+      inline && 'ds-c-help-drawer__toggle--inline',
       className
     );
 

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.test.jsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawerToggle.test.jsx
@@ -38,7 +38,7 @@ describe('HelpDrawerToggle', () => {
   it('applies display utility through inline props', () => {
     const { wrapper } = renderHelpDrawerToggle({ inline: true });
     const toggle = wrapper.find('Button');
-    expect(toggle.hasClass('ds-u-display--inline')).toBe(true);
+    expect(toggle.hasClass('ds-c-help-drawer__toggle--inline')).toBe(true);
   });
 
   it('passes through extra props', () => {

--- a/packages/design-system/src/components/HelpDrawer/__snapshots__/HelpDrawer.test.jsx.snap
+++ b/packages/design-system/src/components/HelpDrawer/__snapshots__/HelpDrawer.test.jsx.snap
@@ -8,17 +8,17 @@ exports[`HelpDrawer renders a snapshot 1`] = `
     className="ds-c-help-drawer__header"
   >
     <div
-      className="ds-u-fill--gray-lightest ds-u-padding--2 ds-u-display--flex ds-u-align-items--start"
+      className="ds-c-help-drawer__header-container"
     >
       <h3
-        className="ds-u-text--lead ds-u-margin-y--0 ds-u-margin-right--2"
+        className="ds-c-help-drawer__header-heading"
         tabIndex="0"
       >
         HelpDrawer title
       </h3>
       <button
         aria-label="Close help drawer"
-        className="ds-c-button ds-c-button--small ds-u-margin-left--auto ds-c-help-drawer__close-button"
+        className="ds-c-button ds-c-button--small ds-c-help-drawer__header-button ds-c-help-drawer__close-button"
         onClick={[Function]}
         type="button"
       >
@@ -30,22 +30,22 @@ exports[`HelpDrawer renders a snapshot 1`] = `
     className="ds-c-help-drawer__body"
   >
     <div
-      className="ds-c-help-drawer__content ds-u-md-font-size--small ds-u-lg-font-size--base ds-u-padding--2"
+      className="ds-c-help-drawer__content"
     >
       <p>
         content
       </p>
     </div>
     <div
-      className="ds-c-help-drawer__footer ds-u-fill--primary-alt-lightest ds-u-md-font-size--small ds-u-lg-font-size--base ds-u-padding--2"
+      className="ds-c-help-drawer__footer"
     >
       <h4
-        className="ds-text ds-u-margin--0"
+        className="ds-c-help-drawer__footer-title"
       >
         Footer title
       </h4>
       <div
-        className="ds-text ds-u-margin--0"
+        className="ds-c-help-drawer__footer-body"
       >
         <div>
           <p>

--- a/packages/design-system/src/styles/components/_HelpDrawer.scss
+++ b/packages/design-system/src/styles/components/_HelpDrawer.scss
@@ -1,5 +1,9 @@
 @import '../settings/index.scss';
 
+$help-drawer-header-fill: $color-gray-lightest;
+$help-drawer-footer-fill: $color-primary-alt-lightest;
+$help-drawer-padding: $spacer-2;
+
 @keyframes slideInHelpDrawer {
   from {
     opacity: 0;
@@ -54,6 +58,21 @@
   }
 }
 
+.ds-c-help-drawer__header-container {
+  align-items: flex-start;
+  background-color: $help-drawer-header-fill;
+  display: flex;
+  padding: $help-drawer-padding;
+}
+
+.ds-c-help-drawer__header-heading {
+  margin: 0 $help-drawer-padding 0 0;
+}
+
+.ds-c-help-drawer__header-button {
+  margin-left: auto;
+}
+
 .ds-c-help-drawer__body {
   display: flex;
   flex-direction: column;
@@ -64,6 +83,8 @@
 .ds-c-help-drawer__content {
   flex-grow: 1;
   flex-shrink: 0;
+  font-size: $base-font-size;
+  padding: $help-drawer-padding;
 
   p:first-child {
     // Prevent too much space at the top of the body area
@@ -72,5 +93,21 @@
 }
 
 .ds-c-help-drawer__footer {
+  background-color: $help-drawer-footer-fill;
   flex-shrink: 0;
+  font-size: $small-font-size;
+  line-height: 1.5;
+  padding: $help-drawer-padding;
+
+  @media (min-width: $width-lg) {
+    font-size: $base-font-size;
+  }
+}
+
+.ds-c-help-drawer__footer-title {
+  margin: 0;
+}
+
+.ds-c-help-drawer__footer-body {
+  margin: 0;
 }

--- a/packages/design-system/src/styles/components/_HelpDrawer.scss
+++ b/packages/design-system/src/styles/components/_HelpDrawer.scss
@@ -44,6 +44,10 @@ $help-drawer-padding: $spacer-2;
   padding: 0;
 }
 
+.ds-c-help-drawer__toggle--inline {
+  display: inline;
+}
+
 .ds-c-help-drawer__close-button {
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
Refactored CSS util classes, consolidating rules into component name-spaced classes. I needed to create some new classes to accommodate this work. Also addressed, [WNMGDS-1073](https://jira.cms.gov/browse/WNMGDS-1073) so the HTML example matched the React example.

## How to test
You can see the changes here (you actually shouldn't see any change outside of the HTML example footer behavior): http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1073-helpdrawer-util-classes

I ran Backstop on this work and 1 issue popped up relating to HelpDrawer. However, it was unclear what was wrong with it. The diff looked like HelpDrawer text was off by maybe 1px, which didn't seem like a real issue.
