### PR TITLE
[WNMGDS-1310] Autocomplete WHCM support

### DIFF
--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -53,6 +53,14 @@ $autocomplete-list-border: $autocomplete-list-border-width $autocomplete-list-bo
 .ds-c-autocomplete__list-item--active {
   background-color: $color-primary-alt-darkest;
   color: $color-white;
+
+  /* stylelint-disable scss/media-feature-value-dollar-variable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    background-color: CanvasText;
+    color: Canvas;
+    -ms-high-contrast-adjust: none;
+  }
+  /* stylelint-enable scss/media-feature-value-dollar-variable */
 }
 
 .ds-c-autocomplete__list-item--message {


### PR DESCRIPTION
<!--
**Note:**
- Add the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) to the PR title like this `[WNMGDS-10] - title of pr here` to link to the related issue in Jira.
- You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- A doc site needs to be generated manually using [Jenkins](https://ci.backends.cms.gov/wds/job/design-system/job/build-demo-sites/). Navigate to "Pipeline build-demo-sites," add your branch name and Slack username, and select the builds you want built. Upon a successful build, you should be able to navigate to a demo url resembling `http://design-system-demo.s3-website-us-east-1.amazonaws.com/[branch-name]/[core|hcgov|mgov]/storybook/` (omit `/storybook` if it's a docs site).
- If your changes involve code please update the snapshots by running `yarn update-snapshots`.

**Please follow the format below and remove any sections that aren't relevant.**
-->

## Summary

[Jira](https://jira.cms.gov/browse/WNMGDS-1310)

### Added

Media query to target if WHCM is enabled. Inverting the background/foreground color palette when an option is selected.

## How to test

You can view the demo url through [our team's Sauce Labs account](http://saucelabs.com/) to ensure the changes are correct, or you can look at this pretty screenshot:
![Screen Shot 2022-01-10 at 10 54 03 AM](https://user-images.githubusercontent.com/5159392/148797711-aa286bd0-6316-4fea-a4ad-71a4a258e898.png)

If you opt to test via Sauce Labs, I'm using Edge 96 to view changes.

