### PR TITLE
[WNMGDS-1712] icon props bugfix

### DIFF
--- a/packages/design-system/src/components/Icons/StarIcon.tsx
+++ b/packages/design-system/src/components/Icons/StarIcon.tsx
@@ -8,24 +8,25 @@ export interface StarIconProps extends IconCommonProps {
 
 const defaultProps = {
   className: '',
-  isFilled: false,
   viewBox: '0 0 18 16',
 };
 
 function StarIcon(props: StarIconProps): React.ReactElement {
+  // don't want to pass isFilled through to SvgIcon
+  const { isFilled, ...otherProps } = props;
   const iconCssClasses = classNames(
     'ds-c-icon--star',
     {
-      'ds-c-icon--star-filled': props.isFilled,
+      'ds-c-icon--star-filled': isFilled,
     },
     props.className
   );
 
-  const title = props.isFilled ? t('icons.starFilled') : t('icons.star');
+  const title = isFilled ? t('icons.starFilled') : t('icons.star');
 
   return (
-    <SvgIcon title={title} {...defaultProps} {...props} className={iconCssClasses}>
-      {props.isFilled ? (
+    <SvgIcon title={title} {...defaultProps} {...otherProps} className={iconCssClasses}>
+      {isFilled ? (
         <path
           d="M8.533 13.063l-5.274 2.69 1.008-5.699L0 6.017l5.896-.831L8.533 0l2.637 5.186 5.897.831-4.267 4.037 1.007 5.7z"
           fillRule="nonzero"

--- a/packages/design-system/src/components/Icons/SvgIcon.test.tsx
+++ b/packages/design-system/src/components/Icons/SvgIcon.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import SvgIcon from './SvgIcon';
+import AddIcon from './AddIcon';
+
+describe('SvgIcon', () => {
+  const renderSvgIcon = (overrideProps?) => {
+    return render(
+      <SvgIcon ariaHidden={false} title="test icon" id="test-icon" {...overrideProps}>
+        <path />
+      </SvgIcon>
+    );
+  };
+
+  it('passes through additional props', () => {
+    const { getByTestId } = renderSvgIcon({ 'data-testid': 'iconTest' });
+    const iconEl = getByTestId('iconTest');
+    expect(iconEl).toMatchSnapshot();
+  });
+
+  it('wrapper icon can pass through additional props', () => {
+    const { getByTestId } = render(<AddIcon data-testid="addIconTest" />);
+    const iconEl = getByTestId('addIconTest');
+    expect(iconEl).toMatchSnapshot();
+  });
+
+  describe('when ariaHidden is false', () => {
+    it('shows accessibility attributes', () => {
+      const { getByRole } = renderSvgIcon();
+      const iconEl = getByRole('img');
+
+      expect(iconEl).toBeDefined();
+      expect(iconEl.getAttribute('aria-labelledby')).toEqual('test-icon__title');
+    });
+
+    it('renders title', () => {
+      const { getByTitle } = renderSvgIcon();
+      const iconEl = getByTitle('test icon');
+      expect(iconEl).toBeDefined();
+    });
+
+    it('updates aria-labelledby if description exists', () => {
+      const { getByRole } = renderSvgIcon({ description: 'i am a description of the svg' });
+      const iconEl = getByRole('img');
+
+      expect(iconEl.getAttribute('aria-labelledby')).toEqual('test-icon__title test-icon__desc');
+    });
+  });
+
+  describe('when ariaHidden is true', () => {
+    it('does not have role="img"', () => {
+      const { queryByRole } = renderSvgIcon({ ariaHidden: true });
+      const iconEl = queryByRole('img');
+      expect(iconEl).toBe(null);
+    });
+
+    it('renders without title or description"', () => {
+      const { getByTestId } = renderSvgIcon({ ariaHidden: true, 'data-testid': 'testId' });
+      const iconEl = getByTestId('testId');
+      expect(iconEl).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/design-system/src/components/Icons/SvgIcon.tsx
+++ b/packages/design-system/src/components/Icons/SvgIcon.tsx
@@ -55,6 +55,7 @@ function SvgIcon({
   inversed,
   title,
   viewBox,
+  ...otherProps
 }: Omit<React.SVGProps<SVGSVGElement>, OmitProps> & SvgIconProps): React.ReactElement {
   const svgClasses = classNames('ds-c-icon', { 'ds-c-icon--inverse': inversed }, className);
 
@@ -63,10 +64,10 @@ function SvgIcon({
   const descriptionId = `${iconId}__desc`;
   const ariaLabelledBy = description ? `${titleId} ${descriptionId}` : titleId;
   const isSrVisible = !ariaHidden;
-  const additionalProps = {};
+  const screenReaderProps = {};
   if (isSrVisible) {
-    additionalProps['aria-labelledby'] = ariaLabelledBy;
-    additionalProps['role'] = 'img';
+    screenReaderProps['aria-labelledby'] = ariaLabelledBy;
+    screenReaderProps['role'] = 'img';
   }
 
   return (
@@ -77,7 +78,8 @@ function SvgIcon({
       id={iconId}
       viewBox={viewBox}
       xmlns="http://www.w3.org/2000/svg"
-      {...additionalProps}
+      {...screenReaderProps}
+      {...otherProps}
     >
       {isSrVisible && <title id={titleId}>{title}</title>}
       {isSrVisible && description && <desc id={descriptionId}>{description}</desc>}

--- a/packages/design-system/src/components/Icons/__snapshots__/SvgIcon.test.tsx.snap
+++ b/packages/design-system/src/components/Icons/__snapshots__/SvgIcon.test.tsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SvgIcon passes through additional props 1`] = `
+<svg
+  aria-hidden="false"
+  aria-labelledby="test-icon__title"
+  class="ds-c-icon"
+  data-testid="iconTest"
+  focusable="false"
+  id="test-icon"
+  role="img"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <title
+    id="test-icon__title"
+  >
+    test icon
+  </title>
+  <path />
+</svg>
+`;
+
+exports[`SvgIcon when ariaHidden is true renders without title or description" 1`] = `
+<svg
+  aria-hidden="true"
+  class="ds-c-icon"
+  data-testid="testId"
+  focusable="false"
+  id="test-icon"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path />
+</svg>
+`;
+
+exports[`SvgIcon wrapper icon can pass through additional props 1`] = `
+<svg
+  aria-hidden="true"
+  class="ds-c-icon ds-c-icon--add "
+  data-testid="addIconTest"
+  focusable="false"
+  id="icon-1"
+  viewBox="3 3 18 18"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+  />
+</svg>
+`;

--- a/packages/design-system/src/components/Icons/icons.stories.tsx
+++ b/packages/design-system/src/components/Icons/icons.stories.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import {
+  AddIcon,
+  AlertCircleIcon,
+  ArrowsStackedIcon,
+  ArrowIcon,
+  BuildingCircleIcon,
+  CheckCircleIcon,
+  CheckIcon,
+  CloseIcon,
+  CloseIconThin,
+  DownloadIcon,
+  ExternalLinkIcon,
+  ImageIcon,
+  InfoCircleIcon,
+  InfoCircleIconThin,
+  LockCircleIcon,
+  LockIcon,
+  MenuIcon,
+  MenuIconThin,
+  NextIcon,
+  PdfIcon,
+  RemoveIcon,
+  StarIcon,
+  UsaFlagIcon,
+  WarningIcon,
+} from './index';
+
+import SvgIcon from './SvgIcon';
+
+export default {
+  title: 'Components/Icons',
+  component: SvgIcon,
+};
+
+const iconData = [
+  {
+    defaultTitle: 'Add',
+    component: <AddIcon />,
+    name: 'AddIcon',
+  },
+  {
+    defaultTitle: 'Alert',
+    component: <AlertCircleIcon />,
+    name: 'AlertCircleIcon',
+  },
+  {
+    defaultTitle: 'Sort',
+    component: <ArrowsStackedIcon />,
+    name: 'ArrowsStackedIcon',
+  },
+  {
+    defaultTitle: '[direction of arrow]',
+    component: (
+      <>
+        <ArrowIcon direction="up" />
+        <ArrowIcon direction="down" />
+        <ArrowIcon direction="left" />
+        <ArrowIcon direction="right" />
+      </>
+    ),
+    name: 'ArrowIcon',
+    notes:
+      'Component takes <code>direction</code> prop to determine if it is up, down, left or right.',
+  },
+  {
+    defaultTitle: 'Building in circle',
+    component: <BuildingCircleIcon />,
+    name: 'BuildingCircleIcon',
+  },
+  {
+    defaultTitle: 'Check mark in circle',
+    component: <CheckCircleIcon />,
+    name: 'CheckCircleIcon',
+  },
+  {
+    defaultTitle: 'Check mark',
+    component: <CheckIcon />,
+    name: 'CheckIcon',
+  },
+  {
+    defaultTitle: 'Close',
+    component: <CloseIcon />,
+    name: 'CloseIcon',
+  },
+  {
+    defaultTitle: 'Close',
+    component: <CloseIconThin />,
+    name: 'CloseIconThin',
+  },
+  {
+    defaultTitle: 'Download',
+    component: <DownloadIcon />,
+    name: 'DownloadIcon',
+  },
+  {
+    defaultTitle: 'External Link',
+    component: <ExternalLinkIcon />,
+    name: 'ExternalLinkIcon',
+  },
+  {
+    defaultTitle: 'Image',
+    component: <ImageIcon />,
+    name: 'ImageIcon',
+  },
+  {
+    defaultTitle: 'Information',
+    component: <InfoCircleIcon />,
+    name: 'InfoCircleIcon',
+  },
+  {
+    defaultTitle: 'Information',
+    component: <InfoCircleIconThin />,
+    name: 'InfoCircleIconThin',
+  },
+  {
+    defaultTitle: 'Lock in circle',
+    component: <LockCircleIcon />,
+    name: 'LockCircleIcon',
+  },
+  {
+    defaultTitle: 'Lock',
+    component: <LockIcon />,
+    name: 'LockIcon',
+  },
+  {
+    defaultTitle: 'Menu Icon',
+    component: <MenuIcon />,
+    name: 'MenuIcon',
+  },
+  {
+    defaultTitle: 'Menu',
+    component: <MenuIconThin />,
+    name: 'MenuIconThin',
+  },
+  {
+    defaultTitle: 'Next',
+    component: <NextIcon />,
+    name: 'NextIcon',
+  },
+  {
+    defaultTitle: 'Pdf',
+    component: <PdfIcon />,
+    name: 'PdfIcon',
+  },
+  {
+    defaultTitle: 'Remove',
+    component: <RemoveIcon />,
+    name: 'RemoveIcon',
+  },
+  {
+    defaultTitle: 'Star / Star Filled',
+    component: (
+      <>
+        <StarIcon />
+        <StarIcon isFilled />
+      </>
+    ),
+    name: 'StarIcon',
+    notes: 'Component takes <code>isFilled</code> prop to determine star is filled or an outline.',
+  },
+  {
+    defaultTitle: 'U.S. flag',
+    component: <UsaFlagIcon />,
+    name: 'UsaFlagIcon',
+  },
+  {
+    defaultTitle: 'Warning',
+    component: <WarningIcon />,
+    name: 'WarningIcon',
+  },
+];
+
+export const AvailableIcons = () => (
+  <>
+    <table className="ds-c-table">
+      <thead>
+        <tr>
+          <th>Icon Component</th>
+          <th>Example</th>
+          <th>
+            Default <code>title</code> attribute
+          </th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {iconData.map(({ defaultTitle, component, name, notes }) => (
+          <tr key={name}>
+            <td>
+              <code>{name}</code>
+            </td>
+            <td className="ds-u-text-align--center">{component}</td>
+            <td>{defaultTitle}</td>
+            <td dangerouslySetInnerHTML={{ __html: notes }} />
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </>
+);

--- a/packages/design-system/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/design-system/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`Pagination should render component 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-left ds-c-pagination__nav--image"
+          direction="left"
           focusable="false"
           id="icon-1"
           viewBox="0 0 320 512"
@@ -119,6 +120,7 @@ exports[`Pagination should render component 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-right ds-c-pagination__nav--image"
+          direction="right"
           focusable="false"
           id="icon-2"
           viewBox="0 0 320 512"
@@ -152,6 +154,7 @@ exports[`Pagination with compact prop enabled should render compact variant 1`] 
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-left ds-c-pagination__nav--image"
+          direction="left"
           focusable="false"
           id="icon-55"
           viewBox="0 0 320 512"
@@ -189,6 +192,7 @@ exports[`Pagination with compact prop enabled should render compact variant 1`] 
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-right ds-c-pagination__nav--image"
+          direction="right"
           focusable="false"
           id="icon-56"
           viewBox="0 0 320 512"

--- a/packages/design-system/src/components/UsaBanner/__snapshots__/UsaBanner.test.jsx.snap
+++ b/packages/design-system/src/components/UsaBanner/__snapshots__/UsaBanner.test.jsx.snap
@@ -44,6 +44,7 @@ exports[`UsaBanner renders correctly 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
+            direction="down"
             focusable="false"
             id="icon-3"
             viewBox="0 0 320 512"


### PR DESCRIPTION
## Summary

The reported bug (#1880) was that a `data-testid` attribute passed to any DS icons was not being applied to the svg element. 
In this PR, I:
* Added a story in storybook for icons for easier testing
* Updated `SvgIcon` to pass through additional props
* Updated `StarIcon` to not pass through an invalid attribute
* Added some tests for `SvgIcon` and updated other tests accordingly

## How to test

run tests with `yarn test` and ensure new unit tests to address this are passing.

You can update the `icons.stories.tsx` file so that one of the icon components has additional props (like `data-other`, etc). Run storybook with `yarn storybook`, navigate to the icon stories. Open dev tools and ensure that your custom attribute shows up on the svg element

Updated story example:
<img width="430" alt="Screen Shot 2022-06-02 at 1 29 31 PM" src="https://user-images.githubusercontent.com/33579665/171722997-f05e8946-5001-4aa7-a632-9162c3115bdf.png">

Result in Storybook:
<img width="1482" alt="Screen Shot 2022-06-02 at 1 29 19 PM" src="https://user-images.githubusercontent.com/33579665/171723083-172d1bbe-4bfb-485a-ac17-4086a3abb2ae.png">

