### PR TITLE
[NO-TICKET] Sync ds-medicare-gov with latest core

### DIFF
--- a/packages/ds-medicare-gov/package.json
+++ b/packages/ds-medicare-gov/package.json
@@ -25,7 +25,7 @@
     "src"
   ],
   "dependencies": {
-    "@cmsgov/design-system": "2.10.0",
+    "@cmsgov/design-system": "^2.11.0-beta.1",
     "@types/react": "^17.0.10",
     "@types/react-dom": "^17.0.10"
   },
@@ -33,8 +33,8 @@
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
     "@babel/preset-typescript": "^7.8.3",
-    "@cmsgov/design-system-docs": "2.10.0",
-    "@cmsgov/design-system-scripts": "2.10.0",
+    "@cmsgov/design-system-docs": "^2.11.0-beta.1",
+    "@cmsgov/design-system-scripts": "^2.11.0-beta.1",
     "@cmsgov/eslint-config-design-system": "2.0.0",
     "@cmsgov/stylelint-config-design-system": "2.0.0",
     "@types/jest": "^25.1.3",


### PR DESCRIPTION
Not sure why lerna didn't update this automatically. Maybe it was the lack of a caret? Either way, it needs to be updated. One symptom on master right now is that if you install dependencies, it updates yarn.lock with entries for the last version of core.