### PR TITLE
[WNMGDS-1795] Add aria-current to active link in VerticalNav

### DIFF
--- a/packages/design-system/src/components/VerticalNav/VerticalNavItemLabel.tsx
+++ b/packages/design-system/src/components/VerticalNav/VerticalNavItemLabel.tsx
@@ -66,6 +66,7 @@ export const VerticalNavItemLabel = (props: VerticalNavItemLabelProps): React.Re
   } else if (LabelComponent !== DEFAULT_COMPONENT_TYPE) {
     // Apply href if <a> or custom component type
     otherProps = {
+      'aria-current': props.selected,
       href: props.url,
     };
   }


### PR DESCRIPTION
Fix #1979

## Test
Visit [demo site](https://cmsgov.github.io/design-system/branch/WNMGDS-1795/add-ariaCurrent-to-VerticalNav/storybook/?path=/story/components-vertical-nav--default-vertical-nav), open dev tools and "Grandchild link" should have `aria-current="true"` set.