### PR TITLE
[BETA-FIX] Remove bad export of type in ds-healthcare-gov

### DIFF
--- a/packages/ds-healthcare-gov/src/types/index.d.ts
+++ b/packages/ds-healthcare-gov/src/types/index.d.ts
@@ -5,4 +5,3 @@ export * from './Logo';
 export { Button } from './Button';
 
 export * from './flags';
-export type { Language } from './i18n';


### PR DESCRIPTION
## Summary

Fixes the following error that was caught in a downstream project during the beta test:
```
./node_modules/@cmsgov/ds-healthcare-gov/dist/esnext/i18n.js
Attempted import error: 'Language' is not exported from '@cmsgov/design-system'.
```
In #1668, I started exporting that type from the core, but I never cleaned out the old explicit export of that type from healthcare's `types/index.d.ts`.

Unfortunately this file isn't type-checked by our current CI tests. I don't know a good way of type-checking this file, since it relies on the child design system being compiled in order for all of its imports to work. I tried building and pointing `tsconfig` to the dist folder, but that didn't catch the bug. Once we have fully deprecated the old Button props, we can remove this file. The only reason we have it is because of the type override.

### Fixed

- Remove bad export of type in `@cmsgov/ds-healthcare-gov` that is already exported from the core. This was a regression from #1668

