### PR TITLE
[WNMGDS-1320] Drawer z-index bug

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,38 @@
-**Note:** 
+<!--
+**Note:**
 - Add the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) to the PR title like this `[WNMGDS-10] - title of pr here` to link to the related issue in Jira.
 - You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
-- A demo doc site is automatically generated for this branch at `http://design-system-demo.s3-website-us-east-1.amazonaws.com/{branch_name}`. For example, the demo for `WNMGDS-10/feature` will be located at `http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-10/feature`.
+- A doc site needs to be generated manually using [Jenkins](https://ci.backends.cms.gov/wds/job/design-system/job/build-demo-sites/). Navigate to "Pipeline build-demo-sites," add your branch name and Slack username, and select the builds you want built. Upon a successful build, you should be able to navigate to a demo url resembling `http://design-system-demo.s3-website-us-east-1.amazonaws.com/[branch-name]/[core|hcgov|mgov]/storybook/` (omit `/storybook` if it's a docs site).
 - If your changes involve code please update the snapshots by running `yarn update-snapshots`.
 
-
 **Please follow the format below and remove any sections that aren't relevant.**
+-->
+
 ## Summary
+
 Overview of changes
 
 ### Added
+
 List new features or components. Include a screenshot for new visual elements.
 
 ### Changed
-List changes in existing functionality or design. 
+
+List changes in existing functionality or design.
 If the change was visual, include a comparison screenshot showing the before and after the visual change.
 
 ### Deprecated
+
 List once-stable features or components to be deprecated in this PR.
 
 ### Removed
+
 List deprecated features or components removed in this PR.
 
 ### Fixed
+
 List any bug fixes.
 
 ## How to test
+
 Instructions on how to test the changes. This is not exhaustive list of ways you should test this PR.

--- a/packages/design-system/src/styles/components/_Drawer.scss
+++ b/packages/design-system/src/styles/components/_Drawer.scss
@@ -5,6 +5,7 @@ $drawer-background-color: $color-background;
 $drawer-box-shadow: -2px 0 0 $border-color;
 $drawer-space: $spacer-2;
 $drawer-animation-timing: $animation-speed-2;
+$drawer-elevation: 500;
 
 // Header vars
 $drawer-header-background-color: $color-gray-lightest;
@@ -53,6 +54,7 @@ $drawer-toggle-space: 0;
   position: fixed;
   right: 0;
   top: 0;
+  z-index: $drawer-elevation;
 
   @media (min-width: $width-md) {
     animation: slideInDrawer $drawer-animation-timing ease-in-out both; // slide in from the right


### PR DESCRIPTION
## Summary
[Jira ticket](https://jira.cms.gov/browse/WNMGDS-1320)

### Added
Added a z-index to the Drawer component. Because our modals have a z-index of 1000, I felt 500 was a safe index for Drawers.

## How to test
You can review the Drawer and HelpDrawer components here:

- [Core Storybook](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1320/bug-helpdrawer-elevation/core/storybook/?path=/story/components-drawer--drawer-default)
- [Hcgov docs](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1320/bug-helpdrawer-elevation/hcgov/components/drawer/)

I tested that this works locally by adding the same z-index solution to the url referenced in the ticket.
