### PR TITLE
[WNMGDS-1355] Fix "document is not defined" error during doc-site build

### DIFF
--- a/packages/design-system/src/components/i18n.ts
+++ b/packages/design-system/src/components/i18n.ts
@@ -5,7 +5,10 @@ import get from 'lodash/get';
 export type Language = 'en' | 'es';
 
 function detectDocumentLanguage(): Language | undefined {
-  const detectedLang = document?.querySelector('html')?.lang ?? '';
+  if (typeof document === 'undefined') {
+    return undefined;
+  }
+  const detectedLang = document.querySelector('html')?.lang ?? '';
   if (['en', 'es'].some((lang) => languageMatches(lang, detectedLang))) {
     return detectedLang as Language;
   } else {


### PR DESCRIPTION


## Summary

This is a follow-up to https://github.com/CMSgov/design-system/pull/1668, where I introduced a doc-site-builder bug.

### Fixed

- Fixed `document is not defined` error during doc-site build. It was insufficient to check for `document?.` because even the reference to `document` is not allowed on node, where it is never defined. I also tried `window.document?.`, but that had the same problem on node.

## How to test

Build the doc site with either `yarn start` or `yarn build-docs`
