### PR TITLE
[WNMGDS-1796] Fix bad border-radius on one side of picker on medicare

### DIFF
--- a/packages/design-system-tokens/src/themes/core-components.ts
+++ b/packages/design-system-tokens/src/themes/core-components.ts
@@ -395,6 +395,8 @@ export const components: AnyTokenValues = {
     '__line-height':                              '1.3',
     '__background-color--disabled':               t.color['gray-lighter'],
     '__border-width':                             '2px',
+    '__border-width--error':                      '3px',
+    '__border-width--success':                    '3px',
     '__border-color':                             t.color['base'],
     '__border-color--disabled':                   t.color['gray-light'],
     '__border-color--error':                      t.color['error'],

--- a/packages/design-system-tokens/src/themes/healthcare-components.ts
+++ b/packages/design-system-tokens/src/themes/healthcare-components.ts
@@ -395,6 +395,8 @@ export const components: AnyTokenValues = {
     '__line-height':                              '1.3',
     '__background-color--disabled':               t.color['gray-lighter'],
     '__border-width':                             '2px',
+    '__border-width--error':                      '3px',
+    '__border-width--success':                    '3px',
     '__border-color':                             t.color['base'],
     '__border-color--disabled':                   t.color['gray-light'],
     '__border-color--error':                      t.color['error'],

--- a/packages/design-system-tokens/src/themes/medicare-components.ts
+++ b/packages/design-system-tokens/src/themes/medicare-components.ts
@@ -396,6 +396,8 @@ export const components: AnyTokenValues = {
     '__line-height':                              '1.3',
     '__background-color--disabled':               t.color['gray-lighter'],
     '__border-width':                             '2px',
+    '__border-width--error':                      '3px',
+    '__border-width--success':                    '3px',
     '__border-color':                             t.color['gray-light'],
     '__border-color--disabled':                   t.color['gray-warm-dark'],
     '__border-color--error':                      t.color['error'],

--- a/packages/design-system-tokens/src/themes/medicare-components.ts
+++ b/packages/design-system-tokens/src/themes/medicare-components.ts
@@ -406,7 +406,7 @@ export const components: AnyTokenValues = {
     '__border-color--success':                    t.color['success-light'],
     '__color':                                    t.color['gray-warm-dark'],
     '__padding':                                  t.spacer['1'],
-    '__border-radius':                            '0',
+    '__border-radius':                            '3px',
   },
 
   'tooltip': {

--- a/packages/design-system/src/styles/components/_SingleInputDateField.scss
+++ b/packages/design-system/src/styles/components/_SingleInputDateField.scss
@@ -494,7 +494,7 @@
       }
 
       &.ds-c-field--error {
-        margin-right: -#{$text-input__border-width};
+        margin-right: -#{$text-input__border-width--error};
       }
     }
   }
@@ -540,16 +540,16 @@
   }
 
   .ds-c-field--error + .ds-c-single-input-date-field__button {
-    border: $text-input__border-width solid $color-error;
+    border: $text-input__border-width--error solid $text-input__border-color--error;
 
     &:after {
-      left: -#{$text-input__border-width};
-      width: $text-input__border-width;
+      left: -#{$text-input__border-width--error};
+      width: $text-input__border-width--error;
     }
   }
 
   .ds-c-field--error.ds-c-field--inverse + .ds-c-single-input-date-field__button {
-    border: $text-input__border-width solid $color-error-light;
+    border: $text-input__border-width--error solid $text-input__border-color--error--inverse;
   }
 
   .ds-c-icon--calendar {

--- a/packages/design-system/src/styles/components/_TextField.scss
+++ b/packages/design-system/src/styles/components/_TextField.scss
@@ -63,13 +63,13 @@ Inverse theme
 // State modifiers and message
 // ==============================
 .ds-c-field--error {
-  border: 3px solid $text-input__border-color--error;
+  border: $text-input__border-width--error solid $text-input__border-color--error;
 
   &.ds-c-field--inverse {
-    border: 3px solid $text-input__border-color--error--inverse;
+    border: $text-input__border-width--error solid $text-input__border-color--error--inverse;
   }
 }
 
 .ds-c-field--success {
-  border: 3px solid $text-input__border-color--success;
+  border: $text-input__border-width--success solid $text-input__border-color--success;
 }

--- a/packages/design-system/src/styles/settings/variables/_core-components-theme.scss
+++ b/packages/design-system/src/styles/settings/variables/_core-components-theme.scss
@@ -295,6 +295,8 @@ $tabs__color--disabled: #404040 !default;
 $text-input__line-height: 1.3 !default;
 $text-input__background-color--disabled: #d9d9d9 !default;
 $text-input__border-width: 2px !default;
+$text-input__border-width--error: 3px !default;
+$text-input__border-width--success: 3px !default;
 $text-input__border-color: #262626 !default;
 $text-input__border-color--disabled: #a6a6a6 !default;
 $text-input__border-color--error: #e31c3d !default;

--- a/packages/docs/src/styles/theme-variables/_core-components-scss-to-css.map.scss
+++ b/packages/docs/src/styles/theme-variables/_core-components-scss-to-css.map.scss
@@ -359,6 +359,8 @@ $tabs__color--disabled: var(--tabs__color--disabled) !default;
 $text-input__line-height: var(--text-input__line-height) !default;
 $text-input__background-color--disabled: var(--text-input__background-color--disabled) !default;
 $text-input__border-width: var(--text-input__border-width) !default;
+$text-input__border-width--error: var(--text-input__border-width--error) !default;
+$text-input__border-width--success: var(--text-input__border-width--success) !default;
 $text-input__border-color: var(--text-input__border-color) !default;
 $text-input__border-color--disabled: var(--text-input__border-color--disabled) !default;
 $text-input__border-color--error: var(--text-input__border-color--error) !default;

--- a/packages/docs/src/styles/theme-variables/_core-components-theme.css
+++ b/packages/docs/src/styles/theme-variables/_core-components-theme.css
@@ -296,6 +296,8 @@
 --text-input__line-height: 1.3;
 --text-input__background-color--disabled: #d9d9d9;
 --text-input__border-width: 2px;
+--text-input__border-width--error: 3px;
+--text-input__border-width--success: 3px;
 --text-input__border-color: #262626;
 --text-input__border-color--disabled: #a6a6a6;
 --text-input__border-color--error: #e31c3d;

--- a/packages/docs/src/styles/theme-variables/_healthcare-components-scss-to-css.map.scss
+++ b/packages/docs/src/styles/theme-variables/_healthcare-components-scss-to-css.map.scss
@@ -317,6 +317,8 @@ $tabs__color--disabled: var(--tabs__color--disabled);
 $text-input__line-height: var(--text-input__line-height);
 $text-input__background-color--disabled: var(--text-input__background-color--disabled);
 $text-input__border-width: var(--text-input__border-width);
+$text-input__border-width--error: var(--text-input__border-width--error);
+$text-input__border-width--success: var(--text-input__border-width--success);
 $text-input__border-color: var(--text-input__border-color);
 $text-input__border-color--disabled: var(--text-input__border-color--disabled);
 $text-input__border-color--error: var(--text-input__border-color--error);

--- a/packages/docs/src/styles/theme-variables/_healthcare-components-theme.css
+++ b/packages/docs/src/styles/theme-variables/_healthcare-components-theme.css
@@ -296,6 +296,8 @@
 --text-input__line-height: 1.3;
 --text-input__background-color--disabled: #d9d9d9;
 --text-input__border-width: 2px;
+--text-input__border-width--error: 3px;
+--text-input__border-width--success: 3px;
 --text-input__border-color: #262626;
 --text-input__border-color--disabled: #a6a6a6;
 --text-input__border-color--error: #e31c3d;

--- a/packages/docs/src/styles/theme-variables/_medicare-components-scss-to-css.map.scss
+++ b/packages/docs/src/styles/theme-variables/_medicare-components-scss-to-css.map.scss
@@ -318,6 +318,8 @@ $tabs__color--disabled: var(--tabs__color--disabled);
 $text-input__line-height: var(--text-input__line-height);
 $text-input__background-color--disabled: var(--text-input__background-color--disabled);
 $text-input__border-width: var(--text-input__border-width);
+$text-input__border-width--error: var(--text-input__border-width--error);
+$text-input__border-width--success: var(--text-input__border-width--success);
 $text-input__border-color: var(--text-input__border-color);
 $text-input__border-color--disabled: var(--text-input__border-color--disabled);
 $text-input__border-color--error: var(--text-input__border-color--error);

--- a/packages/docs/src/styles/theme-variables/_medicare-components-theme.css
+++ b/packages/docs/src/styles/theme-variables/_medicare-components-theme.css
@@ -297,6 +297,8 @@
 --text-input__line-height: 1.3;
 --text-input__background-color--disabled: #d9d9d9;
 --text-input__border-width: 2px;
+--text-input__border-width--error: 3px;
+--text-input__border-width--success: 3px;
 --text-input__border-color: #737373;
 --text-input__border-color--disabled: #404040;
 --text-input__border-color--error: #b20000;

--- a/packages/docs/src/styles/theme-variables/_medicare-components-theme.css
+++ b/packages/docs/src/styles/theme-variables/_medicare-components-theme.css
@@ -307,7 +307,7 @@
 --text-input__border-color--success: #2a9526;
 --text-input__color: #404040;
 --text-input__padding: 8px;
---text-input__border-radius: 0;
+--text-input__border-radius: 3px;
 --tooltip__background-color: #ffffff;
 --tooltip__border-color: #404040;
 --tooltip__color: #404040;

--- a/packages/ds-healthcare-gov/src/styles/settings/_healthcare-components-theme.scss
+++ b/packages/ds-healthcare-gov/src/styles/settings/_healthcare-components-theme.scss
@@ -295,6 +295,8 @@ $tabs__color--disabled: #404040;
 $text-input__line-height: 1.3;
 $text-input__background-color--disabled: #d9d9d9;
 $text-input__border-width: 2px;
+$text-input__border-width--error: 3px;
+$text-input__border-width--success: 3px;
 $text-input__border-color: #262626;
 $text-input__border-color--disabled: #a6a6a6;
 $text-input__border-color--error: #e31c3d;

--- a/packages/ds-medicare-gov/src/styles/components/_override.forms.scss
+++ b/packages/ds-medicare-gov/src/styles/components/_override.forms.scss
@@ -10,7 +10,6 @@
   color: $text-input__color;
   font-family: $font-family-rubik;
   font-size: $font-size-md;
-  border-radius: 3px;
   border-color: $text-input__border-color;
   padding: $spacer-2;
 

--- a/packages/ds-medicare-gov/src/styles/settings/variables/_medicare-components-theme.scss
+++ b/packages/ds-medicare-gov/src/styles/settings/variables/_medicare-components-theme.scss
@@ -296,6 +296,8 @@ $tabs__color--disabled: #404040;
 $text-input__line-height: 1.3;
 $text-input__background-color--disabled: #d9d9d9;
 $text-input__border-width: 2px;
+$text-input__border-width--error: 3px;
+$text-input__border-width--success: 3px;
 $text-input__border-color: #737373;
 $text-input__border-color--disabled: #404040;
 $text-input__border-color--error: #b20000;

--- a/packages/ds-medicare-gov/src/styles/settings/variables/_medicare-components-theme.scss
+++ b/packages/ds-medicare-gov/src/styles/settings/variables/_medicare-components-theme.scss
@@ -306,7 +306,7 @@ $text-input__border-color--inverse: #000000;
 $text-input__border-color--success: #2a9526;
 $text-input__color: #404040;
 $text-input__padding: 8px;
-$text-input__border-radius: 0;
+$text-input__border-radius: 3px;
 $tooltip__background-color: #ffffff;
 $tooltip__border-color: #404040;
 $tooltip__color: #404040;


### PR DESCRIPTION

## Summary

When working on https://github.com/CMSgov/design-system/pull/2033 and testing the medicare version of the picker component, I noticed that the border radius on the calendar button didn't match the border radius for the text input. Even though the picker styles used the `$text-input__border-radius` variable for its border radius so it would match text fields, the text fields in medicare weren't actually taking their value from `$text-input__border-radius`. An override rule was replacing the value defined in the token theme with a static value in Sass.

### Fixed

- Fixed Medicare `ds-c-field` styles not using the `$text-input__border-radius` variable defined in the token theme
- Fixed border radius on the right side of the calendar picker not matching the left side

## How to test

https://cmsgov.github.io/design-system/branch/pwolfert/fix-medicare-text-border-radius/storybook/?path=/story/components-singleinputdatefield--with-error

### Before
<img width="427" alt="Screen Shot 2022-08-10 at 5 14 14 PM" src="https://user-images.githubusercontent.com/7595652/184044583-9ed04ea8-51f3-4d29-8f59-236a309e1f08.png">

### After
<img width="415" alt="Screen Shot 2022-08-10 at 5 23 15 PM" src="https://user-images.githubusercontent.com/7595652/184044937-c4922681-6d8a-4eec-a767-5fe12e808fdd.png">

