### PR TITLE
[WNMGDS] Accordion HCM support

### DIFF
--- a/packages/design-system/src/styles/components/_Accordion.scss
+++ b/packages/design-system/src/styles/components/_Accordion.scss
@@ -41,12 +41,31 @@ $accordion-header-font-family: $font-sans;
   text-align: left;
   text-decoration: none;
   width: 100%;
+
   &:hover {
     background-color: $accordion-header-bg-hover-color;
   }
+
   &:focus {
     @include focus-styles;
   }
+
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    -ms-high-contrast-adjust: none;
+    background-color: LinkText;
+    color: window;
+
+    &:hover,
+    &:focus {
+      -ms-high-contrast-adjust: none;
+      background-color: window;
+      color: LinkText;
+      outline-offset: -4px;
+      outline: 4px solid LinkText;
+    }
+  }
+  /* stylelint-enable */
 
   .ds-c-icon {
     flex-shrink: 0;

--- a/packages/design-system/src/styles/components/_Accordion.scss
+++ b/packages/design-system/src/styles/components/_Accordion.scss
@@ -61,8 +61,8 @@ $accordion-header-font-family: $font-sans;
       -ms-high-contrast-adjust: none;
       background-color: window;
       color: LinkText;
-      outline-offset: -4px;
-      outline: 4px solid LinkText;
+      outline-offset: -$spacer-half;
+      outline: $spacer-half solid LinkText;
     }
   }
   /* stylelint-enable */
@@ -95,7 +95,7 @@ $accordion-header-font-family: $font-sans;
 
 .ds-c-accordion--bordered {
   .ds-c-accordion__content {
-    border: 4px solid $accordion-border-color;
+    border: $spacer-half solid $accordion-border-color;
     border-top: 0;
     padding: $spacer-2 $spacer-2;
   }


### PR DESCRIPTION
<!--
**Note:**
- Add the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) to the PR title like this `[WNMGDS-10] - title of pr here` to link to the related issue in Jira.
- You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- A doc site needs to be generated manually using [Jenkins](https://ci.backends.cms.gov/wds/job/design-system/job/build-demo-sites/). Navigate to "Pipeline build-demo-sites," add your branch name and Slack username, and select the builds you want built. Upon a successful build, you should be able to navigate to a demo url resembling `http://design-system-demo.s3-website-us-east-1.amazonaws.com/[branch-name]/[core|hcgov|mgov]/storybook/` (omit `/storybook` if it's a docs site).
- If your changes involve code please update the snapshots by running `yarn update-snapshots`.

**Please follow the format below and remove any sections that aren't relevant.**
-->

## Summary

[JIRA ticket](https://jira.cms.gov/browse/WNMGDS-1308).

This PR updates [the Accordion component](https://design.cms.gov/components/accordion/) to support Windows High Contrast Mode.

### Added

Media queries that update the Accordion's header button to better describe its size and interactable status.

## How to test

### Before

![Screenshot of the accordion component with Windows High Contrast Mode active. The accordion heading backgrounds are invisible.](https://user-images.githubusercontent.com/634191/150204088-638bcfba-0d9e-4ae3-83bc-ca03aff410ab.png)

### After

https://user-images.githubusercontent.com/634191/150204289-f32208dd-687f-47c1-ad87-7d0073eb9ca6.mp4

Accordion header button is visible in its resting state, and hover/focus interactions are now added.
