### PR TITLE
Fixing dependabot.yml indentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,9 @@ updates:
     schedule:
       interval: 'daily'
   - package-ecosystem: 'npm'
-      directory: '/packages/design-system-docs'
-      schedule:
-        interval: 'daily'
+    directory: '/packages/design-system-docs'
+    schedule:
+      interval: 'daily'
   - package-ecosystem: 'npm'
     directory: '/packages/design-system-scripts'
     schedule:


### PR DESCRIPTION
## Summary
I'm seeing this error for the dependabot yml file.
<img width="922" alt="Screen Shot 2021-11-22 at 9 36 38 AM" src="https://user-images.githubusercontent.com/33579665/142899972-db91da77-81ef-427e-bc3a-98bf182914bf.png">

I think it could be two things
1. I ran the yml through a validator and there was some indentation issues that this PR addresses
2. Other thing I'm guessing could be a problem is that maybe dependabot doesn't like duplicate `package-ecosystem: 'npm'`?
