### PR TITLE
[WNMGDS-1562] information architecture nav updates

### DIFF
--- a/packages/docs/content/4_components/1_overview.mdx
+++ b/packages/docs/content/4_components/1_overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Components Overview
 ---
 
 Component class names follow the format: `ds-c-[BLOCK]__[ELEMENT]--[MODIFIER]`

--- a/packages/docs/content/5_patterns/1_overview.mdx
+++ b/packages/docs/content/5_patterns/1_overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Patterns
+title: Patterns Overview
 ---
 
 Patterns are solutions and researched best practices that solve recurring user interface design problems:

--- a/packages/docs/content/6_utilities/1_overview.mdx
+++ b/packages/docs/content/6_utilities/1_overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Utilities
+title: Utilities Overview
 ---
 
 A utility class modifies a single trait, typically a single CSS property. To apply a trait, or a combination of traits to an element, add the corresponding utility class directly to the HTML element.

--- a/packages/docs/src/components/ContentRenderer.tsx
+++ b/packages/docs/src/components/ContentRenderer.tsx
@@ -9,6 +9,7 @@ import EmbeddedExample from './EmbeddedExample';
 import StorybookExample from './StorybookExample';
 import ComponentThemeOptions from './ComponentThemeOptions';
 import PropTable from './PropTable';
+import ResponsiveExample from './ResponsiveExample';
 
 interface MdxProviderProps {
   children: string | { props: { children?: string } };
@@ -87,6 +88,7 @@ const customComponents = {
   StorybookExample,
   ComponentThemeOptions,
   PropTable,
+  ResponsiveExample,
 };
 
 interface ContentRendererProps {

--- a/packages/docs/src/helpers/urlUtils.ts
+++ b/packages/docs/src/helpers/urlUtils.ts
@@ -8,5 +8,5 @@ export function githubUrl(pathname = '') {
 
 export function makePageUrl(fileRelativePath) {
   let pageUrl = removePositioning(fileRelativePath);
-  return `/${pageUrl.replace('.mdx', '/')}`;
+  return `/${pageUrl}/`;
 }


### PR DESCRIPTION
## Summary

Updated a few things to support new information architecture
1. Changed way we are querying graphql to use `allMdx` instead of `allFiles`. This changes our ability to group things, so a little more work in the component. However, it does allow us to use the frontmatter title as the text shown in the nav bar
2. Had to make some updates into the data conversion. I tried to comment every step

## How to test

`yarn start:gatsby` to build and run the demo site locally.

[Demo site link](https://cmsgov.github.io/design-system/branch/WNMGDS-1562/ia-nav-updates/)
