### PR TITLE
[WNMGDS-1829] Hgov Inset component documentation

### DIFF
--- a/packages/design-system-tokens/src/themes/healthcare-components.ts
+++ b/packages/design-system-tokens/src/themes/healthcare-components.ts
@@ -320,6 +320,10 @@ export const components: AnyTokenValues = {
     '__color--warn':                              t.color['warn'],
   },
 
+  'inset': {
+    '__border-width':                             t.spacer['half']
+  },
+
   'link': {
     '__color':                                    t.color['primary'],
     '__color--active':                            t.color['primary-darkest'],

--- a/packages/docs/content/components/inset.mdx
+++ b/packages/docs/content/components/inset.mdx
@@ -1,0 +1,31 @@
+---
+title: Inset (HC.gov)
+intro: The Inset component is meant to draw attention to important content, or to associate a block of content with another element.
+healthcare:
+  githubLink: ds-healthcare-gov/src/styles/components/_Inset.scss
+---
+import loremIpsumGenerator from '../../src/helpers/loremIpsumGenerator';
+import { Alert } from '@cmsgov/design-system';
+
+<ThemeContent neverThemes={['healthcare']}>
+  <Alert variation="error">
+     <p class="ds-c-alert__text">
+        This component is only used for Healthcare. Please use the theme switcher to view the component with Healthcare styles.
+    </p>
+  </Alert>
+</ThemeContent>
+
+## Examples
+
+<EmbeddedExample>
+    <p class="ds-text">{loremIpsumGenerator('m')}</p>
+    <p class="hc-c-inset ds-text">{loremIpsumGenerator('l')}</p>
+    <p class="ds-text">{loremIpsumGenerator('m')}</p>
+</EmbeddedExample>
+
+## Guidance
+
+### When to use
+
+- Use in a progressive disclosure accordion (ie. for help text)
+- Use on its own as a way to distinguish a block of text from its surrounding content.

--- a/packages/docs/src/styles/index.scss
+++ b/packages/docs/src/styles/index.scss
@@ -19,6 +19,11 @@ $font-path: '@cmsgov/ds-medicare-gov/dist/fonts';
 // @styles is aliased in gatsby-node.js
 @import '@styles/index.scss';
 
+[data-theme='healthcare'] {
+  // TODO: update with index for hgov components. But for now, want to solve errors one component at a time
+  @import '@cmsgov/ds-healthcare-gov/src/styles/components/inset';
+}
+
 @import 'pages/feedback.scss';
 @import 'pages/layout.scss';
 

--- a/packages/docs/src/styles/theme-variables/_healthcare-components-scss-to-css.map.scss
+++ b/packages/docs/src/styles/theme-variables/_healthcare-components-scss-to-css.map.scss
@@ -264,6 +264,7 @@ $icon__color--inverse: var(--icon__color--inverse);
 $icon__color--primary: var(--icon__color--primary);
 $icon__color--success: var(--icon__color--success);
 $icon__color--warn: var(--icon__color--warn);
+$inset__border-width: var(--inset__border-width);
 $link__color: var(--link__color);
 $link__color--active: var(--link__color--active);
 $link__color--hover: var(--link__color--hover);

--- a/packages/docs/src/styles/theme-variables/_healthcare-components-theme.css
+++ b/packages/docs/src/styles/theme-variables/_healthcare-components-theme.css
@@ -243,6 +243,7 @@
 --icon__color--primary: #046791;
 --icon__color--success: #12890e;
 --icon__color--warn: #f8c41f;
+--inset__border-width: 4px;
 --link__color: #046791;
 --link__color--active: #023449;
 --link__color--hover: #034866;

--- a/packages/ds-healthcare-gov/src/styles/components/_Inset.scss
+++ b/packages/ds-healthcare-gov/src/styles/components/_Inset.scss
@@ -1,7 +1,5 @@
-$hc-c-inset-border-width: $spacer-half;
-
 .hc-c-inset {
-  border-left: $hc-c-inset-border-width solid $color-primary;
+  border-left: $inset__border-width solid $color-primary;
   margin-bottom: $spacer-2;
   padding: $spacer-2;
 }
@@ -9,9 +7,9 @@ $hc-c-inset-border-width: $spacer-half;
 // Align the inset's border with the checkbox/radio field when used as part
 // of the Exposed Within pattern
 .ds-c-choice + label + .hc-c-inset {
-  margin-left: ($choice-size * 0.5) - ($hc-c-inset-border-width * 0.5);
+  margin-left: calc(calc(#{$choice-size} * 0.5) - calc(#{$inset__border-width} * 0.5));
 }
 
 .ds-c-choice--small + label + .hc-c-inset {
-  margin-left: ($choice-size-small * 0.5) - ($hc-c-inset-border-width * 0.5);
+  margin-left: calc(calc(#{$choice-size-small} * 0.5) - calc(#{$inset__border-width} * 0.5));
 }

--- a/packages/ds-healthcare-gov/src/styles/settings/_healthcare-components-theme.scss
+++ b/packages/ds-healthcare-gov/src/styles/settings/_healthcare-components-theme.scss
@@ -242,6 +242,7 @@ $icon__color--inverse: #ffffff;
 $icon__color--primary: #046791;
 $icon__color--success: #12890e;
 $icon__color--warn: #f8c41f;
+$inset__border-width: 4px;
 $link__color: #046791;
 $link__color--active: #023449;
 $link__color--hover: #034866;


### PR DESCRIPTION
## Summary

Adding content from the hgov-specific component `Inset`. I had to create an additional component variable for the theme

## How to test

`yarn start:gatsby` and navigate to Components > Inset

Hgov doc page:
<img width="1523" alt="Screen Shot 2022-08-10 at 11 41 48 AM" src="https://user-images.githubusercontent.com/33579665/183981049-eb54d119-d74d-4119-8c65-b31d994ca41d.png">

Other brand doc page:
<img width="1523" alt="Screen Shot 2022-08-10 at 11 42 00 AM" src="https://user-images.githubusercontent.com/33579665/183981087-f553d67a-bb40-4032-a4d4-fe4b7580f814.png">

