### PR TITLE
[WNMGDS-1371] updating inputRef typing on Button component

### DIFF
--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { RefObject } from 'react';
 import classNames from 'classnames';
 
 export type ButtonComponentType = React.ElementType<any> | React.ComponentType<any>;
@@ -8,6 +8,8 @@ export type ButtonSize = 'small' | 'big';
  * The danger variation is deprecated and will be removed in a future release.
  */
 export type ButtonVariation = 'primary' | 'danger' | 'success' | 'transparent';
+
+export type ButtonRef = RefObject<any> | ((...args: any[]) => any);
 
 type CommonButtonProps = {
   /**
@@ -34,7 +36,7 @@ type CommonButtonProps = {
   /**
    * Access a reference to the `button` or `a` element
    */
-  inputRef?: (...args: any[]) => any;
+  inputRef?: ButtonRef;
   /**
    * @hide-prop [Deprecated] Use inversed instead
    */


### PR DESCRIPTION
## Summary

Our integration tests with a consuming application called out that the `inputRef` prop on `<Button>` should probably support RefObjects

## How to test

Opened the branch `design-system-integration-7.0.0-beta.2` in pet-shared-components repo, verified that error
```
Type 'RefObject<HTMLButtonElement>' provides no match for the signature '(...args: any[]): any'.
```
existed.

- Pull down this branch. In the hgov repo, change the `@cmsgov/design-system` dependency version to point at your local version using the `file:..` syntax
- Run `yarn build` to build core
- Run `yarn build healthcare` to build hgov
- Navigate to pet-shared and change the hgov dependency path to your local copy using the `file:` syntax
- Run `yarn install` in pet-shared
- Observe that the TS error for button went away