### PR TITLE
[WNMGDS 1447] [WNMGDS-1483] External link adding and pattern update

### DIFF
--- a/packages/design-system-docs/src/pages/components/Dialog/ThirdPartyLink.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Dialog/ThirdPartyLink.example.jsx
@@ -1,4 +1,4 @@
-import { Button, Dialog } from '@design-system';
+import { Button, Dialog, ExternalLinkIcon } from '@design-system';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -28,6 +28,7 @@ class Example extends React.PureComponent {
           onClick={() => this.showModal()}
         >
           Link to external site
+          <ExternalLinkIcon className="ds-u-margin-left--05" />
         </Button>
 
         {this.state.showModal && (
@@ -35,6 +36,7 @@ class Example extends React.PureComponent {
             onExit={() => this.hideModal()}
             getApplicationNode={() => document.getElementById('App')}
             heading="You are leaving URL"
+            closeButtonText=""
             actions={[
               <Button
                 className="ds-c-button ds-c-button--primary"
@@ -52,8 +54,17 @@ class Example extends React.PureComponent {
               </Button>,
             ]}
           >
-            You are leaving URL and connecting to a 3rd party site. Please click OK to continue or
-            CANCEL to stay on this site.
+            <p>
+              You are leaving URL and connecting to a 3rd party site. Please click OK to continue or
+              CANCEL to stay on this site.
+            </p>
+
+            <p>
+              <a href="https://www.healthcare.gov/links-to-other-sites/">
+                Learn more about links to third-party sites
+              </a>
+              .
+            </p>
           </Dialog>
         )}
       </div>

--- a/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
@@ -13,8 +13,6 @@ Style guide: patterns.external-link
 
 @react-example ThirdPartyLink.example.jsx
 
-@react-props Dialog.tsx
-
 Style guide: patterns.external-link.react
 */
 
@@ -28,6 +26,8 @@ Use this pattern when the user is in the middle of a task or application to let 
 - [CMS policy on external links](https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/PolicyforLinkingtoOutsideWebsites.html)
 - [CMS external link disclaimer](https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/External-Link-Disclaimer.html)
 
+Refer to [Modal dialog]({{root}}/components/dialog) for custom props.
+
 
 ### Related patterns
 
@@ -40,36 +40,8 @@ Style guide: patterns.external-link.guidance
 /*
  Google Analytics
 
-- Refer to [Modal dialog]({{root}}/components/dialog) for details of the Analytics props
+Refer to [Modal dialog]({{root}}/components/dialog) for details of the Analytics props
 
-**Analytics event tracking is disabled by default.**
-
-### Enable event tracking
-
-- Import and set the `setDialogSendsAnalytics` feature flag to `true` in your application's entry file:
-
-```JSX
-import { setDialogSendsAnalytics } from "@cmsgov/<design-system-package>";
-setDialogSendsAnalytics(true);
-```
-On applications where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
-
-### Disable event tracking
-
-- Pass the `onComponentDidMount` prop set to `false` to the component:
-- Pass the `onComponentWillUnmount` prop set to `false` to the component:
-
-```JSX
-analytics={
-  {
-    onComponentDidMount: {false},
-    onComponentWillUnmount: {false}
-  }
-}
-```
-### Override  event tracking
-
-- Pass changes via any of the [available analytics props](#components.alert.analytics).
 
 Style guide: patterns.external-link.guidance-analytics
 */

--- a/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
+++ b/packages/design-system-docs/src/pages/components/Dialog/_ThirdPartyLink.docs.scss
@@ -19,36 +19,28 @@ Style guide: patterns.external-link.react
 */
 
 /*
-Analytics props
-
-- Refer to [Modal dialog]({{root}}/components/dialog) for details of the Analytics props
-
-Style guide: patterns.external-link.analytics
-*/
-
-/*
 ---
 
 Use this pattern when the user is in the middle of a task or application to let them know that the action they are taking will move them away from the current site and or process. This serves as a warning where the user can then decide to remain where they are in the application or process.
 
-### Learn more
+**Any non .gov and .mil links will be treated as external whether they belong to a government agency or not, no exceptions**
 
 - [CMS policy on external links](https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/PolicyforLinkingtoOutsideWebsites.html)
 - [CMS external link disclaimer](https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/External-Link-Disclaimer.html)
-*/
 
-/*
----
 
 ### Related patterns
 
 - [Modal dialog]({{root}}/components/dialog)
 
 Style guide: patterns.external-link.guidance
+
 */
 
 /*
-Google Analytics
+ Google Analytics
+
+- Refer to [Modal dialog]({{root}}/components/dialog) for details of the Analytics props
 
 **Analytics event tracking is disabled by default.**
 

--- a/packages/design-system-docs/src/pages/components/Icon/IconComponent.example.jsx
+++ b/packages/design-system-docs/src/pages/components/Icon/IconComponent.example.jsx
@@ -10,6 +10,7 @@ import {
   CloseIcon,
   CloseIconThin,
   DownloadIcon,
+  ExternalLinkIcon,
   ImageIcon,
   InfoCircleIcon,
   InfoCircleIconThin,
@@ -86,6 +87,11 @@ const iconData = [
     defaultTitle: 'Download',
     component: <DownloadIcon />,
     name: 'DownloadIcon',
+  },
+  {
+    defaultTitle: 'External Link',
+    component: <ExternalLinkIcon />,
+    name: 'ExternalLinkIcon',
   },
   {
     defaultTitle: 'Image',

--- a/packages/design-system/src/components/Icons/ExternalLinkIcon.tsx
+++ b/packages/design-system/src/components/Icons/ExternalLinkIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import SvgIcon, { IconCommonProps } from './SvgIcon';
+
+const defaultProps = {
+  className: '',
+  title: 'External link',
+  viewBox: '0 0 512 512',
+};
+
+function ExternalLinkIcon(props: IconCommonProps): React.ReactElement {
+  const iconCssClasses = `ds-c-icon--external-link ${props.className || ''}`;
+
+  return (
+    <SvgIcon {...defaultProps} {...props} className={iconCssClasses}>
+      <path d="M497.6,0,334.4.17A14.4,14.4,0,0,0,320,14.57V47.88a14.4,14.4,0,0,0,14.69,14.4l73.63-2.72,2.06,2.06L131.52,340.49a12,12,0,0,0,0,17l23,23a12,12,0,0,0,17,0L450.38,101.62l2.06,2.06-2.72,73.63A14.4,14.4,0,0,0,464.12,192h33.31a14.4,14.4,0,0,0,14.4-14.4L512,14.4A14.4,14.4,0,0,0,497.6,0ZM432,288H416a16,16,0,0,0-16,16V458a6,6,0,0,1-6,6H54a6,6,0,0,1-6-6V118a6,6,0,0,1,6-6H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V304A16,16,0,0,0,432,288Z" />
+    </SvgIcon>
+  );
+}
+
+export default ExternalLinkIcon;

--- a/packages/design-system/src/components/Icons/index.ts
+++ b/packages/design-system/src/components/Icons/index.ts
@@ -9,6 +9,7 @@ export { default as CheckIcon } from './CheckIcon';
 export { default as CloseIcon } from './CloseIcon';
 export { default as CloseIconThin } from './CloseIconThin';
 export { default as DownloadIcon } from './DownloadIcon';
+export { default as ExternalLinkIcon } from './ExternalLinkIcon';
 export { default as HHSLogo } from './HhsLogo';
 export { default as ImageIcon } from './ImageIcon';
 export { default as InfoCircleIcon } from './InfoCircleIcon';

--- a/packages/design-system/src/styles/components/_Dialog.scss
+++ b/packages/design-system/src/styles/components/_Dialog.scss
@@ -52,11 +52,11 @@ $dialog-spacer: $spacer-4;
 
 .ds-c-dialog__close {
   margin-left: auto;
-  padding: 0 0 0 (12px + $spacer-1);
+  padding: 0 $spacer-1 0 $spacer-half;
 
   .ds-c-icon {
     font-size: 13px;
-    margin-right: 4px;
+    margin: 0 $spacer-half;
 
     /* stylelint-disable */
     @media (-ms-high-contrast: active), (forced-colors: active) {


### PR DESCRIPTION
## Summary
Adding external link icon and updating the external link pattern to use the icon as well as add guidance 

### Added
- Added external link icon 
- Added guidance for external link pattern

### Changed
- Updated styling for modal button spacing to use variables

## How to test

- Run the doc site locally with `yarn start` and navigate to the icon component page and see the external link icon
- Next navigate to the external link pattern and see the icon used in the example 