### PR TITLE
[NO-TICKET] idle timeout dialog button spacing

### DIFF
--- a/packages/design-system/src/components/IdleTimeout/IdleTimeoutDialog.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeoutDialog.tsx
@@ -62,7 +62,7 @@ export const IdleTimeoutDialog = ({
   showSessionEndButton,
 }: IdleTimeoutDialogProps): React.ReactElement => {
   const renderDialogActions = () => {
-    const continueSessionButtonClasses = showSessionEndButton ? 'ds-u-margin-right--1' : null;
+    const continueSessionButtonClasses = showSessionEndButton ? 'ds-u-margin-right--2' : null;
 
     return (
       <>


### PR DESCRIPTION
## Summary

Updating spacing between buttons in idle timeout dialog to be 16px instead of 8px

<img width="600" alt="Screen Shot 2022-03-01 at 2 12 37 PM" src="https://user-images.githubusercontent.com/33579665/156250030-dbe763b7-7fc7-4c31-8956-96b17e3e7149.png">

