### PR TITLE
[WNMGDS-1142] Configure linters for ds-medicare-gov

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,3 @@
+# Ignore lint errors for ds-medicare-gov until we have a chance to address
+# them separately. The linter has never been run on these files.
+packages/ds-medicare-gov/src/styles/**/*.scss

--- a/packages/ds-medicare-gov/.eslintrc.json
+++ b/packages/ds-medicare-gov/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",

--- a/packages/ds-medicare-gov/babel.config.js
+++ b/packages/ds-medicare-gov/babel.config.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 module.exports = function (api) {
   api.cache(true);
 

--- a/packages/ds-medicare-gov/src/components/GlobalHeader/GlobalHeader.tsx
+++ b/packages/ds-medicare-gov/src/components/GlobalHeader/GlobalHeader.tsx
@@ -19,7 +19,7 @@ interface GlobalHeaderProps {
     /* eslint-enable */
     menuPanel?: JSX.Element;
     hide?: boolean;
-    props?: object;
+    props?: { [index: string]: any };
   }[];
 }
 
@@ -97,6 +97,7 @@ class GlobalHeaderMenu extends PureComponent<GlobalHeaderMenuProps, GlobalHeader
           )}
         </Button>
         {this.state.open && !mobile && (
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
           <div className="m-c-globalHeader__dropdownMenu" tabIndex={0} ref={this.menuRef}>
             {this.props.panel}
           </div>


### PR DESCRIPTION
https://jira.cms.gov/browse/WNMGDS-1142

## Summary
Get lint checks passing for https://github.com/CMSgov/design-system/pull/1212

### Changed
- Make it so the only `eslint` config that matters for `ds-healthcare-gov` is its own. This means I won't have to fix a bunch of lint errors right now, and we can circle back to standardize our linters in the future
- Completely ignore `ds-healthcare-gov` for `stylelint`, because nobody de-linted any style errors before and there are a lot. Again, this will have to be a separate initiative
- Address the three error-level issues for `eslint` that remained

## How to test
Run `yarn lint`