### PR TITLE
Release 4.0.0-beta.2

### DIFF
--- a/packages/design-system-docs/package.json
+++ b/packages/design-system-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/design-system-docs",
-  "version": "3.8.0",
+  "version": "4.0.0-beta.2",
   "publishConfig": {
     "access": "public",
     "tag": "latest"
@@ -13,7 +13,7 @@
   },
   "license": "SEE LICENSE IN LICENSE.md",
   "dependencies": {
-    "@cmsgov/design-system": "3.8.0",
+    "@cmsgov/design-system": "4.0.0-beta.2",
     "classnames": "^2.2.5",
     "lodash": "^4.17.19",
     "prismjs": "^1.11.0",

--- a/packages/design-system-scripts/package.json
+++ b/packages/design-system-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/design-system-scripts",
-  "version": "3.8.0",
+  "version": "4.0.0-beta.2",
   "publishConfig": {
     "access": "public",
     "tag": "latest"

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/design-system",
-  "version": "3.8.0",
+  "version": "4.0.0-beta.2",
   "publishConfig": {
     "access": "public",
     "tag": "latest"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/cms-design-system-docs",
-  "version": "3.8.0",
+  "version": "4.0.0-beta.2",
   "private": true,
   "description": "CMS Design System Documentation",
   "keywords": [
@@ -15,7 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@cmsgov/design-system": "3.8.0",
+    "@cmsgov/design-system": "4.0.0-beta.2",
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
     "classnames": "^2.3.1",

--- a/packages/ds-healthcare-gov/package.json
+++ b/packages/ds-healthcare-gov/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/ds-healthcare-gov",
-  "version": "7.8.0",
+  "version": "8.0.0-beta.2",
   "publishConfig": {
     "tag": "latest",
     "access": "public"
@@ -20,7 +20,7 @@
     "src"
   ],
   "dependencies": {
-    "@cmsgov/design-system": "3.8.0",
+    "@cmsgov/design-system": "4.0.0-beta.2",
     "@types/js-cookie": "^3.0.2",
     "@types/react": "^17.0.10",
     "@types/react-dom": "^17.0.10",
@@ -32,8 +32,8 @@
     "@babel/plugin-proposal-class-properties": "^7.10.1",
     "@babel/plugin-transform-object-assign": "^7.10.4",
     "@babel/preset-typescript": "^7.15.0",
-    "@cmsgov/design-system-docs": "3.8.0",
-    "@cmsgov/design-system-scripts": "3.8.0",
+    "@cmsgov/design-system-docs": "4.0.0-beta.2",
+    "@cmsgov/design-system-scripts": "4.0.0-beta.2",
     "babel-eslint": "^10.1.0",
     "url-parse": "^1.2.0"
   }

--- a/packages/ds-medicare-gov/package.json
+++ b/packages/ds-medicare-gov/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/ds-medicare-gov",
-  "version": "5.8.0",
+  "version": "6.0.0-beta.2",
   "publishConfig": {
     "tag": "latest",
     "access": "public"
@@ -25,7 +25,7 @@
     "src"
   ],
   "dependencies": {
-    "@cmsgov/design-system": "3.8.0",
+    "@cmsgov/design-system": "4.0.0-beta.2",
     "@types/react": "^17.0.10",
     "@types/react-dom": "^17.0.10"
   },
@@ -33,8 +33,8 @@
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
     "@babel/preset-typescript": "^7.8.3",
-    "@cmsgov/design-system-docs": "3.8.0",
-    "@cmsgov/design-system-scripts": "3.8.0",
+    "@cmsgov/design-system-docs": "4.0.0-beta.2",
+    "@cmsgov/design-system-scripts": "4.0.0-beta.2",
     "@types/webpack": "^4.41.6",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",


### PR DESCRIPTION
For this major beta version (4.0.0 / 8.0.0 / 6.0.0), we had to skip `-beta.1` because the `@cmsgove/design-system` package already had the version `4.0.0-beta.1` that seems to have been published in 2020 and unpublished.

 - @cmsgov/design-system-docs@4.0.0-beta.2
 - @cmsgov/design-system-scripts@4.0.0-beta.2
 - @cmsgov/design-system@4.0.0-beta.2
 - @cmsgov/cms-design-system-docs@4.0.0-beta.2
 - @cmsgov/ds-healthcare-gov@8.0.0-beta.2
 - @cmsgov/ds-medicare-gov@6.0.0-beta.2