### PR TITLE
Update docs to remove IE support and broken link.

### DIFF
--- a/packages/design-system-docs/src/pages/guidelines/browser-support.md
+++ b/packages/design-system-docs/src/pages/guidelines/browser-support.md
@@ -3,6 +3,6 @@ title: Browser support
 weight: 7
 ---
 
-The {{name}} follows the [2% rule](https://gds.blog.gov.uk/2012/01/25/support-for-browsers/): we officially support any browser above 2% usage and the last 2 browsers versions for each browser as observed by [analytics.usa.gov](https://analytics.usa.gov/). For specific browser details check out [browserlist](https://browserl.ist/?q=last+2+versions%2C+%3E2%25). **Currently, the latest 2 versions of Chrome, Firefox, Safari, Internet Explorer 11, and Edge are supported.**
+The {{name}} follows the [2% rule](https://gds.blog.gov.uk/2012/01/25/support-for-browsers/): we officially support any browser above 2% usage and the last 2 browsers versions for each browser as observed by [analytics.usa.gov](https://analytics.usa.gov/). **Currently, the latest 2 versions of Chrome, Firefox, Safari, and Edge are supported.**
 
 The CMSDS is designed to be compatible with different operating systems and browser versions in order to provide a broad range of support. [Progressive enhancement and graceful degredation](https://www.w3.org/wiki/Graceful_degradation_versus_progressive_enhancement) methodologies are used to accomplish this.


### PR DESCRIPTION
## Summary
[Jira](https://jira.cms.gov/browse/WNMGDS-1163)

### Removed
- Reference to IE11 (no longer supported)
- Broken link to browserlist (we no longer have a paid account, so the link provides no useful information on current browser usage)

## How to test
Read the [browser support docs](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1163/update-browser-support-docs/guidelines/browser-support/) and notice there's no reference to IE or a link to browserlist.
