### PR TITLE
[NO-TICKET] Make Sass syntax compatible with node-sass compiler

### DIFF
--- a/packages/design-system/src/styles/components/_UsaBanner.scss
+++ b/packages/design-system/src/styles/components/_UsaBanner.scss
@@ -1,7 +1,5 @@
 // @TODO: deprecate usage of these when modification of these in
 // consuming systems is either not done or easily resolved
-@use 'sass:math';
-
 $usa-banner-mobile-close-size: 48px;
 $usa-caret-icon-size: 10px;
 $usa-banner-font-family: $font-sans;
@@ -163,7 +161,7 @@ $usa-banner-font-family: $font-sans;
 .ds-c-usa-banner__lock-image {
   height: 1.5ex;
   vertical-align: inherit;
-  width: math.div(1.5ex * 52, 64);
+  width: calc(1.5ex * 52 / 64);
 
   path {
     fill: currentColor;

--- a/packages/design-system/src/styles/settings/mixins/_layout.scss
+++ b/packages/design-system/src/styles/settings/mixins/_layout.scss
@@ -12,8 +12,8 @@
 }
 
 @mixin flexbox-col($size) {
-  flex: 0 0 percentage($size / $grid-columns);
-  max-width: percentage($size / $grid-columns); // IE10+ and Firefox
+  flex: 0 0 calc($size / $grid-columns) * 100%;
+  max-width: calc($size / $grid-columns) * 100%; // IE10+ and Firefox
 }
 
 @mixin equal-width-flexbox-col() {

--- a/packages/design-system/src/styles/settings/mixins/_layout.scss
+++ b/packages/design-system/src/styles/settings/mixins/_layout.scss
@@ -1,5 +1,3 @@
-@use 'sass:math';
-
 @mixin clearfix {
   &::before {
     content: '';
@@ -14,8 +12,8 @@
 }
 
 @mixin flexbox-col($size) {
-  flex: 0 0 percentage(math.div($size, $grid-columns));
-  max-width: percentage(math.div($size, $grid-columns)); // IE10+ and Firefox
+  flex: 0 0 percentage($size / $grid-columns);
+  max-width: percentage($size / $grid-columns); // IE10+ and Firefox
 }
 
 @mixin equal-width-flexbox-col() {

--- a/packages/design-system/src/styles/utilities/_grid.scss
+++ b/packages/design-system/src/styles/utilities/_grid.scss
@@ -1,5 +1,3 @@
-@use 'sass:math';
-
 @import '../settings/index.scss';
 
 // TODO: Update class namespace to utilities


### PR DESCRIPTION

## Summary

This is an alternative to https://github.com/CMSgov/design-system/pull/1957. I've changed the parts of our Sass code that were incompatible with `node-sass` (the old one) while still avoiding division-syntax deprecation warnings in dart `sass` (the new one).

### Fixed

- Fixes incompatibility of our Sass code with downstream projects that are still using `node-sass`. Everywhere that performed division using the `math.div` function has been replaced with `calc()`, which [according to the Sass documentation](https://sass-lang.com/documentation/breaking-changes/slash-div) might actually be evaluated during compile time when all the information is available.

## How to test


