### PR TITLE
[WNMGDS-1355] Update i18n documentation

### DIFF
--- a/packages/design-system-docs/src/pages/guidelines/i18n.md
+++ b/packages/design-system-docs/src/pages/guidelines/i18n.md
@@ -2,11 +2,13 @@
 title: Internationalization
 ---
 
-The design system's React components accepts all text as `props`, and it is the app's responsibility to provide the internationalized strings.
+## Providing your own internationalized content
 
-For example:
+The design system attempts to make all of its components' text content assignable through their React props. That means you can use your own internationalization solutions to provide the content in your applications. Here is an example:
 
 ```jsx
+// Example of an application providing its own internationalized content
+
 import { Alert } from '{{npm}}';
 import i18n from 'i18n';
 
@@ -14,3 +16,34 @@ export default function () {
   return <Alert heading={i18n('success')}>{i18n('account.created')}</Alert>;
 }
 ```
+
+## Default internationalized content in the design system
+
+<!-- TODO: Once it is true that all default content is internationalized, we can use this opening paragraph instead
+While we want components to be flexible, we also want them to be easy to use, so for some components we do **provide default content**. When we do this, the content comes in English and Spanish.
+-->
+
+<!-- TODO: Replace this paragraph with the above paragraph -->
+
+While we want components to be flexible, we also want them to be easy to use, so for some components we do **provide default content**. Some of this content comes in both English and Spanish, but our goal is to have Spanish translations for all default content in the near future.
+
+For applications that have a `lang` attribute on their html element, **the language will be detected automatically**. If that language is not English or Spanish, the language of the design system will fall back to English. If automatic language detection does not work for your use case, the language can be set manually through the `setLanguage` function. Similarly, the current language can also be read from the `getLanguage` function. Here's an example:
+
+```jsx
+import { getLanguage, setLanguage } from '{{npm}}';
+
+// Set the design system language to something other than the document's detected language
+setLanguage('es');
+
+// Get the design system's current language
+console.log(getLanguage());
+```
+
+<div class="ds-c-alert ds-c-alert--warn ds-u-margin-top--3">
+  <div class="ds-c-alert__body">
+    <h3 class="ds-c-alert__heading">Deprecated per-component langauge props</h3>
+    <p class="ds-c-alert__text">
+      You may notice that some components accept an older `language` or `locale` prop to set the language of the content on a per-component basis, but these per-component props have been deprecated and will be removed in a future breaking-change release.
+    </p>
+  </div>
+</div>

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.stories.jsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.stories.jsx
@@ -24,6 +24,10 @@ export default {
     errorPlacement: {
       defaultValue: 'top',
     },
+    locale: {
+      description:
+        '**This prop has been DEPRECATED.** Do not use. See [internationaliation documentation](https://design.cms.gov/guidelines/i18n/#default-internationalized-content-in-the-design-system)',
+    },
   },
   args: {
     hint: "Month Picker can receive optional help text, giving the user additional information of what's required.",

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
@@ -115,6 +115,12 @@ export const MonthPicker = (props: MonthPickerProps) => {
   const selectedMonths = isControlled ? props.selectedMonths : selectedMonthsState;
   const disabledMonths = props.disabledMonths ?? [];
 
+  if (props.locale) {
+    console.warn(
+      `[Deprecated]: Please remove the 'locale' prop in <MonthPicker> in favor of global language setting. This prop is deprecated and will be removed in a future release.`
+    );
+  }
+
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     if (props.onChange) {
       props.onChange(event);

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
@@ -25,6 +25,9 @@ interface MonthPickerProps {
    */
   name: string;
   /**
+   * @deprecated - This is now deprecated in favor of the global language setting. See guides/internationalization
+   * @hide-prop [Deprecated]
+   *
    * A [BCP 47 language tag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation)
    * for month name localization. For example: Passing `es-US` as a value
    * will render month names in Spanish.

--- a/packages/design-system/src/components/UsaBanner/UsaBanner.stories.jsx
+++ b/packages/design-system/src/components/UsaBanner/UsaBanner.stories.jsx
@@ -7,6 +7,8 @@ export default {
   component: UsaBanner,
   argTypes: {
     locale: {
+      description:
+        '**This prop has been DEPRECATED.** Do not use. See [internationaliation documentation](https://design.cms.gov/guidelines/i18n/#default-internationalized-content-in-the-design-system)',
       control: 'radio',
       options: ['en', 'es'],
     },

--- a/packages/design-system/src/components/UsaBanner/UsaBanner.tsx
+++ b/packages/design-system/src/components/UsaBanner/UsaBanner.tsx
@@ -23,6 +23,9 @@ export interface UsaBannerProps {
    */
   id?: string;
   /**
+   * @deprecated - This is now deprecated in favor of the global language setting. See guides/internationalization
+   * @hide-prop [Deprecated]
+   *
    * The language the USA Banner will be presented in.
    */
   locale?: Language;

--- a/packages/design-system/src/components/UsaBanner/UsaBanner.tsx
+++ b/packages/design-system/src/components/UsaBanner/UsaBanner.tsx
@@ -38,6 +38,12 @@ export const UsaBanner: React.FunctionComponent<UsaBannerProps> = (props: UsaBan
   const id = props.id || uniqueId('gov-banner_');
   const t = tWithLanguage(props.locale);
 
+  if (props.locale) {
+    console.warn(
+      `[Deprecated]: Please remove the 'locale' prop in <UsaBanner> in favor of global language setting. This prop is deprecated and will be removed in a future release.`
+    );
+  }
+
   useEffect(() => {
     let media;
     const onMediaChange = (evt) => {

--- a/packages/ds-healthcare-gov/src/components/Footer/Footer.stories.jsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Footer.stories.jsx
@@ -11,6 +11,8 @@ export default {
       type: { name: 'string', required: false },
     },
     initialLanguage: {
+      description:
+        '**This prop has been DEPRECATED.** Do not use. See [internationaliation documentation](https://design.cms.gov/guidelines/i18n/#default-internationalized-content-in-the-design-system)',
       control: 'radio',
       options: ['en', 'es'],
     },

--- a/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
@@ -10,6 +10,9 @@ export interface FooterProps {
    */
   className?: string;
   /**
+   * @deprecated - This is now deprecated in favor of the global language setting. See guides/internationalization
+   * @hide-prop [Deprecated]
+   *
    * The language the footer will render as.
    */
   initialLanguage?: Language;

--- a/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
@@ -45,6 +45,12 @@ export const Footer = (props: FooterProps) => {
     props.className
   );
 
+  if (props.initialLanguage) {
+    console.warn(
+      `[Deprecated]: Please remove the 'initialLanguage' prop in <Footer> in favor of global language setting. This prop is deprecated and will be removed in a future release.`
+    );
+  }
+
   return (
     <footer className={classes} role="contentinfo">
       {props.footerTop}

--- a/packages/ds-healthcare-gov/src/components/Header/Header.stories.jsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.stories.jsx
@@ -16,6 +16,8 @@ export default {
       control: { type: 'text' },
     },
     initialLanguage: {
+      description:
+        '**This prop has been DEPRECATED.** Do not use. See [internationaliation documentation](https://design.cms.gov/guidelines/i18n/#default-internationalized-content-in-the-design-system)',
       control: 'radio',
       options: ['en', 'es'],
     },

--- a/packages/ds-healthcare-gov/src/components/Header/Header.tsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.tsx
@@ -139,6 +139,12 @@ const Header = (props: HeaderProps) => {
   const [openMenu, setOpenMenu] = useState(false);
   const t = tWithLanguage(props.initialLanguage);
 
+  if (props.initialLanguage) {
+    console.warn(
+      `[Deprecated]: Please remove the 'initialLanguage' prop in <Header> in favor of global language setting. This prop is deprecated and will be removed in a future release.`
+    );
+  }
+
   /**
    * Determines which variation of the header should be displayed,
    * based on the props being passed into the component.

--- a/packages/ds-healthcare-gov/src/components/Header/Header.tsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.tsx
@@ -20,6 +20,9 @@ export interface HeaderProps {
    */
   className?: string;
   /**
+   * @deprecated - This is now deprecated in favor of the global language setting. See guides/internationalization
+   * @hide-prop [Deprecated]
+   *
    * The language the header will render as.
    */
   initialLanguage?: Language;

--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
@@ -48,6 +48,12 @@ export function defaultMenuLinks(options: DefaultMenuLinkOptions = {}) {
   const isSpanish = languageMatches('es', locale);
   const ffmLocalePath = isSpanish ? 'es_MX' : 'en_US';
 
+  if (locale) {
+    console.warn(
+      `[Deprecated]: Please remove the 'initialLanguage' prop in 'defaultMenuLinks' in favor of global language setting. This prop is deprecated and will be removed in a future release.`
+    );
+  }
+
   // NOTE: order matters here and links will be displayed in order added to the arrays
   const loggedOut = [];
   const loggedIn = [];

--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
@@ -13,6 +13,9 @@ export interface DefaultLink extends Link {
 }
 
 export interface DefaultMenuLinkOptions {
+  /**
+   * @deprecated - This is now deprecated in favor of the global language setting. See guides/internationalization
+   */
   locale?: Language;
   deConsumer?: boolean;
   subpath?: string;


### PR DESCRIPTION
## Summary

This is a documentation-update followup to https://github.com/CMSgov/design-system/pull/1668

### Changed

- Rewrote the documentation page for _Internationalization_ to reflect our current stance and features

### Deprecated

- Soft-deprecated old per-component language props in the doc site, Storybook, TypeScript, and in code warnings. These will need to be fully deprecated by removal in a future breaking-change release.
