### PR TITLE
[NO-TICKET] Update @types/node as alternative to #1658

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@storybook/preset-scss": "^1.0.3",
     "@storybook/react": "^6.4.9",
     "@storybook/theming": "^6.4.9",
-    "@types/node": "^17.0.12",
+    "@types/node": "^17.0.22",
     "@typescript-eslint/eslint-plugin": "^4.11.0",
     "@typescript-eslint/parser": "^4.11.0",
     "@whitespace/storybook-addon-html": "^5.0.0",

--- a/packages/design-system-tokens/package.json
+++ b/packages/design-system-tokens/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "CMSDS Design System Tokens",
   "devDependencies": {
-    "@types/node": "^17.0.9",
+    "@types/node": "^17.0.22",
     "ts-node": "^10.4.0",
     "tslib": "^2.3.1",
     "typescript": "^4.5.4"

--- a/packages/ds-medicare-gov/package.json
+++ b/packages/ds-medicare-gov/package.json
@@ -38,7 +38,6 @@
     "@cmsgov/eslint-config-design-system": "2.0.0",
     "@cmsgov/stylelint-config-design-system": "2.0.0",
     "@types/jest": "^25.1.3",
-    "@types/node": "^16.11.12",
     "@types/webpack": "^4.41.6",
     "@typescript-eslint/eslint-plugin": "^2.21.0",
     "@typescript-eslint/parser": "^2.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5387,20 +5387,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.32.tgz#2ca61c9ef8c77f6fa1733be9e623ceb0d372ad96"
   integrity sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==
 
-"@types/node@^16.11.12":
-  version "16.11.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.12.tgz#ac7fb693ac587ee182c3780c26eb65546a1a3c10"
-  integrity sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==
-
-"@types/node@^17.0.12":
-  version "17.0.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
-  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
-
-"@types/node@^17.0.9":
-  version "17.0.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.14.tgz#33b9b94f789a8fedd30a68efdbca4dbb06b61f20"
-  integrity sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==
+"@types/node@^17.0.22":
+  version "17.0.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.22.tgz#38b6c4b9b2f3ed9f2e376cce42a298fb2375251e"
+  integrity sha512-8FwbVoG4fy+ykY86XCAclKZDORttqE5/s7dyWZKLXTdv3vRy5HozBEinG5IqhvPXXzIZEcTVbuHlQEI6iuwcmw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
## Summary

In https://github.com/CMSgov/design-system/pull/1658, dependabot tries to update `@types/node` in `ds-medicare-gov`, but that package doesn't actually need that dev dependency. Instead, let's update it in the package files where it's relevant and remove it from `ds-medicare-gov`.