### PR TITLE
[WNMGDS-828] Update homepages to point to Sketch cloud toolkits

### DIFF
--- a/packages/design-system-docs/src/pages/index.md
+++ b/packages/design-system-docs/src/pages/index.md
@@ -9,8 +9,18 @@ It is currently being applied to [HealthCare.gov](https://www.healthcare.gov/) a
 
 ## Getting started
 
-- **For developers** - [Download the code as a zip file](https://github.com/CMSgov/design-system/releases/latest) or [install with NPM]({{root}}/startup/installation/).
-- **For designers** - [Get the Sketch Library](sketch://add-library?url=https%3A%2F%2Fgithub.com%2FCMSgov%2Fdesign-system%2Fraw%2Fmaster%2Fdesign-assets%2Fcms-design-system-ui-kit.xml) or [download the Sketch UI kit](https://github.com/CMSgov/design-system/raw/master/design-assets/CMS-Design-System-UI-kit.sketch).
+### Developers
+
+Developers and engineers are encouraged to use React which allows for more complex, interactive components, and many of our React components have built-in accessibility optimizations.
+
+- **Recommended option:** [Install the NPM package]({{root}}/startup/installation/) `@cmsgov/design-system` if your project uses npm for package management.
+
+- If you're unfamiliar with npm and package management, [download the code as a zip file](https://github.com/CMSgov/design-system/releases/latest).
+
+### Designers
+
+- **Recomended opion:** [Install the Sketch Library](https://www.sketch.com/s/bffbfeb1-59a1-48dd-842f-a1e0566e457f)
+- [Download the Sketch UI kit](https://www.sketch.com/s/bffbfeb1-59a1-48dd-842f-a1e0566e457f).
 
 ## Goals
 

--- a/packages/ds-healthcare-gov/docs/src/pages/index.md
+++ b/packages/ds-healthcare-gov/docs/src/pages/index.md
@@ -13,14 +13,13 @@ The Healthcare.gov Design System is built on the CMS Design System and extends i
 
 Developers and engineers are encouraged to use React which allows for more complex, interactive components, and many of our React components have built-in accessibility optimizations.
 
-- **Recommended option:** Install the `@cmsgov/ds-healthcare-gov` Node package manager (npm) package if your project uses npm for package management.
-
-  <a href="{{root}}/startup/installation/#install-using-npm" class="ds-c-button">Install with npm</a>
+- **Recommended option:** [Install the NPM package]({{root}}/startup/installation/#install-using-npm) `@cmsgov/ds-healthcare-gov` if your project uses npm for package management.
 
 - If you're unfamiliar with npm and package management, [download the code as a zip file]({{root}}/startup/installation/#download-zip).
 
 ### Designers
 
-Design teams are currently using Figma for creating UIs that follow HealthCare.gov's Design System but will be transitioning to using Sketch in the future.
+Design teams are using Sketch for creating UIs that follow HealthCare.gov's guidelines.
 
-<a href="https://www.figma.com/file/JW5p03MknojQR6fVLn2Paj/Healthcare.gov-Child-Design-System?node-id=2%3A52" class="ds-c-button">Access the Figma file</a>
+- **Recomended opion:** [Install the Sketch Library](https://www.sketch.com/s/4da17849-4fab-4684-b2ef-fe63ba7ff10b)
+- [Download the Sketch UI kit](https://www.sketch.com/s/4da17849-4fab-4684-b2ef-fe63ba7ff10b).

--- a/packages/ds-medicare-gov/docs/src/pages/index.md
+++ b/packages/ds-medicare-gov/docs/src/pages/index.md
@@ -13,12 +13,11 @@ The Medicare.gov Design System is built on the CMS Design System and extends it 
 
 Developers and engineers are encouraged to use React which allows for more complex, interactive components, and many of our React components have built-in accessibility optimizations.
 
-- **Recommended option:** Install the `@cmsgov/ds-medicare-gov` Node package manager (npm) package if your project uses npm for package management.
+- **Recommended option:** [Install the NPM package]({{root}}/startup/installation/#install-using-npm) `@cmsgov/ds-medicare-gov` if your project uses npm for package management.
 
-  <a href="{{root}}/startup/installation/" class="ds-c-button">Install with npm</a>
-
-* If you're unfamiliar with npm and package management, [download the code as a zip file]({{github}}).
+- If you're unfamiliar with npm and package management, [download the code as a zip file]({{root}}/startup/installation/#download-zip).
 
 ### Designers
 
-Reach out to the team for access to the [M.gov InVision](https://cms.invisionapp.com/dsm/cms/medicare) or [download the Sketch UI kit]({{github}}/raw/master/design-assets/).
+- **Recomended opion:** [Install the Sketch Library](https://www.sketch.com/s/c242aee5-25e9-4684-ac7d-0f084ffeb782)
+- [Download the Sketch UI kit](https://www.sketch.com/s/c242aee5-25e9-4684-ac7d-0f084ffeb782).


### PR DESCRIPTION
## Summary
- Updating doc site homepages to point to Sketch cloud versions of the UI toolkits

### Changed
- Changes links to the Sketch UI toolkits to point to Sketch cloud 

## How to test
- check out demo URL for the core update - http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-828
- Run locally to see the changes for Healthcare and Medicare with `yarn start:Healthcare` and `yarn start:Medicare`