### PR TITLE
[NO-TICKET] Update release script to bump exact

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -66,7 +66,7 @@ git checkout -b $BRANCH
 
 echo "${GREEN}Bumping version...${NC}"
 PRE_VERSION_HASH=$(git rev-parse HEAD)
-yarn lerna version --no-push ${EXTRA_OPTS[@]}
+yarn lerna version --no-push --exact ${EXTRA_OPTS[@]}
 POST_VERSION_HASH=$(git rev-parse HEAD)
 
 if [ "$PRE_VERSION_HASH" = "$POST_VERSION_HASH" ]; then


### PR DESCRIPTION
## Summary

We recently patched an old version of the design system, but when that patch for an older version of a child design system was installed in a project, the core version resolved to the latest because npm/yarn deemed the versions compatible because of the caret `^` in our child design systems' package files. This is something we manually fixed once, but Lerna re-added the carets.

### Changed

- Update release script to use exact versions of our design system packages during lerna version bump

## How to test

You can use the release script if you want and then run `yarn release -u` to undo
