### PR TITLE
[WNMGDS-1330] initial markup, styling and small functionality for IdleTimeout

### DIFF
--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.stories.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import IdleTimeout from './IdleTimeout';
+import { useArgs } from '@storybook/client-api';
+
+export default {
+  title: 'Components/Idle Timeout',
+  component: IdleTimeout,
+  argTypes: {},
+  args: {
+    timeToTimeout: 3,
+    timeToWarning: 2,
+    onTimeout: () => {
+      console.log('onTimeout');
+    },
+  },
+};
+
+const Template = ({ ...args }) => <IdleTimeout {...args} />;
+
+export const Default = Template.bind({});

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import React from 'react';
+import IdleTimeout from './IdleTimeout';
+import { render, fireEvent } from '@testing-library/react';
+
+describe('Idle Timeout', () => {
+  const onTimeout = jest.fn();
+
+  const renderIdleTimeout = (overrideProps) => {
+    return render(<IdleTimeout timeToTimeout={5} onTimeout={onTimeout} {...overrideProps} />);
+  };
+  describe('timeout countdown', () => {
+    xit('should be visible at set warning time', () => {});
+
+    xit('should reset countdown if mouse moves', () => {});
+
+    xit('should reset countdown if key is pressed', () => {});
+
+    xit('should call onTimeout when countdown ends', () => {});
+
+    // I don't think it should. I think the application should determine what the "session ended" behavior is
+    xit('should default redirect to logout when countdown ends', () => {});
+
+    // user explicitly says "keep session"
+    xit('should reset countdown if user opts for that', () => {});
+  });
+
+  describe('action buttons', () => {
+    it('should show an end session button if prop set', () => {
+      const { getByText } = renderIdleTimeout({ showSessionEndButton: true });
+      const endSessionBtn = getByText('Logout');
+      expect(endSessionBtn).toBeDefined();
+    });
+
+    // if user chooses 'logout' option
+    it('should call onSessionForcedEnd() when user opts to end session', () => {
+      const onSessionForcedEnd = jest.fn();
+      const { getByText } = renderIdleTimeout({ showSessionEndButton: true, onSessionForcedEnd });
+      const endSessionBtn = getByText('Logout');
+      fireEvent.click(endSessionBtn);
+      expect(onSessionForcedEnd).toHaveBeenCalled();
+    });
+
+    it('should call onTimeout if onSessionForcedEnd is not provided', () => {
+      const { getByText } = renderIdleTimeout({ showSessionEndButton: true });
+      const endSessionBtn = getByText('Logout');
+      fireEvent.click(endSessionBtn);
+      expect(onTimeout).toHaveBeenCalled();
+    });
+
+    it('should call onSessionContinue() when user opts to continue session', () => {
+      const onSessionContinue = jest.fn();
+      const { getByText } = renderIdleTimeout({ onSessionContinue });
+      const keepSessionBtn = getByText('Continue session');
+      fireEvent.click(keepSessionBtn);
+      expect(onSessionContinue).toHaveBeenCalled();
+    });
+  });
+
+  it('should replace token in message', () => {
+    const message = 'Your session will end in <timeToTimeout>.';
+    const { getByRole } = renderIdleTimeout({ message });
+    const dialogBodyText = getByRole('main');
+    expect(dialogBodyText.textContent).toEqual('Your session will end in 5 minutes.');
+  });
+
+  it('should adjust message for singular minute vs multiple', () => {
+    const message = 'Your session will end in <timeToTimeout>.';
+    const { getByRole } = renderIdleTimeout({ message, timeToWarning: 1 });
+    const dialogBodyText = getByRole('main');
+    expect(dialogBodyText.textContent).toEqual('Your session will end in 1 minute.');
+  });
+
+  it('should replace multiple token instances in message', () => {
+    const message = 'Your session will end in <timeToTimeout>. <timeToTimeout> until session ends';
+    const { getByRole } = renderIdleTimeout({ message });
+    const dialogBodyText = getByRole('main');
+    expect(dialogBodyText.textContent).toEqual(
+      'Your session will end in 5 minutes. 5 minutes until session ends'
+    );
+  });
+
+  xit('should replace token in message every minute', () => {});
+});

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
@@ -1,0 +1,134 @@
+/* eslint-disable react/no-multi-comp */
+/* eslint-disable react/no-danger */
+import React from 'react';
+import { Dialog } from '../Dialog';
+import { Button } from '../Button';
+
+export interface IdleTimeoutProps {
+  /**
+   * The text for the 'close' button on the warning dialog
+   */
+  closeDialogText?: string;
+  /**
+   * The text for the 'continue session' button in warning dialog.
+   */
+  continueSessionText?: string;
+  /**
+   * The heading text for the warning dialog.
+   */
+  heading?: string;
+  /**
+   * The text for the button that ends the session in warning dialog.
+   */
+  endSessionButtonText?: string;
+  /**
+   * The message text for the warning dialog.
+   * Note that using the token `<timeToTimeout>` will be replaced in the message text with the number of minutes until timeout.
+   */
+  message?: string;
+  /**
+   * Optional function that is called when the warning dialog's close button is clicked
+   */
+  onClose?: (...args: any[]) => any;
+  /**
+   * Optional function that is called when the user chooses to keep the session alive.
+   * The IdleTimeout component will reset the countdown internally.
+   */
+  onSessionContinue?: (...args: any[]) => any;
+  /**
+   * Optional function that is called when the session is manually ended by user.
+   * If not provided, the behavior of `onTimeout` will be used.
+   */
+  onSessionForcedEnd?: (...args: any[]) => any;
+  /**
+   * Function that is called when the timeout countdown reaches zero.
+   */
+  onTimeout: (...args: any[]) => any;
+  /**
+   * Describes if the button to manually end session should be shown
+   */
+  showSessionEndButton?: boolean;
+  /**
+   * Defines the time (in minutes) until the session is timed out
+   */
+  timeToTimeout: number;
+  /**
+   * Defines the time (in minutes) until the warning message is shown. The default is 5 minutes.
+   */
+  timeToWarning?: number;
+}
+
+const IdleTimeout = ({
+  closeDialogText = 'Close',
+  continueSessionText = 'Continue session',
+  heading = 'Are you still there?',
+  endSessionButtonText = 'Logout',
+  message = 'You’ve been inactive for a while. <br/>Your session will end in <timeToTimeout>. <br/><br/>Select "Continue session" below if you want more time.',
+  onClose,
+  onSessionContinue,
+  onSessionForcedEnd,
+  onTimeout,
+  showSessionEndButton = false,
+  timeToTimeout,
+  timeToWarning = 5,
+}: IdleTimeoutProps) => {
+  const replaceMessageTokens = (timeUntil: number) => {
+    const unitOfTime = timeUntil === 1 ? 'minute' : 'minutes';
+    return message.replace(/<timeToTimeout>/gi, `<strong>${timeUntil} ${unitOfTime}</strong>`);
+  };
+
+  const formattedDialogMessage = replaceMessageTokens(timeToWarning);
+
+  const handleContinueSession = () => {
+    // reset countdown timer
+    if (onSessionContinue) {
+      onSessionContinue();
+    }
+  };
+
+  const handleEndSession = () => {
+    if (onSessionForcedEnd) {
+      // TODO: figure out if any params should be passed back to the app
+      onSessionForcedEnd();
+    } else if (onTimeout) {
+      onTimeout();
+    }
+  };
+
+  const handleDialogClose = () => {
+    if (onClose) {
+      onClose();
+    }
+  };
+
+  const renderDialogActions = () => {
+    return (
+      <>
+        <Button variation="primary" onClick={handleContinueSession}>
+          {continueSessionText}
+        </Button>
+        {showSessionEndButton ? (
+          <Button variation="transparent" href="/logout" onClick={handleEndSession}>
+            {endSessionButtonText}
+          </Button>
+        ) : null}
+      </>
+    );
+  };
+
+  return (
+    <Dialog
+      alert
+      dialogId="session-timeout-dialog"
+      escapeExits={false}
+      heading={heading}
+      closeButtonText={closeDialogText}
+      actions={renderDialogActions()}
+      onExit={handleDialogClose}
+    >
+      <div dangerouslySetInnerHTML={{ __html: formattedDialogMessage }} />
+    </Dialog>
+  );
+};
+
+export default IdleTimeout;

--- a/packages/design-system/src/components/IdleTimeout/index.ts
+++ b/packages/design-system/src/components/IdleTimeout/index.ts
@@ -1,0 +1,1 @@
+export * from './IdleTimeout';

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -12,6 +12,7 @@ export * from './FilterChip';
 export * from './FormControl';
 export * from './FormLabel';
 export * from './HelpDrawer';
+export * from './IdleTimeout';
 export * from './InlineError';
 export * from './MonthPicker';
 export * from './Pagination';


### PR DESCRIPTION
## Summary
PR pt 1 of the new IdleTimeout component. Description of component found here: https://jira.cms.gov/browse/WNMGDS-1330

As I was building this component, I realized the logic might be a bit complicated, so I wanted to section off the changes into several PRs. 
1. This PR (which will also be the "feature branch" that I will merge subsequent PRs into) which includes markup & styling for the warning modal, setup of Storybook for this component & some unit tests
2. A PR for timeout functionality & related unit tests
3. Remaining documentation and testing

You may noticed that I added some props and changed some prop names from the original ticket. I'm trying to keep this component flexible, but naming may also change as I get to the timeout functionality.

## How to test

Run `yarn storybook` and see the new IdleTimeout component. The current version shows what the warning dialog will look like
