### PR TITLE
Update tooltip display to inline-block.

### DIFF
--- a/packages/design-system/src/styles/components/_Tooltip.scss
+++ b/packages/design-system/src/styles/components/_Tooltip.scss
@@ -159,28 +159,28 @@ $tooltip-close-min-width: 32px !default;
 // Tooltip transition styles
 // http://reactcommunity.org/react-transition-group/css-transition
 .ds-c-tooltip-enter {
-  display: block;
+  display: inline-block;
   opacity: 0;
 }
 
 .ds-c-tooltip-enter-active {
-  display: block;
+  display: inline-block;
   opacity: 1;
   transition: opacity $animation-speed-1;
 }
 
 .ds-c-tooltip-enter-done {
-  display: block;
+  display: inline-block;
   opacity: 1;
 }
 
 .ds-c-tooltip-exit {
-  display: block;
+  display: inline-block;
   opacity: 1;
 }
 
 .ds-c-tooltip-exit-active {
-  display: block;
+  display: inline-block;
   opacity: 0;
   transition: opacity $animation-speed-1;
 }


### PR DESCRIPTION
<!--
**Note:**
- Add the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) to the PR title like this `[WNMGDS-10] - title of pr here` to link to the related issue in Jira.
- You can automatically [close related GitHub issues by using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- A doc site needs to be generated manually using [Jenkins](https://ci.backends.cms.gov/wds/job/design-system/job/build-demo-sites/). Navigate to "Pipeline build-demo-sites," add your branch name and Slack username, and select the builds you want built. Upon a successful build, you should be able to navigate to a demo url resembling `http://design-system-demo.s3-website-us-east-1.amazonaws.com/[branch-name]/[core|hcgov|mgov]/storybook/` (omit `/storybook` if it's a docs site).
- If your changes involve code please update the snapshots by running `yarn update-snapshots`.

**Please follow the format below and remove any sections that aren't relevant.**
-->

## Summary

[Jira](https://jira.cms.gov/browse/WNMGDS-1537)

When text is added after the Tooltip component, it's pushed to the next line when tooltip is opened (via hover or toggle).

This appears to have been caused by the block display of the Tooltip.

## How to test

To test, add text after the [inline Tooltip](http://design-system-demo.s3-website-us-east-1.amazonaws.com/WNMGDS-1537/BUGFIX/tooltip-line-wrap/core/components/tooltip/) via browser dev tools. Hovering over inline Tooltip should not result in text moving to next line.
