### PR TITLE
[WNMGDS-1207] Update spacer utils

### DIFF
--- a/packages/design-system-docs/src/pages/utilities/margin/margin.example.html
+++ b/packages/design-system-docs/src/pages/utilities/margin/margin.example.html
@@ -1,11 +1,11 @@
-<% ['', '-x', '-y', '-bottom', '-left', '-right', '-top'].forEach(name => { -%> <% for (var i = 0; i
-< 8; i++) { %>
+<% const spacers = ['0', '05', '1', '2', '3', '4', '5', '6', '7'] -%> <% ['', '-x', '-y', '-bottom',
+'-left', '-right', '-top'].forEach(name => { -%> <% spacers.forEach( size => { %>
 <div class="ds-u-fill--primary-alt ds-u-margin-bottom--2" style="max-width: fit-content;">
-  <div class="ds-u-margin<%= name %>--<%= i %> ds-u-display--inline-block">
-    <code>.ds-u-margin<%= name %>--<%= i %></code>
+  <div class="ds-u-margin<%= name %>--<%= size %> ds-u-display--inline-block">
+    <code>.ds-u-margin<%= name %>--<%= size %></code>
   </div>
 </div>
-<% } -%>
+<% }) -%>
 <div class="ds-u-fill--primary-alt ds-u-margin-bottom--2" style="max-width: fit-content;">
   <div class="ds-u-margin<%= name %>--auto" style="width: 250px;">
     <code>.ds-u-margin<%= name %>--auto</code>

--- a/packages/design-system-docs/src/pages/utilities/padding/padding.example.html
+++ b/packages/design-system-docs/src/pages/utilities/padding/padding.example.html
@@ -1,9 +1,9 @@
-<% ['', '-x', '-y', '-bottom', '-left', '-right', '-top'].forEach(name => { -%> <% for (var i = 0; i
-< 8; i++) { %>
+<% const spacers = ['0', '05', '1', '2', '3', '4', '5', '6', '7'] -%> <% ['', '-x', '-y', '-bottom',
+'-left', '-right', '-top'].forEach(name => { -%> <% spacers.forEach( size => { %>
 <div
-  class="ds-u-fill--primary-alt ds-u-padding<%= name %>--<%= i %> ds-u-margin-bottom--2"
+  class="ds-u-fill--primary-alt ds-u-padding<%= name %>--<%= size %> ds-u-margin-bottom--2"
   style="max-width: fit-content;"
 >
-  <code>.ds-u-padding<%= name %>--<%= i %></code>
+  <code>.ds-u-padding<%= name %>--<%= size %></code>
 </div>
-<% } -%> <% }) -%>
+<% }) -%> <% }) -%>

--- a/packages/design-system/src/styles/settings/variables/_layout.scss
+++ b/packages/design-system/src/styles/settings/variables/_layout.scss
@@ -1,24 +1,36 @@
 $multiple: 8px !default;
 
+// $spacers defines all spacer units. The key (in quotes)
+// is the name appended to the generated utility classes,
+// i.e., `ds-u-sm-padding--05`, and the value ($multiple * X)
+// is what that space evaluates as (in `px`).
 $spacers: (
-  0,
-  $multiple,
-  $multiple * 2,
-  $multiple * 3,
-  $multiple * 4,
-  $multiple * 5,
-  $multiple * 6,
-  $multiple * 7
+  '0': 0,
+  '05': $multiple * 0.5,
+  '1': $multiple,
+  '2': $multiple * 2,
+  '3': $multiple * 3,
+  '4': $multiple * 4,
+  '5': $multiple * 5,
+  '6': $multiple * 6,
+  '7': $multiple * 7,
 ) !default;
 
-$spacer-1: nth($spacers, 2) !default; // 8px
-$spacer-2: nth($spacers, 3) !default; // 16px
-$spacer-3: nth($spacers, 4) !default; // 24px
-$spacer-4: nth($spacers, 5) !default; // 32px
-$spacer-5: nth($spacers, 6) !default; // 40px
-$spacer-6: nth($spacers, 7) !default; // 48px
-$spacer-7: nth($spacers, 8) !default; // 56px
-$spacer-half: $spacer-1 / 2; // 4px
+// Sass variables are generated from $spacers-values (needed
+// due to a different naming syntax between util classes
+// and Sass variables).
+$spacers-values: map-values($spacers);
+
+// 🚨 Note: If you change the order in $spacers, you may
+// need to update the index used to generate the variables
+$spacer-half: nth($spacers-values, 2) !default; // 4px
+$spacer-1: nth($spacers-values, 3) !default; // 8px
+$spacer-2: nth($spacers-values, 4) !default; // 16px
+$spacer-3: nth($spacers-values, 5) !default; // 24px
+$spacer-4: nth($spacers-values, 6) !default; // 32px
+$spacer-5: nth($spacers-values, 7) !default; // 40px
+$spacer-6: nth($spacers-values, 8) !default; // 48px
+$spacer-7: nth($spacers-values, 9) !default; // 56px
 
 // Breakpoint widths
 // INTERNAL: If these values change, the values used for the responsive previews

--- a/packages/design-system/src/styles/utilities/_margin.scss
+++ b/packages/design-system/src/styles/utilities/_margin.scss
@@ -1,10 +1,7 @@
 /* stylelint-disable declaration-no-important */
 @import '../settings/index.scss';
 
-@for $i from 1 through length($spacers) {
-  $size: #{nth($spacers, $i)};
-  $scale: #{$i - 1};
-
+@each $scale, $size in $spacers {
   // Example: ds-u-margin--0
   .ds-u-margin--#{$scale} {
     // Example: margin: 0 !important;
@@ -72,10 +69,7 @@
   $value: map-get($breakpoints, $breakpoint);
 
   @media (min-width: $value) {
-    @for $i from 1 through length($spacers) {
-      $size: #{nth($spacers, $i)};
-      $scale: #{$i - 1};
-
+    @each $scale, $size in $spacers {
       // Example: ds-u-sm-margin--0
       .ds-u-#{$breakpoint}-margin--#{$scale} {
         // Example: margin: 0 !important;

--- a/packages/design-system/src/styles/utilities/_padding.scss
+++ b/packages/design-system/src/styles/utilities/_padding.scss
@@ -1,10 +1,7 @@
 /* stylelint-disable declaration-no-important */
 @import '../settings/index.scss';
 
-@for $i from 1 through length($spacers) {
-  $size: #{nth($spacers, $i)};
-  $scale: #{$i - 1};
-
+@each $scale, $size in $spacers {
   // Example: ds-u-padding--0
   .ds-u-padding--#{$scale} {
     // Example: padding: 0 !important;
@@ -42,10 +39,7 @@
   $value: map-get($breakpoints, $breakpoint);
 
   @media (min-width: $value) {
-    @for $i from 1 through length($spacers) {
-      $size: #{nth($spacers, $i)};
-      $scale: #{$i - 1};
-
+    @each $scale, $size in $spacers {
       // Example: ds-u-sm-padding--0
       .ds-u-#{$breakpoint}-padding--#{$scale} {
         // Example: padding: 0 !important;


### PR DESCRIPTION
## Summary
[Jira](https://jira.cms.gov/browse/WNMGDS-1207)

### Added
New margin/padding util classes supporting a half value.

### Changed
How our Sass spacer variables are created, using a map instead of a list.

## How to test
~You should be able to visit [margin docs](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1207/update-spacer-utils/utilities/margin/) and [padding docs](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1207/update-spacer-utils/utilities/padding/) to see a new half value in the documentation.~ This value should evaluate to 4px (half of our base of 8px).

Looks like build is currently disabled. You can test by building locally until this is resolved.
