### PR TITLE
[No-Ticket] start:gatsby iframes and default lang

### DIFF
--- a/packages/docs/gatsby-node.js
+++ b/packages/docs/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const express = require('express');
 
 exports.onCreateWebpackConfig = ({ stage, actions }) => {
   actions.setWebpackConfig({
@@ -12,6 +13,10 @@ exports.onCreateWebpackConfig = ({ stage, actions }) => {
       },
     },
   });
+};
+
+exports.onCreateDevServer = ({ app }) => {
+  app.use(express.static('static'));
 };
 
 exports.createPages = ({ graphql, actions }) => {

--- a/packages/docs/src/components/Layout.tsx
+++ b/packages/docs/src/components/Layout.tsx
@@ -63,7 +63,7 @@ const Layout = ({
         }}
       >
         <script>{`window.tealiumEnvironment = "${env}";`}</script>
-        <script src="//tags.tiqcdn.com/utag/cmsgov/cms-design/prod/utag.sync.js" defer></script>
+        <script src="//tags.tiqcdn.com/utag/cmsgov/cms-design/prod/utag.sync.js"></script>
       </Helmet>
 
       <SkipNav href="#main" />

--- a/packages/docs/src/components/Layout.tsx
+++ b/packages/docs/src/components/Layout.tsx
@@ -56,9 +56,14 @@ const Layout = ({
 
   return (
     <div className="ds-base">
-      <Helmet title="CMS Design System">
+      <Helmet
+        title="CMS Design System"
+        htmlAttributes={{
+          lang: 'en',
+        }}
+      >
         <script>{`window.tealiumEnvironment = "${env}";`}</script>
-        <script src="//tags.tiqcdn.com/utag/cmsgov/cms-design/prod/utag.sync.js"></script>
+        <script src="//tags.tiqcdn.com/utag/cmsgov/cms-design/prod/utag.sync.js" defer></script>
       </Helmet>
 
       <SkipNav href="#main" />


### PR DESCRIPTION
## Summary

- Managed to get `start:gatsby` working with a helpful fix found with the googles! Express serves the /static dir now when running start:gatsby which gets the iframes going.
- Added a default lang to `html` to get past that accessibility flagging. 

## How to test

`yarn install && yarn build && yarn build-storybook:gatsby && yarn start:gatsby`

Check out the html tag and the iframes!