### PR TITLE
[WNMGDS-1272] Configure project for type-checking and fix errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
         // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md#how-to-use
         'no-use-before-define': 'off',
         '@typescript-eslint/no-use-before-define': ['error'],
+        '@typescript-eslint/ban-ts-comment': 'off',
       },
     },
     {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "update-snapshots": "yarn cmsds test ./packages --updateSnapshot",
     "posttest": "yarn lint",
     "lint": "yarn cmsds lint ./ --ignorePatterns '**/node_modules/**' '**/dist/**' '**/helpers/**' '**/__tests__/**' 'tmp/**' '**/types/**' 'examples/create-react-app-typescript/**' 'examples/create-react-app/**'",
+    "type-check": "yarn tsc --noEmit",
     "prepare": "husky install",
     "storybook": "STORYBOOK_DS=core start-storybook -p 6006 -s ./packages/design-system/src",
     "storybook:healthcare": "STORYBOOK_DS=hcgov start-storybook -p 6006 -s ./packages/design-system/src",

--- a/packages/design-system/src/components/Alert/Alert.test.tsx
+++ b/packages/design-system/src/components/Alert/Alert.test.tsx
@@ -1,5 +1,6 @@
 import Alert, { AlertProps } from './Alert';
 import React from 'react';
+import { UtagContainer } from '../analytics';
 import { setAlertSendsAnalytics } from '../flags';
 import { shallow } from 'enzyme';
 
@@ -102,7 +103,7 @@ describe('Alert', function () {
     beforeEach(() => {
       setAlertSendsAnalytics(true);
       tealiumMock = jest.fn();
-      window.utag = {
+      ((window as any) as UtagContainer).utag = {
         link: tealiumMock,
       };
     });

--- a/packages/design-system/src/components/Button/Button.test.tsx
+++ b/packages/design-system/src/components/Button/Button.test.tsx
@@ -1,4 +1,4 @@
-import Button from './Button';
+import Button, { ButtonProps } from './Button';
 import React from 'react';
 import { shallow } from 'enzyme';
 
@@ -7,31 +7,37 @@ const Link = (props) => {
   return <div {...props}>{props.children}</div>;
 };
 
+const defaultProps = {
+  children: 'Foo',
+};
+
+function renderButton(props: Partial<ButtonProps> = {}) {
+  return shallow(<Button {...defaultProps} {...props} />);
+}
+
 describe('Button', () => {
   const buttonText = 'Foo';
 
   it('renders as button', () => {
-    const wrapper = shallow(<Button>{buttonText}</Button>);
+    const wrapper = renderButton();
     expect(wrapper.is('button')).toBe(true);
     expect(wrapper.prop('type')).toBe('button');
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders as submit button', () => {
-    const props = { type: 'submit' };
-    const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
+    const wrapper = renderButton({ type: 'submit' });
     expect(wrapper.is('button')).toBe(true);
     expect(wrapper.prop('type')).toBe('submit');
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders as an anchor with custom prop', () => {
-    const props = {
+    const wrapper = renderButton({
       href: '/example',
       target: '_blank',
       type: 'submit',
-    };
-    const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
+    });
     expect(wrapper.is('a')).toBe(true);
     expect(wrapper.prop('href')).toBe('/example');
     expect(wrapper.prop('target')).toBe('_blank');
@@ -40,11 +46,10 @@ describe('Button', () => {
   });
 
   it('renders as a Link', () => {
-    const props = {
+    const wrapper = renderButton({
       component: Link,
       type: 'submit',
-    };
-    const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
+    });
     expect(wrapper.is('Link')).toBe(true);
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
     expect(wrapper.render().text()).toBe(buttonText);
@@ -52,37 +57,31 @@ describe('Button', () => {
   });
 
   it('renders disabled Link correctly', () => {
-    const props = {
+    const wrapper = renderButton({
       href: 'javascript:void(0)',
       disabled: true,
-    };
-    const wrapper = shallow(<Button {...props}>Link button</Button>);
+    });
     expect(wrapper.prop('disabled')).not.toBe(true);
     expect(wrapper.hasClass('ds-c-button--disabled')).toBe(true);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies additional classes', () => {
-    const props = { className: 'foobar' };
-    const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
+    const wrapper = renderButton({ className: 'foobar' });
     expect(wrapper.hasClass('foobar')).toBe(true);
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies variation classes', () => {
-    const props = { variation: 'primary' };
-    const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
-
+    const wrapper = renderButton({ variation: 'primary' });
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
     expect(wrapper.hasClass('ds-c-button--primary')).toBe(true);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('applies size classes', () => {
-    const props = { size: 'small' };
-    const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
-
+    const wrapper = renderButton({ size: 'small' });
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
     expect(wrapper.hasClass('ds-c-button--small')).toBe(true);
     expect(wrapper).toMatchSnapshot();
@@ -91,8 +90,7 @@ describe('Button', () => {
   it('applies disabled class', () => {
     const onClick = jest.fn();
     const disabled = true;
-    const props = { onClick, disabled };
-    const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
+    const wrapper = renderButton({ onClick, disabled });
     wrapper.simulate('click');
 
     expect(wrapper.prop('disabled')).toBe(disabled);
@@ -102,13 +100,11 @@ describe('Button', () => {
   });
 
   it('applies disabled, inverse, and variation classes together', () => {
-    const props = {
+    const wrapper = renderButton({
       disabled: true,
       inversed: true,
       variation: 'transparent',
-    };
-    const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
-
+    });
     expect(wrapper.hasClass('ds-c-button--transparent')).toBe(true);
     expect(wrapper.hasClass('ds-c-button--inverse')).toBe(true);
     expect(wrapper.prop('disabled')).toBe(true);
@@ -117,12 +113,10 @@ describe('Button', () => {
   });
 
   it('applies inversed to default/transparent variations', () => {
-    const props = {
+    const wrapper = renderButton({
       inversed: true,
       variation: 'transparent',
-    };
-    const wrapper = shallow(<Button {...props}>{buttonText}</Button>);
-
+    });
     expect(wrapper.hasClass('ds-c-button--inverse')).toBe(true);
     expect(wrapper.hasClass('ds-c-button--transparent')).toBe(true);
     expect(wrapper).toMatchSnapshot();

--- a/packages/design-system/src/components/Button/Button.test.tsx
+++ b/packages/design-system/src/components/Button/Button.test.tsx
@@ -16,8 +16,6 @@ function renderButton(props: Partial<ButtonProps> = {}) {
 }
 
 describe('Button', () => {
-  const buttonText = 'Foo';
-
   it('renders as button', () => {
     const wrapper = renderButton();
     expect(wrapper.is('button')).toBe(true);
@@ -52,7 +50,7 @@ describe('Button', () => {
     });
     expect(wrapper.is('Link')).toBe(true);
     expect(wrapper.hasClass('ds-c-button')).toBe(true);
-    expect(wrapper.render().text()).toBe(buttonText);
+    expect(wrapper.render().text()).toBe(defaultProps.children);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -60,6 +58,7 @@ describe('Button', () => {
     const wrapper = renderButton({
       href: 'javascript:void(0)',
       disabled: true,
+      children: 'Link button',
     });
     expect(wrapper.prop('disabled')).not.toBe(true);
     expect(wrapper.hasClass('ds-c-button--disabled')).toBe(true);

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -10,7 +10,7 @@ export type ButtonType = 'button' | 'submit';
  */
 export type ButtonVariation = 'primary' | 'danger' | 'success' | 'transparent';
 
-interface CommonButtonProps {
+type CommonButtonProps<T> = {
   /**
    * Label text or HTML
    */
@@ -24,7 +24,7 @@ interface CommonButtonProps {
    * When provided, this will render the passed in component. This is useful when
    * integrating with React Router's `<Link>` or using your own custom component.
    */
-  component?: ButtonComponent;
+  component?: T;
   disabled?: boolean;
   /**
    * Access a reference to the `button` or `a` element
@@ -51,26 +51,23 @@ interface CommonButtonProps {
    * The `'danger'` variation is deprecated and will be removed in a future release.
    */
   variation?: ButtonVariation;
-}
+};
 
 type OmitProps = 'children' | 'className' | 'onClick' | 'ref' | 'size' | 'type' | 'href';
 
-type LinkButtonProps = CommonButtonProps &
+type LinkButtonProps = CommonButtonProps<'a'> &
   Omit<React.ComponentPropsWithRef<'a'>, OmitProps> & {
     /**
      * When provided the root component will render as an `<a>` element
      * rather than `button`.
      */
     href?: string; // Still optional because it's optional on the anchor tag
-    component?: 'a';
   };
 
-type ButtonButtonProps = CommonButtonProps &
-  Omit<React.ComponentPropsWithRef<'button'>, OmitProps> & {
-    component?: 'button';
-  };
+type ButtonButtonProps = CommonButtonProps<'button'> &
+  Omit<React.ComponentPropsWithRef<'button'>, OmitProps>;
 
-export type ButtonProps = CommonButtonProps | LinkButtonProps | ButtonButtonProps;
+export type ButtonProps = CommonButtonProps<ButtonComponent> | LinkButtonProps | ButtonButtonProps;
 
 export default class Button extends React.PureComponent<ButtonProps> {
   static defaultProps = {

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -10,7 +10,7 @@ export type ButtonType = 'button' | 'submit';
  */
 export type ButtonVariation = 'primary' | 'danger' | 'success' | 'transparent';
 
-export interface ButtonProps {
+interface CommonButtonProps {
   /**
    * Label text or HTML
    */
@@ -26,11 +26,6 @@ export interface ButtonProps {
    */
   component?: ButtonComponent;
   disabled?: boolean;
-  /**
-   * When provided the root component will render as an `<a>` element
-   * rather than `button`.
-   */
-  href?: string;
   /**
    * Access a reference to the `button` or `a` element
    */
@@ -60,11 +55,24 @@ export interface ButtonProps {
 
 type OmitProps = 'children' | 'className' | 'onClick' | 'ref' | 'size' | 'type' | 'href';
 
-export default class Button extends React.PureComponent<
-  Omit<React.ComponentPropsWithRef<'button'>, OmitProps> &
-    Omit<React.ComponentPropsWithRef<'a'>, OmitProps> &
-    ButtonProps
-> {
+type LinkButtonProps = CommonButtonProps &
+  Omit<React.ComponentPropsWithRef<'a'>, OmitProps> & {
+    /**
+     * When provided the root component will render as an `<a>` element
+     * rather than `button`.
+     */
+    href?: string; // Still optional because it's optional on the anchor tag
+    component?: 'a';
+  };
+
+type ButtonButtonProps = CommonButtonProps &
+  Omit<React.ComponentPropsWithRef<'button'>, OmitProps> & {
+    component?: 'button';
+  };
+
+export type ButtonProps = CommonButtonProps | LinkButtonProps | ButtonButtonProps;
+
+export default class Button extends React.PureComponent<ButtonProps> {
   static defaultProps = {
     type: 'button',
     component: 'button',
@@ -120,7 +128,7 @@ export default class Button extends React.PureComponent<
       attrs.onClick = this.handleClick;
     }
 
-    if (component !== 'button' || this.props.href) {
+    if (component !== 'button' || (this.props as LinkButtonProps).href) {
       // Assume `component` is not a <button> and remove <button> specific attributes
       attrs.role = 'button';
       delete attrs.disabled;
@@ -133,7 +141,7 @@ export default class Button extends React.PureComponent<
   componentType(): string {
     let component = this.props.component;
 
-    if (component === 'button' && this.props.href) {
+    if (component === 'button' && (this.props as LinkButtonProps).href) {
       // If `href` is provided and a custom component is not, we render `<a>` instead
       component = 'a';
     }

--- a/packages/design-system/src/components/DateField/DateInput.test.tsx
+++ b/packages/design-system/src/components/DateField/DateInput.test.tsx
@@ -1,10 +1,10 @@
 jest.mock('lodash/uniqueId', () => (str) => `${str}snapshot`);
 /* eslint-disable import/first */
 import { mount, shallow } from 'enzyme';
-import DateInput from './DateInput';
+import DateInput, { DateInputProps } from './DateInput';
 import React from 'react';
 
-const defaultProps = {
+const defaultProps: DateInputProps = {
   labelId: '1',
   dayName: 'day',
   dayLabel: 'Day',
@@ -14,7 +14,7 @@ const defaultProps = {
   yearLabel: 'year',
 };
 
-function render(customProps = {}, deep = false) {
+function render(customProps: Partial<DateInputProps> = {}, deep = false) {
   const props = { ...defaultProps, ...customProps };
   const component = <DateInput {...props} />;
 
@@ -45,37 +45,36 @@ describe('DateInput', () => {
     expect(render({ yearInvalid: true }).wrapper).toMatchSnapshot();
   });
 
-  it('has custom yearMax and yearMin', () => {
-    expect(render({ yearMax: 2000, yearMin: '1990' }).wrapper).toMatchSnapshot();
-  });
-
   it('is disabled', () => {
     expect(render({ disabled: true }).wrapper).toMatchSnapshot();
   });
 
   it('returns reference to input fields', () => {
-    const refs = {};
+    let dayRef;
+    let monthRef;
+    let yearRef;
+
     const data = render(
       {
         dayDefaultValue: '1',
         dayFieldRef: (el) => {
-          refs.day = el;
+          dayRef = el;
         },
         monthDefaultValue: '22',
         monthFieldRef: (el) => {
-          refs.month = el;
+          monthRef = el;
         },
         yearDefaultValue: '3333',
         yearFieldRef: (el) => {
-          refs.year = el;
+          yearRef = el;
         },
       },
       true
     );
 
-    expect(refs.day.value).toBe(data.props.dayDefaultValue);
-    expect(refs.month.value).toBe(data.props.monthDefaultValue);
-    expect(refs.year.value).toBe(data.props.yearDefaultValue);
+    expect(dayRef.value).toBe(data.props.dayDefaultValue);
+    expect(monthRef.value).toBe(data.props.monthDefaultValue);
+    expect(yearRef.value).toBe(data.props.yearDefaultValue);
   });
 
   describe('event handlers', () => {

--- a/packages/design-system/src/components/DateField/__snapshots__/DateInput.test.tsx.snap
+++ b/packages/design-system/src/components/DateField/__snapshots__/DateInput.test.tsx.snap
@@ -1,55 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DateInput has custom yearMax and yearMin 1`] = `
-<div
-  className="ds-c-datefield__container ds-l-form-row"
->
-  <TextField
-    aria-describedby="1"
-    className="ds-l-col--auto"
-    fieldClassName="ds-c-field--month"
-    inputRef={[Function]}
-    label="Month"
-    labelClassName="ds-c-datefield__label"
-    name="month"
-    numeric={true}
-    type="text"
-  />
-  <span
-    className="ds-c-datefield__separator"
-  >
-    /
-  </span>
-  <TextField
-    aria-describedby="1"
-    className="ds-l-col--auto"
-    fieldClassName="ds-c-field--day"
-    inputRef={[Function]}
-    label="Day"
-    labelClassName="ds-c-datefield__label"
-    name="day"
-    numeric={true}
-    type="text"
-  />
-  <span
-    className="ds-c-datefield__separator"
-  >
-    /
-  </span>
-  <TextField
-    aria-describedby="1"
-    className="ds-l-col--auto"
-    fieldClassName="ds-c-field--year"
-    inputRef={[Function]}
-    label="year"
-    labelClassName="ds-c-datefield__label"
-    name="Year"
-    numeric={true}
-    type="text"
-  />
-</div>
-`;
-
 exports[`DateInput has invalid day 1`] = `
 <div
   className="ds-c-datefield__container ds-l-form-row"

--- a/packages/design-system/src/components/List/List.a11y.test.tsx
+++ b/packages/design-system/src/components/List/List.a11y.test.tsx
@@ -3,7 +3,7 @@ import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/a11y/constants';
 
 import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/a11y/assertNoAxeViolations';
 
-const rootURL = `${ROOT_URL}/example/components.list/`;
+const rootURL = `${ROOT_URL}/example/styles.typography.list/`;
 
 describe('List component', () => {
   it('Should have no accessibility violations', async () => {

--- a/packages/design-system/src/components/TextField/TextInput.test.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.test.tsx
@@ -2,9 +2,7 @@ import TextInput, { OmitProps, TextInputProps } from './TextInput';
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 
-const defaultProps: Omit<React.ComponentPropsWithRef<'textarea'>, OmitProps> &
-  Omit<React.ComponentPropsWithRef<'input'>, OmitProps> &
-  TextInputProps = {
+const defaultProps: TextInputProps<undefined> = {
   name: 'spec-field',
   setRef: jest.fn(),
   id: '1',
@@ -12,7 +10,7 @@ const defaultProps: Omit<React.ComponentPropsWithRef<'textarea'>, OmitProps> &
   errorPlacement: 'top',
 };
 
-function render(customProps = {}, deep = false) {
+function render<T extends boolean | undefined>(customProps: Partial<TextInputProps<T>> = {}, deep = false) {
   const props = { ...defaultProps, ...customProps };
   const component = <TextInput {...props} />;
 
@@ -119,7 +117,7 @@ describe('TextInput', function () {
   });
 
   it('adds min/max input attributes', () => {
-    const data = render({
+    const data = render<false>({
       max: 10,
       min: 1,
     });
@@ -138,6 +136,7 @@ describe('TextInput', function () {
 
   it('adds undocumented prop to input field', () => {
     const data = render({
+      // @ts-ignore: Undocumented prop
       'data-foo': 'bar',
     });
 

--- a/packages/design-system/src/components/TextField/TextInput.test.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.test.tsx
@@ -2,7 +2,9 @@ import TextInput, { OmitProps, TextInputProps } from './TextInput';
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 
-const defaultProps: TextInputProps<undefined> = {
+const defaultProps: Omit<React.ComponentPropsWithRef<'textarea'>, OmitProps> &
+  Omit<React.ComponentPropsWithRef<'input'>, OmitProps> &
+  TextInputProps = {
   name: 'spec-field',
   setRef: jest.fn(),
   id: '1',
@@ -10,7 +12,7 @@ const defaultProps: TextInputProps<undefined> = {
   errorPlacement: 'top',
 };
 
-function render<T extends boolean | undefined>(customProps: Partial<TextInputProps<T>> = {}, deep = false) {
+function render(customProps = {}, deep = false) {
   const props = { ...defaultProps, ...customProps };
   const component = <TextInput {...props} />;
 
@@ -117,7 +119,7 @@ describe('TextInput', function () {
   });
 
   it('adds min/max input attributes', () => {
-    const data = render<false>({
+    const data = render({
       max: 10,
       min: 1,
     });
@@ -136,7 +138,6 @@ describe('TextInput', function () {
 
   it('adds undocumented prop to input field', () => {
     const data = render({
-      // @ts-ignore: Undocumented prop
       'data-foo': 'bar',
     });
 

--- a/packages/design-system/src/components/TextField/TextInput.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.tsx
@@ -9,7 +9,7 @@ export type TextInputSize = 'small' | 'medium';
 export type TextInputValue = string | number;
 export type TextInputErrorPlacement = 'top' | 'bottom';
 
-export interface TextInputProps {
+export interface CommonTextInputProps {
   /**
    * Apply an `aria-label` to the text field to provide additional
    * context to assistive devices.
@@ -84,18 +84,24 @@ export interface TextInputProps {
   value?: TextInputValue;
 }
 
-type OmitProps = 'size' | 'ref';
+export type OmitProps = 'size' | 'ref' | 'onCopy';
+
+export type MultilineTextInputProps = CommonTextInputProps & Omit<React.ComponentPropsWithoutRef<'textarea'>, OmitProps> & {
+  multiline: true;
+}
+
+export type SingleLineTextInputProps = CommonTextInputProps & Omit<React.ComponentPropsWithoutRef<'input'>, OmitProps> & {
+  multiline?: false;
+}
+
+export type TextInputProps = MultilineTextInputProps | SingleLineTextInputProps
 
 /**
  * <TextInput> is an internal component used by <TextField>, which wraps it and handles shared form UI like labels, error messages, etc
  * <TextInput> is also exported for advanced design system use cases, where the internal component can be leveraged to build custom form components
  * As an internal component, it's subject to more breaking changes. Exercise caution using <TextInput> outside of those special cases
  */
-const TextInput: FunctionComponent<
-  Omit<React.ComponentPropsWithoutRef<'textarea'>, OmitProps> &
-    Omit<React.ComponentPropsWithoutRef<'input'>, OmitProps> &
-    TextInputProps
-> = (props: TextInputProps) => {
+const TextInput: FunctionComponent<TextInputProps> = (props: TextInputProps) => {
   const {
     ariaLabel,
     errorId,
@@ -111,6 +117,7 @@ const TextInput: FunctionComponent<
     setRef,
     type,
     pattern,
+    onCopyCapture,
     ...inputProps
   } = props;
 
@@ -157,6 +164,9 @@ const TextInput: FunctionComponent<
       inputMode={numeric ? 'numeric' : undefined}
       pattern={numeric && !pattern ? '[0-9]*' : pattern}
       type={inputType}
+      // @ts-ignore: The ClipboardEventHandler for textareas and inputs are incompatible, and TS
+      // is failing to infer which one is being used here based on ComponentType.
+      onCopyCapture={onCopyCapture}
       {...inputProps}
     />
   );

--- a/packages/design-system/src/components/TextField/TextInput.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.tsx
@@ -9,9 +9,7 @@ export type TextInputSize = 'small' | 'medium';
 export type TextInputValue = string | number;
 export type TextInputErrorPlacement = 'top' | 'bottom';
 
-export type OmitProps = 'size' | 'ref';
-
-export type TextInputProps<MultilineValue extends boolean | undefined> = Omit<React.ComponentPropsWithoutRef<MultilineValue extends true ? 'textarea' : 'input'>, OmitProps> & {
+export interface CommonTextInputProps {
   /**
    * Apply an `aria-label` to the text field to provide additional
    * context to assistive devices.
@@ -53,14 +51,14 @@ export type TextInputProps<MultilineValue extends boolean | undefined> = Omit<Re
   /**
    * Whether or not the text field is a multiline text field
    */
-  multiline?: MultilineValue;
+  multiline?: boolean;
   name?: string;
   /**
    * Sets `inputMode`, `type`, and `pattern` to improve accessiblity and consistency for number fields. Use this prop instead of `type="number"`, see [here](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/) for more information.
    */
   numeric?: boolean;
-  onBlur?: (e: React.FocusEvent<MultilineValue extends true ? HTMLTextAreaElement : HTMLInputElement>) => any;
-  onChange?: (event: React.ChangeEvent<MultilineValue extends true ? HTMLTextAreaElement : HTMLInputElement>) => any;
+  onBlur?: (...args: any[]) => any;
+  onChange?: (...args: any[]) => any;
   /**
    * @hide-prop HTML `input` [pattern](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefpattern).
    */
@@ -86,12 +84,24 @@ export type TextInputProps<MultilineValue extends boolean | undefined> = Omit<Re
   value?: TextInputValue;
 }
 
+export type OmitProps = 'size' | 'ref' | 'onCopy';
+
+export type MultilineTextInputProps = CommonTextInputProps & Omit<React.ComponentPropsWithoutRef<'textarea'>, OmitProps> & {
+  multiline: true;
+}
+
+export type SingleLineTextInputProps = CommonTextInputProps & Omit<React.ComponentPropsWithoutRef<'input'>, OmitProps> & {
+  multiline?: false;
+}
+
+export type TextInputProps = MultilineTextInputProps | SingleLineTextInputProps
+
 /**
  * <TextInput> is an internal component used by <TextField>, which wraps it and handles shared form UI like labels, error messages, etc
  * <TextInput> is also exported for advanced design system use cases, where the internal component can be leveraged to build custom form components
  * As an internal component, it's subject to more breaking changes. Exercise caution using <TextInput> outside of those special cases
  */
-const TextInput = <MultilineValue extends boolean | undefined>(props: TextInputProps<MultilineValue>) => {
+const TextInput: FunctionComponent<TextInputProps> = (props: TextInputProps) => {
   const {
     ariaLabel,
     errorId,
@@ -107,6 +117,7 @@ const TextInput = <MultilineValue extends boolean | undefined>(props: TextInputP
     setRef,
     type,
     pattern,
+    onCopyCapture,
     ...inputProps
   } = props;
 
@@ -128,7 +139,7 @@ const TextInput = <MultilineValue extends boolean | undefined>(props: TextInputP
     inputType = undefined;
   }
 
-  const ComponentType: MultilineValue extends true ? 'textarea' : 'input' = (multiline ? 'textarea' : 'input') as any;
+  const ComponentType = multiline ? 'textarea' : 'input';
 
   /* eslint-disable react/prop-types */
   const ariaAttributes = {
@@ -153,6 +164,9 @@ const TextInput = <MultilineValue extends boolean | undefined>(props: TextInputP
       inputMode={numeric ? 'numeric' : undefined}
       pattern={numeric && !pattern ? '[0-9]*' : pattern}
       type={inputType}
+      // @ts-ignore: The ClipboardEventHandler for textareas and inputs are incompatible, and TS
+      // is failing to infer which one is being used here based on ComponentType.
+      onCopyCapture={onCopyCapture}
       {...inputProps}
     />
   );

--- a/packages/design-system/src/components/TextField/TextInput.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.tsx
@@ -9,7 +9,9 @@ export type TextInputSize = 'small' | 'medium';
 export type TextInputValue = string | number;
 export type TextInputErrorPlacement = 'top' | 'bottom';
 
-export interface CommonTextInputProps {
+export type OmitProps = 'size' | 'ref';
+
+export type TextInputProps<MultilineValue extends boolean | undefined> = Omit<React.ComponentPropsWithoutRef<MultilineValue extends true ? 'textarea' : 'input'>, OmitProps> & {
   /**
    * Apply an `aria-label` to the text field to provide additional
    * context to assistive devices.
@@ -51,14 +53,14 @@ export interface CommonTextInputProps {
   /**
    * Whether or not the text field is a multiline text field
    */
-  multiline?: boolean;
+  multiline?: MultilineValue;
   name?: string;
   /**
    * Sets `inputMode`, `type`, and `pattern` to improve accessiblity and consistency for number fields. Use this prop instead of `type="number"`, see [here](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/) for more information.
    */
   numeric?: boolean;
-  onBlur?: (...args: any[]) => any;
-  onChange?: (...args: any[]) => any;
+  onBlur?: (e: React.FocusEvent<MultilineValue extends true ? HTMLTextAreaElement : HTMLInputElement>) => any;
+  onChange?: (event: React.ChangeEvent<MultilineValue extends true ? HTMLTextAreaElement : HTMLInputElement>) => any;
   /**
    * @hide-prop HTML `input` [pattern](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefpattern).
    */
@@ -84,24 +86,12 @@ export interface CommonTextInputProps {
   value?: TextInputValue;
 }
 
-export type OmitProps = 'size' | 'ref' | 'onCopy';
-
-export type MultilineTextInputProps = CommonTextInputProps & Omit<React.ComponentPropsWithoutRef<'textarea'>, OmitProps> & {
-  multiline: true;
-}
-
-export type SingleLineTextInputProps = CommonTextInputProps & Omit<React.ComponentPropsWithoutRef<'input'>, OmitProps> & {
-  multiline?: false;
-}
-
-export type TextInputProps = MultilineTextInputProps | SingleLineTextInputProps
-
 /**
  * <TextInput> is an internal component used by <TextField>, which wraps it and handles shared form UI like labels, error messages, etc
  * <TextInput> is also exported for advanced design system use cases, where the internal component can be leveraged to build custom form components
  * As an internal component, it's subject to more breaking changes. Exercise caution using <TextInput> outside of those special cases
  */
-const TextInput: FunctionComponent<TextInputProps> = (props: TextInputProps) => {
+const TextInput = <MultilineValue extends boolean | undefined>(props: TextInputProps<MultilineValue>) => {
   const {
     ariaLabel,
     errorId,
@@ -117,7 +107,6 @@ const TextInput: FunctionComponent<TextInputProps> = (props: TextInputProps) => 
     setRef,
     type,
     pattern,
-    onCopyCapture,
     ...inputProps
   } = props;
 
@@ -139,7 +128,7 @@ const TextInput: FunctionComponent<TextInputProps> = (props: TextInputProps) => 
     inputType = undefined;
   }
 
-  const ComponentType = multiline ? 'textarea' : 'input';
+  const ComponentType: MultilineValue extends true ? 'textarea' : 'input' = (multiline ? 'textarea' : 'input') as any;
 
   /* eslint-disable react/prop-types */
   const ariaAttributes = {
@@ -164,9 +153,6 @@ const TextInput: FunctionComponent<TextInputProps> = (props: TextInputProps) => 
       inputMode={numeric ? 'numeric' : undefined}
       pattern={numeric && !pattern ? '[0-9]*' : pattern}
       type={inputType}
-      // @ts-ignore: The ClipboardEventHandler for textareas and inputs are incompatible, and TS
-      // is failing to infer which one is being used here based on ComponentType.
-      onCopyCapture={onCopyCapture}
       {...inputProps}
     />
   );

--- a/packages/design-system/src/components/TextField/TextInput.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.tsx
@@ -9,7 +9,12 @@ export type TextInputSize = 'small' | 'medium';
 export type TextInputValue = string | number;
 export type TextInputErrorPlacement = 'top' | 'bottom';
 
-export interface CommonTextInputProps {
+export type OmitProps = 'size' | 'ref';
+
+export type CommonTextInputProps<MultilineValue extends boolean | undefined> = Omit<
+  React.ComponentPropsWithoutRef<MultilineValue extends true ? 'textarea' : 'input'>,
+  OmitProps
+> & {
   /**
    * Apply an `aria-label` to the text field to provide additional
    * context to assistive devices.
@@ -51,14 +56,18 @@ export interface CommonTextInputProps {
   /**
    * Whether or not the text field is a multiline text field
    */
-  multiline?: boolean;
+  multiline?: MultilineValue;
   name?: string;
   /**
    * Sets `inputMode`, `type`, and `pattern` to improve accessiblity and consistency for number fields. Use this prop instead of `type="number"`, see [here](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/) for more information.
    */
   numeric?: boolean;
-  onBlur?: (...args: any[]) => any;
-  onChange?: (...args: any[]) => any;
+  onBlur?: (
+    e: React.FocusEvent<MultilineValue extends true ? HTMLTextAreaElement : HTMLInputElement>
+  ) => any;
+  onChange?: (
+    event: React.ChangeEvent<MultilineValue extends true ? HTMLTextAreaElement : HTMLInputElement>
+  ) => any;
   /**
    * @hide-prop HTML `input` [pattern](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefpattern).
    */
@@ -82,19 +91,12 @@ export interface CommonTextInputProps {
    * for a controlled component; otherwise, set `defaultValue`.
    */
   value?: TextInputValue;
-}
+};
 
-export type OmitProps = 'size' | 'ref' | 'onCopy';
+export type MultilineTextInputProps = CommonTextInputProps<true>;
+export type SingleLineTextInputProps = CommonTextInputProps<false | undefined>;
 
-export type MultilineTextInputProps = CommonTextInputProps & Omit<React.ComponentPropsWithoutRef<'textarea'>, OmitProps> & {
-  multiline: true;
-}
-
-export type SingleLineTextInputProps = CommonTextInputProps & Omit<React.ComponentPropsWithoutRef<'input'>, OmitProps> & {
-  multiline?: false;
-}
-
-export type TextInputProps = MultilineTextInputProps | SingleLineTextInputProps
+export type TextInputProps = MultilineTextInputProps | SingleLineTextInputProps;
 
 /**
  * <TextInput> is an internal component used by <TextField>, which wraps it and handles shared form UI like labels, error messages, etc

--- a/packages/design-system/src/components/TextField/maskHelpers.ts
+++ b/packages/design-system/src/components/TextField/maskHelpers.ts
@@ -38,7 +38,7 @@ function deliminateRegexGroups(value: string, rx: RegExp): string {
  * @param {String} mask
  * @returns {Boolean}
  */
-function isValueMaskable(value: string, mask: string): boolean {
+function isValueMaskable(value: string, mask?: string): boolean {
   if (value && typeof value === 'string') {
     const hasDigits = value.match(/\d/);
     const hasDigitsAsterisks = value.match(/[\d*]/g);
@@ -91,7 +91,7 @@ export function toCurrency(value: string): string {
  * @param {String} value
  * @returns {String}
  */
-export function maskValue(value = '', mask: string): string {
+export function maskValue(value = '', mask?: string): string {
   if (isValueMaskable(value, mask)) {
     if (mask === 'currency') {
       value = toCurrency(value);
@@ -110,7 +110,7 @@ export function maskValue(value = '', mask: string): string {
  * @param {String} mask
  * @returns {String}
  */
-export function unmaskValue(value: string, mask: string): string {
+export function unmaskValue(value?: string, mask?: string): string {
   if (isValueMaskable(value, mask)) {
     if (mask === 'currency') {
       // Preserve only digits, decimal point, or negative symbol

--- a/packages/design-system/src/components/analytics/SendAnalytics.test.ts
+++ b/packages/design-system/src/components/analytics/SendAnalytics.test.ts
@@ -1,4 +1,4 @@
-import { sendLinkEvent } from './SendAnalytics';
+import { UtagContainer, sendLinkEvent } from './SendAnalytics';
 
 describe('sendLinkEvent', () => {
   const gaEventProps = {
@@ -12,7 +12,7 @@ describe('sendLinkEvent', () => {
   describe('without utag instance', () => {
     it('does nothing if window.utag does not exist', () => {
       const mock = jest.fn();
-      window.utag = undefined;
+      ((window as any) as UtagContainer).utag = undefined;
       sendLinkEvent(gaEventProps);
       expect(mock).not.toHaveBeenCalled();
     });
@@ -20,7 +20,7 @@ describe('sendLinkEvent', () => {
 
   describe('with Utag instance', () => {
     beforeEach(() => {
-      window.utag = {
+      ((window as any) as UtagContainer).utag = {
         link: jest.fn(),
       };
     });
@@ -31,7 +31,7 @@ describe('sendLinkEvent', () => {
 
     it('calls window.utag.link with event', () => {
       sendLinkEvent(gaEventProps);
-      expect(window.utag?.link).toHaveBeenCalledWith(gaEventProps);
+      expect(((window as any) as UtagContainer).utag?.link).toHaveBeenCalledWith(gaEventProps);
     });
   });
 
@@ -40,7 +40,7 @@ describe('sendLinkEvent', () => {
       jest.resetAllMocks();
     });
     it('catches errors on failed sendEvent', () => {
-      window.utag = {
+      ((window as any) as UtagContainer).utag = {
         link: jest.fn(() => {
           // eslint-disable-next-line no-throw-literal
           throw 'test event';
@@ -53,11 +53,11 @@ describe('sendLinkEvent', () => {
       const mock = jest.fn();
       jest.useFakeTimers();
 
-      window.utag = { link: undefined };
+      ((window as any) as UtagContainer).utag = { link: undefined };
       sendLinkEvent(gaEventProps);
       expect(mock).not.toHaveBeenCalled();
 
-      window.utag = { link: mock };
+      ((window as any) as UtagContainer).utag = { link: mock };
       jest.runAllTimers();
       expect(mock).toHaveBeenCalled();
     });
@@ -65,7 +65,7 @@ describe('sendLinkEvent', () => {
     it('stops retry eventually', () => {
       jest.useFakeTimers();
 
-      window.utag = { link: undefined };
+      ((window as any) as UtagContainer).utag = { link: undefined };
       expect(sendLinkEvent(gaEventProps)).toBe(undefined);
 
       jest.runAllTimers();

--- a/packages/design-system/src/components/analytics/SendAnalytics.ts
+++ b/packages/design-system/src/components/analytics/SendAnalytics.ts
@@ -6,8 +6,12 @@
  * - coverage-tools-frontend/src/helpers/objectUtilities.ts
  */
 
-interface UtagObject {
+export interface UtagObject {
   link: (params: AnalyticsEvent) => void;
+}
+
+export interface UtagContainer {
+  utag?: UtagObject;
 }
 
 export type EventType = 'link';
@@ -44,7 +48,7 @@ export function sendAnalytics(
   // feature of TypeScript is well intentioned (because if you're using globals, you want to make sure every
   // module agrees on what they are), but in reality this type definition could vary in trivial ways but
   // break a build.
-  const utag: UtagObject | undefined = (window as any).utag;
+  const utag = ((window as any) as UtagContainer).utag;
 
   if (utag && utag[eventType]) {
     try {

--- a/packages/design-system/src/components/analytics/index.ts
+++ b/packages/design-system/src/components/analytics/index.ts
@@ -1,1 +1,6 @@
-export { default as sendAnalytics, sendLinkEvent } from './SendAnalytics';
+export {
+  default as sendAnalytics,
+  sendLinkEvent,
+  UtagContainer,
+  UtagObject,
+} from './SendAnalytics';

--- a/packages/design-system/src/components/analytics/index.ts
+++ b/packages/design-system/src/components/analytics/index.ts
@@ -1,6 +1,2 @@
-export {
-  default as sendAnalytics,
-  sendLinkEvent,
-  UtagContainer,
-  UtagObject,
-} from './SendAnalytics';
+export { default as sendAnalytics, sendLinkEvent } from './SendAnalytics';
+export type { UtagContainer, UtagObject } from './SendAnalytics';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,14 @@
     "baseUrl": ".",
     // Allows `*.example.tsx` files in `docs` to import directly from the design system source root
     "paths": {
-      "@design-system/*": ["*"]
+      "@design-system": ["packages/design-system/src/components", "packages/ds-medicare-gov/src/components", "packages/ds-healthcare-gov/src/components"]
     }
-  }
+  },
+  "include": [
+    "packages/**/src/**/*",
+  ],
+  // TODO: Remove this once all our TypeScript definitions are generated from source
+  "exclude": [
+    "packages/**/src/types/**/*",
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "baseUrl": ".",
     // Allows `*.example.tsx` files in `docs` to import directly from the design system source root
+    // TODO: Remove this once we get rid of the example files in favor of Storybook stories
     "paths": {
       "@design-system": ["packages/design-system/src/components", "packages/ds-medicare-gov/src/components", "packages/ds-healthcare-gov/src/components"]
     }


### PR DESCRIPTION
## Summary
Overview of changes

### Added
- Added a `yarn type-check` command

### Changed
- TypeScript now checks our src files and ignores the manually-defined definition files found in `packages/**/src/types/`
- ESLint rule disabled that disallows the `@ts-ignore` directive. In certain cases it's not worth the time cost to solve every compiler error and have perfect type-checking. To see my attempt at fixing this error, look at https://github.com/CMSgov/design-system/commit/b5f986571b90338e5ca80d0fb79beb8d7efd8f34

### Fixed
- Fix errors in unit tests about `window.utag`
- Fix errors in Button tests by cleaning up Button prop types
- Fix errors in DateInput tests and remove an obsolete test
- Fix errors in maskHelpers tests by making optional function parameters optional
- Fix errors in TextInput tests by cleaning up TextInput prop types

## How to test
The first three commits configure TypeScript for true type-checking of our source code, and each subsequent commit fixes a set of TypeScript errors. If you want to see these errors, check out https://github.com/CMSgov/design-system/commit/094a72a3064de418e2ed6783f0aca9048eb4ebfa and then run `yarn type-check`. To see them fixed, check out the branch head again and run the same command.
