### PR TITLE
[WNMGDS-1458] idle timeout close

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -259,10 +259,6 @@ export interface DialogProps extends AriaModalProps {
    */
   heading?: React.ReactNode;
   /**
-   * Describes if close button is hidden. Defaults to 'false'
-   */
-  hideCloseButton?: boolean;
-  /**
    * The Dialog's size parameter.
    */
   size?: DialogSize;
@@ -355,7 +351,6 @@ export const Dialog = (props: DialogProps) => {
     escapeExitDisabled,
     headerClassName,
     heading,
-    hideCloseButton,
     onExit,
     size,
     title,
@@ -400,21 +395,19 @@ export const Dialog = (props: DialogProps) => {
               </h1>
             )
           }
-          {!hideCloseButton && (
-            <Button
-              aria-label={ariaCloseLabel}
-              className="ds-c-dialog__close"
-              onClick={onExit}
-              size={closeButtonSize}
-              variation={closeButtonVariation}
-            >
-              {closeIcon}
-              {
-                // TODO: remove closeText support once fully deprecated
-                closeText || closeButtonText
-              }
-            </Button>
-          )}
+          <Button
+            aria-label={ariaCloseLabel}
+            className="ds-c-dialog__close"
+            onClick={onExit}
+            size={closeButtonSize}
+            variation={closeButtonVariation}
+          >
+            {closeIcon}
+            {
+              // TODO: remove closeText support once fully deprecated
+              closeText || closeButtonText
+            }
+          </Button>
         </header>
         <main role="main" className="ds-c-dialog__body">
           <div id="dialog-content">{children}</div>

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
@@ -83,6 +83,26 @@ describe('Idle Timeout', () => {
       expect(dialogEl).toBeDefined();
     });
 
+    it('should reset countdown if user opts to close modal', () => {
+      const { getByLabelText, queryByRole } = renderIdleTimeout();
+      showWarning();
+      const keepSessionBtn = getByLabelText('Close modal dialog');
+      fireEvent.click(keepSessionBtn);
+      const dialogEl = queryByRole('alertdialog');
+      expect(dialogEl).toBeNull();
+      jest.advanceTimersByTime(timeTilWarningShown);
+      expect(dialogEl).toBeDefined();
+    });
+
+    it('should call onSessionContinue if user opts to close modal', () => {
+      const onSessionContinue = jest.fn();
+      const { getByLabelText } = renderIdleTimeout({ onSessionContinue });
+      showWarning();
+      const keepSessionBtn = getByLabelText('Close modal dialog');
+      fireEvent.click(keepSessionBtn);
+      expect(onSessionContinue).toHaveBeenCalled();
+    });
+
     it('warning element should be visible at set warning time', () => {
       const { queryByTestId } = renderIdleTimeout();
       showWarning();

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
@@ -7,6 +7,10 @@ import { checkPassiveSupport } from './utilities/checkPassive';
 
 export interface IdleTimeoutProps {
   /**
+   *  The text for the dialog's 'close' button
+   */
+  closeButtonText?: string;
+  /**
    * The text for the 'continue session' button in warning dialog.
    */
   continueSessionText?: string;
@@ -28,7 +32,7 @@ export interface IdleTimeoutProps {
    */
   formatMessage?: (timeTilTimeout: number) => string | React.ReactNode;
   /**
-   * Optional function that is called when the user chooses to keep the session alive.
+   * Optional function that is called when the user chooses to keep the session alive. Either through the 'continue session' button or the 'close' button
    * The IdleTimeout component will reset the countdown internally.
    */
   onSessionContinue?: (...args: any[]) => any;
@@ -83,6 +87,7 @@ const defaultMessageFormatter = (timeTilTimeout: number): React.ReactNode => {
 const lastActiveCookieName = 'CMS_DS_IT_LAST_ACTIVE';
 
 export const IdleTimeout = ({
+  closeButtonText = 'Close',
   continueSessionText = 'Continue session',
   heading = 'Are you still there?',
   endSessionButtonText = 'Logout',
@@ -227,6 +232,8 @@ export const IdleTimeout = ({
       onSessionContinue={handleSessionContinue}
       onSessionForcedEnd={handleSessionForcedEnd}
       showSessionEndButton={showSessionEndButton}
+      closeButtonText={closeButtonText}
+      onClose={handleSessionContinue}
     />
   ) : null;
 };

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
@@ -32,7 +32,7 @@ export interface IdleTimeoutProps {
    */
   formatMessage?: (timeTilTimeout: number) => string | React.ReactNode;
   /**
-   * Optional function that is called when the user chooses to keep the session alive. Either through the 'continue session' button or the 'close' button
+   * Optional function that is called when the user chooses to keep the session alive. This function is called by the 'continue session' button or the 'close' button.
    * The IdleTimeout component will reset the countdown internally.
    */
   onSessionContinue?: (...args: any[]) => any;

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeoutDialog.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeoutDialog.tsx
@@ -5,6 +5,10 @@ import { Button } from '../Button';
 
 export interface IdleTimeoutDialogProps {
   /**
+   *  The text for the dialog's 'close' button
+   */
+  closeButtonText?: string;
+  /**
    * The text for the 'continue session' button in warning dialog.
    */
   continueSessionText: string;
@@ -26,6 +30,10 @@ export interface IdleTimeoutDialogProps {
    */
   message: string | React.ReactNode;
   /**
+   * Function that is called when the user select the 'close' button for the dialog
+   */
+  onClose: (...args: any[]) => any;
+  /**
    * Function that is called when the user chooses to keep the session alive.
    * The IdleTimeout component will reset the countdown internally.
    */
@@ -42,11 +50,13 @@ export interface IdleTimeoutDialogProps {
 }
 
 export const IdleTimeoutDialog = ({
+  closeButtonText,
   continueSessionText,
   heading,
   endSessionButtonText,
   endSessionUrl,
   message,
+  onClose,
   onSessionContinue,
   onSessionForcedEnd,
   showSessionEndButton,
@@ -73,7 +83,8 @@ export const IdleTimeoutDialog = ({
       escapeExits={false}
       heading={heading}
       actions={renderDialogActions()}
-      hideCloseButton
+      onExit={onClose}
+      closeButtonText={closeButtonText}
     >
       {message}
     </Dialog>


### PR DESCRIPTION
## Summary

Adding a close button to the IdleTimeout dialog. The close button behaves the same way 'continue session' does

### Added

* Close button and associated refs to the IdleTimeout component

### Removed
* The `hideCloseButton` prop in the dialog component that was previously added specifically to support IdleTimeout

## How to test
`yarn storybook`. Navigate to Components > IdleTimeout confirm modal functions as expected
Components > IdleTimeout > IdleTimeoutDialog will show you the dialog markup with the close button

![IdleTimeoutClose](https://user-images.githubusercontent.com/33579665/155613872-fa4a6c93-70c0-48ce-9ff5-ea4e29544290.gif)

