### PR TITLE
[WNMGDS-1670] Gatsby 404 Page

### DIFF
--- a/packages/docs/content/not-in-sidebar/404.mdx
+++ b/packages/docs/content/not-in-sidebar/404.mdx
@@ -1,0 +1,5 @@
+---
+title: Page not found
+---
+
+Sorry, the page you're looking for couldn't be found. It's possible that this page has moved, or the address may have been typed incorrectly.

--- a/packages/docs/src/components/DocSiteSidebar.tsx
+++ b/packages/docs/src/components/DocSiteSidebar.tsx
@@ -52,7 +52,10 @@ const GatsbyLink = (props: VerticalNavItemProps) => {
 const DocSiteSidebar = ({ isMobileNavOpen, location }: DocSiteNavProps) => {
   const data = useStaticQuery(graphql`
     query SiteNavQuery {
-      allFile(sort: { fields: [relativeDirectory, name] }, filter: { ext: { eq: ".mdx" } }) {
+      allFile(
+        sort: { fields: [relativeDirectory, name] }
+        filter: { ext: { eq: ".mdx" }, relativeDirectory: { ne: "not-in-sidebar" } }
+      ) {
         group(field: relativeDirectory) {
           fieldValue
           edges {

--- a/packages/docs/src/pages/404.tsx
+++ b/packages/docs/src/pages/404.tsx
@@ -1,31 +1,25 @@
 import * as React from 'react';
-import { Link } from 'gatsby';
+import { graphql } from 'gatsby';
 
-// TODO: update with information layout page layout. Should look similar to https://design.cms.gov/test/
-const NotFoundPage = () => {
+import Layout from '../components/Layout';
+import { MdxQuery } from '../helpers/graphQLTypes';
+import ContentRenderer from '../components/ContentRenderer';
+
+const NotFoundPage = ({ data, location }: MdxQuery) => {
   return (
-    <main>
-      <title>Not found</title>
-      <h1>Page not found</h1>
-      <p>
-        Sorry{' '}
-        <span role="img" aria-label="Pensive emoji">
-          😔
-        </span>{' '}
-        we couldn’t find what you were looking for.
-        <br />
-        {process.env.NODE_ENV === 'development' ? (
-          <>
-            <br />
-            Try creating a page in <code>src/pages/</code>.
-            <br />
-          </>
-        ) : null}
-        <br />
-        <Link to="/">Go home</Link>.
-      </p>
-    </main>
+    <Layout pageName="Page not found" location={location}>
+      <ContentRenderer data={data.mdx.body} />
+    </Layout>
   );
 };
+
+export const query = graphql`
+  query PageNotFoundQuery {
+    mdx(frontmatter: { title: { eq: "Page not found" } }) {
+      id
+      body
+    }
+  }
+`;
 
 export default NotFoundPage;


### PR DESCRIPTION
## Summary

- Added 404 page markup
- Added 404 page content
- Added new folder `not-in-sidebar` to `content` folder to allow for content items that do not currently live in the sidebar and updated sidebar to exclude that data in it's query

## How to test

`yarn install && yarn build && yarn build:storybook-gatsby && yarn build:gatsby && yarn start:gatsby`

Hit any missing page and since you're in `developer` mode it will give you a button to click to preview the 404 page, in production it will just show this page normally but in development mode you have to click to it.. Notice 404 page content does not show up in sidebar, making it available to edit more easily.

![image](https://user-images.githubusercontent.com/783820/173123864-40926aa8-f5dd-4875-8577-324e7662245e.png)
