### PR TITLE
[NO-TICKET] adding gatsby clean before develop to fix cache issues

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -7,7 +7,7 @@
     "gatsby"
   ],
   "scripts": {
-    "develop": "gatsby develop -H 0.0.0.0",
+    "develop": "gatsby clean && gatsby develop -H 0.0.0.0",
     "start": "gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",


### PR DESCRIPTION
## Summary

Occasionally `start:gatsby` will fail with issues in `.cache`. I've found this happens most when switching branches with different doc site data. This just adds a `gatsby clean` before the develop process to make sure `.cache` and `public` are rebuilt before developing on the site locally.  `gatsby build` does this automatically.