### PR TITLE
[WNMGDS-972] clean up TS exports

### DIFF
--- a/packages/design-system/src/types/index.d.ts
+++ b/packages/design-system/src/types/index.d.ts
@@ -4,8 +4,6 @@
 export { default as Dialog } from './Dialog/Dialog';
 export { default as HelpDrawer } from './HelpDrawer/HelpDrawer';
 export { default as HelpDrawerToggle } from './HelpDrawer/HelpDrawerToggle';
-export { default as MonthPicker, getMonthNames } from './MonthPicker/MonthPicker';
-export { default as Review } from './Review/Review';
 export { default as SkipNav } from './SkipNav/SkipNav';
 export { default as StepList } from './StepList/StepList';
 export { default as Tooltip } from './Tooltip/Tooltip';


### PR DESCRIPTION
## Summary
Removing duplicate TS exports. They were needed when the components were JS, but now that they are TS, the types are generated automatically.
