### PR TITLE
[WNMGDS-1829] healthcare header docs

### DIFF
--- a/packages/docs/content/components/header/healthcare-header.mdx
+++ b/packages/docs/content/components/header/healthcare-header.mdx
@@ -1,0 +1,58 @@
+---
+title: Healthcare.gov Header
+healthcare:
+  githubLink: ds-healthcare-gov/src/components/Header
+  sketchLink: bgDE8k4
+---
+
+import { Alert } from '@cmsgov/design-system';
+
+<ThemeContent neverThemes={['healthcare']}>
+  <Alert variation="error">
+     <p class="ds-c-alert__text">
+        This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.
+    </p>
+  </Alert>
+</ThemeContent>
+
+## Examples
+The HealthCare.gov header component varies depending on the user's state (ie. logged-in) and context (ie. what page the user is on).
+
+### Logged-In
+<StorybookExample
+    componentName="loggedin-header"
+    storyId="healthcare-header--logged-in-header"
+/>
+
+### Logged-Out
+<StorybookExample
+    componentName="loggedout-header"
+    storyId="healthcare-header--logged-out-header"
+/>
+
+### Minimal
+<StorybookExample
+    componentName="minimal-header"
+    storyId="healthcare-header--minimal-header"
+/>
+
+## Code
+
+### React
+
+<PropTable componentName="Header" />
+
+### Google Analytics
+
+**Analytics event tracking is enabled by default.**
+
+On applications where the page has `utag` loaded, the data goes to Tealium which allows it to route to Google Analytics or the currently approved data analytics tools.
+
+#### Disabling event tracking
+
+Import and set the `setHeaderSendsAnalytics` feature flag to `false` in your application's entry file:
+
+```js
+import { setHeaderSendsAnalytics } from "@cmsgov/<design-system-package>";
+setHeaderSendsAnalytics(false);
+```

--- a/packages/docs/src/styles/index.scss
+++ b/packages/docs/src/styles/index.scss
@@ -20,10 +20,9 @@ $font-path: '@cmsgov/ds-medicare-gov/dist/fonts';
 @import '@styles/index.scss';
 
 [data-theme='healthcare'] {
-  // TODO: update with index for hgov components. But for now, want to solve errors one component at a time
-  @import '@cmsgov/ds-healthcare-gov/src/styles/components/inset';
-  @import '@cmsgov/ds-healthcare-gov/src/styles/components/logo';
-  @import '@cmsgov/ds-healthcare-gov/src/styles/components/footer';
+  // Have to set the image path so that the error label's svg can be found
+  $image-path: '@cmsgov/ds-healthcare-gov/src/images';
+  @import '@cmsgov/ds-healthcare-gov/src/styles/components/index';
 }
 
 @import 'pages/feedback.scss';

--- a/packages/ds-healthcare-gov/src/components/Footer/Logo.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Logo.tsx
@@ -12,7 +12,7 @@ interface LogoProps {
  * We use a Babel loader to turn SVG imports into strings.
  * This component renders those strings.
  *
- * Do not add a title to the <a> tag as a substitute for alt
+ * Do not add a title to the `<a>` tag as a substitute for alt
  * text on the linked images. It is a best practice to include
  * a `<title>` tag inside the SVG to provide the text that will
  * be read out to assistive devices. This text is a functional
@@ -22,10 +22,10 @@ interface LogoProps {
  * creating accessible SVG files. At a minimum you will need to
  * have the following elements in your SVG files:
  *
- * 1. aria-labelledby="<TITLE_ID>" attribute in the <svg> tag
- * 2. role="img" attribute in the <svg> tag
- * 3. focusable="false" attribute in the <svg> tag
- * 4. <title id="TITLE_ID"> Description of the image link here </title>
+ * 1. `aria-labelledby="TITLE_ID"` attribute in the `<svg>` tag
+ * 2. role="img" attribute in the `<svg>` tag
+ * 3. focusable="false" attribute in the `<svg>` tag
+ * 4. `<title id="TITLE_ID"> Description of the image link here </title>`
  *
  */
 


### PR DESCRIPTION
## Summary

* Adding docs for the Healthcare header
* Updating some docs in the healthcare Logo component that was causing gatsby build errors

## How to test

`yarn start:gatsby`
