### PR TITLE
[WNMGDS-1465] Update privacy settings dialog

### DIFF
--- a/packages/ds-healthcare-gov/src/components/PrivacySettings/PrivacySettingsDialog.test.jsx
+++ b/packages/ds-healthcare-gov/src/components/PrivacySettings/PrivacySettingsDialog.test.jsx
@@ -36,22 +36,22 @@ describe('<PrivacySettingsDialog />', function () {
     const { setPrivacySettings } = require('./privacySettings');
     const onExit = jest.fn();
     renderComponent({ onExit });
-    const checkboxes = screen.getAllByRole('checkbox');
+    const radios = screen.getAllByRole('radio');
 
-    function getSettingCheckboxes(name) {
-      return checkboxes.filter((checkbox) => checkbox.name === `cookie-${name}`);
+    function getSettingRadios(name) {
+      return radios.filter((radio) => radio.name === `cookie-${name}`);
     }
 
     function getSettingValue(name) {
-      const checkbox = getSettingCheckboxes(name).find((checkbox) => checkbox.checked);
-      return checkbox.value;
+      const radio = getSettingRadios(name).find((radio) => radio.checked);
+      return radio.value;
     }
 
     expect(getSettingValue('c2')).toEqual('0');
     expect(getSettingValue('c3')).toEqual('0');
     expect(getSettingValue('c4')).toEqual('1');
 
-    const allow = getSettingCheckboxes('c3').find((checkbox) => checkbox.value === '1');
+    const allow = getSettingRadios('c3').find((radio) => radio.value === '1');
     fireEvent.click(allow);
     fireEvent.click(screen.getByRole('button', { name: 'privacy.save' }));
 

--- a/packages/ds-healthcare-gov/src/components/PrivacySettings/PrivacySettingsDialog.tsx
+++ b/packages/ds-healthcare-gov/src/components/PrivacySettings/PrivacySettingsDialog.tsx
@@ -41,8 +41,6 @@ export const PrivacySettingsDialog = (props: PrivacySettingsDialogProps) => {
       {...dialogProps}
       heading={t('privacy.dialogTitle')}
       size="full"
-      closeButtonVariation="transparent"
-      actionsClassName="ds-u-text-align--right"
       actions={
         <Button variation="primary" onClick={savePrivacySettings}>
           {t('privacy.save')}

--- a/packages/ds-healthcare-gov/src/components/PrivacySettings/PrivacySettingsTable.tsx
+++ b/packages/ds-healthcare-gov/src/components/PrivacySettings/PrivacySettingsTable.tsx
@@ -33,7 +33,7 @@ export const PrivacySettingsTable = (props: PrivacySettingsTableProps) => {
     const label = <span className="ds-u-visibility--screen-reader">{category}</span>;
     return (
       <ChoiceList
-        type="checkbox"
+        type="radio"
         choices={choices}
         onChange={(event) => {
           setPrivacySetting(settingsKey, event.target.value);

--- a/packages/ds-healthcare-gov/src/components/PrivacySettings/__snapshots__/PrivacySettingsTable.test.jsx.snap
+++ b/packages/ds-healthcare-gov/src/components/PrivacySettings/__snapshots__/PrivacySettingsTable.test.jsx.snap
@@ -66,7 +66,7 @@ exports[`<PrivacySettingsTable /> renders the privacy settings table 1`] = `
           }
           name="cookie-key1"
           onChange={[Function]}
-          type="checkbox"
+          type="radio"
         />
       </td>
     </tr>
@@ -112,7 +112,7 @@ exports[`<PrivacySettingsTable /> renders the privacy settings table 1`] = `
           }
           name="cookie-key2"
           onChange={[Function]}
-          type="checkbox"
+          type="radio"
         />
       </td>
     </tr>
@@ -158,7 +158,7 @@ exports[`<PrivacySettingsTable /> renders the privacy settings table 1`] = `
           }
           name="cookie-key3"
           onChange={[Function]}
-          type="checkbox"
+          type="radio"
         />
       </td>
     </tr>

--- a/packages/ds-healthcare-gov/src/styles/components/_Footer.scss
+++ b/packages/ds-healthcare-gov/src/styles/components/_Footer.scss
@@ -27,6 +27,7 @@
     background-color: inherit;
     border: 0;
     color: inherit;
+    cursor: pointer;
     font-family: inherit;
     font-size: inherit;
     padding: 0;

--- a/packages/ds-healthcare-gov/src/styles/components/_PrivacySettingsDialog.scss
+++ b/packages/ds-healthcare-gov/src/styles/components/_PrivacySettingsDialog.scss
@@ -1,4 +1,0 @@
-.ds-c-dialog__close:not(.ds-c-button--transparent) {
-  background-image: none;
-  padding: ($multiple / 2) $multiple;
-}

--- a/packages/ds-healthcare-gov/src/styles/components/_PrivacySettingsTable.scss
+++ b/packages/ds-healthcare-gov/src/styles/components/_PrivacySettingsTable.scss
@@ -2,6 +2,11 @@
   $breakpoint-large-min: $width-md;
   $breakpoint-small-max: $breakpoint-large-min - 1;
 
+  td:last-child {
+    // Avoid text wrapping on the radio buttons
+    min-width: 132px;
+  }
+
   @media screen and (max-width: $breakpoint-small-max) {
     &,
     tbody {

--- a/packages/ds-healthcare-gov/src/styles/components/_index.scss
+++ b/packages/ds-healthcare-gov/src/styles/components/_index.scss
@@ -4,5 +4,4 @@
 @import 'Header';
 @import 'Inset';
 @import 'Logo';
-@import 'PrivacySettingsDialog';
 @import 'PrivacySettingsTable';


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-1465

### Changed

- Revert the weird, one-off dialog-close button to the default
- Turn the checkboxes to radio buttons
- Give the radio buttons column a minimum width so the text doesn't wrap
- Stop right-aligning the CTA button

## How to test

In the doc site or storybook, view the healthcare Footer component and click the "Privacy Settings" link to bring up the privacy settings dialog

[Healthcare docs site](http://design-system-demo.s3-website-us-east-1.amazonaws.com/pwolfert/fix-privacy-settings-inconsistencies/hcgov/)
[Storybook Healthcare](http://design-system-demo.s3-website-us-east-1.amazonaws.com/pwolfert/fix-privacy-settings-inconsistencies/hcgov/storybook/)

### Before
<img width="1062" alt="Screen Shot 2022-02-25 at 11 00 55 AM" src="https://user-images.githubusercontent.com/7595652/155816255-45c703aa-296a-4f2d-92ab-4244c5fa6bc4.png">

### After
<img width="1071" alt="Screen Shot 2022-02-25 at 11 32 20 AM" src="https://user-images.githubusercontent.com/7595652/155816261-fe9f37a5-3f80-41e3-bbe6-fafe674d0fcf.png">
