### PR TITLE
[WNMGDS-1445] updating link styles for active and focus state

### DIFF
--- a/packages/design-system/src/components/Links/Links.stories.jsx
+++ b/packages/design-system/src/components/Links/Links.stories.jsx
@@ -1,0 +1,27 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+/* eslint-disable react/no-multi-comp */
+import React from 'react';
+
+export default {
+  title: 'Typography/Links',
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+      },
+    },
+  },
+};
+
+export const Links = () => (
+  <>
+    <a href="#" className="ds-c-link ds-u-font-size--lg">
+      Link Text
+    </a>
+    <div className="ds-u-padding--1 ds-base--inverse">
+      <a href="#" className="ds-u-font-size--lg ds-c-link ds-c-link--inverse">
+        Link Text
+      </a>
+    </div>
+  </>
+);

--- a/packages/design-system/src/styles/base/_link.scss
+++ b/packages/design-system/src/styles/base/_link.scss
@@ -77,6 +77,7 @@ $link-underline-offset: auto !default;
   /* stylelint-enable selector-max-specificity */
 
   &:active {
+    background-color: transparent;
     color: $link-inverse-active-color;
     outline: 0 none;
   }


### PR DESCRIPTION
## Summary

Having background of link element be transparent when link has active & focus states.

[Bug report in Jira](https://jira.cms.gov/browse/WNMGDS-1445)

## How to test

- Navigate to the [demo storybook site](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1445/inverse-link-style-updates/core/storybook/?path=/story/typography-links--links)
- View link stories at Typography > Links
- For the inverse link example, click & hold your cursor on the link (this creates an active & focus state). Confirm that the background color is transparent and meets accessibility expectations
  - Alternatively, using dev tools, you can select an element in the the `elements` tab. Click the 3 dots to the left, go to 'focus state' and toggle on active & focus to see the reported state

## Questions for Designers
- Is this the expected styling for a link in this state?
- Are there any accessibility  or other concerns that need to be taken into account?