### PR TITLE
[WNMGDS-1415] focusing drawer toggle only when drawer goes from open to close

### DIFF
--- a/packages/design-system/src/components/Drawer/DrawerToggle.test.tsx
+++ b/packages/design-system/src/components/Drawer/DrawerToggle.test.tsx
@@ -53,7 +53,7 @@ describe('DrawerToggle', () => {
     expect(toggle.getAttribute('aria-label')).toBe(ariaLabel);
   });
 
-  it('focuses button when drawer is closed', () => {
+  it('focuses button when drawer goes from open to closed', () => {
     const { rerender } = renderDrawerToggle({ drawerOpen: true });
     rerender(
       <DrawerToggle {...defaultProps} drawerOpen={false}>
@@ -62,5 +62,11 @@ describe('DrawerToggle', () => {
     );
     const toggle = screen.getByRole('button');
     expect(toggle).toEqual(document.activeElement);
+  });
+
+  it('does not focus button when drawer in initialized to close', () => {
+    renderDrawerToggle({ drawerOpen: false });
+    const toggle = screen.getByRole('button');
+    expect(toggle).not.toEqual(document.activeElement);
   });
 });

--- a/packages/design-system/src/components/Drawer/DrawerToggle.tsx
+++ b/packages/design-system/src/components/Drawer/DrawerToggle.tsx
@@ -1,6 +1,7 @@
 import Button, { ButtonProps } from '../Button/Button';
 import React, { useEffect, useRef } from 'react';
 import classNames from 'classnames';
+import usePrevious from './usePrevious';
 
 export type DrawerToggleProps = ButtonProps & {
   /**
@@ -39,9 +40,11 @@ export const DrawerToggle = ({
   ...others
 }: DrawerToggleProps): React.ReactElement => {
   const buttonRef = useRef(null);
+  const prevDrawerOpenProp = usePrevious(drawerOpen);
 
   useEffect(() => {
-    if (!drawerOpen && buttonRef.current) {
+    // if drawer was open but now closed, focus the toggle
+    if (prevDrawerOpenProp && !drawerOpen && buttonRef.current) {
       buttonRef.current.focus();
     }
   }, [drawerOpen]);

--- a/packages/design-system/src/components/Drawer/usePrevious.ts
+++ b/packages/design-system/src/components/Drawer/usePrevious.ts
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from 'react';
+
+// storing a previous version of a prop for comparison
+// similar to the old previousProps param from `componentDidUpdate`
+const usePrevious = <T>(value: T): T | undefined => {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+export default usePrevious;


### PR DESCRIPTION
## Summary

Addressing reported bug where the drawer toggle is focused whenever the drawer is not open.

### Fixed

Added a custom hook that will keep track of the "previous" value of a prop so that can be used as a comparison point later in the component. It is similar to the `previousProps` param that the `componentDidUpdate` lifecycle had.

`usePrevious` was taken from [this helpful StackOverflow](https://stackoverflow.com/questions/53446020/how-to-compare-oldvalues-and-newvalues-on-react-hooks-useeffect)

I also updated the unit tests to better capture the behavior of the toggle and test for the reported bug

## How to test

1. `yarn storybook`
2. Navigate to the Drawer > Drawer Toggle with Drawer story
3. Confirm that on page load, the toggle does not have focus
4. Open the drawer & close the drawer. Confirm that on close, the drawer toggle gets focus