### PR TITLE
[WNMGDS-1302] Implement HCM disable state

### DIFF
--- a/packages/design-system/src/styles/components/_Choice.scss
+++ b/packages/design-system/src/styles/components/_Choice.scss
@@ -107,6 +107,17 @@ $ds-c-inset-border-width: $spacer-half;
       background-color: $choice-disabled-background-color;
       border-color: $choice-disabled-border-color;
     }
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      color: GrayText;
+
+      &::before {
+        background-color: Window;
+        border-color: GrayText;
+      }
+    }
+    /* stylelint-enable */
   }
 
   // Focused choice

--- a/packages/design-system/src/styles/components/_Tabs.scss
+++ b/packages/design-system/src/styles/components/_Tabs.scss
@@ -33,7 +33,6 @@
   border-radius: 0;
   border-top: 1px solid $border-color;
   color: $color-base;
-  cursor: pointer;
   display: inline-block;
   font-size: $font-size-sm;
   font-weight: $font-bold;
@@ -100,30 +99,10 @@
     /* stylelint-enable */
   }
 
-  &[aria-disabled='true'] {
-    background-color: $color-gray-lighter;
-    border-color: $color-gray-lighter;
-    color: $color-gray-dark;
-    pointer-events: none;
-
-    &:hover,
-    &:active,
-    &:focus {
-      background-color: $color-gray-lighter;
-      border-color: $color-gray-lighter;
-      color: $color-gray-dark;
-    }
-
-    /* stylelint-disable scss/media-feature-value-dollar-variable */
-    @media (-ms-high-contrast: active), (forced-colors: active) {
-      color: GrayText;
-    }
-    /* stylelint-enable scss/media-feature-value-dollar-variable */
-  }
-
   &:hover {
     color: $color-primary;
   }
+
   /* stylelint-disable max-nesting-depth */
   &:focus {
     @include focus-styles;
@@ -133,6 +112,19 @@
 
   &:active {
     color: $color-primary-darker;
+  }
+
+  &[aria-disabled='true'] {
+    background-color: $color-gray-lighter;
+    border-color: $color-gray-lighter;
+    color: $color-gray-dark;
+
+    /* stylelint-disable scss/media-feature-value-dollar-variable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      color: GrayText;
+      cursor: not-allowed;
+    }
+    /* stylelint-enable scss/media-feature-value-dollar-variable */
   }
 
   // SVG icons

--- a/packages/design-system/src/styles/components/_TextField.scss
+++ b/packages/design-system/src/styles/components/_TextField.scss
@@ -22,6 +22,16 @@
   &:disabled {
     background-color: $color-gray-lighter;
     border-color: $color-gray-light;
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      cursor: not-allowed;
+
+      > option {
+        color: GrayText;
+      }
+    }
+    /* stylelint-enable */
   }
 
   &:focus {


### PR DESCRIPTION
<!--
**Note:**
- Add the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) to the PR title like this `[WNMGDS-10] - title of pr here` to link to the related issue in Jira.
- You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- A doc site needs to be generated manually using [Jenkins](https://ci.backends.cms.gov/wds/job/design-system/job/build-demo-sites/). Navigate to "Pipeline build-demo-sites," add your branch name and Slack username, and select the builds you want built. Upon a successful build, you should be able to navigate to a demo url resembling `http://design-system-demo.s3-website-us-east-1.amazonaws.com/[branch-name]/[core|hcgov|mgov]/storybook/` (omit `/storybook` if it's a docs site).
- If your changes involve code please update the snapshots by running `yarn update-snapshots`.

**Please follow the format below and remove any sections that aren't relevant.**
-->

## Summary

[Jira](https://jira.cms.gov/browse/WNMGDS-1307)

### Added

Added HCM disable styles for 
- Choice
- TextField (impacting all form components using this class)
- Tabs

### Changed

I noticed Tabs CSS had some unnecessary styles applied. When a tab is disabled, it becomes a `<span>` under the hood, but the styles were applying/overwriting interactive states it no longer had by virtue of no longer being an `<a>` tag (as interactive tabs are). We were also adding a pointer cursor, then removing with a `pointer-events` style when disabled - that again, seemed unnecessary as these come with being either an `<a>` or a `<span>` tag under the hood.

I also moved the disabled styles to the bottom of the cascade, as this seemed to resolve a lot of the overrides applied. 

Less code === good 😎

## Testing

Visit these links (building) and review HCM in your favorite VM:
- [Checkbox](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1302/whcm-disabled-states/core/storybook/?path=/story/components-choicelist--default-checkbox)
- [MonthPicker](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1302/whcm-disabled-states/core/storybook/?path=/story/components-month-picker--disabled-month-picker)
- [Dropdown](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1302/whcm-disabled-states/core/storybook/?path=/story/components-dropdown--disabled)
- [Tabs](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1302/whcm-disabled-states/core/storybook/?path=/story/components-tabs--tabs)