### PR TITLE
[NO TICKET] New HCM approach to include SR support

### DIFF
--- a/packages/design-system/src/components/Alert/Alert.test.tsx
+++ b/packages/design-system/src/components/Alert/Alert.test.tsx
@@ -21,12 +21,12 @@ describe('Alert', function () {
     expect(wrapper.hasClass('ds-c-alert')).toBe(true);
     expect(wrapper.prop('role')).toBe('region');
     expect($body.length).toBe(1);
-    expect($body.text()).toBe(text);
+    expect($body.text()).toContain(text);
   });
 
   it('renders a heading', () => {
     const { props, wrapper } = render({ heading: 'Error' });
-    const $heading = wrapper.render().find('.ds-c-alert__heading');
+    const $heading = wrapper.render().find('.ds-c-alert__heading').last();
 
     expect($heading.length).toBe(1);
     expect($heading.text()).toBe(props.heading);

--- a/packages/design-system/src/components/Alert/Alert.tsx
+++ b/packages/design-system/src/components/Alert/Alert.tsx
@@ -141,6 +141,12 @@ export class Alert extends React.PureComponent<
   headingId: string;
   eventHeadingText: string;
 
+  a11yLabel = {
+    error: 'Alert',
+    warn: 'Warning',
+    success: 'Success',
+  };
+
   heading(): React.ReactElement | void {
     const { headingLevel, heading } = this.props;
     const Heading = `h${headingLevel}`;
@@ -218,7 +224,19 @@ export class Alert extends React.PureComponent<
       >
         {this.getIcon()}
         <div className="ds-c-alert__body">
-          {this.heading()}
+          {heading ? (
+            <div className="ds-c-alert__header ds-c-alert__heading">
+              <span className="ds-c-alert__a11y-label ds-u-visibility--screen-reader">
+                {variation ? this.a11yLabel[variation] : 'Notice'}:{' '}
+              </span>
+              {this.heading()}
+            </div>
+          ) : (
+            <span className="ds-c-alert__a11y-label ds-u-visibility--screen-reader">
+              {variation ? this.a11yLabel[variation] : 'Notice'}:{' '}
+            </span>
+          )}
+
           {children}
         </div>
       </div>

--- a/packages/design-system/src/components/Badge/Badge.tsx
+++ b/packages/design-system/src/components/Badge/Badge.tsx
@@ -33,8 +33,18 @@ export const Badge: React.FC<React.ComponentPropsWithRef<'span'> & BadgeProps> =
   const variationClass = variation && `ds-c-badge--${variation}`;
   const classes = classNames('ds-c-badge', variationClass, sizeClasses[size], className);
 
+  const a11yLabel = {
+    info: 'Notice',
+    success: 'Success',
+    warn: 'Warning',
+    alert: 'Alert',
+  };
+
   return (
     <span className={classes} {...others}>
+      {a11yLabel[variation] && (
+        <span className="ds-u-visibility--screen-reader">{a11yLabel[variation]}: </span>
+      )}
       {children}
     </span>
   );

--- a/packages/design-system/src/styles/components/_Alert.scss
+++ b/packages/design-system/src/styles/components/_Alert.scss
@@ -51,6 +51,29 @@ $alert-link-color-focus: $color-primary-darkest;
   }
 }
 
+.ds-c-alert__a11y-label {
+  margin-right: 0.5rem;
+
+  /* stylelint-disable */
+  // !important needed to overwrite screen reader utility styles
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    border: none !important;
+    clip: auto !important;
+    height: auto !important;
+    overflow: visible !important;
+    padding: 0 !important;
+    position: relative !important;
+    width: auto !important;
+    // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1241631
+    word-wrap: normal !important;
+  }
+  /* stylelint-enable */
+}
+
+.ds-c-alert__header {
+  display: flex;
+}
+
 .ds-c-alert__icon {
   font-size: $font-size-lg;
   margin-left: $spacer-1;

--- a/packages/design-system/src/styles/components/_Badge.scss
+++ b/packages/design-system/src/styles/components/_Badge.scss
@@ -12,25 +12,6 @@ $badge-font-size-big: $base-font-size;
   /* stylelint-enable scss/media-feature-value-dollar-variable */
 }
 
-@mixin badge-high-contrast-mode-label($label-en, $label-es: null) {
-  /* stylelint-disable */
-  @media (-ms-high-contrast: active), (forced-colors: active) {
-    [lang^='en'] & {
-      &::before {
-        content: $label-en + ': ';
-      }
-    }
-    @if ($label-es != null) {
-      [lang^='es'] & {
-        &::before {
-          content: $label-es + ': ';
-        }
-      }
-    }
-  }
-  /* stylelint-enable */
-}
-
 .ds-c-badge {
   background-color: $color-gray;
   border-radius: $border-radius-pill;
@@ -45,6 +26,22 @@ $badge-font-size-big: $base-font-size;
     margin-right: 0;
   }
 
+  > span {
+    /* stylelint-disable scss/media-feature-value-dollar-variable, declaration-property-value-blacklist */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      border: none;
+      clip: auto;
+      height: auto;
+      overflow: visible;
+      padding: 0;
+      position: relative;
+      width: auto;
+      // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1241631
+      word-wrap: normal;
+    }
+    /* stylelint-enable scss/media-feature-value-dollar-variable, declaration-property-value-blacklist */
+  }
+
   @include badge-high-contrast-mode-remove-color;
 }
 
@@ -56,14 +53,12 @@ $badge-font-size-big: $base-font-size;
   background-color: $color-primary;
 
   @include badge-high-contrast-mode-remove-color;
-  @include badge-high-contrast-mode-label('Notice');
 }
 
 .ds-c-badge--success {
   background-color: $color-success;
 
   @include badge-high-contrast-mode-remove-color;
-  @include badge-high-contrast-mode-label('Success');
 }
 
 .ds-c-badge--warn {
@@ -71,12 +66,10 @@ $badge-font-size-big: $base-font-size;
   color: $color-base;
 
   @include badge-high-contrast-mode-remove-color;
-  @include badge-high-contrast-mode-label('Warning');
 }
 
 .ds-c-badge--alert {
   background-color: $color-error;
 
   @include badge-high-contrast-mode-remove-color;
-  @include badge-high-contrast-mode-label('Alert');
 }


### PR DESCRIPTION
<!--
**Note:**
- Add the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) to the PR title like this `[WNMGDS-10] - title of pr here` to link to the related issue in Jira.
- You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- A doc site needs to be generated manually using [Jenkins](https://ci.backends.cms.gov/wds/job/design-system/job/build-demo-sites/). Navigate to "Pipeline build-demo-sites," add your branch name and Slack username, and select the builds you want built. Upon a successful build, you should be able to navigate to a demo url resembling `http://design-system-demo.s3-website-us-east-1.amazonaws.com/[branch-name]/[core|hcgov|mgov]/storybook/` (omit `/storybook` if it's a docs site).
- If your changes involve code please update the snapshots by running `yarn update-snapshots`.

**Please follow the format below and remove any sections that aren't relevant.**
-->

## Summary

This work is an enhancement to HCM work done for Alert and Badge (#1516, #1537) to include screen reader support. Refactor removes reliance on JS to toggle queries and instead switches a `<span>` labeling the component variation from not visible to visible.

## Testing

Preview [Badge](http://design-system-demo.s3-website-us-east-1.amazonaws.com/NO-TICKET/HCM-alert-badge/core/storybook/?path=/story/components-badge--default) and [Alert](http://design-system-demo.s3-website-us-east-1.amazonaws.com/NO-TICKET/HCM-alert-badge/core/storybook/?path=/story/components-alert--default) links (building).