### PR TITLE
[WNMGDS-1596] Styles > Base content migration

### DIFF
--- a/packages/docs/content/3_styles/1_base.mdx
+++ b/packages/docs/content/3_styles/1_base.mdx
@@ -1,0 +1,30 @@
+---
+title: Base
+---
+import loremIpsumGenerator from '../../src/helpers/loremIpsumGenerator';
+
+
+A base layer of styling can be applied to an area of your site by adding the `.ds-base` class. If you're implementing the design system on a new site, you'd likely want to apply this class to the `<body>` element. On existing sites this might not be desirable. In which case, you could apply the `.ds-base` class to an element which scopes the styling to itself and its children.
+
+Specifically, the base styling sets the following CSS properties:
+
+- `color` is set to `$color-base`
+- `font-family` is set to `$font-sans`
+- `font-size` is set to `$base-font-size`
+- `line-height` is set to `$base-line-height`
+
+<EmbeddedExample>
+    <div class="ds-base ds-u-padding--2">
+        {loremIpsumGenerator('l')}
+    </div>
+</EmbeddedExample>
+
+**Modifier: `.ds-base--inverse` **
+
+Applies an inverse `text color` and `background-color`
+
+<EmbeddedExample>
+    <div class="ds-base ds-base--inverse ds-u-padding--2">
+        {loremIpsumGenerator('l')}
+    </div>
+</EmbeddedExample>

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -28,6 +28,7 @@
     "gatsby-plugin-sitemap": "^5.11.1",
     "gatsby-source-filesystem": "^4.11.1",
     "gatsby-transformer-react-docgen": "^7.13.0",
+    "prettier": "^2.6.2",
     "prismjs": "^1.11.0",
     "react-helmet": "^6.1.0",
     "sass": "^1.43.4"

--- a/packages/docs/src/components/ContentRenderer.tsx
+++ b/packages/docs/src/components/ContentRenderer.tsx
@@ -6,6 +6,8 @@ import { MDXRenderer } from 'gatsby-plugin-mdx';
 import { MDXProvider } from '@mdx-js/react';
 import { toKebabCase } from '../helpers/casingUtils';
 
+import EmbeddedExample from './EmbeddedExample';
+
 interface MdxProviderProps {
   children: string;
 }
@@ -72,6 +74,7 @@ const customComponents = {
   a: LinkWrapper,
   code: CodeWithSyntaxHighlighting,
   pre: PreformattedWithLanguageClass,
+  EmbeddedExample,
 };
 
 interface ContentRendererProps {

--- a/packages/docs/src/components/EmbeddedExample.tsx
+++ b/packages/docs/src/components/EmbeddedExample.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable react/no-danger */
+import React, { useState } from 'react';
+import ReactDOMServer from 'react-dom/server';
+import Prism from 'prismjs';
+import { ArrowIcon } from '@cmsgov/design-system';
+
+interface EmbeddedExampleProps {
+  children: React.ReactElement;
+}
+
+/**
+ * Shows a code example as its rendered form as well as the HTML that is rendered for it
+ *
+ * Using ReactDOMServer's renderToString function to extract the HTML from a React child
+ * @see https://reactjs.org/docs/react-dom-server.html#rendertostring
+ *
+ * @todo HTML formatting is not great -- look into making it better
+ */
+const EmbeddedExample = ({ children }: EmbeddedExampleProps) => {
+  const [open] = useState(false);
+  const html = ReactDOMServer.renderToString(children);
+  const highlightedContent = Prism.highlight(html, Prism.languages.html);
+
+  return (
+    <section className="c-embedded-example">
+      <div className="ds-u-border--1 ds-u-padding--2">{children}</div>
+      <details open={open} className="c-embedded-example__details">
+        <summary className="ds-u-margin-y--1 ds-c-button ds-c-button--small ds-c-button--transparent ds-u-padding--1 ds-u-text-decoration--none">
+          <ArrowIcon direction="right" /> Code snippet
+        </summary>
+        <pre className="ds-u-margin-bottom--4 ds-u-overflow--auto ds-u-padding--2 language-html">
+          <code
+            dangerouslySetInnerHTML={{ __html: highlightedContent }}
+            className="language-html"
+          />
+        </pre>
+      </details>
+    </section>
+  );
+};
+
+export default EmbeddedExample;

--- a/packages/docs/src/components/EmbeddedExample.tsx
+++ b/packages/docs/src/components/EmbeddedExample.tsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import Prism from 'prismjs';
 import { ArrowIcon } from '@cmsgov/design-system';
+import parserHtml from 'prettier/parser-html';
+import prettier from 'prettier';
 
 interface EmbeddedExampleProps {
   children: React.ReactElement;
@@ -19,7 +21,8 @@ interface EmbeddedExampleProps {
 const EmbeddedExample = ({ children }: EmbeddedExampleProps) => {
   const [open] = useState(false);
   const html = ReactDOMServer.renderToString(children);
-  const highlightedContent = Prism.highlight(html, Prism.languages.html);
+  const prettyHtml = prettier.format(html, { parser: 'html', plugins: [parserHtml] });
+  const highlightedContent = Prism.highlight(prettyHtml, Prism.languages.html);
 
   return (
     <section className="c-embedded-example">

--- a/packages/docs/src/helpers/loremIpsumGenerator.ts
+++ b/packages/docs/src/helpers/loremIpsumGenerator.ts
@@ -1,0 +1,19 @@
+type LoremIpsumTextLength = 's' | 'm' | 'l';
+
+const lorem = {
+  s: 'We the People of the United States',
+  m: 'We the People of the United States, in Order to form a more perfect Union',
+  l: 'We the People of the United States, in Order to form a more perfect Union, establish Justice, insure domestic Tranquility, provide for the common defence, promote the general Welfare, and secure the Blessings of Liberty to ourselves and our Posterity, do ordain and establish this Constitution for the United States of America.',
+};
+
+/**
+ * generateLoremIpsum
+ * @param {String} textLength - size of placeholder text to return
+ * @return {String} placeholder text
+ */
+
+export const generateLoremIpsum = (textLength: LoremIpsumTextLength): string => {
+  return lorem[textLength];
+};
+
+export default generateLoremIpsum;

--- a/packages/docs/src/styles/components/embeddedExample.scss
+++ b/packages/docs/src/styles/components/embeddedExample.scss
@@ -1,0 +1,5 @@
+.c-embedded-example__details[open] {
+  .ds-c-icon {
+    transform: rotate(90deg);
+  }
+}

--- a/packages/docs/src/styles/components/syntaxHighlighting.scss
+++ b/packages/docs/src/styles/components/syntaxHighlighting.scss
@@ -1,3 +1,20 @@
+pre,
+code {
+  background-color: $color-gray-lightest;
+  color: $color-black;
+}
+
+pre {
+  display: block;
+  padding: $spacer-2;
+}
+
+code {
+  display: inline-block;
+  font-size: 0.9em;
+  padding: $spacer-half;
+}
+
 /**
  * a11y-light theme for JavaScript, CSS, and HTML
  * Based on the okaidia theme: https://github.com/PrismJS/prism/blob/gh-pages/themes/prism-okaidia.css

--- a/packages/docs/src/styles/index.scss
+++ b/packages/docs/src/styles/index.scss
@@ -4,6 +4,7 @@
 
 @import 'pages/layout.scss';
 
+@import 'components/embeddedExample.scss';
 @import 'components/footer.scss';
 @import 'components/header.scss';
 @import 'components/mobileNavButton.scss';

--- a/yarn.lock
+++ b/yarn.lock
@@ -22964,6 +22964,11 @@ prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
+prettier@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"


### PR DESCRIPTION
## Summary

* Migrating the Styles/Base page content
  * Updated the content for MDX
* Add an `EmbeddedExample` component that will render some elements as well as the HTML for them.
  * I did update the arrow used for the 'Code Snippet' portion to use one of our DS arrows

## How to test

`yarn start:gatsby`. Navigate to Styles > Base and click through page

Code snippets closed:
<img width="1792" alt="Screen Shot 2022-05-03 at 11 38 07 AM" src="https://user-images.githubusercontent.com/33579665/166508432-4042b43b-136b-414d-8336-20c67e54ac0d.png">

Code snippets open:
<img width="1792" alt="Screen Shot 2022-05-03 at 11 38 22 AM" src="https://user-images.githubusercontent.com/33579665/166508469-30706069-5d28-4bb9-829e-02680e55aef0.png">
