### PR TITLE
[No-Ticket] Update release script to no longer create release branch

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,6 +9,8 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No color
 
 read_previous_commit_tags() {
+  # Get the last commit to undo
+  LAST_COMMIT=$(git rev-parse HEAD)
   # Grep the last commit message for package versions
   PACKAGE_VERSIONS=$(git log -1 --pretty=%B | grep -o "@.*$")
   # Take the first one we find to use in example command
@@ -51,6 +53,10 @@ if [ "$DELETE_LAST" = true ]; then
     echo "${GREEN}Undoing last release...${NC}"
     git tag -d $TAGS
     git push origin --delete $TAGS
+    echo "${GREEN}Tags deleted...${NC}"
+    git revert $LAST_COMMIT --no-edit
+    git push origin
+    echo "${GREEN}Version bumps reverted...${NC}"
   fi
   exit 0
 fi
@@ -68,8 +74,8 @@ fi
 echo "${GREEN}Pushing tags and version update commit to Github...${NC}"
 read_previous_commit_tags
 
-# push current branch 
-git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git push --set-upstream origin $BRANCH
 git push origin $TAGS
 
 echo ""
@@ -81,7 +87,7 @@ echo "${YELLOW}-------${NC}"
 echo ""
 echo "${YELLOW}NEXT STEPS:${NC}"
 echo ""
-echo "${YELLOW}  1. Create a pull request for merging \`${CYAN}$BRANCH${YELLOW}\` into master to save the version bump${NC}"
+echo "${YELLOW}  1. Create a pull request for merging \`${CYAN}$BRANCH${YELLOW}\` into master to save the version bump${NC}."
 echo ""
-echo "${YELLOW}  2. Publish this release to npm using the \`${CYAN}publish${YELLOW}\` job${NC}"
+echo "${YELLOW}  2. Publish this release using the \`${CYAN}publish${YELLOW}\` jenkins job${NC}."
 echo ""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -40,7 +40,7 @@ git fetch --tags
 
 if [ "$DELETE_LAST" = true ]; then
   read_previous_commit_tags
-  echo "${RED}This release branch and the following tags will be deleted locally and on origin${NC}"
+  echo "${RED}The following tags will be deleted locally and on origin${NC}"
   echo ""
   echo "${PACKAGE_VERSIONS}"
   echo ""
@@ -49,37 +49,27 @@ if [ "$DELETE_LAST" = true ]; then
   if [[ $REPLY =~ ^[Yy]$ ]]
   then
     echo "${GREEN}Undoing last release...${NC}"
-    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
     git tag -d $TAGS
     git push origin --delete $TAGS
-    git push origin --delete $CURRENT_BRANCH
-    git checkout -
-    git branch -D $CURRENT_BRANCH
   fi
   exit 0
 fi
 
-echo "${GREEN}Creating release branch...${NC}"
-BRANCHREF=$(git rev-parse --short HEAD)
-BRANCH="release-${BRANCHREF}"
-git checkout -b $BRANCH
-
-echo "${GREEN}Bumping version...${NC}"
+echo "${GREEN}Bumping package versions...${NC}"
 PRE_VERSION_HASH=$(git rev-parse HEAD)
 yarn lerna version --no-push --exact ${EXTRA_OPTS[@]}
 POST_VERSION_HASH=$(git rev-parse HEAD)
 
 if [ "$PRE_VERSION_HASH" = "$POST_VERSION_HASH" ]; then
-  echo "${RED}No bump commit detected. Removing release branch and exiting...${NC}"
-  git checkout -
-  git branch -D $BRANCH
+  echo "${RED}No bump commit detected. exiting...${NC}"
   exit 1
 fi
 
-echo "${GREEN}Pushing tag and release commit to Github...${NC}"
+echo "${GREEN}Pushing tags and version update commit to Github...${NC}"
 read_previous_commit_tags
 
-git push --set-upstream origin $BRANCH
+# push current branch 
+git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD)
 git push origin $TAGS
 
 echo ""
@@ -93,5 +83,5 @@ echo "${YELLOW}NEXT STEPS:${NC}"
 echo ""
 echo "${YELLOW}  1. Create a pull request for merging \`${CYAN}$BRANCH${YELLOW}\` into master to save the version bump${NC}"
 echo ""
-echo "${YELLOW}  2. Publish this release to npm using the \`${CYAN}publish-packages${YELLOW}\` job${NC}"
+echo "${YELLOW}  2. Publish this release to npm using the \`${CYAN}publish${YELLOW}\` job${NC}"
 echo ""


### PR DESCRIPTION
## Summary

With our new release structure, releases will always be cut from a particular branch off of master. The automation of creating a release branch only adds another step where that branch has to be merged into two places. Future changes will be made to this script but to get started today, since the `release/4` branch will be created manually from the `@cmsgov/design-system@4.0.0-beta.3` commit tag, no extra branches need be created.  Future bugfixes also won't need a separate branch they will just be tagged from the current release branch. This way we can just do one merge from the `release/4` branch to master to bump the version numbers.

- Removes branch creation/deletion from `scripts/releash.sh`
- Cleans up some of the verbiage to be more accurate

## How to test

`yarn release` bump versions then see them pushed to branch, then run `yarn release -u` to remove those tags.
