### PR TITLE
[WNMGDS-1287] Fix a11y error about logo links having no text

### DIFF
--- a/packages/ds-healthcare-gov/src/components/Footer/LogosRow.jsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/LogosRow.jsx
@@ -12,7 +12,7 @@ const LogosRow = function (props) {
       <div className="ds-l-form-row">
         <div className="ds-l-col ds-l-col--3 ds-l-sm-col--2 ds-l-md-col--auto">
           <Logo href="http://www.hhs.gov/" width="67px">
-            <HHSLogo className="hc-c-logo--hhs-logo" />
+            <HHSLogo className="hc-c-logo--hhs-logo" ariaHidden={false} />
           </Logo>
         </div>
         <div className="ds-l-col ds-l-col--9 ds-l-sm-col--10 ds-l-md-col--auto">
@@ -24,10 +24,10 @@ const LogosRow = function (props) {
         </div>
         <div className="ds-l-col ds-l-col--12 ds-l-lg-col--auto ds-u-lg-margin-top--0 ds-u-margin-top--2 ds-u-margin-left--auto">
           <Logo className="ds-u-margin-right--2" href="http://www.whitehouse.gov/" width="76px">
-            <WhiteHouseLogo className="hc-c-logo--wh-logo" />
+            <WhiteHouseLogo className="hc-c-logo--wh-logo" ariaHidden={false} />
           </Logo>
           <Logo href="http://www.usa.gov/" width="162px">
-            <UsaLogo className="hc-c-logo--usa-logo" />
+            <UsaLogo className="hc-c-logo--usa-logo" ariaHidden={false} />
           </Logo>
         </div>
       </div>

--- a/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/LogosRow.test.jsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/LogosRow.test.jsx.snap
@@ -15,6 +15,7 @@ exports[`LogosRow renders logos and address 1`] = `
         width="67px"
       >
         <HhsLogo
+          ariaHidden={false}
           className="hc-c-logo--hhs-logo"
         />
       </Logo>
@@ -40,6 +41,7 @@ exports[`LogosRow renders logos and address 1`] = `
         width="76px"
       >
         <WhiteHouseLogo
+          ariaHidden={false}
           className="hc-c-logo--wh-logo"
         />
       </Logo>
@@ -48,6 +50,7 @@ exports[`LogosRow renders logos and address 1`] = `
         width="162px"
       >
         <UsaLogo
+          ariaHidden={false}
           className="hc-c-logo--usa-logo"
         />
       </Logo>


### PR DESCRIPTION

## Summary
https://jira.cms.gov/browse/WNMGDS-1287

### Fixed
- Fix a11y error about Healthcare.gov Footer logo links having no text

## How to test
`yarn build-docs && yarn test:a11y:healthcare`
