### PR TITLE
[WNMGDS-1413] Add spacing example to page

### DIFF
--- a/packages/design-system-docs/src/pages/styles/spacing/_spacing.docs.scss
+++ b/packages/design-system-docs/src/pages/styles/spacing/_spacing.docs.scss
@@ -12,5 +12,7 @@ The design system uses multiples of `8px` for all spacing values: dimensions, pa
 
 - [The 8-Point Grid](https://spec.fm/specifics/8-pt-grid)
 
+Markup: spacing.example.html
+
 Style guide: styles.spacing
 */

--- a/packages/design-system-docs/src/pages/styles/spacing/spacing.example.html
+++ b/packages/design-system-docs/src/pages/styles/spacing/spacing.example.html
@@ -63,17 +63,3 @@
     </td>
   </tr>
 </table>
-
-<!-- <% var tokens = [ '', '$spacer-1', '$spacer-2', '$spacer-3', '$spacer-4', '$spacer-5',
-'$spacer-6', '$spacer-7' ]; -%>
-<% var pixels = [ '4', '8', '16', '24', '32', '40','48', '56' ]; -%>
-<div class="">
-  <% tokens.forEach(token => { -%>
-   
-  <article class="ds-u-margin-bottom--1">
-    <code><%= token %></code>
-    <% pixels.forEach(pixel => { -%> <code><%= pixel %>px</code> <% }) -%>
-  </article>
- 
-  <% }) -%>
-</div> -->

--- a/packages/design-system-docs/src/pages/styles/spacing/spacing.example.html
+++ b/packages/design-system-docs/src/pages/styles/spacing/spacing.example.html
@@ -1,0 +1,79 @@
+<table class="ds-c-table ds-c-table--compact ds-c-sm-table--stacked">
+  <thead>
+    <tr role="row">
+      <th>Variable</th>
+      <th>Value</th>
+      <th>Example</th>
+    </tr>
+  </thead>
+  <tr>
+    <td><code>$spacer-half</code></td>
+    <td><code>4px</code></td>
+    <td>
+      <div class="ds-u-fill--primary-alt" style="height: 4px"></div>
+    </td>
+  </tr>
+  <tr>
+    <td><code>$spacer-1</code></td>
+    <td><code>8px</code></td>
+    <td>
+      <div class="ds-u-fill--primary-alt" style="height: 8px"></div>
+    </td>
+  </tr>
+  <tr>
+    <td><code>$spacer-2</code></td>
+    <td><code>16px</code></td>
+    <td>
+      <div class="ds-u-fill--primary-alt" style="height: 16px"></div>
+    </td>
+  </tr>
+  <tr>
+    <td><code>$spacer-3</code></td>
+    <td><code>24px</code></td>
+    <td>
+      <div class="ds-u-fill--primary-alt" style="height: 24px"></div>
+    </td>
+  </tr>
+  <tr>
+    <td><code>$spacer-4</code></td>
+    <td><code>32px</code></td>
+    <td>
+      <div class="ds-u-fill--primary-alt" style="height: 32px"></div>
+    </td>
+  </tr>
+  <tr>
+    <td><code>$spacer-5</code></td>
+    <td><code>40px</code></td>
+    <td>
+      <div class="ds-u-fill--primary-alt" style="height: 40px"></div>
+    </td>
+  </tr>
+  <tr>
+    <td><code>$spacer-6</code></td>
+    <td><code>48px</code></td>
+    <td>
+      <div class="ds-u-fill--primary-alt" style="height: 48px"></div>
+    </td>
+  </tr>
+  <tr>
+    <td><code>$spacer-7</code></td>
+    <td><code>56px</code></td>
+    <td>
+      <div class="ds-u-fill--primary-alt" style="height: 56px"></div>
+    </td>
+  </tr>
+</table>
+
+<!-- <% var tokens = [ '', '$spacer-1', '$spacer-2', '$spacer-3', '$spacer-4', '$spacer-5',
+'$spacer-6', '$spacer-7' ]; -%>
+<% var pixels = [ '4', '8', '16', '24', '32', '40','48', '56' ]; -%>
+<div class="">
+  <% tokens.forEach(token => { -%>
+   
+  <article class="ds-u-margin-bottom--1">
+    <code><%= token %></code>
+    <% pixels.forEach(pixel => { -%> <code><%= pixel %>px</code> <% }) -%>
+  </article>
+ 
+  <% }) -%>
+</div> -->

--- a/packages/design-system-docs/src/pages/styles/spacing/spacing.example.html
+++ b/packages/design-system-docs/src/pages/styles/spacing/spacing.example.html
@@ -10,56 +10,56 @@
     <td><code>$spacer-half</code></td>
     <td><code>4px</code></td>
     <td>
-      <div class="ds-u-fill--primary-alt" style="height: 4px"></div>
+      <div class="ds-u-fill--primary-alt example-spacer-half"></div>
     </td>
   </tr>
   <tr>
     <td><code>$spacer-1</code></td>
     <td><code>8px</code></td>
     <td>
-      <div class="ds-u-fill--primary-alt" style="height: 8px"></div>
+      <div class="ds-u-fill--primary-alt example-spacer-1"></div>
     </td>
   </tr>
   <tr>
     <td><code>$spacer-2</code></td>
     <td><code>16px</code></td>
     <td>
-      <div class="ds-u-fill--primary-alt" style="height: 16px"></div>
+      <div class="ds-u-fill--primary-alt example-spacer-2"></div>
     </td>
   </tr>
   <tr>
     <td><code>$spacer-3</code></td>
     <td><code>24px</code></td>
     <td>
-      <div class="ds-u-fill--primary-alt" style="height: 24px"></div>
+      <div class="ds-u-fill--primary-alt example-spacer-3"></div>
     </td>
   </tr>
   <tr>
     <td><code>$spacer-4</code></td>
     <td><code>32px</code></td>
     <td>
-      <div class="ds-u-fill--primary-alt" style="height: 32px"></div>
+      <div class="ds-u-fill--primary-alt example-spacer-4"></div>
     </td>
   </tr>
   <tr>
     <td><code>$spacer-5</code></td>
     <td><code>40px</code></td>
     <td>
-      <div class="ds-u-fill--primary-alt" style="height: 40px"></div>
+      <div class="ds-u-fill--primary-alt example-spacer-5"></div>
     </td>
   </tr>
   <tr>
     <td><code>$spacer-6</code></td>
     <td><code>48px</code></td>
     <td>
-      <div class="ds-u-fill--primary-alt" style="height: 48px"></div>
+      <div class="ds-u-fill--primary-alt example-spacer-6"></div>
     </td>
   </tr>
   <tr>
     <td><code>$spacer-7</code></td>
     <td><code>56px</code></td>
     <td>
-      <div class="ds-u-fill--primary-alt" style="height: 56px"></div>
+      <div class="ds-u-fill--primary-alt example-spacer-7"></div>
     </td>
   </tr>
 </table>

--- a/packages/design-system-docs/src/styles/base/_index.scss
+++ b/packages/design-system-docs/src/styles/base/_index.scss
@@ -1,4 +1,5 @@
 @import 'body';
 @import 'code';
 @import 'details';
+@import 'spacing';
 @import 'typography';

--- a/packages/design-system-docs/src/styles/base/_spacing.scss
+++ b/packages/design-system-docs/src/styles/base/_spacing.scss
@@ -1,0 +1,31 @@
+.example-spacer-half {
+  height: $spacer-half;
+}
+
+.example-spacer-1 {
+  height: $spacer-1;
+}
+
+.example-spacer-2 {
+  height: $spacer-2;
+}
+
+.example-spacer-3 {
+  height: $spacer-3;
+}
+
+.example-spacer-4 {
+  height: $spacer-4;
+}
+
+.example-spacer-5 {
+  height: $spacer-5;
+}
+
+.example-spacer-6 {
+  height: $spacer-6;
+}
+
+.example-spacer-7 {
+  height: $spacer-7;
+}


### PR DESCRIPTION
## Summary

Adding spacing variables and values to the spacing page

### Added

- Added examples of our spacing values 

![Screen Shot 2022-03-14 at 2 58 59 PM](https://user-images.githubusercontent.com/1449852/158243421-a1ac7f31-8d99-4520-815f-802ef222f160.png)



## How to test

- Run `yarn start` to run the doc site and go to the spacing page which is under styles in the left navigation. 
- See that the spacing examples are on the page
