### PR TITLE
[WNMGDS-1664] Deprecate nav menu Mgov component

### DIFF
--- a/packages/ds-medicare-gov/docs/src/pages/components/NavigationMenu/NavigationMenu.docs.scss
+++ b/packages/ds-medicare-gov/docs/src/pages/components/NavigationMenu/NavigationMenu.docs.scss
@@ -1,6 +1,16 @@
 /*
 Navigation Menu
 
+<div class="ds-c-alert ds-c-alert--error">
+    <div class="ds-c-alert__body">
+      <h2 class="ds-c-alert__heading">Deprecation Notice</h2>
+      <p class="ds-c-alert__text">
+        This component has been marked as 'deprecated' and will be removed in a future release. Please use the component `Consistent Header` instead.
+        See details for `Consistent Header` on the <a href="https://cmsgov.github.io/design-system/medicare/patterns/consistent-header/">Consitent header page</a>.
+      </p>
+    </div>
+</div>
+
 Style guide: components.navigation-menu
 */
 


### PR DESCRIPTION
## Summary

This is no longer in use due to the Consistent header provided by the max team. We can mark this for deprecation on the site.

### Deprecated

Nav menu

## How to test

Run the medicare doc site locally with `yarn start:medicare` and see that the navigation menu page has a deprecation notice 