### PR TITLE
[WNMGDS-1676] component content pt 4

### DIFF
--- a/packages/design-system/src/components/Table/Table.stories.jsx
+++ b/packages/design-system/src/components/Table/Table.stories.jsx
@@ -103,6 +103,9 @@ const Template = (args) => (
 );
 
 export const ScrollableTable = Template.bind({});
+ScrollableTable.args = {
+  scrollable: true,
+};
 
 export const StackableTable = Template.bind({});
 StackableTable.args = {

--- a/packages/design-system/src/components/Tabs/Tabs.stories.jsx
+++ b/packages/design-system/src/components/Tabs/Tabs.stories.jsx
@@ -11,7 +11,7 @@ export default {
   subcomponents: { TabPanel, Tab },
 };
 
-export const Tabs = (args) => (
+export const DefaultTabs = (args) => (
   <TabsComponent {...args}>
     <TabPanel id="summary" tab="Summary">
       The Bill of Rights is the first ten amendments to the United States Constitution.

--- a/packages/docs/content/5_components/accordion.mdx
+++ b/packages/docs/content/5_components/accordion.mdx
@@ -3,6 +3,7 @@ title: Accordion
 status: draft
 relatedUswdsGuidance: components/accordion
 ---
+
 import ViewSourceLink from '../../src/components/ViewSourceLink';
 
 An accordion is a list of headers that hide or reveal additional content when selected.

--- a/packages/docs/content/5_components/accordion.mdx
+++ b/packages/docs/content/5_components/accordion.mdx
@@ -3,6 +3,7 @@ title: Accordion
 status: draft
 relatedUswdsGuidance: components/accordion
 ---
+import ViewSourceLink from '../../src/components/ViewSourceLink';
 
 An accordion is a list of headers that hide or reveal additional content when selected.
 
@@ -20,9 +21,7 @@ An accordion is a list of headers that hide or reveal additional content when se
 
 ## `<AccordionItem>`
 
-<a href="https://github.com/CMSgov/design-system/blob/master/packages/design-system/src/components/Accordion/AccordionItem.tsx">
-  View source file
-</a>
+<ViewSourceLink sourceFilePath="components/Accordion/AccordionItem.tsx" />
 
 `AccordionItem` renders the Accordion element.
 

--- a/packages/docs/content/5_components/drawer.mdx
+++ b/packages/docs/content/5_components/drawer.mdx
@@ -1,6 +1,7 @@
 ---
 title: Drawer & Help Drawer
 ---
+import ViewSourceLink from '../../src/components/ViewSourceLink';
 
 A drawer provides a space for medium to long-form help content — content that's too long or not common enough to warrant being on the page by default.
 
@@ -40,9 +41,7 @@ A focus trap can be set on a drawer if the property `hasFocusTrap` is enabled. A
 
 ## `<DrawerToggle>`
 
-<a href="https://github.com/CMSgov/design-system/blob/master/packages/design-system/src/components/Drawer/DrawerToggle.tsx">
-  View source file{' '}
-</a>
+<ViewSourceLink sourceFilePath="components/Drawer/DrawerToggle.tsx" />
 
 <PropTable componentName="DrawerToggle" />
 
@@ -50,9 +49,7 @@ A focus trap can be set on a drawer if the property `hasFocusTrap` is enabled. A
 
 This component is an enhanced `<Drawer>` component, providing the same properties as `<Drawer>` in addition to Google Analytics properties.
 
-<a href="https://github.com/CMSgov/design-system/blob/master/packages/design-system/src/components/Drawer/DrawerToggle.tsx">
-  View source file{' '}
-</a>
+<ViewSourceLink sourceFilePath="components/HelpDrawer/HelpDrawer.tsx" />
 
 <PropTable componentName="HelpDrawer" />
 

--- a/packages/docs/content/5_components/drawer.mdx
+++ b/packages/docs/content/5_components/drawer.mdx
@@ -1,6 +1,7 @@
 ---
 title: Drawer & Help Drawer
 ---
+
 import ViewSourceLink from '../../src/components/ViewSourceLink';
 
 A drawer provides a space for medium to long-form help content — content that's too long or not common enough to warrant being on the page by default.

--- a/packages/docs/content/5_components/spinner.mdx
+++ b/packages/docs/content/5_components/spinner.mdx
@@ -1,6 +1,7 @@
 ---
 title: Spinner
 ---
+
 import { Spinner, Button } from '@cmsgov/design-system';
 import loremIpsumGenerator from '../../src/helpers/loremIpsumGenerator';
 
@@ -13,12 +14,20 @@ To change the color of the spinner, one only has to change the `color` property 
 ## Use inside buttons
 
 <EmbeddedExample>
-    <>
-        <Button className="ds-u-margin-right--2"><Spinner size="small" /> Loading </Button>
-        <Button variation="primary" className="ds-u-margin-right--2"><Spinner size="small" inversed/> Loading </Button>
-        <Button size="big" className="ds-u-margin-right--2"><Spinner/> Big button </Button>
-        <Button size="big" variation="success" className="ds-u-margin-right--2"><Spinner/> Big green button </Button>
-    </>
+  <>
+    <Button className="ds-u-margin-right--2">
+      <Spinner size="small" /> Loading{' '}
+    </Button>
+    <Button variation="primary" className="ds-u-margin-right--2">
+      <Spinner size="small" inversed /> Loading{' '}
+    </Button>
+    <Button size="big" className="ds-u-margin-right--2">
+      <Spinner /> Big button{' '}
+    </Button>
+    <Button size="big" variation="success" className="ds-u-margin-right--2">
+      <Spinner /> Big green button{' '}
+    </Button>
+  </>
 </EmbeddedExample>
 
 ## "Filled" mode
@@ -26,20 +35,29 @@ To change the color of the spinner, one only has to change the `color` property 
 To provide more contrast when being rendered over other content, the `.ds-c-spinner--filled` class can be added to give it an appropriately shaped background with some padding.
 
 <EmbeddedExample>
-    <>
-        <div class="ds-u-fill--background-inverse ds-u-color--base-inverse ds-u-padding--2"  style="position: relative">
-                <p>{loremIpsumGenerator('l')}</p>
-                <div class="ds-u-display--flex ds-u-justify-content--center ds-u-align-items--center" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0">
-                  <Spinner filled aria-valuetext="Loading"/>
-                </div>
-        </div>
-         <div class="ds-u-padding--2"  style="position: relative">
-                <p>{loremIpsumGenerator('l')}</p>
-                <div class="ds-u-display--flex ds-u-justify-content--center ds-u-align-items--center" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0">
-                  <Spinner filled inversed aria-valuetext="Loading"/>
-                </div>
-        </div>
-    </>
+  <>
+    <div
+      class="ds-u-fill--background-inverse ds-u-color--base-inverse ds-u-padding--2"
+      style="position: relative"
+    >
+      <p>{loremIpsumGenerator('l')}</p>
+      <div
+        class="ds-u-display--flex ds-u-justify-content--center ds-u-align-items--center"
+        style="position: absolute; width: 100%; height: 100%; top: 0; left: 0"
+      >
+        <Spinner filled aria-valuetext="Loading" />
+      </div>
+    </div>
+    <div class="ds-u-padding--2" style="position: relative">
+      <p>{loremIpsumGenerator('l')}</p>
+      <div
+        class="ds-u-display--flex ds-u-justify-content--center ds-u-align-items--center"
+        style="position: absolute; width: 100%; height: 100%; top: 0; left: 0"
+      >
+        <Spinner filled inversed aria-valuetext="Loading" />
+      </div>
+    </div>
+  </>
 </EmbeddedExample>
 
 ## `<Spinner>`

--- a/packages/docs/content/5_components/spinner.mdx
+++ b/packages/docs/content/5_components/spinner.mdx
@@ -1,0 +1,86 @@
+---
+title: Spinner
+---
+import { Spinner, Button } from '@cmsgov/design-system';
+import loremIpsumGenerator from '../../src/helpers/loremIpsumGenerator';
+
+Spinners signify that the application is waiting for an asynchronous operation to complete.
+
+## Changing the spinner color
+
+To change the color of the spinner, one only has to change the `color` property of the spinner element. This can be done with the standard Design System [utility classes](/utilities/color). The color of the spinner also defaults to `inherit`, so it will take on the color of the text in its parent container.
+
+## Use inside buttons
+
+<EmbeddedExample>
+    <>
+        <Button className="ds-u-margin-right--2"><Spinner size="small" /> Loading </Button>
+        <Button variation="primary" className="ds-u-margin-right--2"><Spinner size="small" inversed/> Loading </Button>
+        <Button size="big" className="ds-u-margin-right--2"><Spinner/> Big button </Button>
+        <Button size="big" variation="success" className="ds-u-margin-right--2"><Spinner/> Big green button </Button>
+    </>
+</EmbeddedExample>
+
+## "Filled" mode
+
+To provide more contrast when being rendered over other content, the `.ds-c-spinner--filled` class can be added to give it an appropriately shaped background with some padding.
+
+<EmbeddedExample>
+    <>
+        <div class="ds-u-fill--background-inverse ds-u-color--base-inverse ds-u-padding--2"  style="position: relative">
+                <p>{loremIpsumGenerator('l')}</p>
+                <div class="ds-u-display--flex ds-u-justify-content--center ds-u-align-items--center" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0">
+                  <Spinner filled aria-valuetext="Loading"/>
+                </div>
+        </div>
+         <div class="ds-u-padding--2"  style="position: relative">
+                <p>{loremIpsumGenerator('l')}</p>
+                <div class="ds-u-display--flex ds-u-justify-content--center ds-u-align-items--center" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0">
+                  <Spinner filled inversed aria-valuetext="Loading"/>
+                </div>
+        </div>
+    </>
+</EmbeddedExample>
+
+## `<Spinner>`
+
+<StorybookExample
+  componentName="spinner"
+  sourceFilePath="components/Spinner/Spinner.tsx"
+  storyId="components-spinner--default-spinner"
+/>
+
+### Props
+
+<PropTable componentName="Spinner" />
+
+## Guidance
+
+### When to use
+
+- To indicate a loading state for quick asynchronous tasks
+
+### When to consider alternatives
+
+- When the process it is waiting for takes a long time. Spinners provide no feedback other than that _we're waiting_, so long processes can make users nervous that something went wrong. Consider adding descriptive text or another UX pattern entirely.
+- When you are loading a whole page of content. If all you show the user is a spinner, the user may spend several seconds watching the spinner to be surprised with all the content all at once. Consider using a [_skeleton screen_](https://www.lukew.com/ff/entry.asp?1797) so the user knows what to expect.
+
+### Usage
+
+- If the process takes a long time, use something else.
+
+### Accessibility
+
+- The Spinner element should have an [`aria-valuetext`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute) attribute with a value of `loading` to provide a human readable text alternative for screen readers.
+- When placed within a parent container, the parent element should include several ARIA attributes: `aria-relevant`, `aria-live`, and optionally `aria-atomic`.
+  - `aria-relevant` may include `additions`, `text`, and `removals`. If a section will have items added or removed, use `additions removals`. If there will be additions or text changes without explicit removals, use `additions text`.
+  - `aria-live` should be set to `polite` for a screen reader to speak the changes whenever the user is idle. `aria-live="assertive"` should only be used in situations that require a user&rsquo;s immediate attention.
+  - By default, a screen reader will only speak the contents of a changed node, and not the entire contents of the element. Set `aria-atomic="true"` for cases, such as an address, where a screen reader should read the contents of the entire element.
+
+### Learn more
+
+- [Response Times](https://www.nngroup.com/articles/response-times-3-important-limits/)
+- [Progress Indicators](https://www.nngroup.com/articles/progress-indicators/)
+- [GOV.UK Loading patterns discussion](https://paper.dropbox.com/doc/Loading-patterns-v0x8Xych1PbZQXOlbP3L6)
+- [Avoid the Spinner](https://www.lukew.com/ff/entry.asp?1797)
+- [ARIA Live Regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)

--- a/packages/docs/content/5_components/table.mdx
+++ b/packages/docs/content/5_components/table.mdx
@@ -3,7 +3,15 @@ title: Table
 relatedUswdsGuidance: components/tables
 status: draft
 ---
-import { Table, TableBody, TableCaption, TableCell, TableHead, TableRow } from '@cmsgov/design-system';
+
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableRow,
+} from '@cmsgov/design-system';
 import ResponsiveExample from '../../src/components/ResponsiveExample';
 import ViewSourceLink from '../../src/components/ViewSourceLink';
 
@@ -12,42 +20,60 @@ Tables show tabular data in columns and rows.
 ## Table with multi headers and a caption
 
 <EmbeddedExample>
-    <Table>
-        <TableCaption>Household members</TableCaption>
-        <col />
-        <colgroup span="2"></colgroup>
-        <colgroup span="2"></colgroup>
-        <TableHead>
-            <TableRow>
-                <TableCell component="td" rowspan="1"></TableCell>
-                <TableCell component="th" colspan="2" className="ds-u-text-align--center" scope="colgroup">Address</TableCell>
-                <TableCell component="th" colspan="2" className="ds-u-text-align--center" scope="colgroup">Employment</TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell component="th" scope="col">Name</TableCell>
-                <TableCell component="th" scope="col">Street</TableCell>
-                <TableCell component="th" scope="col">ZIP code</TableCell>
-                <TableCell component="th" scope="col">Employer</TableCell>
-                <TableCell component="th" scope="col">Industry</TableCell>
-            </TableRow>
-        </TableHead>
-        <TableBody>
-            <TableRow>
-                <TableCell component="th" scope="row">John Doe</TableCell>
-                <TableCell component="td">123 Braavos Ave.</TableCell>
-                <TableCell component="td">20005</TableCell>
-                <TableCell component="td">Acme Co.</TableCell>
-                <TableCell component="td">Healthcare</TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell component="th" scope="row">Jane Doe</TableCell>
-                <TableCell component="td">456 King's Landing</TableCell>
-                <TableCell component="td">20005</TableCell>
-                <TableCell component="td">Acme Co.</TableCell>
-                <TableCell component="td">Healthcare</TableCell>
-            </TableRow>
-        </TableBody>
-    </Table>
+  <Table>
+    <TableCaption>Household members</TableCaption>
+    <col />
+    <colgroup span="2"></colgroup>
+    <colgroup span="2"></colgroup>
+    <TableHead>
+      <TableRow>
+        <TableCell component="td" rowspan="1"></TableCell>
+        <TableCell component="th" colspan="2" className="ds-u-text-align--center" scope="colgroup">
+          Address
+        </TableCell>
+        <TableCell component="th" colspan="2" className="ds-u-text-align--center" scope="colgroup">
+          Employment
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell component="th" scope="col">
+          Name
+        </TableCell>
+        <TableCell component="th" scope="col">
+          Street
+        </TableCell>
+        <TableCell component="th" scope="col">
+          ZIP code
+        </TableCell>
+        <TableCell component="th" scope="col">
+          Employer
+        </TableCell>
+        <TableCell component="th" scope="col">
+          Industry
+        </TableCell>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      <TableRow>
+        <TableCell component="th" scope="row">
+          John Doe
+        </TableCell>
+        <TableCell component="td">123 Braavos Ave.</TableCell>
+        <TableCell component="td">20005</TableCell>
+        <TableCell component="td">Acme Co.</TableCell>
+        <TableCell component="td">Healthcare</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell component="th" scope="row">
+          Jane Doe
+        </TableCell>
+        <TableCell component="td">456 King's Landing</TableCell>
+        <TableCell component="td">20005</TableCell>
+        <TableCell component="td">Acme Co.</TableCell>
+        <TableCell component="td">Healthcare</TableCell>
+      </TableRow>
+    </TableBody>
+  </Table>
 </EmbeddedExample>
 
 ## `<Table>`
@@ -59,53 +85,68 @@ responsive features including horizontal scrolling and vertically stacked rows.
 <ViewSourceLink sourceFilePath="components/Table/Table.tsx" />
 
 ### Scrollable Table
-<ResponsiveExample
-  title="Scrollable table example"
-  storyId="components-table--scrollable-table"
-/>
+
+<ResponsiveExample title="Scrollable table example" storyId="components-table--scrollable-table" />
 
 ### Stackable Table
+
 <ResponsiveExample
   componentName="stackable table example"
   storyId="components-table--stackable-table"
 />
 
 ### Table Props
+
 <PropTable componentName="Table" />
 
 ## `<TableCaption>`
+
 `TableCaption` renders the `<caption>` element.
+
 <ViewSourceLink sourceFilePath="components/Table/TableCaption.tsx" />
 
 ### Table Caption Props
+
 <PropTable componentName="TableCaption" />
 
 ## `<TableHead>`
+
 `TableHead` renders the `<thead>` element and will typically contain `TableRow` elements to define table columns.
+
 <ViewSourceLink sourceFilePath="components/Table/TableHead.tsx" />
 
 ### Table Head Props
+
 <PropTable componentName="TableHead" />
 
 ## `<TableBody>`
+
 `TableBody` renders the `<tbody>` element and will typically contain `TableRow` elements to define table data.
+
 <ViewSourceLink sourceFilePath="components/Table/TableBody.tsx" />
 
 ### Table Body Props
+
 <PropTable componentName="TableBody" />
 
 ## `<TableRow>`
+
 `TableRow` renders a `<tr>` element.
+
 <ViewSourceLink sourceFilePath="components/Table/TableRow.tsx" />
 
 ### Table Row Props
+
 <PropTable componentName="TableRow" />
 
 ## `<TableCell>`
+
 `TableCell` dynamically renders a `<th>` or `<td>` element based on the parent component or user specified `component` prop. By default `TableCell` will automatically render a `<th>` element if the parent component is `TableHead`, otherwise it will render a `<td>` element.
+
 <ViewSourceLink sourceFilePath="components/Table/TableCell.tsx" />
 
 ### Table Cell Props
+
 <PropTable componentName="TableCell" />
 
 ## Guidance

--- a/packages/docs/content/5_components/table.mdx
+++ b/packages/docs/content/5_components/table.mdx
@@ -1,0 +1,147 @@
+---
+title: Table
+relatedUswdsGuidance: components/tables
+status: draft
+---
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableRow } from '@cmsgov/design-system';
+import ResponsiveExample from '../../src/components/ResponsiveExample';
+import ViewSourceLink from '../../src/components/ViewSourceLink';
+
+Tables show tabular data in columns and rows.
+
+## Table with multi headers and a caption
+
+<EmbeddedExample>
+    <Table>
+        <TableCaption>Household members</TableCaption>
+        <col />
+        <colgroup span="2"></colgroup>
+        <colgroup span="2"></colgroup>
+        <TableHead>
+            <TableRow>
+                <TableCell component="td" rowspan="1"></TableCell>
+                <TableCell component="th" colspan="2" className="ds-u-text-align--center" scope="colgroup">Address</TableCell>
+                <TableCell component="th" colspan="2" className="ds-u-text-align--center" scope="colgroup">Employment</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell component="th" scope="col">Name</TableCell>
+                <TableCell component="th" scope="col">Street</TableCell>
+                <TableCell component="th" scope="col">ZIP code</TableCell>
+                <TableCell component="th" scope="col">Employer</TableCell>
+                <TableCell component="th" scope="col">Industry</TableCell>
+            </TableRow>
+        </TableHead>
+        <TableBody>
+            <TableRow>
+                <TableCell component="th" scope="row">John Doe</TableCell>
+                <TableCell component="td">123 Braavos Ave.</TableCell>
+                <TableCell component="td">20005</TableCell>
+                <TableCell component="td">Acme Co.</TableCell>
+                <TableCell component="td">Healthcare</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell component="th" scope="row">Jane Doe</TableCell>
+                <TableCell component="td">456 King's Landing</TableCell>
+                <TableCell component="td">20005</TableCell>
+                <TableCell component="td">Acme Co.</TableCell>
+                <TableCell component="td">Healthcare</TableCell>
+            </TableRow>
+        </TableBody>
+    </Table>
+</EmbeddedExample>
+
+## `<Table>`
+
+`Table` is a container component that contains `TableCaption`, `TableHead` and `TableBody` as children,
+as well as `TableRow` and `TableCell` for the table content. These components mostly follow ordinary HTML table semantics, but also include some additional
+responsive features including horizontal scrolling and vertically stacked rows.
+
+<ViewSourceLink sourceFilePath="components/Table/Table.tsx" />
+
+### Scrollable Table
+<ResponsiveExample
+  title="Scrollable table example"
+  storyId="components-table--scrollable-table"
+/>
+
+### Stackable Table
+<ResponsiveExample
+  componentName="stackable table example"
+  storyId="components-table--stackable-table"
+/>
+
+### Table Props
+<PropTable componentName="Table" />
+
+## `<TableCaption>`
+`TableCaption` renders the `<caption>` element.
+<ViewSourceLink sourceFilePath="components/Table/TableCaption.tsx" />
+
+### Table Caption Props
+<PropTable componentName="TableCaption" />
+
+## `<TableHead>`
+`TableHead` renders the `<thead>` element and will typically contain `TableRow` elements to define table columns.
+<ViewSourceLink sourceFilePath="components/Table/TableHead.tsx" />
+
+### Table Head Props
+<PropTable componentName="TableHead" />
+
+## `<TableBody>`
+`TableBody` renders the `<tbody>` element and will typically contain `TableRow` elements to define table data.
+<ViewSourceLink sourceFilePath="components/Table/TableBody.tsx" />
+
+### Table Body Props
+<PropTable componentName="TableBody" />
+
+## `<TableRow>`
+`TableRow` renders a `<tr>` element.
+<ViewSourceLink sourceFilePath="components/Table/TableRow.tsx" />
+
+### Table Row Props
+<PropTable componentName="TableRow" />
+
+## `<TableCell>`
+`TableCell` dynamically renders a `<th>` or `<td>` element based on the parent component or user specified `component` prop. By default `TableCell` will automatically render a `<th>` element if the parent component is `TableHead`, otherwise it will render a `<td>` element.
+<ViewSourceLink sourceFilePath="components/Table/TableCell.tsx" />
+
+### Table Cell Props
+<PropTable componentName="TableCell" />
+
+## Guidance
+
+### When to use
+
+- When you need tabular information, such as statistical data.
+- When users need to compare sets of information.
+
+### When to consider alternatives
+
+- Depending on the type of content, consider using other presentation formats such as definition lists or hierarchical lists.
+- If you're writing out name / value pairs, there's often a more compact way compared to using a table.
+
+### Usage
+
+- Right-align numerical data in tables. You can use the `align` prop on the TableCell to accomplish this. Right alignment makes it easier to scan and compare numerical values.
+
+### Accessibility
+
+- Tables can have two levels of headers. Each header cell should have `scope="col"` or `scope="row"`. [Learn more about the "scope" attribute.](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope)
+- Complex tables are tables with more than two levels of headers. Each header should be given a unique `id` and each data cell should have a `headers` attribute with each related header cell’s `id` listed.
+- When adding a title to a table, include it in a `<caption>` tag inside of the `<table>` element.
+
+### Customization
+
+The following Sass variables can be overridden to theme table fields:
+
+- `$table-border-color`
+- `$table-header-background-color`
+- `$table-striped-background-color`
+- `$table-striped-header-background-color`
+- `$table-padding`
+- `$table-compact-padding`
+
+### Learn more
+
+- [W3C Web Accessibility Tutorial \- Table Concepts](https://www.w3.org/WAI/tutorials/tables/)
+- [Design Better Data Tables](https://medium.com/mission-log/design-better-data-tables-430a30a00d8c)

--- a/packages/docs/content/5_components/tabs.mdx
+++ b/packages/docs/content/5_components/tabs.mdx
@@ -1,0 +1,64 @@
+---
+title: Tabs
+---
+import ViewSourceLink from '../../src/components/ViewSourceLink';
+
+Tabs are a secondary navigation pattern, allowing a user to view only the content they're interested in. They build upon a real world metaphor, and the selected state simulates a folder being physically in front of others in the group.
+
+## `<Tabs>`
+
+`Tabs` is a container component that manages the state of your tabs for you. In most cases, you'll want to use this component rather than the presentational components (`Tab`, `TabPanel`) on their own.
+
+<StorybookExample
+  componentName="tabs"
+  sourceFilePath="components/Tabs/Tabs.tsx"
+  storyId="components-tabs--default-tabs"
+  minHeight={400}
+/>
+
+### Tabs Props
+
+<PropTable componentName="Tabs" />
+
+## `<TabPanel>`
+A `TabPanel` is a presentational component which accepts a tab's content as its `children`.
+
+<ViewSourceLink sourceFilePath="components/Tabs/TabPanel.tsx" />
+
+### Tab Panel Props
+
+<PropTable componentName="TabPanel" />
+
+## Guidance
+
+### When to use
+
+- If you have sub-sections of a page, and there's the need to only show one sub-section at a time.
+
+### When to consider alternatives
+
+- If you have more than four tabs. Consider using a different pattern if your content requires being split into more than four panels.
+- If the panel contents can be displayed at once. This will improve the scanability of your page's content and it's more likely the user will be able to find what they're looking for. Typography, including clear section headers, should be enough to allow the user to navigate the page.
+
+### Usage
+
+- Avoid overflowing tabs to new lines. If the tabs can't fit on one row on small screens, consider using utility classes to apply additional responsive styles or use a different pattern.
+- Tab labels should be descriptive of their content and set the user's expectations.
+- Tab labels should be short — aim for no more than two words.
+
+### Accessibility
+
+- Use an anchor link (`a`) to create the tabs. This allows you to link directly to a tab, and allows you to progressively enhance the page, retaining default browser behavior like opening links in a new window. _Note: You'll need to implement the logic for selecting the correct tab based on the current URL._
+- Ensure the HTML markup includes the proper ARIA attributes:
+  - For tabs: `role`, `aria-selected`, `aria-controls`
+  - For the tabs list parent: `role`, `aria-label`
+  - For a tab panel: `role`, `aria-labelledby`
+
+### Related patterns
+
+- [Vertical navigation](/components/vertical-nav)
+
+### Learn more
+
+- [How Tabs Should Work](https://24ways.org/2015/how-tabs-should-work/)
+- [Simple ARIA tab interface](http://heydonworks.com/practical_aria_examples/#tab-interface)

--- a/packages/docs/content/5_components/tabs.mdx
+++ b/packages/docs/content/5_components/tabs.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tabs
 ---
+
 import ViewSourceLink from '../../src/components/ViewSourceLink';
 
 Tabs are a secondary navigation pattern, allowing a user to view only the content they're interested in. They build upon a real world metaphor, and the selected state simulates a folder being physically in front of others in the group.
@@ -21,6 +22,7 @@ Tabs are a secondary navigation pattern, allowing a user to view only the conten
 <PropTable componentName="Tabs" />
 
 ## `<TabPanel>`
+
 A `TabPanel` is a presentational component which accepts a tab's content as its `children`.
 
 <ViewSourceLink sourceFilePath="components/Tabs/TabPanel.tsx" />

--- a/packages/docs/content/5_components/text-field.mdx
+++ b/packages/docs/content/5_components/text-field.mdx
@@ -2,6 +2,7 @@
 title: Text field
 relatedUswdsGuidance: components/form-controls/#text-input
 ---
+
 import ViewSourceLink from '../../src/components/ViewSourceLink';
 
 Text fields allow users to enter any combination of letters, numbers, or symbols of their choosing (unless otherwise restricted). Text fields can span single or multiple lines.
@@ -9,37 +10,37 @@ Text fields allow users to enter any combination of letters, numbers, or symbols
 ## `<TextField>`
 
 A `TextField` component renders an input field as well as supporting UI elements like a label, error message, and hint text.
+
 <ViewSourceLink sourceFilePath="components/TextField/TextField.tsx" />
 
 ### Single line field
+
 <StorybookExample
   componentName="single text field"
   storyId="components-text-field--single-line-field"
 />
 
 ### Multiline field
+
 <StorybookExample
   componentName="multi text field"
   storyId="components-text-field--multiline-field"
 />
 
 ### Error field
-<StorybookExample
-  componentName="error field"
-  storyId="components-text-field--error-field"
-/>
+
+<StorybookExample componentName="error field" storyId="components-text-field--error-field" />
 
 ### Success field
+
 <StorybookExample
   componentName="success text field"
   storyId="components-text-field--success-field"
 />
 
 ### Disabled field
-<StorybookExample
-  componentName="disabled field"
-  storyId="components-text-field--disabled-field"
-/>
+
+<StorybookExample componentName="disabled field" storyId="components-text-field--disabled-field" />
 
 ### Props
 

--- a/packages/docs/content/5_components/text-field.mdx
+++ b/packages/docs/content/5_components/text-field.mdx
@@ -1,0 +1,96 @@
+---
+title: Text field
+relatedUswdsGuidance: components/form-controls/#text-input
+---
+import ViewSourceLink from '../../src/components/ViewSourceLink';
+
+Text fields allow users to enter any combination of letters, numbers, or symbols of their choosing (unless otherwise restricted). Text fields can span single or multiple lines.
+
+## `<TextField>`
+
+A `TextField` component renders an input field as well as supporting UI elements like a label, error message, and hint text.
+<ViewSourceLink sourceFilePath="components/TextField/TextField.tsx" />
+
+### Single line field
+<StorybookExample
+  componentName="single text field"
+  storyId="components-text-field--single-line-field"
+/>
+
+### Multiline field
+<StorybookExample
+  componentName="multi text field"
+  storyId="components-text-field--multiline-field"
+/>
+
+### Error field
+<StorybookExample
+  componentName="error field"
+  storyId="components-text-field--error-field"
+/>
+
+### Success field
+<StorybookExample
+  componentName="success text field"
+  storyId="components-text-field--success-field"
+/>
+
+### Disabled field
+<StorybookExample
+  componentName="disabled field"
+  storyId="components-text-field--disabled-field"
+/>
+
+### Props
+
+<PropTable componentName="TextField" />
+
+## Guidance
+
+### When to use
+
+- If you can’t reasonably predict a user’s answer to a prompt and there might be wide variability in users’ answers.
+- When using another type of input will make answering more difficult. For example, birthdays and other known dates are easier to type in than they are to select from a calendar picker.
+- When users want to paste in a response.
+
+### When to consider alternatives
+
+- When users are choosing from a specific set of options. Consider [checkboxes, radio buttons](/components/checkbox-and-radio), or a [dropdown](/components/dropdown) in these cases.
+
+### Usage
+
+- Don't use placeholder text in form fields. Use hint text instead, if you need to provide contextual information. Placeholder text disappears after a user types a value, therefore users will no longer have that text available when they need to review their entries. People who have cognitive or visual disabilities have additional problems with placeholder text.
+- The length of the text field provides a hint to users as to how much text to write. Do not require users to write paragraphs of text into a single-line `input` box; use a `textarea` instead.
+- Text fields are among the easiest type of input for desktop users but are more difficult for mobile users.
+- Only show error messages or styling after a user has interacted with a particular field.
+
+**[View the "Forms" guidelines for additional guidance and best practices.](/guidelines/forms/)**
+
+### Accessibility
+
+- Group each set of thematically related controls in a `fieldset` element. Use the `legend` element to offer a label within each `fieldset`. The `fieldset` and `legend` elements make it easier for screen reader users to navigate the form.
+- Keep your form blocks in a vertical pattern. This approach is ideal, from an accessibility standpoint, because of limited vision that makes it hard to scan from left to right.
+
+### Customization
+
+The following Sass variables can be overridden to theme a field:
+
+- `$input-border-color`
+- `$input-border-color-inverse`
+- `$input-border-radius`
+- `$input-line-height`
+- `$input-border-width`
+- `$input-padding`
+
+### Related patterns
+
+- [Masked field](/components/masked-field/)
+- [Date field](/components/date-field/)
+
+### Learn more
+
+- [Form Guidelines](/guidelines/forms/)
+- ["Placeholders in Form Fields Are Harmful"](https://www.nngroup.com/articles/form-design-placeholders/)
+- [Asking for a date of birth](https://designnotes.blog.gov.uk/2013/12/05/asking-for-a-date-of-birth/)
+- [GOV.UK text boxes discussion](https://paper.dropbox.com/doc/Text-boxes-8NLlgz9tjR8OzTz2N9wE3)
+- [Four steps for choosing form elements on the Web (PDF)](http://www.formsthatwork.com/files/Articles/dropdown.pdf)

--- a/packages/docs/content/5_components/tooltip.mdx
+++ b/packages/docs/content/5_components/tooltip.mdx
@@ -1,0 +1,79 @@
+---
+title: Tooltip
+status: draft
+---
+import ViewSourceLink from '../../src/components/ViewSourceLink';
+
+Tooltips provide additional information upon hover, focus or click. The information should be contextual, useful, and nonessential information.
+
+## `<Tooltip>`
+
+The `Tooltip` component can render a variety of content ranging from short descriptive text, to paragraphs with links, or more complex interactive popovers.
+
+The component provides a variety of props to configure tooltip behavior for these different use cases (i.e. `interactive`, `dialog`), and to customize styling (i.e. `offset`, `maxWidth`, `className`). The element that triggers a `Tooltip` can also be fully customized via props (i.e. `triggerComponent`, `triggerContent`).
+
+This component makes use of [`@popperjs/core`](https://popper.js.org/docs/v2/) for tooltip positioning, [`focus-trap-react`](https://github.com/focus-trap/focus-trap-react#readme) for trapping focus in Tooltip Dialogs, and [`react-transition-group`](http://reactcommunity.org/react-transition-group/css-transition) for animations.
+
+### Icon Trigger
+<StorybookExample
+  componentName="icon tooltip"
+  sourceFilePath="components/Tooltip/Tooltip.tsx"
+  storyId="components-tooltip--icon-trigger"
+/>
+
+### Inline
+<StorybookExample
+  componentName="inline tooltip"
+  sourceFilePath="components/Tooltip/Tooltip.tsx"
+  storyId="components-tooltip--inline-trigger"
+/>
+
+### Interactive content
+<StorybookExample
+  componentName="interactive tooltip"
+  sourceFilePath="components/Tooltip/Tooltip.tsx"
+  storyId="components-tooltip--interactive-content"
+  minHeight={350}
+/>
+
+### With Close
+<StorybookExample
+  componentName="tooltip with close"
+  sourceFilePath="components/Tooltip/Tooltip.tsx"
+  storyId="components-tooltip--tooltip-with-close-button"
+  minHeight={350}
+/>
+
+### Tooltip Props
+
+<PropTable componentName="Tooltip" />
+
+## `<TooltipIcon>`
+
+When using the `<TooltipIcon>` as the only child of `<Tooltip>`, be sure to provide an `aria-label` on the `<Tooltip>` to ensure an accessible name for the trigger.
+
+<ViewSourceLink sourceFilePath="components/Tooltip/TooltipIcon.tsx" />
+
+### Tooltip Icon Props
+<PropTable componentName="TooltipIcon" />
+
+## Guidance
+
+### When to use
+- Use for helpful, non-critical information to strengthen an existing message.
+- Use to increase certainty and enhance confidence about an interaction.
+- Use with brief descriptions as tooltips perform best with succinct text.
+- Tooltips are useful as a last resort for space-constrained UI. Explore other options for keeping content visible without a tooltip.
+
+### When to consider alternatives
+- Don’t hide information necessary for completing a task behind a tooltip interaction.
+- Tooltips are microcopy and should be brief. Don't use a tooltip if you need a lot of text.
+- Don’t use a tooltip when its content is repetitive or if usability is obvious.
+- If content can fit outside a tooltip, don't use a tooltip.
+
+### Customization
+
+The following Sass variables can be overridden to theme choice fields:
+- `$tooltip-text-color` - Text color of the tooltip content
+- `$tooltip-icon-color` - Color of the tooltip icon
+- `$tooltip-icon-color-inverse` - Color of the inverse tooltip icon

--- a/packages/docs/content/5_components/tooltip.mdx
+++ b/packages/docs/content/5_components/tooltip.mdx
@@ -2,6 +2,7 @@
 title: Tooltip
 status: draft
 ---
+
 import ViewSourceLink from '../../src/components/ViewSourceLink';
 
 Tooltips provide additional information upon hover, focus or click. The information should be contextual, useful, and nonessential information.
@@ -15,6 +16,7 @@ The component provides a variety of props to configure tooltip behavior for thes
 This component makes use of [`@popperjs/core`](https://popper.js.org/docs/v2/) for tooltip positioning, [`focus-trap-react`](https://github.com/focus-trap/focus-trap-react#readme) for trapping focus in Tooltip Dialogs, and [`react-transition-group`](http://reactcommunity.org/react-transition-group/css-transition) for animations.
 
 ### Icon Trigger
+
 <StorybookExample
   componentName="icon tooltip"
   sourceFilePath="components/Tooltip/Tooltip.tsx"
@@ -22,6 +24,7 @@ This component makes use of [`@popperjs/core`](https://popper.js.org/docs/v2/) f
 />
 
 ### Inline
+
 <StorybookExample
   componentName="inline tooltip"
   sourceFilePath="components/Tooltip/Tooltip.tsx"
@@ -29,6 +32,7 @@ This component makes use of [`@popperjs/core`](https://popper.js.org/docs/v2/) f
 />
 
 ### Interactive content
+
 <StorybookExample
   componentName="interactive tooltip"
   sourceFilePath="components/Tooltip/Tooltip.tsx"
@@ -37,6 +41,7 @@ This component makes use of [`@popperjs/core`](https://popper.js.org/docs/v2/) f
 />
 
 ### With Close
+
 <StorybookExample
   componentName="tooltip with close"
   sourceFilePath="components/Tooltip/Tooltip.tsx"
@@ -55,17 +60,20 @@ When using the `<TooltipIcon>` as the only child of `<Tooltip>`, be sure to prov
 <ViewSourceLink sourceFilePath="components/Tooltip/TooltipIcon.tsx" />
 
 ### Tooltip Icon Props
+
 <PropTable componentName="TooltipIcon" />
 
 ## Guidance
 
 ### When to use
+
 - Use for helpful, non-critical information to strengthen an existing message.
 - Use to increase certainty and enhance confidence about an interaction.
 - Use with brief descriptions as tooltips perform best with succinct text.
 - Tooltips are useful as a last resort for space-constrained UI. Explore other options for keeping content visible without a tooltip.
 
 ### When to consider alternatives
+
 - Don’t hide information necessary for completing a task behind a tooltip interaction.
 - Tooltips are microcopy and should be brief. Don't use a tooltip if you need a lot of text.
 - Don’t use a tooltip when its content is repetitive or if usability is obvious.
@@ -74,6 +82,7 @@ When using the `<TooltipIcon>` as the only child of `<Tooltip>`, be sure to prov
 ### Customization
 
 The following Sass variables can be overridden to theme choice fields:
+
 - `$tooltip-text-color` - Text color of the tooltip content
 - `$tooltip-icon-color` - Color of the tooltip icon
 - `$tooltip-icon-color-inverse` - Color of the inverse tooltip icon

--- a/packages/docs/content/5_components/uSA-banner.mdx
+++ b/packages/docs/content/5_components/uSA-banner.mdx
@@ -6,7 +6,6 @@ relatedUswdsGuidance: components/banner
 
 The USA banner identifies official websites of government organizations in the United States. It also helps visitors understand how to tell that a website is both official and secure.
 
-
 ## `<UsaBanner>`
 
 ### English
@@ -28,6 +27,7 @@ The USA banner identifies official websites of government organizations in the U
 />
 
 ### Props
+
 <PropTable componentName="UsaBanner" />
 
 ## Guidance

--- a/packages/docs/content/5_components/uSA-banner.mdx
+++ b/packages/docs/content/5_components/uSA-banner.mdx
@@ -1,0 +1,49 @@
+---
+title: USA banner
+status: draft
+relatedUswdsGuidance: components/banner
+---
+
+The USA banner identifies official websites of government organizations in the United States. It also helps visitors understand how to tell that a website is both official and secure.
+
+
+## `<UsaBanner>`
+
+### English
+
+<StorybookExample
+  componentName="english USA banner"
+  sourceFilePath="components/UsaBanner/UsaBanner.tsx"
+  storyId="components-usa-banner--english-banner"
+  minHeight={250}
+/>
+
+### Spanish
+
+<StorybookExample
+  componentName="spanish USA banner"
+  sourceFilePath="components/UsaBanner/UsaBanner.tsx"
+  storyId="components-usa-banner--spanish-banner"
+  minHeight={250}
+/>
+
+### Props
+<PropTable componentName="UsaBanner" />
+
+## Guidance
+
+### When to use
+
+- To identify as an official government site. Most government sites should use the banner.
+
+### When to consider alternatives
+
+- If you don't use a .gov domain and HTTPS. The banner text identifies .gov domains and HTTPS as indicators that a website is an official government website. Use the banner only if your site uses both the proper TLD and HTTPS.
+- Any time it would be misleading. The banner should be used to reduce confusion. Avoid using the banner on any site meant only for testing or otherwise not meant to be identified as an official government website.
+
+### Usage
+
+- Use the provided text without customization. The banner is most effective as an identifier and a learning tool when its message is consistent across government websites.
+- Show the banner on every page. Use the banner at the top of every page of a site. It can be confusing or misleading if it appears on some pages and not others.
+- Avoid distraction. The banner appears on every page of your site. Choose background colors that fit with your site theme and avoid color combinations that draw excessive attention to the banner.
+- Keep the text up-to-date. Use the most current version of the banner.

--- a/packages/docs/content/5_components/vertical-navigation.mdx
+++ b/packages/docs/content/5_components/vertical-navigation.mdx
@@ -1,0 +1,68 @@
+---
+title: Vertical navigation
+relatedUswdsGuidance: components/sidenav
+---
+import ViewSourceLink from '../../src/components/ViewSourceLink';
+
+Hierarchical, vertical navigation.
+
+## `<VerticalNav>`
+
+A `VerticalNav` component accepts list items as a JSON object and includes additional functionality like collapsible nested menus.
+
+<StorybookExample
+  componentName="vertical nav"
+  sourceFilePath="components/VerticalNav/VerticalNav.tsx"
+  storyId="components-vertical-nav--default-vertical-nav"
+/>
+
+### Vertical Nav Props
+<PropTable componentName="VerticalNav" />
+
+
+## `<VerticalNavItem>`
+<ViewSourceLink sourceFilePath="components/VerticalNav/VerticalNavItem.tsx" />
+
+### Vertical Nav Item Props
+<PropTable componentName="VerticalNavItem" />
+
+## Guidance
+
+### When to use
+
+- To display a navigational hierarchy with one to three levels.
+- To display the “sub-navigation” within a section of the website.
+
+### When to consider alternatives
+
+- If the site has fewer than five pages, consider organizing the page without a navigational hierarchy.
+- If your page already has a horizontal and vertical navigation bar, consider ways to simplify your navigation system.
+- If your content is within a frame or sub-area of a page, consider ways to simplify your navigation system.
+
+### Usage
+
+- Indicate where a user is within the navigational hierarchy. Use the `.ds-c-vertical-nav__label--current` modifier to show users which page they have navigated to.
+- Keep the navigation links short and follow sentence case. They can be shorter derivatives of page titles themselves.
+- If the navigation hierarchy is too long, users may miss items at the bottom. If it’s too deep, users may miss items that require too many clicks. Usability test to find the right balance between breadth and depth.
+
+### Accessibility
+
+- Users should be able to tab through each link.
+- If you have nested menus that are collapsible, ensure the toggle button has its `aria-controls` and `aria-expanded` attributes set. This is done automatically for you
+if you're using the React components.
+- If your navigation list is longer than 3 items, consider using a skip navigation link. This allows screen reader and keyboard users to skip to the main content area(s).
+- If a skip navigation link is not an option, consider using:
+  * A valid, descriptive page header
+  * Landmark regions like `<header>`, `<main>`, `<aside>`, `<footer>`
+- When naming the optional `ariaNavLabel` prop, keep in mind:
+    * This prop is necessary only when there is more than one nav element on a page.
+    * Don't include the word "Menu" in the label. Most screen readers will announce that information already. Instead, provide more context to what's in the menu and/or its location. Like "Main" or "Social".
+
+### Related patterns
+
+- [Tabs](/components/tabs)
+
+### Learn more
+
+- [18F Content Guide \- Heading capitalization](https://content-guide.18f.gov/capitalization/#headings)
+- [18F Content Guide \- Headings and titles](https://content-guide.18f.gov/headings-and-titles/)

--- a/packages/docs/content/5_components/vertical-navigation.mdx
+++ b/packages/docs/content/5_components/vertical-navigation.mdx
@@ -2,6 +2,7 @@
 title: Vertical navigation
 relatedUswdsGuidance: components/sidenav
 ---
+
 import ViewSourceLink from '../../src/components/ViewSourceLink';
 
 Hierarchical, vertical navigation.
@@ -17,13 +18,15 @@ A `VerticalNav` component accepts list items as a JSON object and includes addit
 />
 
 ### Vertical Nav Props
+
 <PropTable componentName="VerticalNav" />
 
-
 ## `<VerticalNavItem>`
+
 <ViewSourceLink sourceFilePath="components/VerticalNav/VerticalNavItem.tsx" />
 
 ### Vertical Nav Item Props
+
 <PropTable componentName="VerticalNavItem" />
 
 ## Guidance
@@ -49,14 +52,14 @@ A `VerticalNav` component accepts list items as a JSON object and includes addit
 
 - Users should be able to tab through each link.
 - If you have nested menus that are collapsible, ensure the toggle button has its `aria-controls` and `aria-expanded` attributes set. This is done automatically for you
-if you're using the React components.
+  if you're using the React components.
 - If your navigation list is longer than 3 items, consider using a skip navigation link. This allows screen reader and keyboard users to skip to the main content area(s).
 - If a skip navigation link is not an option, consider using:
-  * A valid, descriptive page header
-  * Landmark regions like `<header>`, `<main>`, `<aside>`, `<footer>`
+  - A valid, descriptive page header
+  - Landmark regions like `<header>`, `<main>`, `<aside>`, `<footer>`
 - When naming the optional `ariaNavLabel` prop, keep in mind:
-    * This prop is necessary only when there is more than one nav element on a page.
-    * Don't include the word "Menu" in the label. Most screen readers will announce that information already. Instead, provide more context to what's in the menu and/or its location. Like "Main" or "Social".
+  - This prop is necessary only when there is more than one nav element on a page.
+  - Don't include the word "Menu" in the label. Most screen readers will announce that information already. Instead, provide more context to what's in the menu and/or its location. Like "Main" or "Social".
 
 ### Related patterns
 

--- a/packages/docs/src/components/PropTable.tsx
+++ b/packages/docs/src/components/PropTable.tsx
@@ -48,6 +48,7 @@ const PropTable = ({ componentName }: PropTableProps) => {
                 childMdx {
                   body
                 }
+                text
               }
               id
               name
@@ -68,15 +69,20 @@ const PropTable = ({ componentName }: PropTableProps) => {
   // moving from the deeply nested graphql structure to something flatter
   const transformedData: PropTableDataItem[] = propsForComponent?.node.props.reduce(
     (acc, prop: PropQuery) => {
-      const newProp = {
-        name: prop.name,
-        type: prop.tsType?.raw || prop.tsType?.name,
-        defaultValue: prop.defaultValue?.value,
-        description: prop.description?.childMdx?.body,
-        isRequired: prop.required,
-        id: prop.id,
-      };
-      return [...acc, newProp];
+      // if prop description includes '@hide-prop`, don't show it in props table
+      const hideProp = prop.description.text.match(/@hide-prop/i);
+      if (!hideProp) {
+        const newProp = {
+          name: prop.name,
+          type: prop.tsType?.raw || prop.tsType?.name,
+          defaultValue: prop.defaultValue?.value,
+          description: prop.description?.childMdx?.body,
+          isRequired: prop.required,
+          id: prop.id,
+        };
+        return [...acc, newProp];
+      }
+      return acc;
     },
     []
   );

--- a/packages/docs/src/components/StorybookExample.tsx
+++ b/packages/docs/src/components/StorybookExample.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { ExternalLinkIcon, Spinner } from '@cmsgov/design-system';
 import CodeSnippet from './CodeSnippet';
 import { withPrefix } from 'gatsby';
+import ViewSourceLink from './ViewSourceLink';
 
 interface StorybookExampleProps {
   /**
@@ -80,15 +81,7 @@ const StorybookExample = ({
 
   return (
     <>
-      {sourceFilePath && (
-        <p>
-          <a
-            href={`https://github.com/CMSgov/design-system/blob/master/packages/design-system/src/${sourceFilePath}`}
-          >
-            View Source File
-          </a>
-        </p>
-      )}
+      {sourceFilePath && <ViewSourceLink sourceFilePath={sourceFilePath} />}
       <div className="c-storybook-example">
         <div
           className={classnames('c-storybook-example__iframe-wrapper', {

--- a/packages/docs/src/components/ViewSourceLink.tsx
+++ b/packages/docs/src/components/ViewSourceLink.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface ViewSourceLinkProps {
+  sourceFilePath: string;
+}
+
+const ViewSourceLink = ({ sourceFilePath }: ViewSourceLinkProps) => {
+  return (
+    <p>
+      <a
+        href={`https://github.com/CMSgov/design-system/blob/master/packages/design-system/src/${sourceFilePath}`}
+      >
+        View Source File
+      </a>
+    </p>
+  );
+};
+
+export default ViewSourceLink;

--- a/packages/docs/src/helpers/graphQLTypes.ts
+++ b/packages/docs/src/helpers/graphQLTypes.ts
@@ -32,6 +32,7 @@ export interface PropQuery {
     childMdx: {
       body: string;
     };
+    text?: string;
   };
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

* Component content migration for:
  * Spinner
  * Table
  * Tabs
  * TextField
  * Tooltip
  * USA Banner
  * Vertical Nav
* Made reusable 'View Source' link to standardize github url
* Updated the `PropTable` component to hide props that have the `@hide-prop` signifier in their description -- same as current site

## How to test

`yarn build-storybook:gatsby` to build storybook once
`yarn build:gatsby && yarn serve:gatsby` to see doc site locally with storybook
