### PR TITLE
[WNMGDS-1773] Fix long choice hint text wrapping the whole label in Safari

### DIFF
--- a/packages/design-system/src/styles/components/_Choice.scss
+++ b/packages/design-system/src/styles/components/_Choice.scss
@@ -9,7 +9,6 @@
 // Layout styles for wrapping choice container
 .ds-c-choice-wrapper {
   display: flex;
-  flex-wrap: wrap;
   gap: 0.5rem;
   margin: 0.5rem 0;
   max-width: $form__max-width;
@@ -19,7 +18,8 @@
 .ds-c-choice + label,
 .ds-c-choice + .ds-c-label {
   cursor: pointer;
-  flex: 1 1 min-content;
+  flex-grow: 1;
+  flex-basis: min-content;
   font-weight: $font-normal;
   margin-top: 0;
   max-width: max-content;
@@ -61,6 +61,7 @@ label,
   border-radius: $choice__border-radius;
   cursor: pointer;
   display: grid;
+  flex-shrink: 0;
   height: $choice__size;
   justify-items: center;
   margin: 0;


### PR DESCRIPTION

## Summary

https://jira.cms.gov/browse/WNMGDS-1773

The `flex-basis: min-content` declaration is not supported by Safari yet, so we can't rely on it to build our layout

### Fixed

- Fixed choices with long, wrapping label content pushing the whole label to the next line beneath the checkbox or radio button

## How to test

1. Open up one of the choice list stories and modify it to have some really long hint text (or any text inside the label)
2. View it in Safari. Notice that on master the whole label will wrap below the checkbox or radio button
