### PR TITLE
[NO-TICKET] Use exact design-system version in child design systems

### DIFF
--- a/packages/design-system-docs/package.json
+++ b/packages/design-system-docs/package.json
@@ -13,7 +13,7 @@
   },
   "license": "SEE LICENSE IN LICENSE.md",
   "dependencies": {
-    "@cmsgov/design-system": "^3.3.1",
+    "@cmsgov/design-system": "3.3.1",
     "classnames": "^2.2.5",
     "lodash": "^4.17.19",
     "prismjs": "^1.11.0",

--- a/packages/ds-healthcare-gov/package.json
+++ b/packages/ds-healthcare-gov/package.json
@@ -20,7 +20,7 @@
     "src"
   ],
   "dependencies": {
-    "@cmsgov/design-system": "^3.3.1",
+    "@cmsgov/design-system": "3.3.1",
     "@types/js-cookie": "^3.0.2",
     "@types/react": "^17.0.10",
     "@types/react-dom": "^17.0.10",

--- a/packages/ds-medicare-gov/package.json
+++ b/packages/ds-medicare-gov/package.json
@@ -25,7 +25,7 @@
     "src"
   ],
   "dependencies": {
-    "@cmsgov/design-system": "^3.3.1",
+    "@cmsgov/design-system": "3.3.1",
     "@types/react": "^17.0.10",
     "@types/react-dom": "^17.0.10"
   },


### PR DESCRIPTION

## Summary

Because we're releasing packages at the same time, there's no reason for child design systems to have the more fuzzy `^` version matcher. A certain child design system release is always built for a specific core design system release. If teams ever need to revert or use a specific version of their child design system, the exact version will ensure that their resolved core package dependency in their lockfiles will always stay in sync.

### Changed

- Changed child-design-system and docs package files to use an exact version of the core design-system package
