### PR TITLE
[WNMGDS-1772] BUGFIX: medicare focus-dark was missing the correct color

### DIFF
--- a/packages/design-system-tokens/src/themes/medicare.ts
+++ b/packages/design-system-tokens/src/themes/medicare.ts
@@ -65,7 +65,7 @@ export const themeColors: ColorTokens = {
   //
   'focus':                      color['copper-500'],
   'focus-border-inverse':       color['goldenrod-800'],
-  'focus-dark':                 color['orchid-500'],
+  'focus-dark':                 color['copper-500'],
   'focus-inverse':              color['sky-500'],
   'focus-light':                color['white-solid'],
   'focus-shadow':               color['granite-900'],

--- a/packages/ds-medicare-gov/src/styles/settings/variables/_medicare-theme.scss
+++ b/packages/ds-medicare-gov/src/styles/settings/variables/_medicare-theme.scss
@@ -55,7 +55,7 @@ $color-error-lighter: #f7bbc5;
 $color-error-lightest: #f7e6e6;
 $color-focus: #c97532;
 $color-focus-border-inverse: #7c6210;
-$color-focus-dark: #bd13b8;
+$color-focus-dark: #c97532;
 $color-focus-inverse: #02bfe7;
 $color-focus-light: #ffffff;
 $color-focus-shadow: #262626;


### PR DESCRIPTION
## Summary

Apparently `$color-focus-dark` for Medicare got overwritten or was not set correctly for the current implementation, this came in with the token branch merge. This fix set's the focus color to it's correct value.

## How to test

`yarn install && yarn build && yarn build:medicare && yarn start:medicare`

Validate the focus color is the correct copper color `#c97532`