### PR TITLE
[WNMGDS-1097] Separate our build commands in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ These scripts can all be run from the root level of the repo:
   - Compile/transpile/uglify everything and makes things release-ready.
   - `yarn build:healthcare` to build the Healthcare.gov Design System
   - `yarn build:medicare` to build the Medicare.gov Design System
+- `yarn build-docs`
+  - Build the design system and the documentation site
+  - `yarn build-docs:healthcare` to build the Healthcare.gov Design System docs site
+  - `yarn build-docs:medicare` to build the Medicare.gov Design System docs site
 - `yarn test`
   - Runs JS unit tests
   - Runs Prettier for formatting

--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
     "start": "yarn cmsds start",
     "start:healthcare": "yarn cmsds start --config cmsds.healthcare.config.js",
     "start:medicare": "yarn cmsds start --config cmsds.medicare.config.js",
-    "build": "yarn cmsds build-docs",
-    "build:healthcare": "yarn cmsds build-docs --config cmsds.healthcare.config.js",
-    "build:medicare": "yarn cmsds build-docs --config cmsds.medicare.config.js",
+    "build": "yarn cmsds build",
+    "build:healthcare": "yarn cmsds build --config cmsds.healthcare.config.js",
+    "build:medicare": "yarn cmsds build --config cmsds.medicare.config.js",
+    "build-docs": "yarn cmsds build-docs",
+    "build-docs:healthcare": "yarn cmsds build-docs --config cmsds.healthcare.config.js",
+    "build-docs:medicare": "yarn cmsds build-docs --config cmsds.medicare.config.js",
     "release": "./release.sh",
     "publish-release": "./publish.sh",
     "precommit": "lint-staged",
@@ -26,8 +29,8 @@
     "lint": "yarn cmsds lint ./ --ignorePatterns '**/node_modules/**' '**/dist/**' '**/helpers/**' '**/__tests__/**' 'tmp/**' '**/types/**' 'examples/create-react-app-typescript/**' 'examples/create-react-app/**'",
     "prepare": "husky install",
     "gh-pages": "yarn gh-pages:healthcare && yarn gh-pages:medicare",
-    "gh-pages:healthcare": "yarn build:healthcare && gh-pages -d './packages/ds-healthcare-gov/docs/dist' --dest 'healthcare'",
-    "gh-pages:medicare": "yarn build:medicare && gh-pages -d './packages/ds-medicare-gov/docs/dist' --dest 'medicare'"
+    "gh-pages:healthcare": "yarn build-docs:healthcare && gh-pages -d './packages/ds-healthcare-gov/docs/dist' --dest 'healthcare'",
+    "gh-pages:medicare": "yarn build-docs:medicare && gh-pages -d './packages/ds-medicare-gov/docs/dist' --dest 'medicare'"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.11.0",

--- a/packages/design-system-scripts/cli.js
+++ b/packages/design-system-scripts/cli.js
@@ -207,7 +207,9 @@ yargs
         // TODO: This is really ugly, but soon we'll decouple browser tests from the
         // docs site entirely, and a lot of this code can be deleted.
         const command =
-          config.rootPath === 'design-system/healthcare' ? 'build:healthcare' : 'build:medicare';
+          config.rootPath === 'design-system/healthcare'
+            ? 'build-docs:healthcare'
+            : 'build-docs:medicare';
         process.env.BUILD_COMMAND = `yarn ${command} --skipLatest --ignoreRootPath`;
       }
 

--- a/packages/design-system-scripts/jest/a11y.global-setup.js
+++ b/packages/design-system-scripts/jest/a11y.global-setup.js
@@ -9,9 +9,12 @@ const APP_PORT = 3001;
 function buildApp() {
   log(chalk.green('\nBuilding docs site in production mode...\n'));
   // Build files in production while ignoring rootPath
-  childProcess.execSync(process.env.BUILD_COMMAND || 'yarn build --skipLatest --ignoreRootPath', {
-    stdio: ['ignore', 'ignore', process.stderr],
-  });
+  childProcess.execSync(
+    process.env.BUILD_COMMAND || 'yarn build-docs --skipLatest --ignoreRootPath',
+    {
+      stdio: ['ignore', 'ignore', process.stderr],
+    }
+  );
   log(chalk.green('done ✓'));
 }
 


### PR DESCRIPTION
## Summary
Related to work under https://jira.cms.gov/browse/WNMGDS-1097, I want there to be a separate command for just building the packages vs building the docs site. Our underlying `cmsds` command-line utility supports two separate commands, so I'm making our `package.json` script aliases reflect that.

## How to test
Run the `build` and `build-docs` commands to make sure everything works.
