### PR TITLE
Add GitHub release generator config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: 🚨 Breaking changes
+      labels:
+        - "Release: Major"
+    - title: 🚀 Added and changed
+      labels:
+        - "Release: Minor"
+    - title: 🛠 Fixed
+      labels:
+        - "Release: Patch"
+    - title: 📦 Internal
+      labels:
+        - "Release: Internal"
+    - title: 🤖 Updated dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
Add a config file for GitHub's [built-in release-notes-generating feature](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes). I don't know of a way to test this without merging it into master.