### PR TITLE
[WNMGDS-1812] Add unstyled list guidance for Safari

### DIFF
--- a/packages/docs/content/foundation/typography.mdx
+++ b/packages/docs/content/foundation/typography.mdx
@@ -95,6 +95,7 @@ Lists organize written information for users.
 ### Accessibility
 
 - When a list has a heading, consider adding an `id` attribute to the heading element, and an `aria-labelledby` attribute to the list element. Screen readers will then announce the heading text when users navigate to the list.
+- When using an unstyled list, `role="list"` should be added to the list element.
 
 ### Learn more
 
@@ -126,13 +127,19 @@ Lists organize written information for users.
   </article>
 </EmbeddedExample>
 
+<Alert variation="warn" weight="lightweight" class="ds-u-margin-y--3">
+  <p class="ds-u-margin-top--0">It's worth mentioning that when <code>list-style</code> is removed from a list, <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns" target="_blank">Safari will not recognize it as a list</a> in the accessibility tree.</p>
+
+  <p class="ds-u-margin-bottom--0">To resolve this issue, <code>role="list"</code> should be added to a list where the styles have been removed.</p>
+</Alert>
+
 <EmbeddedExample>
   <article>
     <h2 class="ds-h6" id="unstyled-list-id">
       Unstyled list
     </h2>
     <code class="ds-u-margin-y--0 ds-u-margin-bottom--1">.ds-c-list .ds-c-list--bare</code>
-    <ul class="ds-c-list ds-c-list--bare" aria-labelledby="unstyled-list-id">
+    <ul role="list" class="ds-c-list ds-c-list--bare" aria-labelledby="unstyled-list-id">
       <li>List item 1</li>
       <li>List item 2</li>
     </ul>


### PR DESCRIPTION
[Jira ticket](https://jira.cms.gov/browse/WNMGDS-1812)

The design system provides a way for folks to create unstyled lists by using a CSS class. What's not documented is that [Safari will remove an unstyled list](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html) from the accessibility tree without proper workarounds.

I've updated our documentation to call this issue out and updated the code example to reflect the Safari fix.

[Demo docs](https://cmsgov.github.io/design-system/branch/WNMGDS-1812/update-list-docs/foundation/typography?theme=core#list)