### PR TITLE
[WNMGDS-1642] Make sure Alerts always have an `aria-labelledby`

### DIFF
--- a/packages/design-system/src/components/Alert/Alert.test.tsx
+++ b/packages/design-system/src/components/Alert/Alert.test.tsx
@@ -101,6 +101,21 @@ describe('Alert', function () {
       renderAlert({ variation: 'warn' });
       expect(screen.getByText('Warning:')).toBeInTheDocument();
     });
+
+    it('points aria-labelledby to heading', () => {
+      const heading = 'Elvis has left the building';
+      renderAlert({ heading, variation: 'error' });
+      const alert = screen.getByRole('region');
+      const id = alert.getAttribute('aria-labelledby');
+      expect(alert.querySelector(`#${id}`).textContent).toContain(`Alert: ${heading}`);
+    });
+
+    it('falls back aria-labelledby to a11y label when no heading is provided', () => {
+      renderAlert();
+      const alert = screen.getByRole('region');
+      const id = alert.getAttribute('aria-labelledby');
+      expect(alert.querySelector(`#${id}`).textContent).toContain('Notice');
+    });
   });
 
   describe('Analytics event tracking', () => {

--- a/packages/design-system/src/components/Alert/Alert.tsx
+++ b/packages/design-system/src/components/Alert/Alert.tsx
@@ -79,11 +79,19 @@ export class Alert extends React.PureComponent<
     headingLevel: '2',
   };
 
+  // Alert class properties
+  alertTextRef: any;
+  focusRef: any;
+  headingId: string;
+  a11yLabelId: string;
+  eventHeadingText: string;
+
   constructor(props: AlertProps) {
     super(props);
     this.alertTextRef = null;
     this.focusRef = null;
     this.headingId = this.props.headingId || uniqueId('alert_');
+    this.a11yLabelId = this.props.a11yLabelId || uniqueId('alert_a11y_label_');
 
     if (process.env.NODE_ENV !== 'production') {
       if (!props.heading && !props.children) {
@@ -136,21 +144,11 @@ export class Alert extends React.PureComponent<
     }
   }
 
-  // Alert class properties
-  alertTextRef: any;
-  focusRef: any;
-  headingId: string;
-  eventHeadingText: string;
-
   heading(): React.ReactElement | void {
     const { headingLevel, heading } = this.props;
-    const Heading = `h${headingLevel}`;
     if (heading) {
-      const headingProps = {
-        className: 'ds-c-alert__heading',
-        id: this.headingId,
-      };
-      return React.createElement(Heading, headingProps, heading);
+      const Heading = `h${headingLevel}` as const;
+      return <Heading className="ds-c-alert__heading">{heading}</Heading>;
     }
   }
 
@@ -201,7 +199,7 @@ export class Alert extends React.PureComponent<
     );
 
     const a11yLabel = (
-      <span className="ds-c-alert__a11y-label ds-u-visibility--screen-reader">
+      <span className="ds-c-alert__a11y-label ds-u-visibility--screen-reader" id={this.a11yLabelId}>
         {t(`alert.${variation ?? 'defaultLabel'}`)}:{' '}
       </span>
     );
@@ -219,11 +217,11 @@ export class Alert extends React.PureComponent<
         }}
         tabIndex={alertRef || autoFocus ? -1 : null}
         role={role}
-        aria-labelledby={heading ? this.headingId : undefined}
+        aria-labelledby={heading ? this.headingId : this.a11yLabelId}
         {...alertProps}
       >
         {this.getIcon()}
-        <div className="ds-c-alert__body">
+        <div className="ds-c-alert__body" id={this.headingId}>
           {heading ? (
             <div className="ds-c-alert__header ds-c-alert__heading">
               {a11yLabel}

--- a/packages/design-system/src/styles/components/_Alert.scss
+++ b/packages/design-system/src/styles/components/_Alert.scss
@@ -116,11 +116,3 @@ $alert-link-color-focus: $color-primary-darkest;
   background-color: $color-success-lightest;
   border-color: $color-success;
 }
-
-.ds-c-alert--heading__hcm {
-  display: flex;
-
-  .ds-c-alert__heading {
-    margin-left: 0.5rem;
-  }
-}


### PR DESCRIPTION
I also moved the id for the header up one level so it would capture our a11y label as well. I discovered that it didn't include the a11y label when I was writing new unit tests.

## Summary

https://jira.cms.gov/browse/WNMGDS-1642

### Fixed

- Previously Alerts without headings had no `aria-labelledby` attribute. The `aria-labelledby` attribute now falls back to the a11y label so that we satisfy the requirement for all `role="region"` elements to have an aria label.

## How to test

<details>
  <summary>Look at the accessibility tree in devtools:</summary>
  
  <img width="1212" alt="Screen Shot 2022-05-02 at 11 46 51 AM" src="https://user-images.githubusercontent.com/7595652/166307025-444e2f2e-2d9f-45e6-ace1-4d8eeda6a716.png">
</details>

## Discussion

There's maybe an opportunity to simplify the HTML here.

```html
<div class="ds-c-alert__header ds-c-alert__heading">
  <span
    class="ds-c-alert__a11y-label ds-u-visibility--screen-reader"
    id="alert_a11y_label_6"
  >
    Notice:
  </span>
  <h2 class="ds-c-alert__heading">This is a simple heading</h2>
</div>
```

Right now we actually have two components with that `ds-c-alert__heading` class. I propose that we actually move the `a11yLabel` inside the `<h#>` heading element. However, [@zarahzachz might have some insight into why it was structured like that](https://github.com/CMSgov/design-system/commit/c549eb59a8e86f92a8c10ded80c5926573aff312#diff-37f97c547f54f69ff76e16809c0f91ced438648da53436cd7dc23b5848286bf9L221) and if it was done for a particular reason.