### PR TITLE
text field storybook stories

### DIFF
--- a/packages/design-system/src/components/TextField/TextField.stories.jsx
+++ b/packages/design-system/src/components/TextField/TextField.stories.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import TextField from './TextField';
+
+export default {
+  title: 'Components/Text Field',
+  component: TextField,
+  argTypes: {
+    defaultValue: {
+      control: { type: 'text' },
+    },
+    errorMessage: {
+      control: { type: 'text' },
+    },
+    hint: {
+      control: { type: 'text' },
+    },
+    label: {
+      control: { type: 'text' },
+    },
+    requirementLabel: {
+      control: { type: 'text' },
+    },
+    rows: {
+      control: { type: 'number' },
+    },
+    size: {
+      type: { name: 'string', required: false },
+      description: 'Set the max-width of the input either to `small` or `medium`.',
+      table: {
+        type: { summary: 'string' },
+      },
+      control: {
+        type: 'radio',
+      },
+      options: ['small', 'medium', 'default'],
+    },
+    type: {
+      description:
+        'HTML `input` [type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#<input>_types) attribute. If you are using `type=number` please use the numeric prop instead.',
+      control: { type: 'text' },
+    },
+  },
+  args: {
+    label: 'Text Field Label',
+    onChange: () => {},
+    name: 'text-field-story',
+  },
+  parameters: {},
+};
+
+const Template = ({ data, ...args }) => <TextField {...args} />;
+
+export const SingleLineField = Template.bind({});
+export const MultilineField = Template.bind({});
+MultilineField.args = {
+  multiline: true,
+  rows: 3,
+};
+export const MaskedField = Template.bind({});
+MaskedField.args = {
+  mask: 'currency',
+  label: 'Currency Field',
+  inputMode: 'numeric',
+};
+export const ErrorField = Template.bind({});
+ErrorField.args = {
+  errorMessage: 'Example error message',
+};
+export const SuccessField = Template.bind({});
+SuccessField.args = {
+  fieldClassName: 'ds-c-field--success',
+};
+export const DisabledField = Template.bind({});
+DisabledField.args = {
+  disabled: true,
+};

--- a/packages/design-system/src/components/TextField/TextField.stories.jsx
+++ b/packages/design-system/src/components/TextField/TextField.stories.jsx
@@ -66,6 +66,7 @@ MaskedField.args = {
 export const ErrorField = Template.bind({});
 ErrorField.args = {
   errorMessage: 'Example error message',
+  hint: 'Helpful hint text',
 };
 export const SuccessField = Template.bind({});
 SuccessField.args = {


### PR DESCRIPTION
## Summary
Added stories for the TextField component that represent
* Single line state
* Multiline state
* error state
* disabled state
* success state
* Masked field

Should the Masked input be its own section? Should there be more variations?

## How to test
Run `yarn storybook` and verify that TextField stories look okay.
