### PR TITLE
[NO-TICKET] Restrict dependabot's scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-  - package-ecosystem: 'npm'
     directory: '/packages/design-system'
     schedule:
       interval: 'daily'
   - package-ecosystem: 'npm'
     directory: '/packages/design-system-docs'
-    schedule:
-      interval: 'daily'
-  - package-ecosystem: 'npm'
-    directory: '/packages/design-system-scripts'
     schedule:
       interval: 'daily'
   - package-ecosystem: 'npm'


### PR DESCRIPTION
We decided to limit the scope of dependabot's search because most of what it was flagging were dev dependencies that are less important than our actual package dependencies. Hopefully this cleans up a lot of them. If they don't, we may need to just disable it entirely until a time when we can keep up with Dependabot.