### PR TITLE
[NO-TICKET] making doc site pages full height

### DIFF
--- a/packages/docs/src/components/Layout.tsx
+++ b/packages/docs/src/components/Layout.tsx
@@ -61,9 +61,9 @@ const Layout = ({ children, frontmatter, location, theme, tableOfContentsData }:
 
       <UsaBanner className="ds-u-display--none ds-u-md-display--block" />
 
-      <div className="ds-l-row ds-u-margin--0">
+      <div className="ds-l-row ds-u-margin--0 full-height">
         <Navigation location={location} />
-        <main id="main" className="ds-l-md-col ds-u-padding--0 ds-u-padding-bottom--4">
+        <main id="main" className="ds-l-md-col ds-u-padding--0 ds-u-padding-bottom--4 page-main">
           <PageHeader frontmatter={frontmatter} theme={theme} />
           <article className="ds-u-md-display--flex ds-u-padding-x--3 ds-u-sm-padding-x--6 ds-u-sm-padding-bottom--6 ds-u-sm-padding-top--1 ds-u-padding-bottom--3 page-content">
             <div className="page-content__content ds-l-lg-col--9 ds-u-padding-left--0">

--- a/packages/docs/src/styles/pages/layout.scss
+++ b/packages/docs/src/styles/pages/layout.scss
@@ -2,8 +2,23 @@ body {
   margin: 0;
 }
 
+.full-height {
+  // viewport height minus the USA banner at the top
+  height: calc(100vh - 22px);
+}
+
+.page-main {
+  display: flex;
+  flex-direction: column;
+
+  .c-footer {
+    flex-shrink: 0;
+  }
+}
+
 .page-content {
   max-width: 81rem;
+  flex: 1 0 auto;
 }
 
 @media (min-width: $width-lg) {


### PR DESCRIPTION
## Summary
 The problem: with the new footer, some pages with a short amount of contents were not taking up the full vertical screen.
<img width="1226" alt="Screen Shot 2022-07-26 at 4 51 53 PM" src="https://user-images.githubusercontent.com/33579665/181126185-c0c93417-e446-452c-99bb-f805b6099ea1.png">


Solution: updated the page styles a bit to ensure the footer stays at the bottom

<img width="1226" alt="Screen Shot 2022-07-26 at 4 51 25 PM" src="https://user-images.githubusercontent.com/33579665/181126286-ffcba6e8-fc46-4788-890e-9fbaaaa7e462.png">

## How to test

`yarn start:gatsby`
