### PR TITLE
[WNMGDS-1326] Bugfix - Wordbreak for modals

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -409,7 +409,7 @@ export const Dialog = (props: DialogProps) => {
             }
           </Button>
         </header>
-        <main role="main">
+        <main role="main" className="ds-c-dialog__body">
           <div id="dialog-content">{children}</div>
         </main>
         {actions && (

--- a/packages/design-system/src/components/Dialog/__snapshots__/Dialog.test.jsx.snap
+++ b/packages/design-system/src/components/Dialog/__snapshots__/Dialog.test.jsx.snap
@@ -36,6 +36,7 @@ Object {
         </Button>
       </header>
       <main
+        className="ds-c-dialog__body"
         role="main"
       >
         <div
@@ -154,6 +155,7 @@ exports[`Dialog renders react-aria-modal 1`] = `
                     </button>
                   </header>
                   <main
+                    class="ds-c-dialog__body"
                     role="main"
                   >
                     <div
@@ -286,6 +288,7 @@ exports[`Dialog renders react-aria-modal 1`] = `
                     </Button>
                   </header>
                   <main
+                    className="ds-c-dialog__body"
                     role="main"
                   >
                     <div
@@ -346,6 +349,7 @@ Object {
         </Button>
       </header>
       <main
+        className="ds-c-dialog__body"
         role="main"
       >
         <div

--- a/packages/design-system/src/styles/components/_Dialog.scss
+++ b/packages/design-system/src/styles/components/_Dialog.scss
@@ -34,6 +34,12 @@ $dialog-spacer: $spacer-4;
   padding-bottom: $spacer-1;
 }
 
+.ds-c-dialog__body {
+  overflow-wrap: break-word;
+  // IE fallback
+  word-wrap: break-word;
+}
+
 .ds-c-dialog__actions {
   margin-top: $spacer-3;
 }


### PR DESCRIPTION
<!--
**Note:**
- Add the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) to the PR title like this `[WNMGDS-10] - title of pr here` to link to the related issue in Jira.
- You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- A doc site needs to be generated manually using [Jenkins](https://ci.backends.cms.gov/wds/job/design-system/job/build-demo-sites/). Navigate to "Pipeline build-demo-sites," add your branch name and Slack username, and select the builds you want built. Upon a successful build, you should be able to navigate to a demo url resembling `http://design-system-demo.s3-website-us-east-1.amazonaws.com/[branch-name]/[core|hcgov|mgov]/storybook/` (omit `/storybook` if it's a docs site).
- If your changes involve code please update the snapshots by running `yarn update-snapshots`.

**Please follow the format below and remove any sections that aren't relevant.**
-->

## Summary

[Jira ticket](https://jira.cms.gov/browse/WNMGDS-1326)

### Added

Added new class to body of Dialog and applied word break styles to said class. Updated snapshot for testing.

I did **not** add hyphen styles since that may result in broken URLs. This just adds word break styles to keep content in its modal.

## How to test

I didn't want to commit a weird and long word to our Dialog story just to showcase this fix. To test, you'll need to run this branch locally (`yarn storybook`) and change the Dialog story to include a supercalafragilistically long word (should be around line 27 (children)).

I took a screenshot of what I saw and your results should be similar:
<img width="587" alt="Screen Shot 2022-01-10 at 4 07 30 PM" src="https://user-images.githubusercontent.com/5159392/148839775-6568858c-c28d-42cc-a0e9-31b16d56998b.png">

