### PR TITLE
[WNMGDS-1156] updating scripts to build storybook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ node_modules
 # .DS_Store Mac
 .DS_Store
 /.vscode
+
+storybook-static/

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "storybook": "STORYBOOK_DS=core start-storybook -p 6006 -s ./packages/design-system/src",
     "storybook:healthcare": "STORYBOOK_DS=hcgov start-storybook -p 6006 -s ./packages/design-system/src",
     "storybook:medicare": "STORYBOOK_DS=mgov start-storybook -p 6006 -s ./packages/design-system/src,./packages/ds-medicare-gov/src",
-    "build-storybook": "build-storybook",
+    "build-storybook": "STORYBOOK_DS=core build-storybook -s ./packages/design-system/src -o storybook-static/core",
+    "build-storybook:healthcare": "STORYBOOK_DS=hcgov build-storybook -s ./packages/design-system/src -o storybook-static/healthcare",
+    "build-storybook:medicare": "STORYBOOK_DS=mgov build-storybook -s ./packages/design-system/src,./packages/ds-medicare-gov/src -o storybook-static/medicare",
     "gh-pages": "yarn gh-pages:healthcare && yarn gh-pages:medicare",
     "gh-pages:healthcare": "yarn build-docs:healthcare && gh-pages -d './packages/ds-healthcare-gov/docs/dist' --dest 'healthcare'",
     "gh-pages:medicare": "yarn build-docs:medicare && gh-pages -d './packages/ds-medicare-gov/docs/dist' --dest 'medicare'"


### PR DESCRIPTION
## Summary
Creating / updating `build-storybook` scripts to allow for serving on static site for devops pipeline

## How to test
Running `yarn build-storybook`, `yarn build-storybook:medicare` & `yarn build-storybook:healthcare` will build storybook in a static-site friendly way. The outputs of these commands will go in the directories `storybook-static/core`, `storybook-static/medicare` & `storybook-static/healthcare`, respectively.

I also added the `storybook-static` directory to gitignore since those files do not need to be tracked in version control
