### PR TITLE
getting graphql data for table of contents

### DIFF
--- a/packages/docs/content/5_components/modal-dialog.mdx
+++ b/packages/docs/content/5_components/modal-dialog.mdx
@@ -14,7 +14,7 @@ Apply one of the size modifier classes to the `ds-c-dialog` element to change th
 - `.ds-c-dialog--wide`
 - `.ds-c-dialog--full`
 
-## `<Dialog />`
+## `<Dialog>`
 
 <StorybookExample
   componentName="dialog"

--- a/packages/docs/src/components/ContentRenderer.tsx
+++ b/packages/docs/src/components/ContentRenderer.tsx
@@ -3,7 +3,7 @@ import Prism from 'prismjs';
 
 import { MDXRenderer } from 'gatsby-plugin-mdx';
 import { MDXProvider } from '@mdx-js/react';
-import { toKebabCase } from '../helpers/casingUtils';
+import { toKebabCase, toLowerCaseOneWord } from '../helpers/casingUtils';
 
 import EmbeddedExample from './EmbeddedExample';
 import StorybookExample from './StorybookExample';
@@ -22,7 +22,7 @@ const HeadingWithId = (props: MdxProviderProps, Component) => {
   } else {
     // for headings that have code blocks, extract the text
     const text = props.children?.props?.children;
-    return <Component {...props} id={toKebabCase(text)} />;
+    return <Component {...props} id={toLowerCaseOneWord(text)} />;
   }
 };
 

--- a/packages/docs/src/components/InfoPage.tsx
+++ b/packages/docs/src/components/InfoPage.tsx
@@ -27,6 +27,7 @@ const InfoPage = ({ data, location }: MdxQuery) => {
       showJumpToGuidance={showGuidance}
       status={status}
       location={location}
+      tableOfContentsData={tableOfContents?.items}
     >
       <ContentRenderer data={body} />
     </Layout>
@@ -43,7 +44,7 @@ export const query = graphql`
         relatedUswdsGuidance
       }
       body
-      tableOfContents
+      tableOfContents(maxDepth: 2)
     }
   }
 `;

--- a/packages/docs/src/components/Layout.tsx
+++ b/packages/docs/src/components/Layout.tsx
@@ -5,33 +5,13 @@ import { Link } from 'gatsby';
 import Footer from './DocSiteFooter';
 import Navigation from './DocSiteNavigation';
 import { SkipNav, Badge, UsaBanner } from '@cmsgov/design-system';
-import { LocationInterface } from '../helpers/graphQLTypes';
+import { LocationInterface, TableOfContentsItem } from '../helpers/graphQLTypes';
 import TableOfContents from './TableOfContents';
 import TableOfContentsMobile from './TableOfContentsMobile';
 
 import '../styles/index.scss';
 
 export type PageStatus = 'draft' | 'do not use';
-
-// TODO: delete this variable and use graphQL data instead
-const mockTOCdata = [
-  {
-    url: '#install-using-npm',
-    title: 'Install using npm',
-  },
-  {
-    url: '#download-zip',
-    title: 'Download zip',
-  },
-  {
-    url: '#utilize-the-cdn',
-    title: 'Utilize the CDN',
-  },
-  {
-    url: '#need-help-or-ran-into-an-issue',
-    title: 'Need help or ran into an issue?',
-  },
-];
 
 interface LayoutProps {
   /**
@@ -58,6 +38,10 @@ interface LayoutProps {
    * describes status of page. used for component pages
    */
   status?: PageStatus;
+  /**
+   * list of heading items to be used in table of contents
+   */
+  tableOfContentsData?: TableOfContentsItem[];
 }
 
 const Layout = ({
@@ -67,6 +51,7 @@ const Layout = ({
   showJumpToGuidance,
   status,
   location,
+  tableOfContentsData,
 }: LayoutProps) => {
   const env = 'prod';
 
@@ -125,12 +110,12 @@ const Layout = ({
           <article className="ds-u-md-display--flex ds-u-padding-x--3 ds-u-sm-padding-x--6 ds-u-sm-padding-bottom--6 ds-u-sm-padding-top--1 ds-u-padding-bottom--3 page-content">
             <div className="page-content__content ds-l-lg-col--9 ds-u-padding-left--0">
               <div className="ds-u-display--block ds-u-lg-display--none">
-                <TableOfContentsMobile data={mockTOCdata} />
+                <TableOfContentsMobile data={tableOfContentsData || []} />
               </div>
               {children}
             </div>
             <div className="ds-l-lg-col--3 ds-u-display--none ds-u-lg-display--block">
-              <TableOfContents data={mockTOCdata} />
+              <TableOfContents data={tableOfContentsData || []} />
             </div>
           </article>
         </main>

--- a/packages/docs/src/components/TableOfContents.tsx
+++ b/packages/docs/src/components/TableOfContents.tsx
@@ -10,7 +10,7 @@ export interface TableOfContentsProps {
  * The Desktop version of the table of contents
  */
 const TableOfContents = ({ data }: TableOfContentsProps) => {
-  return (
+  return data.length ? (
     <div className="c-table-of-contents">
       <h2 className="c-table-of-contents__heading ds-u-margin-y--0 ds-u-font-size--base">
         On this page{' '}
@@ -23,7 +23,7 @@ const TableOfContents = ({ data }: TableOfContentsProps) => {
         ))}
       </ul>
     </div>
-  );
+  ) : null;
 };
 
 export default TableOfContents;

--- a/packages/docs/src/components/TableOfContentsMobile.tsx
+++ b/packages/docs/src/components/TableOfContentsMobile.tsx
@@ -7,7 +7,7 @@ import { TableOfContentsProps } from './TableOfContents';
  * The mobile version of the table of contents
  */
 const TableOfContentsMobile = ({ data }: TableOfContentsProps) => {
-  return (
+  return data.length ? (
     <Accordion className="c-table-of-contents-mobile">
       <AccordionItem heading="On this page">
         <ul className="c-table-of-contents-mobile__list">
@@ -19,7 +19,7 @@ const TableOfContentsMobile = ({ data }: TableOfContentsProps) => {
         </ul>
       </AccordionItem>
     </Accordion>
-  );
+  ) : null;
 };
 
 export default TableOfContentsMobile;

--- a/packages/docs/src/helpers/casingUtils.ts
+++ b/packages/docs/src/helpers/casingUtils.ts
@@ -15,6 +15,22 @@ export const toKebabCase = (currentText: string) => {
   return currentText;
 };
 
+/**
+ * toLowerCaseOneWord - needed to match graphql's heading urls
+ * @param currentText takes a string that is English cased
+ * @returns the same text with all letters lowercase and a single word without breaks
+ *
+ */
+export const toLowerCaseOneWord = (currentText: string) => {
+  if (currentText && typeof currentText === 'string') {
+    return currentText
+      .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
+      .map((x) => x.toLowerCase())
+      .join('');
+  }
+  return currentText;
+};
+
 export const removePositioning = (text: string): string => {
   return text.replace(/\d+_/g, '');
 };

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -7,7 +7,11 @@ import ContentRenderer from '../components/ContentRenderer';
 // Main landing page for site
 const IndexPage = ({ data, location }: MdxQuery) => {
   return (
-    <Layout pageName="Introduction" location={location}>
+    <Layout
+      pageName="Introduction"
+      location={location}
+      tableOfContentsData={data.mdx.tableOfContents?.items}
+    >
       <ContentRenderer data={data.mdx.body} />
     </Layout>
   );
@@ -18,6 +22,7 @@ export const query = graphql`
     mdx(frontmatter: { title: { eq: "Introduction" } }) {
       id
       body
+      tableOfContents(maxDepth: 2)
     }
   }
 `;


### PR DESCRIPTION
## Summary

Pulling Table of Contents data from graphql & also adding a null check on TOC data. If no data exists, don't show the components.

## How to test

`yarn start:gatsby`

![TOC](https://user-images.githubusercontent.com/33579665/178329680-762150bb-62b1-4ff4-98f8-596ac7cad44b.gif)

