### PR TITLE
[NO-TICKET] Add missing node-sass dependency to TS example

### DIFF
--- a/examples/create-react-app-typescript/package.json
+++ b/examples/create-react-app-typescript/package.json
@@ -7,6 +7,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
+    "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.3",


### PR DESCRIPTION
## Summary

The `examples/create-react-app` example has this dependency, but `examples/create-react-app-typescript` doesn't. Fixes #1122

### Fixed

- Fixed missing dependency in the `create-react-app-typescript` example, which only shows up if you are running it outside the context of our monorepo workspace

## How to test

1. Copy the `examples/create-react-app-typescript` directory somewhere else on your filesystem, and cd to it
2. Run `yarn install && yarn start`
