### PR TITLE
[NO-TICKET] Update ds-healthcare-gov package.json versions

### DIFF
--- a/packages/ds-healthcare-gov/package.json
+++ b/packages/ds-healthcare-gov/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/ds-healthcare-gov",
-  "version": "6.0.0",
+  "version": "6.2.0-beta.1",
   "publishConfig": {
     "tag": "latest",
     "access": "public"
@@ -32,7 +32,7 @@
     "src"
   ],
   "dependencies": {
-    "@cmsgov/design-system": "^2.9.0",
+    "@cmsgov/design-system": "^2.10.0-beta.1",
     "@types/react": "^17.0.10",
     "@types/react-dom": "^17.0.10",
     "classnames": "^2.0.0",
@@ -45,8 +45,8 @@
     "@babel/plugin-proposal-class-properties": "^7.10.1",
     "@babel/plugin-transform-object-assign": "^7.10.4",
     "@babel/preset-typescript": "^7.15.0",
-    "@cmsgov/design-system-docs": "^2.9.0",
-    "@cmsgov/design-system-scripts": "^2.9.0",
+    "@cmsgov/design-system-docs": "^2.10.0-beta.1",
+    "@cmsgov/design-system-scripts": "^2.10.0-beta.1",
     "@cmsgov/eslint-config-design-system": "2.0.0",
     "@cmsgov/stylelint-config-design-system": "2.0.0",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
HC.gov DS has had some version bumps since merging. There are no code changes to the package, though, that aren't represented already.