### PR TITLE
[WNMGDS-1142] Update release-publish and gh-pages commands for medicare

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "posttest": "yarn lint",
     "lint": "yarn cmsds lint ./ --ignorePatterns '**/node_modules/**' '**/dist/**' '**/helpers/**' '**/__tests__/**' 'tmp/**' '**/types/**' 'examples/create-react-app-typescript/**' 'examples/create-react-app/**'",
     "prepare": "husky install",
-    "gh-pages": "yarn build:healthcare && gh-pages -d './packages/ds-healthcare-gov/docs/dist' --dest 'healthcare'"
+    "gh-pages": "yarn gh-pages:healthcare && yarn gh-pages:medicare",
+    "gh-pages:healthcare": "yarn build:healthcare && gh-pages -d './packages/ds-healthcare-gov/docs/dist' --dest 'healthcare'",
+    "gh-pages:medicare": "yarn build:medicare && gh-pages -d './packages/ds-medicare-gov/docs/dist' --dest 'medicare'"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.11.0",

--- a/publish.sh
+++ b/publish.sh
@@ -21,6 +21,7 @@ echo "${GREEN}Building packages...${NC}"
 yarn install
 yarn build
 yarn build:healthcare
+yarn build:medicare
 
 echo "${GREEN}Publishing ${CYAN}$1${GREEN} to npm...${NC}"
 if [[ $1 == *"beta"* ]]; then
@@ -35,6 +36,7 @@ npm pack ./packages/design-system/
 npm pack ./packages/design-system-docs/
 npm pack ./packages/design-system-scripts/
 npm pack ./packages/ds-healthcare-gov/
+npm pack ./packages/ds-medicare-gov/
 
 echo "${GREEN}Done.${NC}"
 echo ""


### PR DESCRIPTION
https://jira.cms.gov/browse/WNMGDS-1142

## Summary
For context, see https://github.com/CMSgov/design-system/pull/1212

### Changed
- Updated the `gh-pages` command to also deploy medicare to GitHub Pages
- Updated the release-publish script to build and zip the ds-medicare-gov package