### PR TITLE
[WNMGDS-1306] SVG HCM support

### DIFF
--- a/packages/design-system/src/styles/components/_Accordion.scss
+++ b/packages/design-system/src/styles/components/_Accordion.scss
@@ -71,6 +71,14 @@ $accordion-header-font-family: $font-sans;
     flex-shrink: 0;
     height: 1.25em;
     width: 1.25em;
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      path {
+        fill: Window;
+      }
+    }
+    /* stylelint-enable */
   }
 }
 

--- a/packages/design-system/src/styles/components/_Alert.scss
+++ b/packages/design-system/src/styles/components/_Alert.scss
@@ -49,7 +49,7 @@ $alert-link-color-focus: $color-primary-darkest;
   /* stylelint-disable */
   @media (-ms-high-contrast: active), (forced-colors: active) {
     border: 1px solid windowText;
-    border-left-size: $alert-bar-size;
+    border-left: $alert-bar-size solid windowText;
   }
   /* stylelint-enable */
 

--- a/packages/design-system/src/styles/components/_Choice.scss
+++ b/packages/design-system/src/styles/components/_Choice.scss
@@ -42,6 +42,13 @@ $ds-c-inset-border-width: $spacer-half;
     position: absolute;
     top: 0;
     width: $choice-size;
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      // background-color: window;
+      border-color: ButtonText;
+    }
+    /* stylelint-enable */
   }
 
   // Checkmark icon
@@ -65,7 +72,15 @@ $ds-c-inset-border-width: $spacer-half;
   // Choice radio button
   &[type='radio'] + label::before {
     border-radius: 100%;
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      -ms-high-contrast-adjust: none;
+      background-color: window;
+    }
+    /* stylelint-enable */
   }
+
   &[type='radio'] + label::after {
     background-color: $choice-checked-border-color;
     border: 0;
@@ -75,10 +90,25 @@ $ds-c-inset-border-width: $spacer-half;
     top: 5px;
     transform: none;
     width: $choice-radio-button-size;
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      -ms-high-contrast-adjust: none;
+      background-color: WindowText;
+    }
+    /* stylelint-enable */
   }
+
   &:checked[type='radio'] + label::before {
     background-color: $color-white;
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      background-color: window;
+    }
+    /* stylelint-enable */
   }
+
   // Errored choice
   @if $ds-include-choice-error-highlight {
     &.ds-c-choice--error + label::before {
@@ -91,6 +121,12 @@ $ds-c-inset-border-width: $spacer-half;
     &::before {
       background-color: $choice-checked-background-color;
       border-color: $choice-checked-border-color;
+
+      /* stylelint-disable */
+      @media (-ms-high-contrast: active), (forced-colors: active) {
+        border-color: ButtonText;
+      }
+      /* stylelint-enable */
     }
 
     &::after {
@@ -197,6 +233,12 @@ $ds-c-inset-border-width: $spacer-half;
 
 .ds-c-choice:checked:focus + label::before {
   border-color: $color-primary-darker;
+
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    border-color: window;
+  }
+  /* stylelint-enable */
 }
 
 // TODO: rename to .ds-c-choice__checked-child

--- a/packages/design-system/src/styles/components/_Dialog.scss
+++ b/packages/design-system/src/styles/components/_Dialog.scss
@@ -13,6 +13,12 @@ $dialog-spacer: $spacer-4;
   text-align: left;
   vertical-align: middle;
   width: 95%; // provide space for the background layer to peek through
+
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    outline: $spacer-2 solid WindowText;
+  }
+  /* stylelint-enable */
 }
 
 .ds-c-dialog--narrow {
@@ -51,13 +57,21 @@ $dialog-spacer: $spacer-4;
   .ds-c-icon {
     font-size: 13px;
     margin-right: 4px;
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      path {
+        fill: ButtonText;
+      }
+    }
+    /* stylelint-enable */
   }
 
-  /* stylelint-disable scss/media-feature-value-dollar-variable */
+  /* stylelint-disable */
   @media (-ms-high-contrast: active), (forced-colors: active) {
     padding: $spacer-half $spacer-2;
   }
-  /* stylelint-enable scss/media-feature-value-dollar-variable */
+  /* stylelint-enable */
 }
 
 .ds-c-dialog-wrap {

--- a/packages/design-system/src/styles/components/_Drawer.scss
+++ b/packages/design-system/src/styles/components/_Drawer.scss
@@ -41,11 +41,11 @@ $drawer-toggle-space: 0;
   font-weight: $drawer-toggle-font-weight;
   padding: $drawer-toggle-space;
 
-  /* stylelint-disable scss/media-feature-value-dollar-variable */
+  /* stylelint-disable */
   @media (-ms-high-contrast: active), (forced-colors: active) {
     padding: $spacer-half $spacer-2;
   }
-  /* stylelint-enable scss/media-feature-value-dollar-variable */
+  /* stylelint-enable */
 }
 
 .ds-c-drawer__toggle--inline {
@@ -71,11 +71,12 @@ $drawer-toggle-space: 0;
     max-width: $measure-base;
   }
 
-  /* stylelint-disable scss/media-feature-value-dollar-variable */
+  /* stylelint-disable */
   @media (-ms-high-contrast: active), (forced-colors: active) {
-    border-left: 2px solid WindowText;
+    border: 1px solid WindowText;
+    border-left: $spacer-3 solid WindowText;
   }
-  /* stylelint-enable scss/media-feature-value-dollar-variable */
+  /* stylelint-enable */
 }
 
 .ds-c-drawer__window {
@@ -101,6 +102,12 @@ $drawer-toggle-space: 0;
   @supports (display: flex) {
     flex: 0 0 auto;
   }
+
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    border-bottom: 1px solid ButtonText;
+  }
+  /* stylelint-enable */
 }
 
 .ds-c-drawer__header-heading {
@@ -139,6 +146,12 @@ $drawer-toggle-space: 0;
   @supports (display: flex) {
     flex: 1 1 auto;
   }
+
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    border-top: 1px solid ButtonText;
+  }
+  /* stylelint-enable */
 }
 
 /* Help drawer footer */

--- a/packages/design-system/src/styles/components/_FilterChip.scss
+++ b/packages/design-system/src/styles/components/_FilterChip.scss
@@ -75,11 +75,27 @@ $filter-chip-border-radius: $border-radius-pill !default;
     position: relative;
     top: ($filter-chip-icon-container-size - 2 - $filter-chip-icon-size) / 2;
     width: $filter-chip-icon-size;
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      path {
+        fill: ButtonText;
+      }
+    }
+    /* stylelint-enable */
   }
 
   .ds-c-icon--close-thin {
     height: $filter-chip-icon-size + 2;
     width: $filter-chip-icon-size + 2;
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      path {
+        stroke: ButtonText !important;
+      }
+    }
+    /* stylelint-enable */
   }
 
   .ds-c-filter-chip__button:active &,

--- a/packages/design-system/src/styles/components/_Pagination.scss
+++ b/packages/design-system/src/styles/components/_Pagination.scss
@@ -151,5 +151,13 @@ $pagination-page-count-color: $color-gray;
   .ds-c-pagination__nav--image {
     height: 18px;
     width: 18px;
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      path {
+        fill: LinkText;
+      }
+    }
+    /* stylelint-enable */
   }
 }

--- a/packages/design-system/src/styles/components/_SvgIcon.scss
+++ b/packages/design-system/src/styles/components/_SvgIcon.scss
@@ -24,6 +24,12 @@
 // Icon color variations
 .ds-c-icon-color--primary {
   color: $color-primary;
+
+  /* stylelint-disable scss/media-feature-value-dollar-variable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    color: WindowText;
+  }
+  /* stylelint-enable scss/media-feature-value-dollar-variable */
 }
 
 .ds-c-icon-color--inverse {

--- a/packages/design-system/src/styles/components/_SvgIcon.scss
+++ b/packages/design-system/src/styles/components/_SvgIcon.scss
@@ -8,6 +8,17 @@
   stroke-width: 0;
   vertical-align: middle;
   width: 1.5em;
+
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    fill: WindowText;
+
+    path {
+      fill: WindowText;
+      stroke: WindowText;
+    }
+  }
+  /* stylelint-enable */
 }
 
 // Icon color variations
@@ -47,4 +58,54 @@
 
 .ds-c-icon--pdf__text {
   fill: $color-white;
+
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    fill: Window !important;
+  }
+  /* stylelint-enable */
+}
+
+.ds-c-icon--star {
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    path {
+      fill: Window;
+      stroke: WindowText;
+    }
+  }
+  /* stylelint-enable */
+}
+
+.ds-c-icon--star-filled {
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    path {
+      fill: WindowText;
+      stroke: WindowText;
+    }
+  }
+  /* stylelint-enable */
+}
+
+.ds-c-icon--usa-flag {
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    -ms-high-contrast-adjust: none;
+
+    path:nth-of-type(1),
+    path:nth-of-type(5) {
+      fill: #ffffff;
+    }
+
+    path:nth-of-type(2),
+    path:nth-of-type(4) {
+      fill: #db3e1f;
+    }
+
+    path:nth-of-type(3) {
+      fill: #1e33b1;
+    }
+  }
+  /* stylelint-enable */
 }

--- a/packages/design-system/src/styles/components/_Tooltip.scss
+++ b/packages/design-system/src/styles/components/_Tooltip.scss
@@ -62,15 +62,24 @@ $tooltip-background-color: $color-background !default;
   @extend %trigger-underline-styles;
   color: $color-primary;
   padding: 0;
+
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    color: ButtonText;
+  }
+  /* stylelint-enable */
 }
 
-// stylelint-disable-next-line selector-class-pattern
+/* stylelint-disable */
 .ds-base--inverse .ds-c-tooltip__trigger-link {
   @extend %link-inverse;
   @extend %trigger-underline-styles;
-}
 
-// stylelint-enable selector-no-qualifying-type
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    color: ButtonText;
+  }
+}
+/* stylelint-enable */
 
 // Tooltip arrow
 .ds-c-tooltip__arrow {

--- a/packages/design-system/src/styles/components/_TooltipIcon.scss
+++ b/packages/design-system/src/styles/components/_TooltipIcon.scss
@@ -8,6 +8,12 @@
   position: relative;
   vertical-align: middle;
   width: $tooltip-icon-container-size;
+
+  /* stylelint-disable scss/media-feature-value-dollar-variable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    border-color: Window;
+  }
+  /* stylelint-enable scss/media-feature-value-dollar-variable */
 }
 
 // SVG icon styles/positioning
@@ -24,6 +30,14 @@
   text-align: center;
   top: 0;
   width: $tooltip-icon-size;
+
+  /* stylelint-disable scss/media-feature-value-dollar-variable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    path {
+      fill: ButtonText;
+    }
+  }
+  /* stylelint-enable scss/media-feature-value-dollar-variable */
 }
 
 // Add border style when tooltip is activated in addition to on hover

--- a/packages/design-system/src/styles/components/_UsaBanner.scss
+++ b/packages/design-system/src/styles/components/_UsaBanner.scss
@@ -155,6 +155,12 @@ $usa-caret-icon-size: 10px;
 
   &.ds-c-icon--lock-circle {
     color: #719f2a;
+
+    /* stylelint-disable scss/media-feature-value-dollar-variable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      color: WindowText;
+    }
+    /* stylelint-enable scss/media-feature-value-dollar-variable */
   }
 }
 
@@ -162,9 +168,18 @@ $usa-caret-icon-size: 10px;
   height: 1.5ex;
   vertical-align: inherit;
   width: 1.5ex * 52 / 64;
+
   path {
     fill: currentColor;
   }
+
+  /* stylelint-disable scss/media-feature-value-dollar-variable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    path {
+      fill: WindowText;
+    }
+  }
+  /* stylelint-enable scss/media-feature-value-dollar-variable */
 }
 
 .ds-c-usa-banner__media-img {

--- a/packages/design-system/src/styles/components/_VerticalNav.scss
+++ b/packages/design-system/src/styles/components/_VerticalNav.scss
@@ -171,6 +171,7 @@
 .ds-c-vertical-nav .ds-c-vertical-nav__item {
   @media (-ms-high-contrast: active), (forced-colors: active) {
     border-top: 1px solid LinkText;
+    border-bottom: 1px solid LinkText;
   }
 }
 

--- a/packages/design-system/src/styles/components/_VerticalNav.scss
+++ b/packages/design-system/src/styles/components/_VerticalNav.scss
@@ -105,6 +105,14 @@
     color: $color-base;
     height: $font-size-md;
     width: $font-size-md;
+
+    /* stylelint-disable */
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      path {
+        fill: Window;
+      }
+    }
+    /* stylelint-enable */
   }
 }
 
@@ -163,6 +171,15 @@
 .ds-c-vertical-nav .ds-c-vertical-nav__item {
   @media (-ms-high-contrast: active), (forced-colors: active) {
     border-top: 1px solid LinkText;
+  }
+}
+
+.ds-c-vertical-nav__subnav .ds-c-vertical-nav__label {
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
   }
 }
 /* stylelint-enable */

--- a/packages/design-system/src/styles/settings/mixins/_icons.scss
+++ b/packages/design-system/src/styles/settings/mixins/_icons.scss
@@ -7,4 +7,10 @@
   top: -0.1em;
   vertical-align: middle;
   width: 1em;
+
+  /* stylelint-disable */
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    fill: ButtonText;
+  }
+  /* stylelint-enable */
 }


### PR DESCRIPTION
## Summary

[JIRA ticket](https://jira.cms.gov/browse/WNMGDS-1306).

This PR updates our SVG icon component, components that use the SVG icon component, as well as minor usability tweaks when Windows High Contrast Mode is active. It is also a replacement PR for https://github.com/CMSgov/design-system/pull/1571.

### Added

High Contrast Mode media queries that:

- Update the base treatment of all SVG icons, including their fill and stroke values.
- Tweak SVG utilized in components, where the base treatment is insufficient.
- Tweak components to better demarcate component boundaries and communicate their interactivity.

## How to test

<details>
<summary><b>Accordion</b></summary>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152055266-12224cf7-f7b6-4bad-913b-137cc32e89b1.png"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152055290-9b579f97-c1a6-4936-b479-91c9c399cdb3.PNG"/>
</details>

<details>
<summary><b>Alert</b></summary>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152055346-d73f59b5-8b1c-47d2-b770-b22ec4cdd69a.PNG"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152055375-dcee9d6d-34bc-4bf8-8528-f23b6dd04a67.PNG"/>
</details>

<details>
<summary><b>Button</b></summary>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152055552-375ecf90-0333-44a6-bc2c-df83fa6371ff.PNG"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152055578-164cabdf-4a28-4d17-9eb1-d3a0f66c90dd.PNG"/>
</details>

<details>
<summary><b>Checkbox and Radio</b></summary>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152055625-a4851218-c003-4ffa-97e9-c72093774f0c.PNG"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152418652-073d45c5-c13b-4ee7-9e5c-38e90ea18307.PNG"/>
</details>

<details>
<summary><b>Drawer</b></summary>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152055720-d822d7f4-24ec-4958-b8d5-0ba5d03c48c1.PNG"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152055735-4cd5d7ad-2471-4183-ae9d-7543bdd64fa6.PNG"/>
</details>

<details>
<summary><b>Filter Chip</b></summary>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152055831-f23d75fc-1b4c-4ea4-9615-bb661d5855eb.PNG"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152055874-4dbc11ea-acc1-43cb-9489-7b89215f94d7.PNG"/>
</details>

<details>
<summary><b>Icons</b></summary>
<p><b>Note:</b> This screenshot represents a sampling of solid fill icons, icons that use a stroke, icons that use both a stroke and a fill, and icons that need to have their color preserved in HCM to communicate meaning.</p>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152056015-3e08101a-d111-4874-ab6d-34f8635026bd.PNG"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152418714-ed9da61f-6bed-43ac-9c7d-24075943dd2e.PNG"/>

</details>

<details>
<summary><b>Modal</b></summary>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152056381-1e2b3931-1f8d-4feb-af89-037d059ebba6.png"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152056399-409f9dc1-a622-4119-87ad-b3bdfc4ea3f1.png"/>
</details>

<details>
<summary><b>Pagination</b></summary>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152056598-6529c3a3-01af-4951-b298-b9319a86cf97.PNG"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152056606-c3d98b6a-1a4f-4d91-aab1-f104f3df2dd9.PNG"/>
</details>

<details>
<summary><b>Tooltip</b></summary>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152056744-0bd3f4ed-604c-4087-b775-de085c1b038e.png"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152056763-c434ceff-ea22-40d9-8fac-842ee776a67c.png"/>
</details>

<details>
<summary><b>USA Banner</b></summary>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152057014-98524b1b-ac01-4735-865d-25e632c826c5.PNG"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152057076-01b90c62-677e-4087-8dbd-59fbf781b29d.PNG"/>
</details>

<details>
<summary><b>Vertical Nav</b></summary>
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/634191/152057844-1eb40fcd-0761-4629-b36e-ce3aab89b7d0.PNG"/>
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/634191/152057775-e25fe29e-cc19-4480-bbd9-2e5b986f50c3.PNG"/>
</details>
