### PR TITLE
[WNMGDS-1304] Form fields and states HCM support

### DIFF
--- a/packages/design-system/src/components/InlineError/InlineError.tsx
+++ b/packages/design-system/src/components/InlineError/InlineError.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import classNames from 'classnames';
-import { getInlineErrorIconDisplay } from '../flags';
 import AlertCircleIcon from '../Icons/AlertCircleIcon';
 
 /**
@@ -11,7 +10,6 @@ import AlertCircleIcon from '../Icons/AlertCircleIcon';
 interface InlineErrorProps {
   children?: React.ReactNode;
   className?: string;
-  displayErrorIcon?: boolean;
   id?: string;
   inversed?: boolean;
 }
@@ -19,12 +17,9 @@ interface InlineErrorProps {
 export function InlineError({
   children,
   className,
-  displayErrorIcon,
   id,
   inversed,
 }: InlineErrorProps): React.ReactElement {
-  const displayIcon = displayErrorIcon || getInlineErrorIconDisplay();
-
   const classes = classNames(
     'ds-c-inline-error',
     'ds-c-field__error-message',
@@ -35,7 +30,7 @@ export function InlineError({
 
   return (
     <span className={classes} id={id} role="alert">
-      {displayIcon && <AlertCircleIcon viewBox={viewbox} />}
+      <AlertCircleIcon viewBox={viewbox} />
       {children}
     </span>
   );

--- a/packages/design-system/src/components/InlineError/__snapshots__/InlineError.test.tsx.snap
+++ b/packages/design-system/src/components/InlineError/__snapshots__/InlineError.test.tsx.snap
@@ -6,6 +6,9 @@ exports[`InlineError renders inline error 1`] = `
   id="error1"
   role="alert"
 >
+  <AlertCircleIcon
+    viewBox="36 -12 186 186"
+  />
   Error message
 </span>
 `;
@@ -16,6 +19,9 @@ exports[`InlineError renders inverse error 1`] = `
   id="error1"
   role="alert"
 >
+  <AlertCircleIcon
+    viewBox="36 -12 186 186"
+  />
   Error message
 </span>
 `;

--- a/packages/design-system/src/components/flags.ts
+++ b/packages/design-system/src/components/flags.ts
@@ -17,10 +17,6 @@ const flags: flagsType = {
   DISPLAY_INLINE_ERROR_ICON: false,
 };
 
-export function getInlineErrorIconDisplay(): boolean {
-  return flags.DISPLAY_INLINE_ERROR_ICON;
-}
-
 export function setInlineErrorIconDisplay(value: boolean): void {
   flags.DISPLAY_INLINE_ERROR_ICON = value;
 }


### PR DESCRIPTION
## Summary

[JIRA ticket](https://jira.cms.gov/browse/WNMGDS-1304).

This PR updates input validation error messages to always show an inline error icon before the string describing the error. This allows error messages to be understood as errors regardless of viewing mode.

Additional context:

- [Explanatory slide deck](https://docs.google.com/presentation/d/1OQ61eiufU4JQHgslEZaOM3YMdGS0EXDvRIXWEtSgbBQ/edit?usp=sharing)
- [Confluence decision log](https://confluence.cms.gov/pages/viewpage.action?spaceKey=HCDSG&title=Weekly+Design+System+design+sync#WeeklyDesignSystemdesignsync-Feb8,2022)

### Removed

All design systems now display an inline error icon:

- `displayErrorIcon` and its associated logic is removed
- `getInlineErrorIconDisplay()` has also been removed

## How to test

Run `yarn storybook` and trigger the error state of any component that uses `InlineError`.

### Before

<img width="487" alt="A text input with a red validation error message. Screenshot." src="https://user-images.githubusercontent.com/634191/153219419-3461cd37-92f7-4835-a4a0-868df5898aeb.png">

### After

<img width="495" alt="A text input with a red validation error message that has a small error icon placed before it. Screenshot." src="https://user-images.githubusercontent.com/634191/153219501-b9ce5990-5840-42e4-934e-13603bf33f1c.png">

