### PR TITLE
Fix spinner on HCM

### DIFF
--- a/packages/design-system/src/styles/components/_Spinner.scss
+++ b/packages/design-system/src/styles/components/_Spinner.scss
@@ -48,6 +48,13 @@ $spinner-color-inverse: $color-white;
     border-right-color: transparent;
     border-top-color: transparent;
     transform: translateZ(0);
+
+    /* stylelint-disable scss/media-feature-value-dollar-variable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      border-color: WindowText;
+      border-left-color: Window;
+    }
+    /* stylelint-enable scss/media-feature-value-dollar-variable */
   }
 
   .ds-c-button > & {


### PR DESCRIPTION
<!--
**Note:**
- Add the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) to the PR title like this `[WNMGDS-10] - title of pr here` to link to the related issue in Jira.
- You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- A doc site needs to be generated manually using [Jenkins](https://ci.backends.cms.gov/wds/job/design-system/job/build-demo-sites/). Navigate to "Pipeline build-demo-sites," add your branch name and Slack username, and select the builds you want built. Upon a successful build, you should be able to navigate to a demo url resembling `http://design-system-demo.s3-website-us-east-1.amazonaws.com/[branch-name]/[core|hcgov|mgov]/storybook/` (omit `/storybook` if it's a docs site).
- If your changes involve code please update the snapshots by running `yarn update-snapshots`.

**Please follow the format below and remove any sections that aren't relevant.**
-->

## Summary

[Jira](https://jira.cms.gov/browse/WNMGDS-1312)

HCM doesn't understand "transparent" color values. I replaced the transparent borders on Spinner with the Window, or background, color so you can see the animation.## How to test

Before:
![Screen Shot 2022-01-23 at 6 16 38 PM](https://user-images.githubusercontent.com/5159392/150702171-3fc918df-7be8-4b01-b579-ec128d1f432d.png)

After:
![Screen Shot 2022-01-23 at 6 16 58 PM](https://user-images.githubusercontent.com/5159392/150702180-a34ccf61-427e-46ef-b4fc-5fbda363f10a.png)

## How to test

Visit [this link](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1312/HCM-spinner/core/storybook/?path=/story/components-spinner--default-spinner) to see the Spinner in action. Test in VM of your choice.
