### PR TITLE
[NO-TICKET] Different loki targets in CI job

### DIFF
--- a/loki.config.js
+++ b/loki.config.js
@@ -1,14 +1,14 @@
 module.exports = {
   configurations: {
     'chrome.laptop': {
-      target: 'chrome.docker',
+      target: process.env.CI ? 'chrome.app' : 'chrome.docker',
       width: 1366,
       height: 768,
       deviceScaleFactor: 1,
       mobile: false,
     },
     'chrome.iphone7': {
-      target: 'chrome.docker',
+      target: process.env.CI ? 'chrome.app' : 'chrome.docker',
       preset: 'iPhone 7',
     },
   },


### PR DESCRIPTION
## Summary
In order to implement visual regression testing on Jenkins, I was modifying the loki config to change the targets to not operate chrome inside a docker container. Instead, the docker image used by loki was used to create the Jenkins job container. We can cut out the file manipulation by implementing some switch logic here.
