### PR TITLE
[WNMGDS-1551] Remove translation parameter from defaultMenuLinks function

### DIFF
--- a/packages/design-system/src/__mocks__/i18next.js
+++ b/packages/design-system/src/__mocks__/i18next.js
@@ -7,5 +7,9 @@ i18next.init = jest.fn();
 i18next.addResourceBundle = jest.fn();
 i18next.changeLanguage = jest.fn();
 i18next.language = 'en';
+i18next.t = function (key, params) {
+  const paramString = params ? ` | ${JSON.stringify(params)}` : '';
+  return `${key}${paramString}`;
+};
 
 export default i18next;

--- a/packages/design-system/src/__mocks__/react-i18next.js
+++ b/packages/design-system/src/__mocks__/react-i18next.js
@@ -1,11 +1,9 @@
 /* eslint-disable */
+const i18next = require('./i18next').default;
 const reactI18next = jest.genMockFromModule('react-i18next');
 const React = require('react');
 
-function t(key, params) {
-  const paramString = params ? ` | ${JSON.stringify(params)}` : '';
-  return `${key}${paramString}`;
-}
+const t = i18next.t;
 
 reactI18next.withTranslation = () => (Component) => (props) => <Component t={t} {...props} />;
 reactI18next.useTranslation = () => ({ t });

--- a/packages/ds-healthcare-gov/src/components/Header/Header.test.jsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.test.jsx
@@ -84,7 +84,7 @@ describe('Header', function () {
     const menu = wrapper.find('Menu');
     expect(menu.prop('links').length).toBe(4);
 
-    expect(menu.prop('links')[2].label).toEqual('header.español');
+    expect(menu.prop('links')[2].label).toContain('header.español');
   });
 
   it('should not add Spanish toggle when hideLanguageSwitch set', () => {
@@ -94,7 +94,7 @@ describe('Header', function () {
     const menu = wrapper.find('Menu');
     expect(menu.prop('links').length).toBe(1);
 
-    expect(menu.prop('links')[0].label).not.toEqual('header.español');
+    expect(menu.prop('links')[0].label).not.toContain('header.español');
   });
 
   it('should not add Login Link when hideLoginLink set', () => {
@@ -104,7 +104,7 @@ describe('Header', function () {
     const menu = wrapper.find('Menu');
     expect(menu.prop('links').length).toBe(1);
 
-    expect(menu.prop('links')[0].label).not.toEqual('header.login');
+    expect(menu.prop('links')[0].label).not.toContain('header.login');
   });
 
   it('should not add Logout Link when hideLogoutLink set', () => {
@@ -114,7 +114,7 @@ describe('Header', function () {
     const menu = wrapper.find('Menu');
     expect(menu.prop('links').length).toBe(1);
 
-    expect(menu.prop('links')[0].label).not.toEqual('header.logout');
+    expect(menu.prop('links')[0].label).not.toContain('header.logout');
   });
 
   it('should have "logout" as last item when logged in', () => {
@@ -126,7 +126,7 @@ describe('Header', function () {
     const lastLink = menuLinks.dive().find('a').last();
 
     expect(lastLink).toBeDefined();
-    expect(lastLink.text()).toEqual('header.logout');
+    expect(lastLink.text()).toContain('header.logout');
   });
 
   it('renders links with absolute URLs if provided a primaryDomain prop', () => {

--- a/packages/ds-healthcare-gov/src/components/Header/Header.tsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.tsx
@@ -180,17 +180,17 @@ const Header = (props: HeaderProps) => {
   const classes = classnames(`hc-c-header hc-c-header--${variation()}`, props.className);
 
   const hasCustomLinks = !!props.links;
-  const defaultLinksForVariation = defaultMenuLinks(
-    props.initialLanguage ?? getLanguage(),
-    props.deConsumer,
-    props.subpath,
-    props.primaryDomain,
-    props.switchLocaleLink,
-    props.hideLoginLink,
-    props.hideLogoutLink,
-    props.hideLanguageSwitch,
-    hasCustomLinks
-  )[variation()];
+  const defaultLinksForVariation = defaultMenuLinks({
+    locale: props.initialLanguage ?? getLanguage(),
+    deConsumer: props.deConsumer,
+    subpath: props.subpath,
+    primaryDomain: props.primaryDomain,
+    switchLocaleLink: props.switchLocaleLink,
+    hideLoginLink: props.hideLoginLink,
+    hideLogoutLink: props.hideLogoutLink,
+    hideLanguageSwitch: props.hideLanguageSwitch,
+    customLinksPassedIn: hasCustomLinks,
+  })[variation()];
 
   const links = hasCustomLinks
     ? props.links.concat(defaultLinksForVariation)

--- a/packages/ds-healthcare-gov/src/components/Header/Header.tsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.tsx
@@ -181,7 +181,6 @@ const Header = (props: HeaderProps) => {
 
   const hasCustomLinks = !!props.links;
   const defaultLinksForVariation = defaultMenuLinks(
-    t,
     props.initialLanguage ?? getLanguage(),
     props.deConsumer,
     props.subpath,

--- a/packages/ds-healthcare-gov/src/components/Header/__snapshots__/Header.test.jsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Header/__snapshots__/Header.test.jsx.snap
@@ -29,12 +29,12 @@ exports[`Header renders Direct Enrollment banner 1`] = `
           Array [
             Object {
               "href": "https://www.cuidadodesalud.gov/es/",
-              "label": "header.español",
+              "label": "header.español | {\\"ns\\":\\"en\\"}",
             },
             Object {
               "href": "/login?check_de=1",
               "identifier": "login",
-              "label": "header.login",
+              "label": "header.login | {\\"ns\\":\\"en\\"}",
             },
           ]
         }
@@ -49,12 +49,12 @@ exports[`Header renders Direct Enrollment banner 1`] = `
       Array [
         Object {
           "href": "https://www.cuidadodesalud.gov/es/",
-          "label": "header.español",
+          "label": "header.español | {\\"ns\\":\\"en\\"}",
         },
         Object {
           "href": "/login?check_de=1",
           "identifier": "login",
-          "label": "header.login",
+          "label": "header.login | {\\"ns\\":\\"en\\"}",
         },
       ]
     }
@@ -96,12 +96,12 @@ exports[`Header renders Spanish header 1`] = `
           Array [
             Object {
               "href": "https://www.healthcare.gov/",
-              "label": "header.english",
+              "label": "header.english | {\\"ns\\":\\"es\\"}",
             },
             Object {
               "href": "/login",
               "identifier": "login",
-              "label": "header.login",
+              "label": "header.login | {\\"ns\\":\\"es\\"}",
             },
           ]
         }
@@ -116,12 +116,12 @@ exports[`Header renders Spanish header 1`] = `
       Array [
         Object {
           "href": "https://www.healthcare.gov/",
-          "label": "header.english",
+          "label": "header.english | {\\"ns\\":\\"es\\"}",
         },
         Object {
           "href": "/login",
           "identifier": "login",
-          "label": "header.login",
+          "label": "header.login | {\\"ns\\":\\"es\\"}",
         },
       ]
     }
@@ -159,12 +159,12 @@ exports[`Header renders full/homepage header 1`] = `
           Array [
             Object {
               "href": "https://www.cuidadodesalud.gov/es/",
-              "label": "header.español",
+              "label": "header.español | {\\"ns\\":\\"en\\"}",
             },
             Object {
               "href": "/login",
               "identifier": "login",
-              "label": "header.login",
+              "label": "header.login | {\\"ns\\":\\"en\\"}",
             },
           ]
         }
@@ -179,12 +179,12 @@ exports[`Header renders full/homepage header 1`] = `
       Array [
         Object {
           "href": "https://www.cuidadodesalud.gov/es/",
-          "label": "header.español",
+          "label": "header.español | {\\"ns\\":\\"en\\"}",
         },
         Object {
           "href": "/login",
           "identifier": "login",
-          "label": "header.login",
+          "label": "header.login | {\\"ns\\":\\"en\\"}",
         },
       ]
     }
@@ -222,12 +222,12 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
           Array [
             Object {
               "href": "https://www.cuidadodesalud.gov/es/",
-              "label": "header.español",
+              "label": "header.español | {\\"ns\\":\\"en\\"}",
             },
             Object {
               "href": "https://www.healthcare.gov/login",
               "identifier": "login",
-              "label": "header.login",
+              "label": "header.login | {\\"ns\\":\\"en\\"}",
             },
           ]
         }
@@ -242,12 +242,12 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
       Array [
         Object {
           "href": "https://www.cuidadodesalud.gov/es/",
-          "label": "header.español",
+          "label": "header.español | {\\"ns\\":\\"en\\"}",
         },
         Object {
           "href": "https://www.healthcare.gov/login",
           "identifier": "login",
-          "label": "header.login",
+          "label": "header.login | {\\"ns\\":\\"en\\"}",
         },
       ]
     }
@@ -286,20 +286,20 @@ exports[`Header renders logged-in header with firstName 1`] = `
           Array [
             Object {
               "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-              "label": "header.myApplicationsAndCoverage",
+              "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
             },
             Object {
               "href": "/marketplace/auth/global/en_US/myProfile#settings",
-              "label": "header.myProfile",
+              "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
             },
             Object {
               "href": "https://www.cuidadodesalud.gov/es/",
-              "label": "header.español",
+              "label": "header.español | {\\"ns\\":\\"en\\"}",
             },
             Object {
               "href": "/logout",
               "identifier": "logout",
-              "label": "header.logout",
+              "label": "header.logout | {\\"ns\\":\\"en\\"}",
             },
           ]
         }
@@ -322,20 +322,20 @@ exports[`Header renders logged-in header with firstName 1`] = `
       Array [
         Object {
           "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-          "label": "header.myApplicationsAndCoverage",
+          "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
         },
         Object {
           "href": "/marketplace/auth/global/en_US/myProfile#settings",
-          "label": "header.myProfile",
+          "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
         },
         Object {
           "href": "https://www.cuidadodesalud.gov/es/",
-          "label": "header.español",
+          "label": "header.español | {\\"ns\\":\\"en\\"}",
         },
         Object {
           "href": "/logout",
           "identifier": "logout",
-          "label": "header.logout",
+          "label": "header.logout | {\\"ns\\":\\"en\\"}",
         },
       ]
     }
@@ -373,20 +373,20 @@ exports[`Header renders logged-in header without firstName 1`] = `
           Array [
             Object {
               "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-              "label": "header.myApplicationsAndCoverage",
+              "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
             },
             Object {
               "href": "/marketplace/auth/global/en_US/myProfile#settings",
-              "label": "header.myProfile",
+              "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
             },
             Object {
               "href": "https://www.cuidadodesalud.gov/es/",
-              "label": "header.español",
+              "label": "header.español | {\\"ns\\":\\"en\\"}",
             },
             Object {
               "href": "/logout",
               "identifier": "logout",
-              "label": "header.logout",
+              "label": "header.logout | {\\"ns\\":\\"en\\"}",
             },
           ]
         }
@@ -402,20 +402,20 @@ exports[`Header renders logged-in header without firstName 1`] = `
       Array [
         Object {
           "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-          "label": "header.myApplicationsAndCoverage",
+          "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
         },
         Object {
           "href": "/marketplace/auth/global/en_US/myProfile#settings",
-          "label": "header.myProfile",
+          "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
         },
         Object {
           "href": "https://www.cuidadodesalud.gov/es/",
-          "label": "header.español",
+          "label": "header.español | {\\"ns\\":\\"en\\"}",
         },
         Object {
           "href": "/logout",
           "identifier": "logout",
-          "label": "header.logout",
+          "label": "header.logout | {\\"ns\\":\\"en\\"}",
         },
       ]
     }

--- a/packages/ds-healthcare-gov/src/components/Header/__snapshots__/defaultMenuLinks.test.js.snap
+++ b/packages/ds-healthcare-gov/src/components/Header/__snapshots__/defaultMenuLinks.test.js.snap
@@ -5,31 +5,31 @@ Object {
   "logged-in": Array [
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#settings",
-      "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
+      "label": "header.myProfile | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español | {\\"ns\\":\\"en\\"}",
+      "label": "header.español | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout | {\\"ns\\":\\"en\\"}",
+      "label": "header.logout | {\\"ns\\":\\"healthcare\\"}",
     },
   ],
   "logged-out": Array [
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español | {\\"ns\\":\\"en\\"}",
+      "label": "header.español | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "/login",
       "identifier": "login",
-      "label": "header.login | {\\"ns\\":\\"en\\"}",
+      "label": "header.login | {\\"ns\\":\\"healthcare\\"}",
     },
   ],
 }
@@ -285,23 +285,23 @@ Object {
   "logged-in": Array [
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#settings",
-      "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
+      "label": "header.myProfile | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout | {\\"ns\\":\\"en\\"}",
+      "label": "header.logout | {\\"ns\\":\\"healthcare\\"}",
     },
   ],
   "logged-out": Array [
     Object {
       "href": "/login",
       "identifier": "login",
-      "label": "header.login | {\\"ns\\":\\"en\\"}",
+      "label": "header.login | {\\"ns\\":\\"healthcare\\"}",
     },
   ],
 }
@@ -312,26 +312,26 @@ Object {
   "logged-in": Array [
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#settings",
-      "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
+      "label": "header.myProfile | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español | {\\"ns\\":\\"en\\"}",
+      "label": "header.español | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout | {\\"ns\\":\\"en\\"}",
+      "label": "header.logout | {\\"ns\\":\\"healthcare\\"}",
     },
   ],
   "logged-out": Array [
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español | {\\"ns\\":\\"en\\"}",
+      "label": "header.español | {\\"ns\\":\\"healthcare\\"}",
     },
   ],
 }
@@ -342,26 +342,26 @@ Object {
   "logged-in": Array [
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#settings",
-      "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
+      "label": "header.myProfile | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español | {\\"ns\\":\\"en\\"}",
+      "label": "header.español | {\\"ns\\":\\"healthcare\\"}",
     },
   ],
   "logged-out": Array [
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español | {\\"ns\\":\\"en\\"}",
+      "label": "header.español | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "/login",
       "identifier": "login",
-      "label": "header.login | {\\"ns\\":\\"en\\"}",
+      "label": "header.login | {\\"ns\\":\\"healthcare\\"}",
     },
   ],
 }
@@ -372,23 +372,23 @@ Object {
   "logged-in": Array [
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español | {\\"ns\\":\\"en\\"}",
+      "label": "header.español | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout | {\\"ns\\":\\"en\\"}",
+      "label": "header.logout | {\\"ns\\":\\"healthcare\\"}",
     },
   ],
   "logged-out": Array [
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español | {\\"ns\\":\\"en\\"}",
+      "label": "header.español | {\\"ns\\":\\"healthcare\\"}",
     },
     Object {
       "href": "/login",
       "identifier": "login",
-      "label": "header.login | {\\"ns\\":\\"en\\"}",
+      "label": "header.login | {\\"ns\\":\\"healthcare\\"}",
     },
   ],
 }

--- a/packages/ds-healthcare-gov/src/components/Header/__snapshots__/defaultMenuLinks.test.js.snap
+++ b/packages/ds-healthcare-gov/src/components/Header/__snapshots__/defaultMenuLinks.test.js.snap
@@ -5,31 +5,31 @@ Object {
   "logged-in": Array [
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#settings",
-      "label": "header.myProfile",
+      "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout",
+      "label": "header.logout | {\\"ns\\":\\"en\\"}",
     },
   ],
   "logged-out": Array [
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/login",
       "identifier": "login",
-      "label": "header.login",
+      "label": "header.login | {\\"ns\\":\\"en\\"}",
     },
   ],
 }
@@ -39,32 +39,32 @@ exports[`MenuList English returns array of menu list objects with absolute URLs 
 Object {
   "logged-in": Array [
     Object {
-      "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage",
+      "href": "https://www.healthcare.gov/marketplace/auth/global/en_US/myProfile#landingPage",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
     },
     Object {
-      "href": "/marketplace/auth/global/en_US/myProfile#settings",
-      "label": "header.myProfile",
+      "href": "https://www.healthcare.gov/marketplace/auth/global/en_US/myProfile#settings",
+      "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
     },
     Object {
-      "href": "https://www.cuidadodesalud.gov/es/https://www.healthcare.gov",
-      "label": "header.español",
+      "href": "https://www.cuidadodesalud.gov/es/",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
-      "href": "/logout",
+      "href": "https://www.healthcare.gov/logout",
       "identifier": "logout",
-      "label": "header.logout",
+      "label": "header.logout | {\\"ns\\":\\"en\\"}",
     },
   ],
   "logged-out": Array [
     Object {
-      "href": "https://www.cuidadodesalud.gov/es/https://www.healthcare.gov",
-      "label": "header.español",
+      "href": "https://www.cuidadodesalud.gov/es/",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
-      "href": "/login",
+      "href": "https://www.healthcare.gov/login",
       "identifier": "login",
-      "label": "header.login",
+      "label": "header.login | {\\"ns\\":\\"en\\"}",
     },
   ],
 }
@@ -74,32 +74,32 @@ exports[`MenuList English returns array of menu list objects with custom locale 
 Object {
   "logged-in": Array [
     Object {
-      "href": "https://ayudalocal.cuidadodesalud.gov/es/marketplace/auth/global/en_US/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage",
+      "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
     },
     Object {
-      "href": "https://ayudalocal.cuidadodesalud.gov/es/marketplace/auth/global/en_US/myProfile#settings",
-      "label": "header.myProfile",
+      "href": "/marketplace/auth/global/en_US/myProfile#settings",
+      "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
     },
     Object {
-      "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "href": "https://ayudalocal.cuidadodesalud.gov/es",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
-      "href": "https://ayudalocal.cuidadodesalud.gov/es/logout",
+      "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout",
+      "label": "header.logout | {\\"ns\\":\\"en\\"}",
     },
   ],
   "logged-out": Array [
     Object {
-      "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "href": "https://ayudalocal.cuidadodesalud.gov/es",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
-      "href": "https://ayudalocal.cuidadodesalud.gov/es/login",
+      "href": "/login",
       "identifier": "login",
-      "label": "header.login",
+      "label": "header.login | {\\"ns\\":\\"en\\"}",
     },
   ],
 }
@@ -110,31 +110,31 @@ Object {
   "logged-in": Array [
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#settings",
-      "label": "header.myProfile",
+      "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
     },
     Object {
-      "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "href": "https://www.cuidadodesalud.gov/es/tax-tool/",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout",
+      "label": "header.logout | {\\"ns\\":\\"en\\"}",
     },
   ],
   "logged-out": Array [
     Object {
-      "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "href": "https://www.cuidadodesalud.gov/es/tax-tool/",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
-      "href": "/login?check_de=1",
+      "href": "/login",
       "identifier": "login",
-      "label": "header.login",
+      "label": "header.login | {\\"ns\\":\\"en\\"}",
     },
   ],
 }
@@ -145,31 +145,31 @@ Object {
   "logged-in": Array [
     Object {
       "href": "/marketplace/auth/global/es_MX/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"es\\"}",
     },
     Object {
       "href": "/marketplace/auth/global/es_MX/myProfile#settings",
-      "label": "header.myProfile",
+      "label": "header.myProfile | {\\"ns\\":\\"es\\"}",
     },
     Object {
       "href": "https://www.healthcare.gov/",
-      "label": "header.english",
+      "label": "header.english | {\\"ns\\":\\"es\\"}",
     },
     Object {
       "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout",
+      "label": "header.logout | {\\"ns\\":\\"es\\"}",
     },
   ],
   "logged-out": Array [
     Object {
       "href": "https://www.healthcare.gov/",
-      "label": "header.english",
+      "label": "header.english | {\\"ns\\":\\"es\\"}",
     },
     Object {
       "href": "/login",
       "identifier": "login",
-      "label": "header.login",
+      "label": "header.login | {\\"ns\\":\\"es\\"}",
     },
   ],
 }
@@ -179,32 +179,32 @@ exports[`MenuList Spanish returns array of menu list objects with absolute URLs 
 Object {
   "logged-in": Array [
     Object {
-      "href": "/marketplace/auth/global/es_MX/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage",
+      "href": "https://www.cuidadodesalud.gov/marketplace/auth/global/es_MX/myProfile#landingPage",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"es\\"}",
     },
     Object {
-      "href": "/marketplace/auth/global/es_MX/myProfile#settings",
-      "label": "header.myProfile",
+      "href": "https://www.cuidadodesalud.gov/marketplace/auth/global/es_MX/myProfile#settings",
+      "label": "header.myProfile | {\\"ns\\":\\"es\\"}",
     },
     Object {
-      "href": "https://www.healthcare.gov/https://www.healthcare.gov",
-      "label": "header.english",
+      "href": "https://www.healthcare.gov/",
+      "label": "header.english | {\\"ns\\":\\"es\\"}",
     },
     Object {
-      "href": "/logout",
+      "href": "https://www.cuidadodesalud.gov/logout",
       "identifier": "logout",
-      "label": "header.logout",
+      "label": "header.logout | {\\"ns\\":\\"es\\"}",
     },
   ],
   "logged-out": Array [
     Object {
-      "href": "https://www.healthcare.gov/https://www.healthcare.gov",
-      "label": "header.english",
+      "href": "https://www.healthcare.gov/",
+      "label": "header.english | {\\"ns\\":\\"es\\"}",
     },
     Object {
-      "href": "/login",
+      "href": "https://www.cuidadodesalud.gov/login",
       "identifier": "login",
-      "label": "header.login",
+      "label": "header.login | {\\"ns\\":\\"es\\"}",
     },
   ],
 }
@@ -214,32 +214,32 @@ exports[`MenuList Spanish returns array of menu list objects with custom locale 
 Object {
   "logged-in": Array [
     Object {
-      "href": "https://localhelp.healthcare.gov/marketplace/auth/global/es_MX/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage",
+      "href": "/marketplace/auth/global/es_MX/myProfile#landingPage",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"es\\"}",
     },
     Object {
-      "href": "https://localhelp.healthcare.gov/marketplace/auth/global/es_MX/myProfile#settings",
-      "label": "header.myProfile",
+      "href": "/marketplace/auth/global/es_MX/myProfile#settings",
+      "label": "header.myProfile | {\\"ns\\":\\"es\\"}",
     },
     Object {
-      "href": "https://www.healthcare.gov/",
-      "label": "header.english",
+      "href": "https://localhelp.healthcare.gov",
+      "label": "header.english | {\\"ns\\":\\"es\\"}",
     },
     Object {
-      "href": "https://localhelp.healthcare.gov/logout",
+      "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout",
+      "label": "header.logout | {\\"ns\\":\\"es\\"}",
     },
   ],
   "logged-out": Array [
     Object {
-      "href": "https://www.healthcare.gov/",
-      "label": "header.english",
+      "href": "https://localhelp.healthcare.gov",
+      "label": "header.english | {\\"ns\\":\\"es\\"}",
     },
     Object {
-      "href": "https://localhelp.healthcare.gov/login",
+      "href": "/login",
       "identifier": "login",
-      "label": "header.login",
+      "label": "header.login | {\\"ns\\":\\"es\\"}",
     },
   ],
 }
@@ -250,31 +250,31 @@ Object {
   "logged-in": Array [
     Object {
       "href": "/marketplace/auth/global/es_MX/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"es\\"}",
     },
     Object {
       "href": "/marketplace/auth/global/es_MX/myProfile#settings",
-      "label": "header.myProfile",
+      "label": "header.myProfile | {\\"ns\\":\\"es\\"}",
     },
     Object {
-      "href": "https://www.healthcare.gov/",
-      "label": "header.english",
+      "href": "https://www.healthcare.gov/tax-tool/",
+      "label": "header.english | {\\"ns\\":\\"es\\"}",
     },
     Object {
       "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout",
+      "label": "header.logout | {\\"ns\\":\\"es\\"}",
     },
   ],
   "logged-out": Array [
     Object {
-      "href": "https://www.healthcare.gov/",
-      "label": "header.english",
+      "href": "https://www.healthcare.gov/tax-tool/",
+      "label": "header.english | {\\"ns\\":\\"es\\"}",
     },
     Object {
-      "href": "/login?check_de=1",
+      "href": "/login",
       "identifier": "login",
-      "label": "header.login",
+      "label": "header.login | {\\"ns\\":\\"es\\"}",
     },
   ],
 }
@@ -285,23 +285,23 @@ Object {
   "logged-in": Array [
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#settings",
-      "label": "header.myProfile",
+      "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout",
+      "label": "header.logout | {\\"ns\\":\\"en\\"}",
     },
   ],
   "logged-out": Array [
     Object {
       "href": "/login",
       "identifier": "login",
-      "label": "header.login",
+      "label": "header.login | {\\"ns\\":\\"en\\"}",
     },
   ],
 }
@@ -312,26 +312,26 @@ Object {
   "logged-in": Array [
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#settings",
-      "label": "header.myProfile",
+      "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout",
+      "label": "header.logout | {\\"ns\\":\\"en\\"}",
     },
   ],
   "logged-out": Array [
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
   ],
 }
@@ -342,26 +342,26 @@ Object {
   "logged-in": Array [
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#landingPage",
-      "label": "header.myApplicationsAndCoverage",
+      "label": "header.myApplicationsAndCoverage | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/marketplace/auth/global/en_US/myProfile#settings",
-      "label": "header.myProfile",
+      "label": "header.myProfile | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
   ],
   "logged-out": Array [
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/login",
       "identifier": "login",
-      "label": "header.login",
+      "label": "header.login | {\\"ns\\":\\"en\\"}",
     },
   ],
 }
@@ -372,23 +372,23 @@ Object {
   "logged-in": Array [
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/logout",
       "identifier": "logout",
-      "label": "header.logout",
+      "label": "header.logout | {\\"ns\\":\\"en\\"}",
     },
   ],
   "logged-out": Array [
     Object {
       "href": "https://www.cuidadodesalud.gov/es/",
-      "label": "header.español",
+      "label": "header.español | {\\"ns\\":\\"en\\"}",
     },
     Object {
       "href": "/login",
       "identifier": "login",
-      "label": "header.login",
+      "label": "header.login | {\\"ns\\":\\"en\\"}",
     },
   ],
 }

--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.test.js
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.test.js
@@ -12,20 +12,19 @@ describe('MenuList', function () {
 
   it('leaves out login link if hideLoginLink true', () => {
     expect(
-      defaultMenuLinks(t, undefined, undefined, undefined, undefined, undefined, true)
+      defaultMenuLinks(undefined, undefined, undefined, undefined, undefined, true)
     ).toMatchSnapshot();
   });
 
   it('leaves out logout link if hideLogoutLink true', () => {
     expect(
-      defaultMenuLinks(t, undefined, undefined, undefined, undefined, undefined, undefined, true)
+      defaultMenuLinks(undefined, undefined, undefined, undefined, undefined, undefined, true)
     ).toMatchSnapshot();
   });
 
   it('leaves out locale links if hideLanguageSwitch true', () => {
     expect(
       defaultMenuLinks(
-        t,
         undefined,
         undefined,
         undefined,
@@ -41,7 +40,6 @@ describe('MenuList', function () {
   it('leaves out the myProfile and myApplicationsAndCoverage when customLinksPassedIn is true', () => {
     expect(
       defaultMenuLinks(
-        t,
         undefined,
         undefined,
         undefined,
@@ -61,36 +59,36 @@ describe('MenuList', function () {
     });
 
     it('returns array of menu list objects with subpath', () => {
-      expect(defaultMenuLinks(t, 'en', 'tax-tool/')).toMatchSnapshot();
+      expect(defaultMenuLinks('en', 'tax-tool/')).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with absolute URLs', () => {
-      expect(defaultMenuLinks(t, 'en', undefined, 'https://www.healthcare.gov')).toMatchSnapshot();
+      expect(defaultMenuLinks('en', undefined, 'https://www.healthcare.gov')).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with custom locale switch link', () => {
       expect(
-        defaultMenuLinks(t, 'en', undefined, undefined, 'https://ayudalocal.cuidadodesalud.gov/es')
+        defaultMenuLinks('en', undefined, undefined, 'https://ayudalocal.cuidadodesalud.gov/es')
       ).toMatchSnapshot();
     });
   });
 
   describe('Spanish', () => {
     it('returns array of menu list objects', () => {
-      expect(defaultMenuLinks(t, 'es')).toMatchSnapshot();
+      expect(defaultMenuLinks('es')).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with subpath', () => {
-      expect(defaultMenuLinks(t, 'es', 'tax-tool/')).toMatchSnapshot();
+      expect(defaultMenuLinks('es', 'tax-tool/')).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with absolute URLs', () => {
-      expect(defaultMenuLinks(t, 'es', undefined, 'https://www.healthcare.gov')).toMatchSnapshot();
+      expect(defaultMenuLinks('es', undefined, 'https://www.healthcare.gov')).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with custom locale switch link', () => {
       expect(
-        defaultMenuLinks(t, 'es', undefined, undefined, 'https://localhelp.healthcare.gov')
+        defaultMenuLinks('es', undefined, undefined, 'https://localhelp.healthcare.gov')
       ).toMatchSnapshot();
     });
   });

--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.test.js
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.test.js
@@ -9,46 +9,19 @@ describe('MenuList', function () {
   });
 
   it('leaves out login link if hideLoginLink true', () => {
-    expect(
-      defaultMenuLinks(undefined, undefined, undefined, undefined, undefined, true)
-    ).toMatchSnapshot();
+    expect(defaultMenuLinks({ hideLoginLink: true })).toMatchSnapshot();
   });
 
   it('leaves out logout link if hideLogoutLink true', () => {
-    expect(
-      defaultMenuLinks(undefined, undefined, undefined, undefined, undefined, undefined, true)
-    ).toMatchSnapshot();
+    expect(defaultMenuLinks({ hideLogoutLink: true })).toMatchSnapshot();
   });
 
   it('leaves out locale links if hideLanguageSwitch true', () => {
-    expect(
-      defaultMenuLinks(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        true
-      )
-    ).toMatchSnapshot();
+    expect(defaultMenuLinks({ hideLanguageSwitch: true })).toMatchSnapshot();
   });
 
   it('leaves out the myProfile and myApplicationsAndCoverage when customLinksPassedIn is true', () => {
-    expect(
-      defaultMenuLinks(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        true
-      )
-    ).toMatchSnapshot();
+    expect(defaultMenuLinks({ customLinksPassedIn: true })).toMatchSnapshot();
   });
 
   describe('English', () => {
@@ -57,36 +30,43 @@ describe('MenuList', function () {
     });
 
     it('returns array of menu list objects with subpath', () => {
-      expect(defaultMenuLinks('en', 'tax-tool/')).toMatchSnapshot();
+      expect(defaultMenuLinks({ locale: 'en', subpath: 'tax-tool/' })).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with absolute URLs', () => {
-      expect(defaultMenuLinks('en', undefined, 'https://www.healthcare.gov')).toMatchSnapshot();
+      expect(
+        defaultMenuLinks({ locale: 'en', primaryDomain: 'https://www.healthcare.gov' })
+      ).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with custom locale switch link', () => {
       expect(
-        defaultMenuLinks('en', undefined, undefined, 'https://ayudalocal.cuidadodesalud.gov/es')
+        defaultMenuLinks({
+          locale: 'en',
+          switchLocaleLink: 'https://ayudalocal.cuidadodesalud.gov/es',
+        })
       ).toMatchSnapshot();
     });
   });
 
   describe('Spanish', () => {
     it('returns array of menu list objects', () => {
-      expect(defaultMenuLinks('es')).toMatchSnapshot();
+      expect(defaultMenuLinks({ locale: 'es' })).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with subpath', () => {
-      expect(defaultMenuLinks('es', 'tax-tool/')).toMatchSnapshot();
+      expect(defaultMenuLinks({ locale: 'es', subpath: 'tax-tool/' })).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with absolute URLs', () => {
-      expect(defaultMenuLinks('es', undefined, 'https://www.healthcare.gov')).toMatchSnapshot();
+      expect(
+        defaultMenuLinks({ locale: 'es', primaryDomain: 'https://www.cuidadodesalud.gov' })
+      ).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with custom locale switch link', () => {
       expect(
-        defaultMenuLinks('es', undefined, undefined, 'https://localhelp.healthcare.gov')
+        defaultMenuLinks({ locale: 'es', switchLocaleLink: 'https://localhelp.healthcare.gov' })
       ).toMatchSnapshot();
     });
   });

--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.test.js
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.test.js
@@ -2,8 +2,6 @@ import defaultMenuLinks, {
   defaultMenuLinks as namedExportDefaultMenuLinks,
 } from './defaultMenuLinks';
 
-const t = (key) => key;
-
 describe('MenuList', function () {
   it('includes a named export', () => {
     // Some apps may need to import the default menu links in order to extend them
@@ -55,7 +53,7 @@ describe('MenuList', function () {
 
   describe('English', () => {
     it('returns array of menu list objects', () => {
-      expect(defaultMenuLinks(t)).toMatchSnapshot();
+      expect(defaultMenuLinks()).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with subpath', () => {

--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
@@ -2,7 +2,7 @@ import { Link, VARIATION_NAMES } from './Header';
 import localeLink from './localeLink';
 import loginLink from './loginLink';
 import { TFunction } from 'i18next';
-import { Language } from '../i18n';
+import { i18n, Language } from '../i18n';
 
 export enum LinkIdentifier {
   LOGIN = 'login',
@@ -14,12 +14,29 @@ export interface DefaultLink extends Link {
 }
 
 /**
+ * In order for the `t` function to be able to find the right translations under the right
+ * keys, we need to look in the appropriate namespace. This function returns a version of
+ * the `i18n.t` function that is bound to a specific namespace.
+ */
+function tWithNamespace(namespace: string) {
+  return (...args: Parameters<TFunction>) => {
+    let originalOptions = {};
+    if (typeof args[1] === 'object') originalOptions = args[1];
+    else if (typeof args[2] === 'object') originalOptions = args[2];
+    const options = {
+      ...originalOptions,
+      ns: namespace,
+    };
+    return i18n.t(args[0], options);
+  };
+}
+
+/**
  * Default menu links for each header variation.
  * Apps can import this method into their app if they need to
  * extend the existing default list of menu links.
  */
 export function defaultMenuLinks(
-  t: TFunction,
   locale: Language = 'en',
   deConsumer?: boolean,
   subpath?: string,
@@ -30,6 +47,7 @@ export function defaultMenuLinks(
   hideLanguageSwitch?: boolean,
   customLinksPassedIn?: boolean
 ) {
+  const t = tWithNamespace(locale ?? 'healthcare');
   const isSpanish = locale === 'es';
   const ffmLocalePath = isSpanish ? 'es_MX' : 'en_US';
 

--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
@@ -50,7 +50,7 @@ export interface DefaultMenuLinkOptions {
  */
 export function defaultMenuLinks(options: DefaultMenuLinkOptions = {}) {
   const {
-    locale = 'en',
+    locale,
     deConsumer,
     subpath,
     primaryDomain = '',
@@ -61,7 +61,7 @@ export function defaultMenuLinks(options: DefaultMenuLinkOptions = {}) {
     customLinksPassedIn,
   } = options;
   const t = tWithNamespace(locale ?? 'healthcare');
-  const isSpanish = languageMatches(locale, 'es');
+  const isSpanish = languageMatches('es', locale);
   const ffmLocalePath = isSpanish ? 'es_MX' : 'en_US';
 
   // NOTE: order matters here and links will be displayed in order added to the arrays

--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
@@ -31,22 +31,35 @@ function tWithNamespace(namespace: string) {
   };
 }
 
+export interface DefaultMenuLinkOptions {
+  locale?: Language;
+  deConsumer?: boolean;
+  subpath?: string;
+  primaryDomain?: string;
+  switchLocaleLink?: string;
+  hideLoginLink?: boolean;
+  hideLogoutLink?: boolean;
+  hideLanguageSwitch?: boolean;
+  customLinksPassedIn?: boolean;
+}
+
 /**
  * Default menu links for each header variation.
  * Apps can import this method into their app if they need to
  * extend the existing default list of menu links.
  */
-export function defaultMenuLinks(
-  locale: Language = 'en',
-  deConsumer?: boolean,
-  subpath?: string,
-  primaryDomain = '',
-  switchLocaleLink?: string,
-  hideLoginLink?: boolean,
-  hideLogoutLink?: boolean,
-  hideLanguageSwitch?: boolean,
-  customLinksPassedIn?: boolean
-) {
+export function defaultMenuLinks(options: DefaultMenuLinkOptions = {}) {
+  const {
+    locale = 'en',
+    deConsumer,
+    subpath,
+    primaryDomain = '',
+    switchLocaleLink,
+    hideLoginLink,
+    hideLogoutLink,
+    hideLanguageSwitch,
+    customLinksPassedIn,
+  } = options;
   const t = tWithNamespace(locale ?? 'healthcare');
   const isSpanish = languageMatches(locale, 'es');
   const ffmLocalePath = isSpanish ? 'es_MX' : 'en_US';

--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
@@ -2,7 +2,7 @@ import { Link, VARIATION_NAMES } from './Header';
 import localeLink from './localeLink';
 import loginLink from './loginLink';
 import { TFunction } from 'i18next';
-import { i18n, Language } from '../i18n';
+import { Language, i18n, languageMatches } from '@cmsgov/design-system';
 
 export enum LinkIdentifier {
   LOGIN = 'login',
@@ -48,7 +48,7 @@ export function defaultMenuLinks(
   customLinksPassedIn?: boolean
 ) {
   const t = tWithNamespace(locale ?? 'healthcare');
-  const isSpanish = locale === 'es';
+  const isSpanish = languageMatches(locale, 'es');
   const ffmLocalePath = isSpanish ? 'es_MX' : 'en_US';
 
   // NOTE: order matters here and links will be displayed in order added to the arrays


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-1551

As part of our 7.0 release, I had updated the `defaultMenuLinks` function to accept a required `t` (`i18next` _translate_) function, but I did not realize this function was being used externally. The way the translations are set up to support the old component-specific language props, it is impractical to expect teams to supply this function, which needs to use our internal `i18next` instance and be configured to use the right namespace.

Additionally, the list of parameters for that function was way too long, and the unit tests for it were actually full of mistakes where the wrong parameters were being sent. I switched this long list of parameters with an object with named properties, and I've updated the unit tests and snapshots to be correct.

### Changed

- Changed the function signature of `defaultMenuLinks` from a long list of positional parameters to a single object parameter with named properties

### Fixed

- Remove required `t` (`i18next` _translate_) function parameter for the `defaultMenuLinks` function used in the healthcare.gov `Header` component

## How to test

Run the unit test and also make sure the Header component works in Storybook

## Discussion

This could potentially be considered a breaking change. I don't know of other teams using this function directly besides the App3 team. If there are, we might want to bump `ds-healthcare-gov` to `8.0.0`. Otherwise, maybe we can consider it only a bugfix even though the API is changing. It'd be safer to call it a breaking change.