### PR TITLE
[NO-TICKET] Gatsby path prefix

### DIFF
--- a/packages/docs/gatsby-config.ts
+++ b/packages/docs/gatsby-config.ts
@@ -38,4 +38,8 @@ const config: GatsbyConfig = {
   ],
 };
 
+if (process.env.PATH_PREFIX) {
+  config.pathPrefix = process.env.PATH_PREFIX;
+}
+
 export default config;


### PR DESCRIPTION
## Summary

Read an optional `PATH_PREFIX` environment variable inside the Gatsby config file to allow for using a custom path in our demo sites.

## How to test

Run `PATH_PREFIX='/hello-world' PREFIX_PATHS=true yarn build:gatsby` and check to make sure the resources in `docs/public/index.html` are prefixed with `/hello-world`
