### PR TITLE
[WNMGDS-1684] Add command to deploy branch demo to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ These scripts can all be run from the root level of the repo:
   - `yarn loki:medicare test` to run the Medicare.gov visual regression tests
 - `yarn lint`
   - Runs just the linting portion of the tests, eslint and stylelint
+- `yarn deploy-demo`
+  - Builds the doc site locally and deploys it to a branch-specific path on GitHub Pages
 - `yarn release`
   - Bumps package versions and tags a release commit. Read our [Release Process guide](/guides/RELEASE-PROCESS.md) for more info.
 

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "build-storybook:gatsby": "STORYBOOK_DS=core build-storybook -o packages/docs/static/storybook",
     "build-storybook:healthcare": "STORYBOOK_DS=healthcare build-storybook -o storybook-static/healthcare",
     "build-storybook:medicare": "STORYBOOK_DS=medicare build-storybook -o storybook-static/medicare",
-    "gh-pages": "yarn gh-pages:healthcare && yarn gh-pages:medicare",
     "gh-pages:healthcare": "yarn build-docs:healthcare && gh-pages -d './packages/ds-healthcare-gov/docs/dist' --dest 'healthcare'",
     "gh-pages:medicare": "yarn build-docs:medicare && gh-pages -d './packages/ds-medicare-gov/docs/dist' --dest 'medicare'",
+    "deploy-demo": "./scripts/deploy-demo.sh",
     "scan-dependents": "ts-node scripts/scanDependents/index.ts",
     "token:dist": "yarn --cwd ./packages/design-system-tokens build themes scss && yarn --cwd ./packages/design-system-tokens dist"
   },

--- a/scripts/deploy-demo.sh
+++ b/scripts/deploy-demo.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 # Build the demo site
+yarn --cwd ./packages/docs clean
 yarn build-storybook:gatsby
 PATH_PREFIX="/design-system/branch/${BRANCH}" PREFIX_PATHS=true yarn build:gatsby
 

--- a/scripts/deploy-demo.sh
+++ b/scripts/deploy-demo.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Build the demo site
+yarn build-storybook:gatsby
+PATH_PREFIX="/design-system/branch/${BRANCH}" PREFIX_PATHS=true yarn build:gatsby
+
+
+# Deploy the demo site to a directory on GitHub Pages
+yarn gh-pages -d './packages/docs/public' --dest "branch/${BRANCH}"
+
+echo "Deployed demo doc site to https://cmsgov.github.io/design-system/branch/${BRANCH}"


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-1684

We need a new place to put our branch demos

### Added

- Added a `yarn deploy-demo` command that builds and deploys a demo for your branch to GitHub Pages
  - Or we could call it `yarn demo`. Thoughts?

## How to test

Take a look at https://cmsgov.github.io/design-system/branch/pwolfert/gh-pages-branch-demos/

You can also try the command out locally, which will override this directory.
