### PR TITLE
[NO-TICKET] Fix backplate in forced-colors mode on non-IE/Edge browsers

### DIFF
--- a/packages/design-system/src/styles/components/_Accordion.scss
+++ b/packages/design-system/src/styles/components/_Accordion.scss
@@ -52,12 +52,14 @@ $accordion-header-font-family: $font-sans;
 
   @media (-ms-high-contrast: active), (forced-colors: active) {
     -ms-high-contrast-adjust: none;
+    forced-color-adjust: none;
     background-color: LinkText;
     color: window;
 
     &:hover,
     &:focus {
       -ms-high-contrast-adjust: none;
+      forced-color-adjust: none;
       background-color: window;
       color: LinkText;
       outline-offset: -$spacer-half;

--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -58,6 +58,7 @@ $autocomplete-list-border: $autocomplete-list-border-width $autocomplete-list-bo
     background-color: WindowText;
     color: Window;
     -ms-high-contrast-adjust: none;
+    forced-color-adjust: none;
   }
 }
 

--- a/packages/design-system/src/styles/components/_Badge.scss
+++ b/packages/design-system/src/styles/components/_Badge.scss
@@ -7,6 +7,7 @@ $badge-font-size-big: $base-font-size;
     background-color: windowText;
     color: window;
     -ms-high-contrast-adjust: none;
+    forced-color-adjust: none;
   }
 }
 

--- a/packages/design-system/src/styles/components/_StepList.scss
+++ b/packages/design-system/src/styles/components/_StepList.scss
@@ -64,6 +64,7 @@ $current-step-color: $color-primary !default;
       border-color: GrayText;
       color: GrayText;
       -ms-high-contrast-adjust: none;
+      forced-color-adjust: none;
     }
   }
 

--- a/packages/design-system/src/styles/components/_SvgIcon.scss
+++ b/packages/design-system/src/styles/components/_SvgIcon.scss
@@ -87,6 +87,7 @@
 .ds-c-icon--usa-flag {
   @media (-ms-high-contrast: active), (forced-colors: active) {
     -ms-high-contrast-adjust: none;
+    forced-color-adjust: none;
 
     path:nth-of-type(1),
     path:nth-of-type(5) {

--- a/packages/design-system/src/styles/components/_VerticalNav.scss
+++ b/packages/design-system/src/styles/components/_VerticalNav.scss
@@ -83,11 +83,13 @@
 
   @media (-ms-high-contrast: active), (forced-colors: active) {
     -ms-high-contrast-adjust: none;
+    forced-color-adjust: none;
     background-color: LinkText;
 
     &:hover,
     &:focus {
       -ms-high-contrast-adjust: none;
+      forced-color-adjust: none;
       background-color: window;
       color: LinkText;
       outline: $spacer-half solid LinkText;


### PR DESCRIPTION

## Summary

Just going through my todo-list and it was easier to make this change than to write the ticket for it. Discovered this issue when working on the date picker. Should probably create a Jira ticket for this work.

### Fixed

- Fix backplate under text in forced-colors mode on non-IE/Edge browsers making the text unreadble

<details>
  <summary>Screenshots of broken components:</summary>
  
  #### VerticalNav
  <img width="207" alt="Screen Shot 2022-06-14 at 4 49 19 PM" src="https://user-images.githubusercontent.com/7595652/173708173-97d4794a-9050-4a5b-86a0-8fbc3024b394.png">
  
  #### StepList
  <img width="96" alt="Screen Shot 2022-06-14 at 4 48 53 PM" src="https://user-images.githubusercontent.com/7595652/173708176-c903e6b2-9107-4543-8fb8-d7bb189f0375.png">
  
  #### Badge
  <img width="275" alt="Screen Shot 2022-06-14 at 4 47 57 PM" src="https://user-images.githubusercontent.com/7595652/173708183-aee2ca95-6ede-4831-beaf-59c8c9025c42.png">
  
  #### Accordion
  <img width="275" alt="Screen Shot 2022-06-14 at 4 46 48 PM" src="https://user-images.githubusercontent.com/7595652/173708184-d307aeaf-bbb4-4c77-80a2-753c5302dce5.png">
</details>




## How to test

1. Open up dev tools and hit cmd+shift+P
2. Select the option for emulating forced-colors mode

<img width="1325" alt="Screen Shot 2022-06-14 at 4 48 26 PM" src="https://user-images.githubusercontent.com/7595652/173708178-1ee2ae45-a36a-406a-952e-9c453465ec86.png">
