### PR TITLE
[NO-TICKET] Remove a missed withTranslation instance

### DIFF
--- a/packages/ds-healthcare-gov/src/components/Header/DeConsumerMessage.test.jsx
+++ b/packages/ds-healthcare-gov/src/components/Header/DeConsumerMessage.test.jsx
@@ -2,12 +2,16 @@ import DeConsumerMessage from './DeConsumerMessage';
 import React from 'react';
 import { shallow } from 'enzyme';
 
+const t = (key) => key;
+
 describe('DeConsumerMessage', function () {
   it('renders message with broker name', () => {
-    expect(shallow(<DeConsumerMessage deBrokerName="Acme Co." />).shallow()).toMatchSnapshot();
+    expect(
+      shallow(<DeConsumerMessage t={t} deBrokerName="Acme Co." />).shallow()
+    ).toMatchSnapshot();
   });
 
   it('renders message with fallback broker name', () => {
-    expect(shallow(<DeConsumerMessage />).shallow()).toMatchSnapshot();
+    expect(shallow(<DeConsumerMessage t={t} />).shallow()).toMatchSnapshot();
   });
 });

--- a/packages/ds-healthcare-gov/src/components/Header/DeConsumerMessage.test.jsx
+++ b/packages/ds-healthcare-gov/src/components/Header/DeConsumerMessage.test.jsx
@@ -2,7 +2,7 @@ import DeConsumerMessage from './DeConsumerMessage';
 import React from 'react';
 import { shallow } from 'enzyme';
 
-const t = (key) => key;
+const t = (key, data) => key + (data ? ` | ${JSON.stringify(data)}` : '');
 
 describe('DeConsumerMessage', function () {
   it('renders message with broker name', () => {

--- a/packages/ds-healthcare-gov/src/components/Header/DeConsumerMessage.tsx
+++ b/packages/ds-healthcare-gov/src/components/Header/DeConsumerMessage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TFunction, withTranslation } from 'react-i18next';
+import { TFunction } from 'react-i18next';
 
 interface DeConsumerMessageProps {
   deBrokerName: string;
@@ -28,4 +28,4 @@ const DeConsumerMessage = (props: DeConsumerMessageProps) => {
   );
 };
 
-export default withTranslation()(DeConsumerMessage);
+export default DeConsumerMessage;

--- a/packages/ds-healthcare-gov/src/components/Header/Header.tsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.tsx
@@ -232,7 +232,7 @@ const Header = (props: HeaderProps) => {
         submenuBottom={props.submenuBottom}
       />
 
-      {props.deConsumer && <DeConsumerMessage deBrokerName={props.deBrokerName} />}
+      {props.deConsumer && <DeConsumerMessage t={t} deBrokerName={props.deBrokerName} />}
       {props.headerBottom}
     </header>
   );

--- a/packages/ds-healthcare-gov/src/components/Header/__snapshots__/DeConsumerMessage.test.jsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Header/__snapshots__/DeConsumerMessage.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`DeConsumerMessage renders message with broker name 1`] = `
   <div
     className="ds-l-container"
   >
-    header.deConsumerMessage
+    header.deConsumerMessage | {"brokerName":"Acme Co."}
   </div>
 </div>
 `;
@@ -19,7 +19,7 @@ exports[`DeConsumerMessage renders message with fallback broker name 1`] = `
   <div
     className="ds-l-container"
   >
-    header.deConsumerMessage
+    header.deConsumerMessage | {"brokerName":"header.deBrokerNameFallback"}
   </div>
 </div>
 `;

--- a/packages/ds-healthcare-gov/src/components/Header/__snapshots__/DeConsumerMessage.test.jsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Header/__snapshots__/DeConsumerMessage.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`DeConsumerMessage renders message with broker name 1`] = `
   <div
     className="ds-l-container"
   >
-    header.deConsumerMessage | {"brokerName":"Acme Co."}
+    header.deConsumerMessage
   </div>
 </div>
 `;
@@ -19,7 +19,7 @@ exports[`DeConsumerMessage renders message with fallback broker name 1`] = `
   <div
     className="ds-l-container"
   >
-    header.deConsumerMessage | {"brokerName":"header.deBrokerNameFallback"}
+    header.deConsumerMessage
   </div>
 </div>
 `;

--- a/packages/ds-healthcare-gov/src/components/Header/__snapshots__/Header.test.jsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Header/__snapshots__/Header.test.jsx.snap
@@ -60,8 +60,9 @@ exports[`Header renders Direct Enrollment banner 1`] = `
     }
     open={false}
   />
-  <Component
+  <DeConsumerMessage
     deBrokerName="Foo"
+    t={[Function]}
   />
 </header>
 `;


### PR DESCRIPTION
## Summary

As of https://github.com/CMSgov/design-system/pull/1454, we don't use the `withTranslation` HOC anymore. Somehow this was forgotten.

### Fixed

- Fixed `DeConsumerMessage` (part of HC.gov `Header`) using the old `withTranslation` HOC from `react-i18next`