### PR TITLE
[WNMGDS-1781] adding hover, active, focus styling to tooltip trigger

### DIFF
--- a/packages/design-system/src/components/Tooltip/Tooltip.stories.jsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.stories.jsx
@@ -95,3 +95,16 @@ TooltipWithCloseButton.args = {
   showCloseButton: true,
   className: 'ds-c-button',
 };
+
+export const InversedTrigger = Template.bind({});
+InversedTrigger.parameters = {
+  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+};
+InversedTrigger.args = {
+  data: <p className="ds-u-margin--0 ds-u-color--base-inverse">Tooltip with icon trigger</p>,
+  ariaLabel: 'Label describing the subject of the tooltip',
+  className: 'ds-c-tooltip__trigger-icon',
+  title: 'Tooltip trigger uses <TooltipIcon> for the trigger content',
+  children: <TooltipIcon inversed />,
+  inversed: true,
+};

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -224,7 +224,7 @@ export const Tooltip = (props: TooltipProps) => {
 
     const TriggerComponent = component;
     const triggerClasses = classNames('ds-base', 'ds-c-tooltip__trigger', className, {
-      [activeClassName]: active,
+      [activeClassName]: activeClassName && active,
       'ds-c-tooltip__trigger--inverse': inversed,
     });
     const linkTriggerOverrides = {

--- a/packages/design-system/src/styles/components/_TooltipIcon.scss
+++ b/packages/design-system/src/styles/components/_TooltipIcon.scss
@@ -35,7 +35,11 @@
 }
 
 // Add border style when tooltip is activated in addition to on hover
-.ds-c-tooltip-icon--active {
+// TODO: deprecate and remove `ds-c-tooltip-icon--active class and use pseudo element selectors instead
+.ds-c-tooltip-icon--active,
+.ds-c-tooltip__trigger:active,
+.ds-c-tooltip__trigger:hover,
+.ds-c-tooltip__trigger:focus {
   .ds-c-tooltip-icon__container {
     border-color: $tooltip-icon__color;
     border-color: rgba($tooltip-icon__color, 0.25);
@@ -47,7 +51,11 @@
 }
 
 .ds-c-tooltip__trigger--inverse {
-  &.ds-c-tooltip-icon--active {
+  // TODO: deprecate and remove `ds-c-tooltip-icon--active class and use pseudo element selectors instead
+  &.ds-c-tooltip-icon--active,
+  &.ds-c-tooltip__trigger:active,
+  &.ds-c-tooltip__trigger:hover,
+  &.ds-c-tooltip__trigger:focus {
     .ds-c-tooltip-icon__container {
       border-color: $tooltip-icon__color--inverse;
       border-color: rgba($tooltip-icon__color--inverse, 0.25);


### PR DESCRIPTION
## Summary

Pre-storybook, our tooltip trigger examples had states for focus, active and hover. It's because our previous examples were using the `<Tooltip>` component's prop `activeClassName`. Instead of updating our examples, we can use CSS pseudo-selectors to add this styling instead of a whole class. We still need to support the `activeClassName` for backwards compatibility.

In this PR, I:
- Added a story for inverse tooltips to check this change
- Added selectors so that the active styling of tooltip triggers shows up
- Updated the logic for the `activeClassName` css class. Previously, if that optional prop was not provided, the tooltip trigger would get `undefined` added to its list of classes. Now, that value is just ignored.

## How to test

`yarn start-storybook` to test changes in Tooltip stories

Before:
<img width="426" alt="Screen Shot 2022-07-25 at 11 35 35 AM" src="https://user-images.githubusercontent.com/33579665/180840866-83ef0c85-84cb-4450-9ae8-4d4399619685.png">

After (on light & on dark):
<img width="426" alt="Screen Shot 2022-07-25 at 11 35 00 AM" src="https://user-images.githubusercontent.com/33579665/180840896-fffcbba6-3d9c-4fa7-9124-cf82049a5f66.png">

<img width="426" alt="Screen Shot 2022-07-25 at 11 34 44 AM" src="https://user-images.githubusercontent.com/33579665/180840919-ee119b10-bf0b-45ef-a57a-6506b43a59ed.png">


