### PR TITLE
[NO-TICKET] Storybook language switcher

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,5 @@
 import './storybookStyles.scss';
-import React, { useEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 import { setLanguage } from '../packages/design-system/src/components/i18n';
 import { setLanguage as setLanguageFromPackage } from '@cmsgov/design-system';
 import { addons } from '@storybook/addons';
@@ -41,10 +41,8 @@ export const globalTypes = {
 
 const languageSettingDecorator = (Story, context) => {
   const { language } = context.globals;
-  // setLanguage(language);
-  useEffect(() => {
-    // This could be called in the main render function, but side-effects are discouraged.
-    // When we do it inside this useEffect, we need to force a re-render
+
+  useLayoutEffect(() => {
     setLanguage(language);
     // In order for it to work in child design systems, which import i18n things from
     // node_modules, we need to also call this version of the function which comes from

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,8 @@
 import './storybookStyles.scss';
+import React, { useEffect } from 'react';
+import { setLanguage } from '../packages/design-system/src/components/i18n';
+import { addons } from '@storybook/addons';
+import { FORCE_RE_RENDER } from '@storybook/core-events';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -18,3 +22,33 @@ export const parameters = {
     ],
   },
 };
+
+export const globalTypes = {
+  language: {
+    name: 'Language',
+    description: 'Internationalization language',
+    defaultValue: 'en',
+    toolbar: {
+      icon: 'globe',
+      items: [
+        { value: 'en', title: 'English' },
+        { value: 'es', title: 'Español' },
+      ],
+    },
+  },
+};
+
+const languageSettingDecorator = (Story, context) => {
+  const { language } = context.globals;
+  // setLanguage(language);
+  useEffect(() => {
+    // This could be called in the main render function, but side-effects are discouraged.
+    // When we do it inside this useEffect, we need to force a re-render
+    setLanguage(language);
+    addons.getChannel().emit(FORCE_RE_RENDER);
+  }, [language]);
+
+  return <Story {...context} />;
+};
+
+export const decorators = [languageSettingDecorator];

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,7 @@
 import './storybookStyles.scss';
 import React, { useEffect } from 'react';
 import { setLanguage } from '../packages/design-system/src/components/i18n';
+import { setLanguage as setLanguageFromPackage } from '@cmsgov/design-system';
 import { addons } from '@storybook/addons';
 import { FORCE_RE_RENDER } from '@storybook/core-events';
 
@@ -45,6 +46,10 @@ const languageSettingDecorator = (Story, context) => {
     // This could be called in the main render function, but side-effects are discouraged.
     // When we do it inside this useEffect, we need to force a re-render
     setLanguage(language);
+    // In order for it to work in child design systems, which import i18n things from
+    // node_modules, we need to also call this version of the function which comes from
+    // our node_modules
+    setLanguageFromPackage(language);
     addons.getChannel().emit(FORCE_RE_RENDER);
   }, [language]);
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,7 @@
 import './storybookStyles.scss';
-import React, { useLayoutEffect } from 'react';
+import React from 'react';
 import { setLanguage } from '../packages/design-system/src/components/i18n';
 import { setLanguage as setLanguageFromPackage } from '@cmsgov/design-system';
-import { addons } from '@storybook/addons';
-import { FORCE_RE_RENDER } from '@storybook/core-events';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -42,14 +40,13 @@ export const globalTypes = {
 const languageSettingDecorator = (Story, context) => {
   const { language } = context.globals;
 
-  useLayoutEffect(() => {
-    setLanguage(language);
-    // In order for it to work in child design systems, which import i18n things from
-    // node_modules, we need to also call this version of the function which comes from
-    // our node_modules
-    setLanguageFromPackage(language);
-    addons.getChannel().emit(FORCE_RE_RENDER);
-  }, [language]);
+  // Yes, this is a side-effect in a render function, but it's the most performant way
+  // to avoid a flash of content in the wrong language.
+  setLanguage(language);
+  // In order for it to work in child design systems, which import i18n things from
+  // node_modules, we need to also call this version of the function which comes from
+  // our node_modules
+  setLanguageFromPackage(language);
 
   return <Story {...context} />;
 };

--- a/packages/design-system/src/components/i18n.ts
+++ b/packages/design-system/src/components/i18n.ts
@@ -23,6 +23,7 @@ export function getLanguage() {
 }
 
 export function setLanguage(lang: Language) {
+  console.log('hey', language);
   language = lang;
 }
 

--- a/packages/design-system/src/components/i18n.ts
+++ b/packages/design-system/src/components/i18n.ts
@@ -23,7 +23,6 @@ export function getLanguage() {
 }
 
 export function setLanguage(lang: Language) {
-  console.log('hey', language);
   language = lang;
 }
 


### PR DESCRIPTION

## Summary

After implementing https://github.com/CMSgov/design-system/pull/1756, I decided to go back and try to set up an easy way to switch between languages in our Storybook.

### Added

Added a language-switching button in our Storybook toolbar

## How to test

- `yarn storybook` - Go to the `UsaBanner` story
- `yarn build && yarn storybook:healthcare` - Check out the `UsaBanner` story, but also check out the healthcare.gov `Header`

## Feedback

My implementation does a React no-no in that it calls a function with side-effects inside a render function. Until https://github.com/CMSgov/design-system/commit/e2736bee7872f71a22be71ebdb8ab4935e251bf6, I was doing it "the right way", but the right way was more complicated, more verbose, and less performant (I surmise at least). I decided to simplify. But would ya'll have kept it as it was?