### PR TITLE
[WNMGDS-1771] Fix locale link relying on deprecated `initialLanguage` prop

### DIFF
--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.test.js
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.test.js
@@ -1,6 +1,7 @@
 import defaultMenuLinks, {
   defaultMenuLinks as namedExportDefaultMenuLinks,
 } from './defaultMenuLinks';
+import { setLanguage } from '@cmsgov/design-system';
 
 describe('MenuList', function () {
   it('includes a named export', () => {
@@ -51,7 +52,12 @@ describe('MenuList', function () {
 
   describe('Spanish', () => {
     it('returns array of menu list objects', () => {
-      expect(defaultMenuLinks({ locale: 'es' })).toMatchSnapshot();
+      // Make sure you can specify the language through the deprecated `locale` prop or by the global setting
+      const linksA = defaultMenuLinks({ locale: 'es' });
+      setLanguage('es');
+      const linksB = defaultMenuLinks();
+      expect(linksA).toEqual(linksB);
+      expect(linksB).toMatchSnapshot();
     });
 
     it('returns array of menu list objects with subpath', () => {

--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
@@ -1,7 +1,7 @@
 import { Link, VARIATION_NAMES } from './Header';
 import localeLink from './localeLink';
 import loginLink from './loginLink';
-import { Language, languageMatches, tWithLanguage } from '../i18n';
+import { Language, getLanguage, languageMatches, tWithLanguage } from '../i18n';
 
 export enum LinkIdentifier {
   LOGIN = 'login',
@@ -73,7 +73,7 @@ export function defaultMenuLinks(options: DefaultMenuLinkOptions = {}) {
   }
 
   if (!hideLanguageSwitch) {
-    const locLink = localeLink(t, locale, subpath, switchLocaleLink);
+    const locLink = localeLink(t, locale ?? getLanguage(), subpath, switchLocaleLink);
     loggedOut.push(locLink);
     loggedIn.push(locLink);
   }

--- a/packages/ds-healthcare-gov/src/components/Header/localeLink.ts
+++ b/packages/ds-healthcare-gov/src/components/Header/localeLink.ts
@@ -1,4 +1,4 @@
-import { Language, TFunction } from '@cmsgov/design-system';
+import { Language, TFunction, languageMatches } from '@cmsgov/design-system';
 
 /**
  * Returns a link pointing to the opposite locale
@@ -9,12 +9,11 @@ export default function localeLink(
   subpath = '',
   switchLocaleLink?: string
 ) {
-  const defaultLocaleLink =
-    locale === 'es'
-      ? `https://www.healthcare.gov/${subpath}`
-      : `https://www.cuidadodesalud.gov/es/${subpath}`;
+  const defaultLocaleLink = languageMatches(locale, 'es')
+    ? `https://www.healthcare.gov/${subpath}`
+    : `https://www.cuidadodesalud.gov/es/${subpath}`;
   return {
-    label: locale === 'es' ? t('header.english') : t('header.español'),
-    href: switchLocaleLink || defaultLocaleLink,
+    label: languageMatches(locale, 'es') ? t('header.english') : t('header.español'),
+    href: switchLocaleLink ?? defaultLocaleLink,
   };
 }


### PR DESCRIPTION

## Summary

https://jira.cms.gov/browse/WNMGDS-1771

### Fixed

- Fixed the healthcare `Header` component's language-switching link relying on the deprecated `initialLanguage` prop to render

## How to test

1. On master, `yarn build && yarn storybook:healthcare` and view http://localhost:6006/?path=/story/components-header--logged-out-header&globals=language:es. If you switch the global language to Spanish, the component will throw an error
2. On this branch, repeat the above steps. Should not throw errors
