### PR TITLE
[NO-TICKET] Update release script to only push the new tags to origin

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -26,13 +26,15 @@ if [ "$PRE_VERSION_HASH" = "$POST_VERSION_HASH" ]; then
 fi
 
 echo "${GREEN}Pushing tag and release commit to Github...${NC}"
-git push --set-upstream origin $BRANCH
-git push origin --tags
-
 # Grep the last commit message for package versions
 PACKAGE_VERSIONS=$(git log -1 --pretty=%B | grep -o "@.*$")
 # Take the first one we find to use in example command
 PACKAGE_VERSION=$(echo "$PACKAGE_VERSIONS" | head -1)
+# Get it all on one line so we can push these tags at once
+TAGS=$(echo "$PACKAGE_VERSIONS" | tr '\n' ' ')
+
+git push --set-upstream origin $BRANCH
+git push origin $TAGS
 
 echo ""
 echo "${GREEN}Release has been tagged and pushed to origin.${NC}"


### PR DESCRIPTION
## Summary
If you've got other local tags and run the release script, it'll try to push all those that aren't found on origin to origin, and it may fail. We really only need to be pushing the new tags.

Example:
```
To https://github.com/CMSgov/design-system.git
 * [new tag]           @cmsgov/design-system-docs@2.12.0-beta.3 -> @cmsgov/design-system-docs@2.12.0-beta.3
 * [new tag]           @cmsgov/design-system@2.12.0-beta.3 -> @cmsgov/design-system@2.12.0-beta.3
 * [new tag]           @cmsgov/ds-healthcare-gov@6.4.0-beta.3 -> @cmsgov/ds-healthcare-gov@6.4.0-beta.3
 * [new tag]           @cmsgov/ds-medicare-gov@3.4.0-beta.5 -> @cmsgov/ds-medicare-gov@3.4.0-beta.5
 * [new tag]           @cmsgov/ds-medicare-gov@3.5.0-beta.1 -> @cmsgov/ds-medicare-gov@3.5.0-beta.1
 * [new tag]           test-tag -> test-tag
 * [new tag]           test-tag-beta -> test-tag-beta
 ! [rejected]          @cmsgov/design-system-docs@2.12.0-beta.1 -> @cmsgov/design-system-docs@2.12.0-beta.1 (already exists)
 ! [rejected]          @cmsgov/design-system-scripts@2.12.0-beta.1 -> @cmsgov/design-system-scripts@2.12.0-beta.1 (already exists)
 ! [rejected]          @cmsgov/design-system@2.12.0-beta.1 -> @cmsgov/design-system@2.12.0-beta.1 (already exists)
 ! [rejected]          @cmsgov/ds-healthcare-gov@6.4.0-beta.1 -> @cmsgov/ds-healthcare-gov@6.4.0-beta.1 (already exists)
error: failed to push some refs to 'https://github.com/CMSgov/design-system.git'
hint: Updates were rejected because the tag already exists in the remote.
```

### Fixed
- Update release script to only push the new tags to origin
