### PR TITLE
[WNMGDS-912] Remove aside tag from modal

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -411,12 +411,9 @@ export const Dialog = (props: DialogProps) => {
         </header>
         <main role="main" className="ds-c-dialog__body">
           <div id="dialog-content">{children}</div>
+
+          {actions && <div className={actionsClassNames}>{actions}</div>}
         </main>
-        {actions && (
-          <aside className={actionsClassNames} role="complementary">
-            {actions}
-          </aside>
-        )}
       </div>
     </AriaModal>
   );

--- a/packages/design-system/src/components/Dialog/__snapshots__/Dialog.test.jsx.snap
+++ b/packages/design-system/src/components/Dialog/__snapshots__/Dialog.test.jsx.snap
@@ -351,15 +351,14 @@ Object {
         >
           Foo
         </div>
+        <div
+          className="ds-c-dialog__actions test-action"
+        >
+          <span>
+            Pretend these are actions
+          </span>
+        </div>
       </main>
-      <aside
-        className="ds-c-dialog__actions test-action"
-        role="complementary"
-      >
-        <span>
-          Pretend these are actions
-        </span>
-      </aside>
     </div>
   </Displaced>,
 }

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.test.tsx
@@ -171,7 +171,7 @@ describe('Idle Timeout', () => {
     const { getByRole } = renderIdleTimeout();
     showWarning();
     const dialogBodyText = getByRole('main');
-    expect(dialogBodyText.textContent).toEqual(
+    expect(dialogBodyText.firstChild.textContent).toEqual(
       `You've been inactive for a while.Your session will end in 2 minutes.Select "Continue session" below if you want more time.`
     );
   });
@@ -180,7 +180,7 @@ describe('Idle Timeout', () => {
     const { getByRole } = renderIdleTimeout({ timeToWarning: 4 });
     showWarning(MOCK_START_TIME + 4 * 60000); // setting time to match timeToWarning in this test
     const dialogBodyText = getByRole('main');
-    expect(dialogBodyText.textContent).toEqual(
+    expect(dialogBodyText.firstChild.textContent).toEqual(
       `You've been inactive for a while.Your session will end in 1 minute.Select "Continue session" below if you want more time.`
     );
   });
@@ -190,15 +190,15 @@ describe('Idle Timeout', () => {
     const { getByRole } = renderIdleTimeout({ formatMessage, timeToWarning: 2 });
     showWarning(MOCK_START_TIME + 2 * 60000);
     const dialogBodyText = getByRole('main');
-    expect(dialogBodyText.textContent).toEqual('Your session will end in 3.');
+    expect(dialogBodyText.firstChild.textContent).toEqual('Your session will end in 3.');
     // have to advance Date.now() and also retrigger the checkStatus interval
     mockTime(MOCK_START_TIME + 3 * 60000);
     jest.advanceTimersByTime(60000);
-    expect(dialogBodyText.textContent).toEqual('Your session will end in 2.');
+    expect(dialogBodyText.firstChild.textContent).toEqual('Your session will end in 2.');
     // have to advance Date.now() and also retrigger the checkStatus interval
     mockTime(MOCK_START_TIME + 4 * 60000);
     jest.advanceTimersByTime(60000);
-    expect(dialogBodyText.textContent).toEqual('Your session will end in 1.');
+    expect(dialogBodyText.firstChild.textContent).toEqual('Your session will end in 1.');
   });
 
   it('should cleanup timers on unmount', () => {


### PR DESCRIPTION
<!--
**Note:**
- Add the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) to the PR title like this `[WNMGDS-10] - title of pr here` to link to the related issue in Jira.
- You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- A doc site needs to be generated manually using [Jenkins](https://ci.backends.cms.gov/wds/job/design-system/job/build-demo-sites/). Navigate to "Pipeline build-demo-sites," add your branch name and Slack username, and select the builds you want built. Upon a successful build, you should be able to navigate to a demo url resembling `http://design-system-demo.s3-website-us-east-1.amazonaws.com/[branch-name]/[core|hcgov|mgov]/storybook/` (omit `/storybook` if it's a docs site).
- If your changes involve code please update the snapshots by running `yarn update-snapshots`.

**Please follow the format below and remove any sections that aren't relevant.**
-->

## Summary

[Jira](https://jira.cms.gov/browse/WNMGDS-912)

Our modal's action buttons are wrapped in an `<aside>` that's a sibling to the modal's `<main>` content. Replace the `<aside>` tag with a `<div>` and move to inside of `<main>` container.

There should be no visual changes.

## How to test

Run `yarn storybook` or visit [testing url](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-912/bugfix/remove-aside-from-modal/core/storybook/?path=/story/components-dialog--dialog) and confirm the modal matches the [modal in prod](https://design.cms.gov/components/dialog/).

This is the PROD modal:
![Screen Shot 2022-03-18 at 11 50 08 AM](https://user-images.githubusercontent.com/5159392/159036681-811fc544-711d-4a72-8eb4-6c48966f1b71.png)

This is the local:
![Screen Shot 2022-03-18 at 11 49 45 AM](https://user-images.githubusercontent.com/5159392/159036733-61f15232-277d-432e-8b61-a6a84b0cfe6b.png)
