### PR TITLE
[WNMGDS-1403] Update spacing for prev/next nav in pagination 

### DIFF
--- a/packages/design-system/src/styles/components/_Pagination.scss
+++ b/packages/design-system/src/styles/components/_Pagination.scss
@@ -143,10 +143,13 @@ $pagination-page-count-color: $color-gray;
   }
   .ds-c-pagination__nav--img-container {
     display: inline-block;
-    height: 24px;
-    margin-left: 4px;
-    vertical-align: middle;
-    width: 20px;
+    vertical-align: text-top;
+    &-next {
+      margin-left: $spacer-half;
+    }
+    &-previous {
+      margin-right: $spacer-half;
+    }
   }
   .ds-c-pagination__nav--image {
     height: 18px;


### PR DESCRIPTION
## Summary
- https://jira.cms.gov/browse/WNMGDS-1403
- Updated margin for previous and next pagination navigation items to be consistent 
- Also centered up the image with the text more

## How to test
- Run the demo storybook site with `yarn storybook`
- View pagination stories at Components > Pagination
- See that the spacing between the icon and text for the previous and next navigation is now consistent compared to what is currently live https://design.cms.gov/components/pagination/ 