### PR TITLE
[WNMGDS-983] Remove base html ruleset variable 

### DIFF
--- a/examples/child-design-system/src/styles/settings/variables/_override.build.scss
+++ b/examples/child-design-system/src/styles/settings/variables/_override.build.scss
@@ -6,8 +6,5 @@
 $font-path: './fonts';
 $image-path: './images';
 
-// Set $ds-include-base-html-rulesets to enable applying styles directly to HTML elements (i.e. <a>)
-$ds-include-base-html-rulesets: true;
-
 // Set $ds-include-focus-styles to enable the CMSDS focus styles.
 $ds-include-focus-styles: true;

--- a/packages/design-system-docs/src/pages/styles/typography/_typography.docs.scss
+++ b/packages/design-system-docs/src/pages/styles/typography/_typography.docs.scss
@@ -31,7 +31,7 @@ Link
 
 Links connect users to a different page or further information.
 
-The only base HTML element the design system applies styling to is the `<a>` element. To prevent this, you can override the `$ds-include-base-html-rulesets` Sass variable and set it to `false`. You can also use `.ds-c-link` and `.ds-c-link--inverse` for styling links.
+The only base HTML element the design system applies styling to is the `<a>` element. You can also use `.ds-c-link` and `.ds-c-link--inverse` for styling links.
 
 Markup: link.example.html
 

--- a/packages/design-system/src/styles/base/_link.scss
+++ b/packages/design-system/src/styles/base/_link.scss
@@ -97,6 +97,7 @@ $link-underline-offset: auto !default;
 }
 
 // Rename to ds-link
+a,
 .ds-c-link {
   @extend %link;
 }
@@ -105,26 +106,15 @@ $link-underline-offset: auto !default;
   @extend %link-inverse;
 }
 
-@if $ds-include-base-html-rulesets {
-  // <a> is the only base HTML element in the design system that
-  // has a style declaration. In all other cases, styles are applied using a
-  // namespaced class name. This selector isn't scoped under .ds-base, since that
-  // would cause the selector's specificity to be higher than most other component
-  // selectors (i.e. ds-c-button), necessitating overly specific selectors anytime
-  // a developer wanted to change an anchor's color property.
-  a {
-    @extend %link;
-  }
-  // Change color of links that are descendants of '.ds-base--inverse'
-  //
-  // Fix TODO: Because this selector's specificity is higher than most components,
-  // changing inverse links will require unusually specific selectors
-  //
-  // Specifically exclude '.ds-c-button' because this is most likely case where
-  // a inverse link element will have other styles applied
-  // Also exclude '.ds-c-tooltip__trigger-link' as we need to set
-  // text decoration styles for the tooltip trigger links
-  .ds-base--inverse a:not(.ds-c-button):not(.ds-c-tooltip__trigger-link) {
-    @extend %link-inverse;
-  }
+// Change color of links that are descendants of '.ds-base--inverse'
+//
+// Fix TODO: Because this selector's specificity is higher than most components,
+// changing inverse links will require unusually specific selectors
+//
+// Specifically exclude '.ds-c-button' because this is most likely case where
+// a inverse link element will have other styles applied
+// Also exclude '.ds-c-tooltip__trigger-link' as we need to set
+// text decoration styles for the tooltip trigger links
+.ds-base--inverse a:not(.ds-c-button):not(.ds-c-tooltip__trigger-link) {
+  @extend %link-inverse;
 }

--- a/packages/design-system/src/styles/components/_Alert.scss
+++ b/packages/design-system/src/styles/components/_Alert.scss
@@ -58,11 +58,7 @@ $alert-icon-size: $spacer-5;
     background-image: none;
   }
 
-  @if $ds-include-base-html-rulesets {
-    a {
-      @extend %link-darker;
-    }
-  }
+  a,
   .ds-c-link {
     @extend %link-darker;
   }

--- a/packages/design-system/src/styles/settings/variables/_build.scss
+++ b/packages/design-system/src/styles/settings/variables/_build.scss
@@ -3,8 +3,6 @@ $font-path: '../fonts' !default;
 $image-path: '../images' !default;
 
 // Override these variables to change what CSS rulesets get outputted when
-// the Sass is transpiled to CSS
-$ds-include-base-html-rulesets: true !default;
 
 // Set $ds-include-focus-styles to enable the CMSDS focus styles.
 $ds-include-focus-styles: true !default;

--- a/packages/ds-medicare-gov/docs/src/pages/styles/typography/_typography.docs.scss
+++ b/packages/ds-medicare-gov/docs/src/pages/styles/typography/_typography.docs.scss
@@ -60,7 +60,7 @@ Link
 
 Links connect users to a different page or further information.
 
-The only base HTML element the design system applies styling to is the `<a>` element. To prevent this, you can override the `$ds-include-base-html-rulesets` Sass variable and set it to `false`. You can also use `.ds-c-link` and `.ds-c-link--inverse` for styling links.
+The only base HTML element the design system applies styling to is the `<a>` element. You can also use `.ds-c-link` and `.ds-c-link--inverse` for styling links.
 
 Markup: link.example.html
 

--- a/packages/ds-medicare-gov/src/styles/settings/_variables.build.scss
+++ b/packages/ds-medicare-gov/src/styles/settings/_variables.build.scss
@@ -1,5 +1,2 @@
-// Includes rulesets to base html (i.e. applies styles to <a>)
-$ds-include-base-html-rulesets: true;
-
 // Disabling the design system focus styles
 $ds-include-focus-styles: false;


### PR DESCRIPTION
## Summary
Removing the `$ds-include-base-html-rulesets: true !default;` setting because it's never been set to false and is not needed. This was specifically used for styling an A tag only. 

From the doc site 
> The only base HTML element the design system applies styling to is the `<a>` element. You can also use `.ds-c-link` and `.ds-c-link--inverse` for styling links.


### Removed
- Removed instances where the `ds-include-base-html-rulesets` was set to true
- Removed the instances where the `ds-include-base-html-rulesets` were wrapping an a tag

## How to test
- Run the doc site locally `yarn start` and see if links appear differently than the live site. do the same for Medicare and Healthcare with `yarn start:medicare` and `yarn start:healthcare`
