### PR TITLE
[WNMGDS-1770] ev-emitter downgrade for ES6 issue

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -29,7 +29,7 @@
     "core-js": "^3.6.5",
     "date-fns": "^2.28.0",
     "downshift": "^3.2.10",
-    "ev-emitter": "^2.1.2",
+    "ev-emitter": "^1.1.1",
     "focus-trap-react": "^6.0.0",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
https://jira.cms.gov/browse/WNMGDS-1770

Downgrades ev-emitter to v1.1.1 which was previously upgraded by dependabot but introduced ES6 which broke healthcare's v2.2 webpack build