### PR TITLE
[WNMGDS-1141] Add script for publishing child design systems to GitHub Pages

### DIFF
--- a/cmsds.healthcare.config.js
+++ b/cmsds.healthcare.config.js
@@ -6,7 +6,7 @@ module.exports = {
   // The relative path to the directory containing the doc site `src`. The doc site build files will be saved here under "dist".
   docsDir: './packages/ds-healthcare-gov/docs',
   // The URL root path for the published docs site. I.e. if your docs site is hosted at www.domain.com/design/ your rootPath would be `design`. `rootPath` is only used when building for production.
-  rootPath: 'healthcare',
+  rootPath: 'design-system/healthcare',
 
   // Name of the design system. This replaces the {{name}} template in documentation content.
   name: 'HealthCare.gov Design System',

--- a/package.json
+++ b/package.json
@@ -20,13 +20,15 @@
     "update-snapshots": "yarn cmsds test ./packages --updateSnapshot",
     "posttest": "yarn lint",
     "lint": "yarn cmsds lint ./ --ignorePatterns '**/node_modules/**' '**/dist/**' '**/helpers/**' '**/__tests__/**' 'tmp/**' '**/types/**' 'examples/create-react-app-typescript/**' 'examples/create-react-app/**'",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "gh-pages": "yarn build:healthcare && gh-pages -d './packages/ds-healthcare-gov/docs/dist' --dest 'healthcare'"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.11.0",
     "@typescript-eslint/parser": "^4.11.0",
     "backstopjs": "^5.0.4",
     "eslint": "^6.8.0",
+    "gh-pages": "^3.2.3",
     "husky": "^7.0.0",
     "lerna": "^3.20.0",
     "lint-staged": "^10.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7877,7 +7877,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gh-pages@^3.1.0:
+gh-pages@^3.1.0, gh-pages@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-3.2.3.tgz#897e5f15e111f42af57d21d430b83e5cdf29472c"
   integrity sha512-jA1PbapQ1jqzacECfjUaO9gV8uBgU6XNMV0oXLtfCX3haGLe5Atq8BxlrADhbD6/UdG9j6tZLWAkAybndOXTJg==


### PR DESCRIPTION
See #1193 for context. This PR adds a script for publishing child design systems (only ds-healthcare-gov so far) to GitHub Pages. See it live at https://cmsgov.github.io/design-system/healthcare/patterns/header/

Note: Rebase from `pwolfert/ds-healthcare-gov-in-monorepo` after https://github.com/CMSgov/design-system/pull/1194 is merged.