### PR TITLE
[NO-TICKET] Upgrade react-i18next again

### DIFF
--- a/packages/ds-healthcare-gov/package.json
+++ b/packages/ds-healthcare-gov/package.json
@@ -26,7 +26,7 @@
     "classnames": "^2.0.0",
     "i18next": "^21.5.5",
     "js-cookie": "^2.2.0",
-    "react-i18next": "^9.0.10"
+    "react-i18next": "^11.14.3"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/ds-healthcare-gov/src/__mocks__/react-i18next.js
+++ b/packages/ds-healthcare-gov/src/__mocks__/react-i18next.js
@@ -7,7 +7,7 @@ function t(key, params) {
   return `${key}${paramString}`;
 }
 
-i18next.translate = () => (Component) => (props) => <Component t={t} {...props} />;
+i18next.withTranslation = () => (Component) => (props) => <Component t={t} {...props} />;
 
 i18next.use = () => ({
   init: jest.fn(),

--- a/packages/ds-healthcare-gov/src/components/Footer/Footer.jsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Footer.jsx
@@ -3,7 +3,7 @@ import LogosRow from './LogosRow';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { translate } from 'react-i18next';
+import { withTranslation } from 'react-i18next';
 
 const _Footer = function (props) {
   const classes = classnames(
@@ -56,5 +56,5 @@ _Footer.propTypes = {
   footerTop: PropTypes.node,
 };
 
-export const Footer = translate()(_Footer);
+export const Footer = withTranslation()(_Footer);
 export default Footer;

--- a/packages/ds-healthcare-gov/src/components/Footer/PrivacySettingsLink.jsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/PrivacySettingsLink.jsx
@@ -1,6 +1,6 @@
 import PrivacySettingsDialog from '../PrivacySettings/PrivacySettingsDialog';
 import React from 'react';
-import { translate } from 'react-i18next';
+import { withTranslation } from 'react-i18next';
 
 class _PrivacySettingsLink extends React.PureComponent {
   constructor(props) {
@@ -26,5 +26,5 @@ class _PrivacySettingsLink extends React.PureComponent {
   }
 }
 
-export const PrivacySettingsLink = translate()(_PrivacySettingsLink);
+export const PrivacySettingsLink = withTranslation()(_PrivacySettingsLink);
 export default PrivacySettingsLink;

--- a/packages/ds-healthcare-gov/src/components/Header/ActionMenu.jsx
+++ b/packages/ds-healthcare-gov/src/components/Header/ActionMenu.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { sendHeaderEvent } from './analytics';
-import { translate } from 'react-i18next';
+import { withTranslation } from 'react-i18next';
 
 const menuId = 'hc-c-menu';
 
@@ -141,4 +141,4 @@ MenuButton.propTypes = {
   className: PropTypes.string,
 };
 
-export default translate()(ActionMenu);
+export default withTranslation()(ActionMenu);

--- a/packages/ds-healthcare-gov/src/components/Header/DeConsumerMessage.jsx
+++ b/packages/ds-healthcare-gov/src/components/Header/DeConsumerMessage.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { translate } from 'react-i18next';
+import { withTranslation } from 'react-i18next';
 
 /**
  * Instead of coming to the Marketplace and seeing all plans that
@@ -26,4 +26,4 @@ DeConsumerMessage.propTypes = {
   deBrokerName: PropTypes.string,
 };
 
-export default translate()(DeConsumerMessage);
+export default withTranslation()(DeConsumerMessage);

--- a/packages/ds-healthcare-gov/src/components/Header/Header.jsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { SkipNav } from '@cmsgov/design-system';
 import classnames from 'classnames';
 import defaultMenuLinks from './defaultMenuLinks';
-import { translate } from 'react-i18next';
+import { withTranslation } from 'react-i18next';
 
 export const VARIATION_NAMES = {
   LOGGED_IN: 'logged-in',
@@ -254,5 +254,5 @@ _Header.propTypes = {
   headerBottom: PropTypes.node,
 };
 
-export const Header = translate()(_Header);
+export const Header = withTranslation()(_Header);
 export default Header;

--- a/packages/ds-healthcare-gov/src/components/Header/I18nHeader.js
+++ b/packages/ds-healthcare-gov/src/components/Header/I18nHeader.js
@@ -8,7 +8,7 @@ import i18n from '../i18n';
 /**
  * A container component responsible for passing an instance
  * of i18next to all child components using react-i18next's
- * `translate` HOC. Note that we use I18nextProvider in order
+ * `withTranslation` HOC. Note that we use I18nextProvider in order
  * to avoid conflicts with other apps using react-i18next.
  * See https://github.com/i18next/react-i18next/issues/382 for
  * more context on why we need to do it this way.

--- a/packages/ds-healthcare-gov/src/components/PrivacySettings/PrivacySettingsDialog.jsx
+++ b/packages/ds-healthcare-gov/src/components/PrivacySettings/PrivacySettingsDialog.jsx
@@ -3,7 +3,7 @@ import { getPrivacySettings, setPrivacySettings } from './privacySettings';
 import PrivacySettingsTable from './PrivacySettingsTable';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { translate } from 'react-i18next';
+import { withTranslation } from 'react-i18next';
 
 const privacySettingConfigs = [
   { settingsKey: 'c3', translationKey: 'advertising' },
@@ -63,5 +63,5 @@ _PrivacySettingsDialog.propTypes = {
   onExit: PropTypes.func.isRequired,
 };
 
-export const PrivacySettingsDialog = translate()(_PrivacySettingsDialog);
+export const PrivacySettingsDialog = withTranslation()(_PrivacySettingsDialog);
 export default PrivacySettingsDialog;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2026,7 +2026,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.5", "@babel/runtime@^7.14.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
   integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
@@ -12198,13 +12198,6 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
-  integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
-  dependencies:
-    react-is "^16.3.2"
-
 hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -12276,12 +12269,12 @@ html-minifier-terser@^5.0.1:
     relateurl "^0.2.7"
     terser "^4.6.3"
 
-html-parse-stringify2@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz#dc5670b7292ca158b7bc916c9a6735ac8872834a"
-  integrity sha1-3FZwtyksoVi3vJFsmmc1rIhyg0o=
+html-parse-stringify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
+  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
   dependencies:
-    void-elements "^2.0.1"
+    void-elements "3.1.0"
 
 html-tags@^3.1.0:
   version "3.1.0"
@@ -18279,14 +18272,13 @@ react-hot-loader@^3.1.3:
     redbox-react "^1.3.6"
     source-map "^0.6.1"
 
-react-i18next@^9.0.10:
-  version "9.0.10"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-9.0.10.tgz#ba596b98e8dd06dbb805cf720147459ad55a3ada"
-  integrity sha512-xpeCWNut7ylQLs3Qqyo7dT13kgZbML1CdftbdnswLCv0RbRT16bRP16ma59iLe1KHIbn92VJo0Q8LSKYoXVNvg==
+react-i18next@^11.14.3:
+  version "11.14.3"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.14.3.tgz#b44b5c4d1aadac5211be011827a2830be60f2522"
+  integrity sha512-Hf2aanbKgYxPjG8ZdKr+PBz9sY6sxXuZWizxCYyJD2YzvJ0W9JTQcddVEjDaKyBoCyd3+5HTerdhc9ehFugc6g==
   dependencies:
-    "@babel/runtime" "^7.3.1"
-    hoist-non-react-statics "3.2.1"
-    html-parse-stringify2 "2.0.1"
+    "@babel/runtime" "^7.14.5"
+    html-parse-stringify "^3.0.1"
 
 react-inspector@^5.1.0:
   version "5.1.1"
@@ -18302,7 +18294,7 @@ react-is@17.0.2, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -22056,10 +22048,10 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-void-elements@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
-  integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
+void-elements@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
+  integrity sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION

## Summary
Over the course of several TypeScript config fixes, I think all of the problems causing us to revert the upgrade in https://github.com/CMSgov/design-system/pull/1405 are now resolved. Commits that I think collectively fixed the issue:
- https://github.com/CMSgov/design-system/commit/85f8f866f869ea3476a217efde0e6323267912be
- https://github.com/CMSgov/design-system/commit/7bf9c52d5e3d434f58817d0680aa2bb9685b205d
- https://github.com/CMSgov/design-system/commit/5171b7ecfa09956e8dd09196245d8998c5658084

### Changed
- Upgraded `react-i18next` from `9.0.10` to `11.14.3`, which fixes TypeScript errors that pop up when we start trying to convert modules to TypeScript that use `react-i18next`

## How to test
Install dependencies and then try all the build targets, including build, build-docs, start, storybook, and both child design systems. Also try `yarn type-check`.
