### PR TITLE
[WNMGDS-1118] initial add of SVGIcon component with two icons

### DIFF
--- a/packages/design-system-docs/src/pages/components/Icon/IconComponent.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Icon/IconComponent.example.jsx
@@ -1,0 +1,11 @@
+import { AddIcon, ArrowsStacked } from '@design-system';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+ReactDOM.render(
+  <>
+    <AddIcon />
+    <ArrowsStacked />
+  </>,
+  document.getElementById('js-example')
+);

--- a/packages/design-system-docs/src/pages/components/Icon/_IconComponent.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Icon/_IconComponent.docs.scss
@@ -1,0 +1,16 @@
+/*
+Svg Icon
+
+Style guide: components.icon
+*/
+
+/*
+`<Icon>`
+
+@react-example IconComponent.example.jsx
+
+@react-props SvgIcon.tsx
+
+Style guide: components.icon.react
+
+*/

--- a/packages/design-system/src/components/Icons/AddIcon.tsx
+++ b/packages/design-system/src/components/Icons/AddIcon.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import SvgIcon, { SvgIconProps } from './SvgIcon';
+
+function AddIcon(props: SvgIconProps): React.ReactElement {
+  return (
+    <SvgIcon {...props}>
+      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+    </SvgIcon>
+  );
+}
+
+AddIcon.defaultProps = {
+  title: 'Add',
+  viewBox: '0 0 24 24',
+};
+
+export default AddIcon;

--- a/packages/design-system/src/components/Icons/ArrowsStacked.tsx
+++ b/packages/design-system/src/components/Icons/ArrowsStacked.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import SvgIcon, { SvgIconProps } from './SvgIcon';
+
+function ArrowsStacked(props: SvgIconProps): React.ReactElement {
+  return (
+    <SvgIcon {...props}>
+      <path
+        d="M.626 6h8.747a.624.624 0 00.443-1.067L5.44.183a.614.614 0 00-.875 0L.184 4.934a.614.614 0 000 .876.604.604 0 00.442.19zm8.747 2H.626a.604.604 0 00-.442.181.614.614 0 000 .876l4.38 4.76a.614.614 0 00.876 0l4.376-4.75A.624.624 0 009.373 8z"
+        fillRule="evenodd"
+      />
+    </SvgIcon>
+  );
+}
+
+ArrowsStacked.defaultProps = {
+  title: 'Sort',
+};
+
+export default ArrowsStacked;

--- a/packages/design-system/src/components/Icons/SvgIcon.tsx
+++ b/packages/design-system/src/components/Icons/SvgIcon.tsx
@@ -1,0 +1,68 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import classNames from 'classnames';
+
+export interface SvgIconProps {
+  /**
+   * Additional CSS classes to be added to the svg element
+   */
+  className?: string;
+  /**
+   * The elements that make up the SVG
+   */
+  children: React.ReactNode;
+  /**
+   * If `true` sets inverse fill color.
+   */
+  inversed?: boolean;
+  /**
+   * Describes if the SVG icon is a decorative element. If `true`, an `aria-hidden="true"` will be added to the svg along with a `role="img"`
+   */
+  isDecorative?: boolean;
+  /**
+   * The descriptive nave for the SVG icon
+   */
+  title?: string;
+  /**
+   * A string describing the viewbox of the SVG
+   */
+  viewBox?: string;
+}
+
+type OmitProps = 'className' | 'children' | 'title' | 'viewBox';
+
+// TODO: Should this extend SVG props?
+function SvgIcon({
+  className,
+  children,
+  isDecorative,
+  title,
+  viewBox,
+}: Omit<React.SVGProps<SVGSVGElement>, OmitProps> & SvgIconProps): React.ReactElement {
+  const svgClasses = classNames(
+    'ds-c-icon',
+
+    className
+  );
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden={isDecorative ? true : undefined}
+      className={svgClasses}
+      focusable={false}
+      viewBox={viewBox}
+      role={isDecorative ? 'img' : undefined}
+    >
+      <title>{title}</title>
+      {children}
+    </svg>
+  );
+}
+
+SvgIcon.defaultProps = {
+  inversed: false,
+  isDecorative: false,
+};
+
+export default SvgIcon;

--- a/packages/design-system/src/components/Icons/index.ts
+++ b/packages/design-system/src/components/Icons/index.ts
@@ -1,0 +1,3 @@
+export { default as SvgIcon } from './SvgIcon';
+export { default as AddIcon } from './AddIcon';
+export { default as ArrowsStacked } from './ArrowsStacked';

--- a/packages/design-system/src/components/index.js
+++ b/packages/design-system/src/components/index.js
@@ -29,5 +29,6 @@ export * from './Tooltip';
 export * from './UsaBanner';
 export * from './VerticalNav';
 export * from './analytics';
+export * from './Icons';
 
 export * from './flags';

--- a/packages/design-system/src/styles/components/_SvgIcon.scss
+++ b/packages/design-system/src/styles/components/_SvgIcon.scss
@@ -1,0 +1,17 @@
+.ds-c-icon {
+  display: inline-block;
+  fill: currentColor;
+  height: 24px;
+  stroke: currentColor;
+  stroke-width: 0;
+  vertical-align: middle;
+  width: 24px;
+}
+
+.ds-c-icon--primary {
+  fill: $color-primary;
+}
+
+.ds-c-icon--inverse {
+  fill: $color-white;
+}

--- a/packages/design-system/src/styles/components/index.scss
+++ b/packages/design-system/src/styles/components/index.scss
@@ -17,6 +17,7 @@
 @import 'SkipNav.scss';
 @import 'Spinner.scss';
 @import 'StepList.scss';
+@import 'SvgIcon.scss';
 @import 'Table.scss';
 @import 'Tabs.scss';
 // Mask and Date field styles need imported

--- a/packages/design-system/src/types/index.d.ts
+++ b/packages/design-system/src/types/index.d.ts
@@ -33,6 +33,7 @@ export * from './Spinner';
 export * from './Table';
 export * from './TextField';
 export * from './Tooltip';
+export * from './Icons';
 
 export * from './analytics';
 export * from './flags';


### PR DESCRIPTION
## Summary
Starting the addition of exporting SVG icons as individual React components

### Added
New components for 
- `SvgIcon`: A wrapper for SVG markup to standardize props and styles. The idea is that this can be imported individually by products and they can fill in their own paths, etc
- `AddIcon`: the React icon for the `+` icon
- `ArrowsStacked`: The React icon for the stacked arrows icon

## To Test
- Navigate to doc site to Components > SvgIcon
- In the React example section, you will see the two new icons

## Still TODO:
- Convert the rest of the existing icons
- Figure out base styles, what is necessary, etc
- Full accessibility updates, optimization and size standardizing will be in another PR
- Documentation
