### PR TITLE
[WNMGDS-1730] Discussion Link in TOC

### DIFF
--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -3,6 +3,7 @@ title: Alert
 intro: Alerts keep users informed of important and sometimes time-sensitive changes.
 core:
   githubLink: design-system/src/components/Alert
+  githubDiscussionLink: design-system/discussions/2006
   sketchLink: 9P3rvwn
   storybookLink: components-alert--default
 healthcare:

--- a/packages/docs/src/components/InfoPage.tsx
+++ b/packages/docs/src/components/InfoPage.tsx
@@ -35,6 +35,7 @@ export const query = graphql`
         intro
         core {
           githubLink
+          githubDiscussionLink
           sketchLink
           storybookLink
         }

--- a/packages/docs/src/components/Layout.tsx
+++ b/packages/docs/src/components/Layout.tsx
@@ -68,12 +68,15 @@ const Layout = ({ children, frontmatter, location, theme, tableOfContentsData }:
           <article className="ds-u-md-display--flex ds-u-padding-x--3 ds-u-sm-padding-x--6 ds-u-sm-padding-bottom--6 ds-u-sm-padding-top--1 ds-u-padding-bottom--3 page-content">
             <div className="page-content__content ds-l-lg-col--9 ds-u-padding-left--0">
               <div className="ds-u-display--block ds-u-lg-display--none">
-                <TableOfContentsMobile items={tableOfContentsData || []} />
+                <TableOfContentsMobile
+                  frontmatter={frontmatter}
+                  items={tableOfContentsData || []}
+                />
               </div>
               {children}
             </div>
             <div className="ds-l-lg-col--3 ds-u-display--none ds-u-lg-display--block">
-              <TableOfContents items={tableOfContentsData || []} />
+              <TableOfContents frontmatter={frontmatter} items={tableOfContentsData || []} />
             </div>
           </article>
           <Footer />

--- a/packages/docs/src/components/TableOfContents.tsx
+++ b/packages/docs/src/components/TableOfContents.tsx
@@ -53,7 +53,7 @@ export const TableOfContentsFeedback = ({ frontmatter }: TableOfContentsFeedback
       <h2 className="c-table-of-contents__heading ds-u-margin-top--0 ds-u-margin-bottom--1 ds-u-font-size--base">
         Have Ideas?
       </h2>
-      <ul className="c-table-of-contents__list">
+      <ul className="ds-c-list--bare ds-u-md-margin-y--2">
         {githubDiscussionLink && (
           <li
             key="discussion-link"
@@ -68,7 +68,7 @@ export const TableOfContentsFeedback = ({ frontmatter }: TableOfContentsFeedback
           key="feedback-link"
           className="c-table-of-contents__list-item c-table-of-contents__list-item--no-marker"
         >
-          <a href="/feedback">Propose a change, offer feedback.</a>
+          <a href="/feedback">Propose a change.</a>
         </li>
       </ul>
     </>

--- a/packages/docs/src/components/TableOfContents.tsx
+++ b/packages/docs/src/components/TableOfContents.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FrontmatterInterface } from '../helpers/graphQLTypes';
 import { TableOfContentsItem } from '../helpers/graphQLTypes';
 
 export interface TableOfContentsProps {
@@ -14,7 +15,13 @@ export interface TableOfContentsProps {
    * additional className string to append to the list
    */
   className?: string;
+  /**
+   * current frontmatter to get current page information
+   */
+  frontmatter?: FrontmatterInterface;
 }
+
+type TableOfContentsFeedbackProps = Pick<TableOfContentsProps, 'frontmatter'>;
 
 export const TableOfContentsList = ({ items, level, className = '' }: TableOfContentsProps) => {
   const itemClasses =
@@ -34,17 +41,52 @@ export const TableOfContentsList = ({ items, level, className = '' }: TableOfCon
   );
 };
 
+/*
+ * Feedback section
+ */
+export const TableOfContentsFeedback = ({ frontmatter }: TableOfContentsFeedbackProps) => {
+  const { title, core } = frontmatter;
+  const githubDiscussionLink = core?.githubDiscussionLink || null;
+
+  return (
+    <>
+      <h2 className="c-table-of-contents__heading ds-u-margin-top--0 ds-u-margin-bottom--1 ds-u-font-size--base">
+        Have Ideas?
+      </h2>
+      <ul className="c-table-of-contents__list">
+        {githubDiscussionLink && (
+          <li
+            key="discussion-link"
+            className="c-table-of-contents__list-item c-table-of-contents__list-item--no-marker"
+          >
+            <a href={'https://github.com/CMSgov/' + githubDiscussionLink}>
+              Join in the discussion for &apos;{title}&apos;
+            </a>
+          </li>
+        )}
+        <li
+          key="feedback-link"
+          className="c-table-of-contents__list-item c-table-of-contents__list-item--no-marker"
+        >
+          <a href="/feedback">Propose a change, offer feedback.</a>
+        </li>
+      </ul>
+    </>
+  );
+};
+
 /**
  * The Desktop version of the table of contents
  */
-const TableOfContents = ({ items }: TableOfContentsProps) => {
+const TableOfContents = ({ items, frontmatter }: TableOfContentsProps) => {
   const level = 1;
   return items.length ? (
     <div className="c-table-of-contents">
       <h2 className="c-table-of-contents__heading ds-u-margin-top--0 ds-u-margin-bottom--1 ds-u-font-size--base">
-        On this page{' '}
+        On this page
       </h2>
       <TableOfContentsList items={items} level={level} />
+      <TableOfContentsFeedback frontmatter={frontmatter} />
     </div>
   ) : null;
 };

--- a/packages/docs/src/components/TableOfContentsMobile.tsx
+++ b/packages/docs/src/components/TableOfContentsMobile.tsx
@@ -1,15 +1,20 @@
 import React from 'react';
 import { Accordion, AccordionItem } from '@cmsgov/design-system';
-import { TableOfContentsProps, TableOfContentsList } from './TableOfContents';
+import {
+  TableOfContentsFeedback,
+  TableOfContentsProps,
+  TableOfContentsList,
+} from './TableOfContents';
 
 /**
  * The mobile version of the table of contents
  */
-const TableOfContentsMobile = ({ items }: TableOfContentsProps) => {
+const TableOfContentsMobile = ({ items, frontmatter }: TableOfContentsProps) => {
   return items.length ? (
     <Accordion className="c-table-of-contents-mobile">
       <AccordionItem heading="On this page">
         <TableOfContentsList items={items} level={1} className="c-table-of-contents-mobile__list" />
+        <TableOfContentsFeedback frontmatter={frontmatter} />
       </AccordionItem>
     </Accordion>
   ) : null;

--- a/packages/docs/src/helpers/graphQLTypes.ts
+++ b/packages/docs/src/helpers/graphQLTypes.ts
@@ -8,6 +8,7 @@ export interface TableOfContentsItem {
 
 export interface ComponentLinksInterface {
   githubLink?: string;
+  githubDiscussionLink?: string;
   sketchLink?: string;
   storybookLink?: string;
 }


### PR DESCRIPTION
## Summary

Initial PR for implementation, links to happen next

- Added github discussion link to frontmatter for pages which takes everything in the url after `https://github.com/CMSgov/` as the url
- Including feedback link for when we merge Sarah's PR for the feedback page link

## How to test

`yarn start:gatsby` and view pages, only page that has this content at the moment is the 'Alert' page and as of now the link goes to a different discussion

## Question

Before I go creating a bunch of discussions and updating frontmatter, do we wish to agree with @line47 's comment in the ticket:

```
My thought for this was to create 3 discussion categories for the following and then create a discussion for each component 

Components
Component discussions 
Patterns
Pattern discussions
Utilities 
Utility discussions 
```

Which would mean to me, one discussion per component, then a single discussion for Patterns and a single discussion for Utilities, does that sound correct? Any other opinions?
