### PR TITLE
[WNMGDS-1796] Fix border width issue for pickers in error state

### DIFF
--- a/packages/design-system-tokens/src/themes/core-components.ts
+++ b/packages/design-system-tokens/src/themes/core-components.ts
@@ -395,6 +395,8 @@ export const components: AnyTokenValues = {
     '__line-height':                              '1.3',
     '__background-color--disabled':               t.color['gray-lighter'],
     '__border-width':                             '2px',
+    '__border-width--error':                      '3px',
+    '__border-width--success':                    '3px',
     '__border-color':                             t.color['base'],
     '__border-color--disabled':                   t.color['gray-light'],
     '__border-color--error':                      t.color['error'],

--- a/packages/design-system-tokens/src/themes/healthcare-components.ts
+++ b/packages/design-system-tokens/src/themes/healthcare-components.ts
@@ -395,6 +395,8 @@ export const components: AnyTokenValues = {
     '__line-height':                              '1.3',
     '__background-color--disabled':               t.color['gray-lighter'],
     '__border-width':                             '2px',
+    '__border-width--error':                      '3px',
+    '__border-width--success':                    '3px',
     '__border-color':                             t.color['base'],
     '__border-color--disabled':                   t.color['gray-light'],
     '__border-color--error':                      t.color['error'],

--- a/packages/design-system-tokens/src/themes/medicare-components.ts
+++ b/packages/design-system-tokens/src/themes/medicare-components.ts
@@ -396,6 +396,8 @@ export const components: AnyTokenValues = {
     '__line-height':                              '1.3',
     '__background-color--disabled':               t.color['gray-lighter'],
     '__border-width':                             '2px',
+    '__border-width--error':                      '3px',
+    '__border-width--success':                    '3px',
     '__border-color':                             t.color['gray-light'],
     '__border-color--disabled':                   t.color['gray-warm-dark'],
     '__border-color--error':                      t.color['error'],

--- a/packages/design-system/src/styles/components/_SingleInputDateField.scss
+++ b/packages/design-system/src/styles/components/_SingleInputDateField.scss
@@ -494,7 +494,7 @@
       }
 
       &.ds-c-field--error {
-        margin-right: -#{$text-input__border-width};
+        margin-right: -#{$text-input__border-width--error};
       }
     }
   }
@@ -540,16 +540,16 @@
   }
 
   .ds-c-field--error + .ds-c-single-input-date-field__button {
-    border: $text-input__border-width solid $color-error;
+    border: $text-input__border-width--error solid $text-input__border-color--error;
 
     &:after {
-      left: -#{$text-input__border-width};
-      width: $text-input__border-width;
+      left: -#{$text-input__border-width--error};
+      width: $text-input__border-width--error;
     }
   }
 
   .ds-c-field--error.ds-c-field--inverse + .ds-c-single-input-date-field__button {
-    border: $text-input__border-width solid $color-error-light;
+    border: $text-input__border-width--error solid $text-input__border-color--error--inverse;
   }
 
   .ds-c-icon--calendar {

--- a/packages/design-system/src/styles/components/_TextField.scss
+++ b/packages/design-system/src/styles/components/_TextField.scss
@@ -63,13 +63,13 @@ Inverse theme
 // State modifiers and message
 // ==============================
 .ds-c-field--error {
-  border: 3px solid $text-input__border-color--error;
+  border: $text-input__border-width--error solid $text-input__border-color--error;
 
   &.ds-c-field--inverse {
-    border: 3px solid $text-input__border-color--error--inverse;
+    border: $text-input__border-width--error solid $text-input__border-color--error--inverse;
   }
 }
 
 .ds-c-field--success {
-  border: 3px solid $text-input__border-color--success;
+  border: $text-input__border-width--success solid $text-input__border-color--success;
 }

--- a/packages/design-system/src/styles/settings/variables/_core-components-theme.scss
+++ b/packages/design-system/src/styles/settings/variables/_core-components-theme.scss
@@ -295,6 +295,8 @@ $tabs__color--disabled: #404040 !default;
 $text-input__line-height: 1.3 !default;
 $text-input__background-color--disabled: #d9d9d9 !default;
 $text-input__border-width: 2px !default;
+$text-input__border-width--error: 3px !default;
+$text-input__border-width--success: 3px !default;
 $text-input__border-color: #262626 !default;
 $text-input__border-color--disabled: #a6a6a6 !default;
 $text-input__border-color--error: #e31c3d !default;

--- a/packages/docs/src/styles/theme-variables/_core-components-scss-to-css.map.scss
+++ b/packages/docs/src/styles/theme-variables/_core-components-scss-to-css.map.scss
@@ -359,6 +359,8 @@ $tabs__color--disabled: var(--tabs__color--disabled) !default;
 $text-input__line-height: var(--text-input__line-height) !default;
 $text-input__background-color--disabled: var(--text-input__background-color--disabled) !default;
 $text-input__border-width: var(--text-input__border-width) !default;
+$text-input__border-width--error: var(--text-input__border-width--error) !default;
+$text-input__border-width--success: var(--text-input__border-width--success) !default;
 $text-input__border-color: var(--text-input__border-color) !default;
 $text-input__border-color--disabled: var(--text-input__border-color--disabled) !default;
 $text-input__border-color--error: var(--text-input__border-color--error) !default;

--- a/packages/docs/src/styles/theme-variables/_core-components-theme.css
+++ b/packages/docs/src/styles/theme-variables/_core-components-theme.css
@@ -296,6 +296,8 @@
 --text-input__line-height: 1.3;
 --text-input__background-color--disabled: #d9d9d9;
 --text-input__border-width: 2px;
+--text-input__border-width--error: 3px;
+--text-input__border-width--success: 3px;
 --text-input__border-color: #262626;
 --text-input__border-color--disabled: #a6a6a6;
 --text-input__border-color--error: #e31c3d;

--- a/packages/docs/src/styles/theme-variables/_healthcare-components-scss-to-css.map.scss
+++ b/packages/docs/src/styles/theme-variables/_healthcare-components-scss-to-css.map.scss
@@ -317,6 +317,8 @@ $tabs__color--disabled: var(--tabs__color--disabled);
 $text-input__line-height: var(--text-input__line-height);
 $text-input__background-color--disabled: var(--text-input__background-color--disabled);
 $text-input__border-width: var(--text-input__border-width);
+$text-input__border-width--error: var(--text-input__border-width--error);
+$text-input__border-width--success: var(--text-input__border-width--success);
 $text-input__border-color: var(--text-input__border-color);
 $text-input__border-color--disabled: var(--text-input__border-color--disabled);
 $text-input__border-color--error: var(--text-input__border-color--error);

--- a/packages/docs/src/styles/theme-variables/_healthcare-components-theme.css
+++ b/packages/docs/src/styles/theme-variables/_healthcare-components-theme.css
@@ -296,6 +296,8 @@
 --text-input__line-height: 1.3;
 --text-input__background-color--disabled: #d9d9d9;
 --text-input__border-width: 2px;
+--text-input__border-width--error: 3px;
+--text-input__border-width--success: 3px;
 --text-input__border-color: #262626;
 --text-input__border-color--disabled: #a6a6a6;
 --text-input__border-color--error: #e31c3d;

--- a/packages/docs/src/styles/theme-variables/_medicare-components-scss-to-css.map.scss
+++ b/packages/docs/src/styles/theme-variables/_medicare-components-scss-to-css.map.scss
@@ -318,6 +318,8 @@ $tabs__color--disabled: var(--tabs__color--disabled);
 $text-input__line-height: var(--text-input__line-height);
 $text-input__background-color--disabled: var(--text-input__background-color--disabled);
 $text-input__border-width: var(--text-input__border-width);
+$text-input__border-width--error: var(--text-input__border-width--error);
+$text-input__border-width--success: var(--text-input__border-width--success);
 $text-input__border-color: var(--text-input__border-color);
 $text-input__border-color--disabled: var(--text-input__border-color--disabled);
 $text-input__border-color--error: var(--text-input__border-color--error);

--- a/packages/docs/src/styles/theme-variables/_medicare-components-theme.css
+++ b/packages/docs/src/styles/theme-variables/_medicare-components-theme.css
@@ -297,6 +297,8 @@
 --text-input__line-height: 1.3;
 --text-input__background-color--disabled: #d9d9d9;
 --text-input__border-width: 2px;
+--text-input__border-width--error: 3px;
+--text-input__border-width--success: 3px;
 --text-input__border-color: #737373;
 --text-input__border-color--disabled: #404040;
 --text-input__border-color--error: #b20000;

--- a/packages/ds-healthcare-gov/src/styles/settings/_healthcare-components-theme.scss
+++ b/packages/ds-healthcare-gov/src/styles/settings/_healthcare-components-theme.scss
@@ -295,6 +295,8 @@ $tabs__color--disabled: #404040;
 $text-input__line-height: 1.3;
 $text-input__background-color--disabled: #d9d9d9;
 $text-input__border-width: 2px;
+$text-input__border-width--error: 3px;
+$text-input__border-width--success: 3px;
 $text-input__border-color: #262626;
 $text-input__border-color--disabled: #a6a6a6;
 $text-input__border-color--error: #e31c3d;

--- a/packages/ds-medicare-gov/src/styles/settings/variables/_medicare-components-theme.scss
+++ b/packages/ds-medicare-gov/src/styles/settings/variables/_medicare-components-theme.scss
@@ -296,6 +296,8 @@ $tabs__color--disabled: #404040;
 $text-input__line-height: 1.3;
 $text-input__background-color--disabled: #d9d9d9;
 $text-input__border-width: 2px;
+$text-input__border-width--error: 3px;
+$text-input__border-width--success: 3px;
 $text-input__border-color: #737373;
 $text-input__border-color--disabled: #404040;
 $text-input__border-color--error: #b20000;


### PR DESCRIPTION

## Summary

https://jira.cms.gov/browse/WNMGDS-1796

The error-state border width wasn't previously being defined as a design token theme variable. 

### Fixed

- Fixed a problem where the different border width of error-state text fields caused the calendar picker border to look funny in the `SingleInputDateField`

## How to test

Using [the storybook instance from this branch](https://cmsgov.github.io/design-system/branch/pwolfert/fix-error-border-width/storybook/?path=/story/components-singleinputdatefield--with-error), look at the error story for the calendar picker and confirm that it has been fixed

### Before
<img width="227" alt="Screen Shot 2022-07-22 at 10 51 44 AM" src="https://user-images.githubusercontent.com/7595652/184043527-c0f2d813-5f92-414f-b402-8dd84b799508.png">

### After
<img width="223" alt="Screen Shot 2022-08-10 at 5 11 04 PM" src="https://user-images.githubusercontent.com/7595652/184043953-145980ce-580c-4e0a-bd01-435aac3a1e80.png">

