### PR TITLE
[WNMGDS-1467] Fix StepLink custom component typedef rejecting correct usage

### DIFF
--- a/packages/design-system/src/components/StepList/Step.tsx
+++ b/packages/design-system/src/components/StepList/Step.tsx
@@ -18,7 +18,7 @@ export interface StepObject {
   started?: boolean;
   isNextStep?: boolean;
   onClick?: StepLinkProps['onClick'];
-  component?: React.ComponentType | keyof JSX.IntrinsicElements;
+  component?: StepLinkProps['component'];
   steps?: StepObject[];
 }
 

--- a/packages/design-system/src/components/StepList/StepLink.tsx
+++ b/packages/design-system/src/components/StepList/StepLink.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
 
+export interface StepLinkComponentProps {
+  href?: string;
+  onClick: (event: React.SyntheticEvent<any>) => any;
+  className?: string;
+  children: React.ReactNode;
+}
+
 export interface StepLinkProps {
   /**
    * Label text or HTML.
@@ -10,7 +17,7 @@ export interface StepLinkProps {
   screenReaderText?: string;
   className?: string;
   onClick?: (href?: string, stepId?: string) => any;
-  component?: React.ComponentType | keyof JSX.IntrinsicElements;
+  component?: React.ComponentType<StepLinkComponentProps> | keyof JSX.IntrinsicElements;
 }
 
 export const StepLink = (props: StepLinkProps) => {

--- a/packages/design-system/src/components/StepList/index.ts
+++ b/packages/design-system/src/components/StepList/index.ts
@@ -1,2 +1,3 @@
 export * from './StepList';
 export type { StepObject } from './Step';
+export type { StepLinkComponentProps } from './StepLink';


### PR DESCRIPTION
https://jira.cms.gov/browse/WNMGDS-1467

## Summary

A product team was passing a custom `component` to `StepList` steps, but they were getting a TypeScript error that their provided component was incompatible with what we expected. The problem was that the `React.ComponentType` [that we use here in the `StepLinkProps` definition](https://github.com/CMSgov/design-system/blob/master/packages/design-system/src/components/StepList/StepLink.tsx#L13) does not specify props for that component type, and therefore it seems to apply some default definition for props. The `React.ComponentType` type is actually a generic and can take a parameter. We were correctly using the `React.ComponentType` in other places in our project but not here.

### Fixed

- Fix `StepLink` custom component type definition rejecting correct usage

## How to test

Message me for the repo and branch name where the fix can be verified.
