### PR TITLE
adding copper swatches and assigning focus style

### DIFF
--- a/packages/design-system-tokens/src/themes/medicare.ts
+++ b/packages/design-system-tokens/src/themes/medicare.ts
@@ -63,7 +63,7 @@ const themeColors: ColorTokens = {
   'error-lighter':              color['rose-100'],
   'error-lightest':             color['crimson-50'],
   //
-  'focus':                      color['darksky-500'],
+  'focus':                      color['copper-500'],
   'focus-border-inverse':       color['goldenrod-800'],
   'focus-dark':                 color['orchid-500'],
   'focus-inverse':              color['sky-500'],

--- a/packages/design-system-tokens/src/tokens/color.ts
+++ b/packages/design-system-tokens/src/tokens/color.ts
@@ -196,6 +196,18 @@ const color = to<ColorTokens>()({
   'persimmon-800':   '#6f1b02',
   'persimmon-900':   '#421001',
   'persimmon-1000':  '#160500',
+
+  'copper-50':       '#faf1eb',
+  'copper-100':      '#efd6c2',
+  'copper-200':      '#e4ba99',
+  'copper-300':      '#d99e70',
+  'copper-400':      '#ce8347',
+  'copper-500':      '#C97532',
+  'copper-600':      '#b5692d',
+  'copper-700':      '#8d5223',
+  'copper-800':      '#653b19',
+  'copper-900':      '#3c230f',
+  'copper-1000':     '#140c05',
 });
 
 export default color;


### PR DESCRIPTION
## Summary

Adds copper colors to color tokens and changes medicare focus token to `copper-500`
