### PR TITLE
[WNMGDS-1319] removing role button from links

### DIFF
--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -151,7 +151,6 @@ export const Button = ({
   if (ComponentType !== 'button') {
     // Assume `component` is not a custom component rendering a <button>
     // and remove <button> specific attributes
-    attrs.role = 'button';
     delete attrs.disabled;
     delete attrs.type;
   }

--- a/packages/design-system/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/design-system/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -60,7 +60,6 @@ exports[`Button applies variation classes 1`] = `
 exports[`Button renders as a custom Link component 1`] = `
 <Link
   className="ds-c-button"
-  role="button"
   to="anywhere"
 >
   Foo
@@ -72,7 +71,6 @@ exports[`Button renders as an anchor with custom prop 1`] = `
   className="ds-c-button"
   href="/example"
   onKeyPress={[Function]}
-  role="button"
   target="_blank"
 >
   Foo
@@ -102,7 +100,6 @@ exports[`Button renders disabled link correctly 1`] = `
   className="ds-c-button ds-c-button--disabled"
   href="javascript:void(0)"
   onKeyPress={[Function]}
-  role="button"
 >
   Link button
 </a>

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -230,7 +230,6 @@ export const Tooltip = (props: TooltipProps) => {
       'ds-c-tooltip__trigger--inverse': inversed,
     });
     const linkTriggerOverrides = {
-      role: TriggerComponent === 'a' ? 'button' : undefined,
       tabIndex: TriggerComponent === 'a' ? 0 : undefined,
     };
     const eventHandlers = dialog

--- a/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.jsx.snap
+++ b/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.jsx.snap
@@ -5,7 +5,6 @@ exports[`Tooltip renders custom trigger component 1`] = `
   aria-describedby="trigger_5"
   aria-label="tooltip trigger"
   class="ds-base ds-c-tooltip__trigger ds-c-tooltip__trigger-icon"
-  role="button"
   tabindex="0"
 >
   <span


### PR DESCRIPTION
## Summary

After discussing with accessibility experts, it is better to not include `role="button"` on link elements if we are not going to support additional functionality to make a link truly act like a button. So, removing it from our button & tooltip components

Also, updated snapshot tests. Once merged, this might affect other teams' snapshot tests.
