### PR TITLE
[WNMGDS-1330] warning time refactor

### DIFF
--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.stories.jsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.stories.jsx
@@ -35,7 +35,7 @@ export default {
 };
 
 const Template = ({ ...args }) => {
-  const [{ timeToTimeout, timeToWarning }] = useArgs({ timeToTimeout: 2, timeToWarning: 0.5 });
+  const [{ timeToTimeout, timeToWarning }] = useArgs();
   return (
     <>
       <p>Idle Timeout modal will show after {timeToWarning} minutes of inactivity.</p>

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.stories.jsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.stories.jsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {},
   args: {
     timeToTimeout: 2,
-    timeToWarning: 2,
+    timeToWarning: 0.5,
     onTimeout: () => {
       console.log('onTimeout');
     },
@@ -35,8 +35,13 @@ export default {
 };
 
 const Template = ({ ...args }) => {
-  const [{ timeToTimeout, timeToWarning }] = useArgs({ timeToTimeout: 2, timeToWarning: 1 });
-  return <IdleTimeout timeToTimeout={timeToTimeout} timeToWarning={timeToWarning} {...args} />;
+  const [{ timeToTimeout, timeToWarning }] = useArgs({ timeToTimeout: 2, timeToWarning: 0.5 });
+  return (
+    <>
+      <p>Idle Timeout modal will show after {timeToWarning} minutes of inactivity.</p>
+      <IdleTimeout timeToTimeout={timeToTimeout} timeToWarning={timeToWarning} {...args} />
+    </>
+  );
 };
 
 export const Default = Template.bind({});

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
@@ -5,9 +5,8 @@ import { render, fireEvent } from '@testing-library/react';
 import { mockTime, restoreTime } from './utilities/mockTime';
 
 describe('Idle Timeout', () => {
+  const MOCK_START_TIME = 1643811720; // setting starting date time to 2/22/2022 2:22
   const ADVANCE_TIMER_MS = 30000;
-  const WARNING_DATETIME = 1643991720; // start time + (3 * 60000ms) (3 minutes)
-  const TIMEOUT_DATETIME = 1644111720; // start time + (5 * 60000ms) (3 minutes)
   const onTimeout = jest.fn();
   const defaultProps = {
     timeToTimeout: 5,
@@ -15,6 +14,8 @@ describe('Idle Timeout', () => {
     onTimeout,
   };
   const timeTilWarningShown = defaultProps.timeToWarning * 60000;
+  const WARNING_DATETIME = MOCK_START_TIME + defaultProps.timeToWarning * 60000; // date time when warning should appear
+  const TIMEOUT_DATETIME = MOCK_START_TIME + defaultProps.timeToTimeout * 60000; // date time when timeout should occur
 
   const renderIdleTimeout = (overrideProps?) => {
     return render(<IdleTimeout {...defaultProps} {...overrideProps} />);
@@ -28,8 +29,8 @@ describe('Idle Timeout', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
-    // setting starting date time to 2/22/2022 2:22
-    mockTime(1643811720);
+    // setting start time for consistent tests
+    mockTime(MOCK_START_TIME);
   });
 
   afterEach(() => {
@@ -157,7 +158,7 @@ describe('Idle Timeout', () => {
 
   it('default formatMessage should adjust message for singular minute vs multiple', () => {
     const { getByRole } = renderIdleTimeout({ timeToWarning: 4 });
-    showWarning(1644051720); // start time + (4 * 60000ms) (4 minutes)
+    showWarning(MOCK_START_TIME + 4 * 60000); // setting time to match timeToWarning in this test
     const dialogBodyText = getByRole('main');
     expect(dialogBodyText.textContent).toEqual(
       `You've been inactive for a while.Your session will end in 1 minute.Select "Continue session" below if you want more time.`
@@ -167,15 +168,15 @@ describe('Idle Timeout', () => {
   it('should replace token in message every minute', () => {
     const formatMessage = (time) => `Your session will end in ${time}.`;
     const { getByRole } = renderIdleTimeout({ formatMessage, timeToWarning: 2 });
-    showWarning(1643931720);
+    showWarning(MOCK_START_TIME + 2 * 60000);
     const dialogBodyText = getByRole('main');
     expect(dialogBodyText.textContent).toEqual('Your session will end in 3.');
     // have to advance Date.now() and also retrigger the checkStatus interval
-    mockTime(1643991720);
+    mockTime(MOCK_START_TIME + 3 * 60000);
     jest.advanceTimersByTime(60000);
     expect(dialogBodyText.textContent).toEqual('Your session will end in 2.');
     // have to advance Date.now() and also retrigger the checkStatus interval
-    mockTime(1644051720);
+    mockTime(MOCK_START_TIME + 4 * 60000);
     jest.advanceTimersByTime(60000);
     expect(dialogBodyText.textContent).toEqual('Your session will end in 1.');
   });

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
@@ -52,13 +52,13 @@ describe('Idle Timeout', () => {
     it('should reset countdown if mouse moves', () => {
       renderIdleTimeout();
       fireEvent.mouseMove(document);
-      expect(localStorage.setItem).toHaveBeenCalledTimes(2);
+      expect(localStorage.setItem).toHaveBeenCalledTimes(3);
     });
 
     it('should reset countdown if key is pressed', () => {
       renderIdleTimeout();
       fireEvent.keyPress(document);
-      expect(localStorage.setItem).toHaveBeenCalledTimes(2);
+      expect(localStorage.setItem).toHaveBeenCalledTimes(3);
     });
 
     it('should set time since last active in local storage', () => {
@@ -118,6 +118,34 @@ describe('Idle Timeout', () => {
     });
   });
 
+  it('should reset timeouts if timeToTimeout changes', () => {
+    const { rerender } = renderIdleTimeout();
+    rerender(<IdleTimeout {...defaultProps} timeToTimeout={10} />);
+    expect(localStorage.setItem).toHaveBeenCalledTimes(3);
+  });
+
+  it('should reset timeouts if timeToWarning changes', () => {
+    const { rerender } = renderIdleTimeout();
+    rerender(<IdleTimeout {...defaultProps} timeToWarning={4} />);
+    expect(localStorage.setItem).toHaveBeenCalledTimes(3);
+  });
+
+  it('should update message time if timeToTimeout changes', () => {
+    const formatMessage = jest.fn();
+    const { rerender } = renderIdleTimeout({ formatMessage });
+    rerender(<IdleTimeout {...defaultProps} timeToTimeout={10} formatMessage={formatMessage} />);
+    showWarning();
+    expect(formatMessage).toHaveBeenNthCalledWith(1, 7);
+  });
+
+  it('should update message time if timeToWarning changes', () => {
+    const formatMessage = jest.fn();
+    const { rerender } = renderIdleTimeout({ formatMessage });
+    rerender(<IdleTimeout {...defaultProps} timeToWarning={4} formatMessage={formatMessage} />);
+    showWarning(1644051720); // start time + (4 * 60000ms) (4 minutes)
+    expect(formatMessage).toHaveBeenNthCalledWith(1, 1);
+  });
+
   it('default formatMessage should replace time in message', () => {
     const { getByRole } = renderIdleTimeout();
     showWarning();
@@ -175,14 +203,14 @@ describe('Idle Timeout', () => {
       const { unmount } = renderIdleTimeout();
       unmount();
       fireEvent.mouseMove(document);
-      expect(localStorage.setItem).toHaveBeenCalledTimes(1);
+      expect(localStorage.setItem).toHaveBeenCalledTimes(2);
     });
 
     it('should not reset countdown if key is pressed after unmount', () => {
       const { unmount } = renderIdleTimeout();
       unmount();
       fireEvent.keyPress(document);
-      expect(localStorage.setItem).toHaveBeenCalledTimes(1);
+      expect(localStorage.setItem).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
@@ -6,15 +6,15 @@ import { mockTime, restoreTime } from './utilities/mockTime';
 
 describe('Idle Timeout', () => {
   const ADVANCE_TIMER_MS = 30000;
-  const WARNING_DATETIME = 1643931720;
-  const TIMEOUT_DATETIME = 1644111720;
+  const WARNING_DATETIME = 1643991720; // start time + (3 * 60000ms) (3 minutes)
+  const TIMEOUT_DATETIME = 1644111720; // start time + (5 * 60000ms) (3 minutes)
   const onTimeout = jest.fn();
   const defaultProps = {
     timeToTimeout: 5,
     timeToWarning: 3,
     onTimeout,
   };
-  const timeTilWarningShown = (defaultProps.timeToTimeout - defaultProps.timeToWarning) * 60000;
+  const timeTilWarningShown = defaultProps.timeToWarning * 60000;
 
   const renderIdleTimeout = (overrideProps?) => {
     return render(<IdleTimeout {...defaultProps} {...overrideProps} />);
@@ -123,13 +123,13 @@ describe('Idle Timeout', () => {
     showWarning();
     const dialogBodyText = getByRole('main');
     expect(dialogBodyText.textContent).toEqual(
-      `You've been inactive for a while.Your session will end in 3 minutes.Select "Continue session" below if you want more time.`
+      `You've been inactive for a while.Your session will end in 2 minutes.Select "Continue session" below if you want more time.`
     );
   });
 
   it('default formatMessage should adjust message for singular minute vs multiple', () => {
-    const { getByRole } = renderIdleTimeout({ timeToWarning: 1 });
-    showWarning(1644051720);
+    const { getByRole } = renderIdleTimeout({ timeToWarning: 4 });
+    showWarning(1644051720); // start time + (4 * 60000ms) (4 minutes)
     const dialogBodyText = getByRole('main');
     expect(dialogBodyText.textContent).toEqual(
       `You've been inactive for a while.Your session will end in 1 minute.Select "Continue session" below if you want more time.`
@@ -138,8 +138,8 @@ describe('Idle Timeout', () => {
 
   it('should replace token in message every minute', () => {
     const formatMessage = (time) => `Your session will end in ${time}.`;
-    const { getByRole } = renderIdleTimeout({ formatMessage });
-    showWarning();
+    const { getByRole } = renderIdleTimeout({ formatMessage, timeToWarning: 2 });
+    showWarning(1643931720);
     const dialogBodyText = getByRole('main');
     expect(dialogBodyText.textContent).toEqual('Your session will end in 3.');
     // have to advance Date.now() and also retrigger the checkStatus interval

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
@@ -50,7 +50,7 @@ export interface IdleTimeoutProps {
    */
   timeToTimeout: number;
   /**
-   * Defines the time (in minutes) until the warning message is shown. The default is 5 minutes.
+   * Defines the amount of minutes of idle activity that will trigger the warning message. The default is 5 minutes.
    */
   timeToWarning?: number;
 }
@@ -103,10 +103,10 @@ const IdleTimeout = ({
   const MS_BETWEEN_STATUS_CHECKS = 30000;
   // convert minutes to milliseconds
   const msToTimeout = timeToTimeout * 60000;
-  const msToWarning = (timeToTimeout - timeToWarning) * 60000;
+  const msToWarning = timeToWarning * 60000;
   const [checkStatusTime, setCheckStatusTime] = useState<number>(null);
   const [showWarning, setShowWarning] = useState<boolean>(false);
-  const [timeInWarning, setTimeInWarning] = useState<number>(timeToWarning);
+  const [timeInWarning, setTimeInWarning] = useState<number>(timeToTimeout - timeToWarning);
 
   // cleanup timeouts & intervals
   const clearTimeouts = () => {

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
@@ -186,6 +186,11 @@ const IdleTimeout = ({
     };
   }, []);
 
+  useEffect(() => {
+    setTimeInWarning(timeToTimeout - timeToWarning);
+    resetTimeouts();
+  }, [timeToWarning, timeToTimeout]);
+
   // setup interval to check status every 30 seconds
   useInterval(checkWarningStatus, checkStatusTime);
 

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
@@ -50,9 +50,9 @@ export interface IdleTimeoutProps {
    */
   timeToTimeout: number;
   /**
-   * Defines the amount of minutes of idle activity that will trigger the warning message. The default is 5 minutes.
+   * Defines the amount of minutes of idle activity that will trigger the warning message.
    */
-  timeToWarning?: number;
+  timeToWarning: number;
 }
 
 /**
@@ -93,7 +93,7 @@ const IdleTimeout = ({
   onTimeout,
   showSessionEndButton = false,
   timeToTimeout,
-  timeToWarning = 5,
+  timeToWarning,
 }: IdleTimeoutProps): JSX.Element => {
   if (timeToWarning > timeToTimeout) {
     console.error(
@@ -106,7 +106,9 @@ const IdleTimeout = ({
   const msToWarning = timeToWarning * 60000;
   const [checkStatusTime, setCheckStatusTime] = useState<number>(null);
   const [showWarning, setShowWarning] = useState<boolean>(false);
-  const [timeInWarning, setTimeInWarning] = useState<number>(timeToTimeout - timeToWarning);
+  const [timeInWarning, setTimeInWarning] = useState<number>(
+    Math.ceil(timeToTimeout - timeToWarning)
+  );
 
   // cleanup timeouts & intervals
   const clearTimeouts = () => {
@@ -187,7 +189,7 @@ const IdleTimeout = ({
   }, []);
 
   useEffect(() => {
-    setTimeInWarning(timeToTimeout - timeToWarning);
+    setTimeInWarning(Math.ceil(timeToTimeout - timeToWarning));
     resetTimeouts();
   }, [timeToWarning, timeToTimeout]);
 


### PR DESCRIPTION
## Summary

Some updates to the IdleTimeout component

### Added

* an effect that updates the time-in-message as well as the timeout cookie if the `timeToWarning` or `timeToTimeout` prop changes
* unit tests to support changes

### Changed

* IdleTimeout story has some additional text to provide context for how the component works & a short time until warning modal is shown
* The `timeToWarning` prop so now its value represents how many minutes (from current time) of idle activity will trigger the warning modal
*   it used to be relative to the timeout time

### Fixed

* IdleTimeout story so now the component gets updated args properly

## How to test

`yarn storybook` and navigate to the idle timeout component