### PR TITLE
[WNMGDS-1141] Update release scripts

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -34,6 +34,7 @@ echo "${GREEN}Creating release zip...${NC}"
 npm pack ./packages/design-system/
 npm pack ./packages/design-system-docs/
 npm pack ./packages/design-system-scripts/
+npm pack ./packages/ds-healthcare-gov/
 
 echo "${GREEN}Done.${NC}"
 echo ""

--- a/publish.sh
+++ b/publish.sh
@@ -14,9 +14,8 @@ CYAN="\033[0;36m"
 NC='\033[0m' # No color
 
 echo "${GREEN}Checking out release $1...${NC}"
-TAG_PREFIX=$(node -pe "require('./lerna.json').tagVersionPrefix")
 git fetch --tags
-git checkout tags/$TAG_PREFIX$1
+git checkout tags/$1
 
 echo "${GREEN}Building packages...${NC}"
 yarn install

--- a/publish.sh
+++ b/publish.sh
@@ -20,6 +20,7 @@ git checkout tags/$1
 echo "${GREEN}Building packages...${NC}"
 yarn install
 yarn build
+yarn build:healthcare
 
 echo "${GREEN}Publishing ${CYAN}$1${GREEN} to npm...${NC}"
 if [[ $1 == *"beta"* ]]; then

--- a/publish.sh
+++ b/publish.sh
@@ -28,7 +28,7 @@ if [[ $1 == *"beta"* ]]; then
 else
   NPM_TAG=""
 fi
-yarn lerna publish from-git $NPM_TAG
+# yarn lerna publish from-git $NPM_TAG
 
 echo "${GREEN}Creating release zip...${NC}"
 npm pack ./packages/design-system/

--- a/publish.sh
+++ b/publish.sh
@@ -28,7 +28,7 @@ if [[ $1 == *"beta"* ]]; then
 else
   NPM_TAG=""
 fi
-# yarn lerna publish from-git $NPM_TAG
+yarn lerna publish from-git $NPM_TAG
 
 echo "${GREEN}Creating release zip...${NC}"
 npm pack ./packages/design-system/

--- a/release.sh
+++ b/release.sh
@@ -26,8 +26,8 @@ if [ "$PRE_VERSION_HASH" = "$POST_VERSION_HASH" ]; then
 fi
 
 echo "${GREEN}Pushing tag and release commit to Github...${NC}"
-git push --set-upstream origin $BRANCH
-git push origin --tags
+# git push --set-upstream origin $BRANCH
+# git push origin --tags
 
 # Grep the last commit message for package versions
 PACKAGE_VERSIONS=$(git log -1 --pretty=%B | grep -o "@.*$")

--- a/release.sh
+++ b/release.sh
@@ -14,10 +14,12 @@ BRANCH="release-${DATE}"
 git checkout -b $BRANCH
 
 echo "${GREEN}Bumping version...${NC}"
+PRE_VERSION_HASH=$(git rev-parse HEAD)
 yarn lerna version --no-push
+POST_VERSION_HASH=$(git rev-parse HEAD)
 
-if git diff-index --quiet HEAD --; then
-  echo "${RED}No local changes detected, therefore version bump did not occur. Removing release branch and exiting...${NC}"
+if [ "$PRE_VERSION_HASH" = "$POST_VERSION_HASH" ]; then
+  echo "${RED}No bump commit detected. Removing release branch and exiting...${NC}"
   git checkout -
   git branch -d $BRANCH
   exit 1

--- a/release.sh
+++ b/release.sh
@@ -26,8 +26,8 @@ if [ "$PRE_VERSION_HASH" = "$POST_VERSION_HASH" ]; then
 fi
 
 echo "${GREEN}Pushing tag and release commit to Github...${NC}"
-# git push --set-upstream origin $BRANCH
-# git push origin --tags
+git push --set-upstream origin $BRANCH
+git push origin --tags
 
 # Grep the last commit message for package versions
 PACKAGE_VERSIONS=$(git log -1 --pretty=%B | grep -o "@.*$")

--- a/release.sh
+++ b/release.sh
@@ -9,10 +9,7 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No color
 
 echo "${GREEN}Bumping version...${NC}"
-yarn lerna version \
-  --no-push \
-  --no-git-tag-version \
-  --force-publish=@cmsgov/design-system,@cmsgov/design-system-docs,@cmsgov/design-system-scripts
+yarn lerna version --no-push
 
 if git diff-index --quiet HEAD --; then
   echo "${RED}No local changes detected, therefore version bump did not occur. Exiting...${NC}"
@@ -20,31 +17,31 @@ if git diff-index --quiet HEAD --; then
 fi
 
 echo "${GREEN}Pushing tag and release commit to Github...${NC}"
-PACKAGE_VERSION=$(node -pe "require('./lerna.json').version")
-TAG_PREFIX=$(node -pe "require('./lerna.json').tagVersionPrefix")
-TAG="$TAG_PREFIX$PACKAGE_VERSION"
-BRANCH="release-$PACKAGE_VERSION"
+# PACKAGE_VERSION=$(node -pe "require('./lerna.json').version")
+# TAG_PREFIX=$(node -pe "require('./lerna.json').tagVersionPrefix")
+# TAG="$TAG_PREFIX$PACKAGE_VERSION"
+# BRANCH="release-$PACKAGE_VERSION"
 
 # Create and push release branch containing the updated package versions
-git checkout -b $BRANCH
-git add --all
-git commit -m "Bump package version to $PACKAGE_VERSION"
-git push --set-upstream origin $BRANCH
+# git checkout -b $BRANCH
+# git add --all
+# git commit -m "Bump package version to $PACKAGE_VERSION"
+# git push --set-upstream origin $BRANCH
 
 # Create and push tag
-git tag $TAG
-git push origin $TAG
+# git tag $TAG
+# git push origin $TAG
 
-echo ""
-echo "${GREEN}Release ${CYAN}$PACKAGE_VERSION${GREEN} has been tagged and pushed to origin.${NC}"
-echo ""
-echo "${YELLOW}-------${NC}"
-echo ""
-echo "${YELLOW}NEXT STEPS:${NC}"
-echo ""
-echo "${YELLOW}  1. Create a pull request for merging \`${CYAN}$BRANCH${YELLOW}\` into master to save the version bump${NC}"
-echo ""
-echo "${YELLOW}  2. Publish this release to npm by running:${NC}"
-echo ""
-echo "     ${CYAN}\$${NC} yarn publish-release $PACKAGE_VERSION"
-echo ""
+# echo ""
+# echo "${GREEN}Release ${CYAN}$PACKAGE_VERSION${GREEN} has been tagged and pushed to origin.${NC}"
+# echo ""
+# echo "${YELLOW}-------${NC}"
+# echo ""
+# echo "${YELLOW}NEXT STEPS:${NC}"
+# echo ""
+# echo "${YELLOW}  1. Create a pull request for merging \`${CYAN}$BRANCH${YELLOW}\` into master to save the version bump${NC}"
+# echo ""
+# echo "${YELLOW}  2. Publish this release to npm by running:${NC}"
+# echo ""
+# echo "     ${CYAN}\$${NC} yarn publish-release $PACKAGE_VERSION"
+# echo ""

--- a/release.sh
+++ b/release.sh
@@ -8,32 +8,27 @@ YELLOW='\033[0;33m'
 CYAN='\033[0;36m'
 NC='\033[0m' # No color
 
+echo "${GREEN}Creating release branch.${NC}"
+DATE=$(date "+%Y-%m-%d")
+BRANCH="release-${DATE}"
+git checkout -b $BRANCH
+
 echo "${GREEN}Bumping version...${NC}"
 yarn lerna version --no-push
 
 if git diff-index --quiet HEAD --; then
-  echo "${RED}No local changes detected, therefore version bump did not occur. Exiting...${NC}"
+  echo "${RED}No local changes detected, therefore version bump did not occur. Removing release branch and exiting...${NC}"
+  git checkout -
+  git branch -d $BRANCH
   exit 1
 fi
 
 echo "${GREEN}Pushing tag and release commit to Github...${NC}"
-# PACKAGE_VERSION=$(node -pe "require('./lerna.json').version")
-# TAG_PREFIX=$(node -pe "require('./lerna.json').tagVersionPrefix")
-# TAG="$TAG_PREFIX$PACKAGE_VERSION"
-# BRANCH="release-$PACKAGE_VERSION"
-
-# Create and push release branch containing the updated package versions
-# git checkout -b $BRANCH
-# git add --all
-# git commit -m "Bump package version to $PACKAGE_VERSION"
 # git push --set-upstream origin $BRANCH
-
-# Create and push tag
-# git tag $TAG
-# git push origin $TAG
+# git push origin --tags
 
 # echo ""
-# echo "${GREEN}Release ${CYAN}$PACKAGE_VERSION${GREEN} has been tagged and pushed to origin.${NC}"
+# echo "${GREEN}Release has been tagged and pushed to origin.${NC}"
 # echo ""
 # echo "${YELLOW}-------${NC}"
 # echo ""

--- a/release.sh
+++ b/release.sh
@@ -8,7 +8,7 @@ YELLOW='\033[0;33m'
 CYAN='\033[0;36m'
 NC='\033[0m' # No color
 
-echo "${GREEN}Creating release branch.${NC}"
+echo "${GREEN}Creating release branch...${NC}"
 DATE=$(date "+%Y-%m-%d")
 BRANCH="release-${DATE}"
 git checkout -b $BRANCH
@@ -26,19 +26,26 @@ if [ "$PRE_VERSION_HASH" = "$POST_VERSION_HASH" ]; then
 fi
 
 echo "${GREEN}Pushing tag and release commit to Github...${NC}"
-# git push --set-upstream origin $BRANCH
-# git push origin --tags
+git push --set-upstream origin $BRANCH
+git push origin --tags
 
-# echo ""
-# echo "${GREEN}Release has been tagged and pushed to origin.${NC}"
-# echo ""
-# echo "${YELLOW}-------${NC}"
-# echo ""
-# echo "${YELLOW}NEXT STEPS:${NC}"
-# echo ""
-# echo "${YELLOW}  1. Create a pull request for merging \`${CYAN}$BRANCH${YELLOW}\` into master to save the version bump${NC}"
-# echo ""
-# echo "${YELLOW}  2. Publish this release to npm by running:${NC}"
-# echo ""
-# echo "     ${CYAN}\$${NC} yarn publish-release $PACKAGE_VERSION"
-# echo ""
+# Grep the last commit message for package versions
+PACKAGE_VERSIONS=$(git log -1 --pretty=%B | grep -o "@.*$")
+# Take the first one we find to use in example command
+PACKAGE_VERSION=$(echo "$PACKAGE_VERSIONS" | head -1)
+
+echo ""
+echo "${GREEN}Release has been tagged and pushed to origin.${NC}"
+echo ""
+echo "${PACKAGE_VERSIONS}"
+echo ""
+echo "${YELLOW}-------${NC}"
+echo ""
+echo "${YELLOW}NEXT STEPS:${NC}"
+echo ""
+echo "${YELLOW}  1. Create a pull request for merging \`${CYAN}$BRANCH${YELLOW}\` into master to save the version bump${NC}"
+echo ""
+echo "${YELLOW}  2. Publish this release to npm by running:${NC}"
+echo ""
+echo "     ${CYAN}\$${NC} yarn publish-release $PACKAGE_VERSION"
+echo ""

--- a/release.sh
+++ b/release.sh
@@ -21,7 +21,7 @@ POST_VERSION_HASH=$(git rev-parse HEAD)
 if [ "$PRE_VERSION_HASH" = "$POST_VERSION_HASH" ]; then
   echo "${RED}No bump commit detected. Removing release branch and exiting...${NC}"
   git checkout -
-  git branch -d $BRANCH
+  git branch -D $BRANCH
   exit 1
 fi
 


### PR DESCRIPTION
## Changes
### Release script
- Now allows the `lerna version` command to do the tagging and committing. This results in tags for each of the packages that changed
- Creating the version bump branch now happens before the `lerna version` command. This doesn't result in any overall behavioral changes for the script; it's just what I had to do in order to cleanly get the automatically generated bump commit happen on a separate branch instead of master in a way that was easy to revert if someone exited out of the `lerna version` command or said "No" to the final question
- We now print out all the version tags and choose the first one in the example `yarn publish-release` command at the end of the script

## How to test

1. Check out fe13e57ff56e7f3c8c98de0fbc643f9d4551eafe, which removes the teeth of the script. It won't push anything to origin or publish. 
2. Run `yarn release` and then run the command that it gives you at the end
3. Clean up by removing the tags it made with `git tag -d [tags...]` and removing the branch it made. Both of these things are listed in the initial release script output. Example:
    ```git tag -d @cmsgov/design-system-docs@3.0.0 @cmsgov/design-system-scripts@3.0.0 @cmsgov/design-system@3.0.0 @cmsgov/ds-healthcare-gov@7.0.0```