### PR TITLE
[WNMGDS-1142] Fix footer SVG rendering

### DIFF
--- a/packages/ds-healthcare-gov/src/components/Footer/Logo.jsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Logo.jsx
@@ -42,7 +42,7 @@ function Logo(props) {
 
 Logo.propTypes = {
   /** The SVG content as a string */
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   className: PropTypes.string,
   href: PropTypes.string.isRequired,
   width: PropTypes.string,

--- a/packages/ds-healthcare-gov/src/components/Footer/Logo.jsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Logo.jsx
@@ -32,13 +32,11 @@ function Logo(props) {
   return (
     <a
       className={classnames('hc-c-footer__logo ds-u-display--inline-block', props.className)}
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{
-        __html: props.children,
-      }}
       href={props.href}
       style={style}
-    />
+    >
+      {props.children}
+    </a>
   );
 }
 

--- a/packages/ds-healthcare-gov/src/components/Footer/LogosRow.jsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/LogosRow.jsx
@@ -1,9 +1,9 @@
 import Logo from './Logo';
 import PropTypes from 'prop-types';
 import React from 'react';
-import hhsLogo from '../../images/logo-hhs.svg';
-import usaLogo from '../../images/logo-usa.svg';
-import whiteHouseLogo from '../../images/logo-white-house.svg';
+import HhsLogo from '../../images/logo-hhs.svg';
+import UsaLogo from '../../images/logo-usa.svg';
+import WhiteHouseLogo from '../../images/logo-white-house.svg';
 
 /**
  * The logos row includes agency/branch logos and address info
@@ -14,7 +14,7 @@ const LogosRow = function (props) {
       <div className="ds-l-form-row">
         <div className="ds-l-col ds-l-col--3 ds-l-sm-col--2 ds-l-md-col--auto">
           <Logo href="http://www.hhs.gov/" width="67px">
-            {hhsLogo}
+            <HhsLogo />
           </Logo>
         </div>
         <div className="ds-l-col ds-l-col--9 ds-l-sm-col--10 ds-l-md-col--auto">
@@ -26,10 +26,10 @@ const LogosRow = function (props) {
         </div>
         <div className="ds-l-col ds-l-col--12 ds-l-lg-col--auto ds-u-lg-margin-top--0 ds-u-margin-top--2 ds-u-margin-left--auto">
           <Logo className="ds-u-margin-right--2" href="http://www.whitehouse.gov/" width="76px">
-            {whiteHouseLogo}
+            <WhiteHouseLogo />
           </Logo>
           <Logo href="http://www.usa.gov/" width="162px">
-            {usaLogo}
+            <UsaLogo />
           </Logo>
         </div>
       </div>

--- a/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/LogosRow.test.jsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/LogosRow.test.jsx.snap
@@ -15,7 +15,6 @@ exports[`LogosRow renders logos and address 1`] = `
         width="67px"
       >
         <HhsLogo
-          aria-labelledby="hhs-title"
           viewBox="0 0 252 252"
           xmlns="http://www.w3.org/2000/svg"
         />
@@ -42,7 +41,6 @@ exports[`LogosRow renders logos and address 1`] = `
         width="76px"
       >
         <WhiteHouseLogo
-          aria-labelledby="wh-title"
           viewBox="0 0 670 450"
           xmlns="http://www.w3.org/2000/svg"
         />
@@ -52,7 +50,6 @@ exports[`LogosRow renders logos and address 1`] = `
         width="162px"
       >
         <UsaLogo
-          aria-labelledby="usa-title"
           viewBox="0 0 291 89"
           xmlns="http://www.w3.org/2000/svg"
         />

--- a/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/LogosRow.test.jsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/LogosRow.test.jsx.snap
@@ -14,7 +14,11 @@ exports[`LogosRow renders logos and address 1`] = `
         href="http://www.hhs.gov/"
         width="67px"
       >
-        <Component />
+        <HhsLogo
+          aria-labelledby="hhs-title"
+          viewBox="0 0 252 252"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </Logo>
     </div>
     <div
@@ -37,13 +41,21 @@ exports[`LogosRow renders logos and address 1`] = `
         href="http://www.whitehouse.gov/"
         width="76px"
       >
-        <Component />
+        <WhiteHouseLogo
+          aria-labelledby="wh-title"
+          viewBox="0 0 670 450"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </Logo>
       <Logo
         href="http://www.usa.gov/"
         width="162px"
       >
-        <Component />
+        <UsaLogo
+          aria-labelledby="usa-title"
+          viewBox="0 0 291 89"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </Logo>
     </div>
   </div>


### PR DESCRIPTION
Context: https://github.com/CMSgov/design-system/pull/1212#issuecomment-964526632

This can either be merged into the existing PR for medicare.gov or rebased after that one is merged, depending on which one is approved first.

Fixes the healthcare.gov `Footer` component, which previously rendered what looked like garbage (the svg markup) rather than logos. The babel config specific to hc.gov was removed, so we needed to switch to using the svg loader plugin that the root babel config uses.

To compare, view the Footer component with `yarn start:healthcare` on both master and this branch.