### PR TITLE
[WNMGTAXTOOLS-136] Update skip-nav Spanish translation

### DIFF
--- a/packages/ds-healthcare-gov/src/locale/es.json
+++ b/packages/ds-healthcare-gov/src/locale/es.json
@@ -24,7 +24,7 @@
     "myApplicationsAndCoverage": "Mis solicitudes & cobertura",
     "myProfile": "Mi perfil",
     "openMenu": "Abrir menú",
-    "skipNav": "Omitir Navegación"
+    "skipNav": "Ir al contenido principal"
   },
   "privacy": {
     "advertising": {


### PR DESCRIPTION
https://jira.cms.gov/browse/WNMGTAXTOOLS-136

## Summary
While working on https://jira.cms.gov/browse/WNMGTAXTOOLS-127 it was discovered that the Spanish translation for the skip-nav label did not match English. The current English translation is `Skip to main content` while the Spanish translation was `Omitir Navegación` which translates to `Skip Navigation`. As part of the work for TT-127 Meghan gave the translation `Ir al contenido principal` to be used for Spanish.

### Changed
Update the Spanish translation for `skipNav` to `Ir al contenido principal`

## How to test
http://localhost:3000/patterns/header/ is the component but it seems like the example is broken when toggling to use Spanish. The unit tests are also not set up to render translations