### PR TITLE
[WNMGDS-1830] mgov icons & logos documentation

### DIFF
--- a/packages/design-system/src/components/Icons/icons.stories.tsx
+++ b/packages/design-system/src/components/Icons/icons.stories.tsx
@@ -12,6 +12,7 @@ import {
   CloseIconThin,
   DownloadIcon,
   ExternalLinkIcon,
+  HHSLogo,
   ImageIcon,
   InfoCircleIcon,
   InfoCircleIconThin,
@@ -217,3 +218,5 @@ export const AvailableIcons = () => (
     </table>
   </>
 );
+
+export const HhsLogo = () => <HHSLogo />;

--- a/packages/docs/content/components/icon.mdx
+++ b/packages/docs/content/components/icon.mdx
@@ -5,6 +5,8 @@ core:
   githubLink: design-system/src/components/Icons
   sketchLink: ZOm83Y3
   storybookLink: components-icons--available-icons
+medicare:
+  githubLink: ds-medicare-gov/src/components/Icons
 ---
 
 import { CloseIcon, SvgIcon } from '@cmsgov/design-system';
@@ -16,10 +18,18 @@ This component is used by each individual icon component listed below.
 
 <StorybookExample
   componentName="icons"
-  sourceFilePath="components/Icons/SvgIcon.tsx"
   storyId="components-icons--available-icons"
   minHeight={250}
 />
+
+<ThemeContent onlyThemes={['medicare']}>
+  <h3 id="medicare-specific-icons"> Medicare-Specific Icons </h3>
+  <StorybookExample
+    componentName="icons-medicare"
+    storyId="medicare-icons--available-icons"
+    minHeight={250}
+  />
+</ThemeContent>
 
 ### Changing icon color
 

--- a/packages/docs/content/components/logos/hhs-logo.mdx
+++ b/packages/docs/content/components/logos/hhs-logo.mdx
@@ -1,0 +1,22 @@
+---
+title: HHS Logo
+intro: Renders the HHS logo.
+core:
+  githubLink: design-system/src/components/Icons/HhsLogo.tsx
+  storybookLink: components-icons--hhs-logo
+---
+
+## Examples
+
+<StorybookExample
+    componentName="hhsLogo"
+    storyId="components-icons--hhs-logo"
+/>
+
+## Code
+
+### React
+
+<PropTable componentName="SvgIcon" />
+
+

--- a/packages/docs/content/components/logos/medicare-logo.mdx
+++ b/packages/docs/content/components/logos/medicare-logo.mdx
@@ -1,0 +1,31 @@
+---
+title: Medicare.gov Logo
+intro: Renders the Medicare.gov logo.
+medicare:
+  githubLink: ds-medicare-gov/src/components/MedicaregovLogo
+  sketchLink: nRzKJna
+  storybookLink: medicare-logo--logo
+---
+import { Alert } from '@cmsgov/design-system';
+
+<ThemeContent neverThemes={['medicare']}>
+  <Alert variation="error">
+     <p class="ds-c-alert__text">
+        This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.
+    </p>
+  </Alert>
+</ThemeContent>
+
+## Examples
+
+<StorybookExample
+    componentName="medicareLogo"
+    storyId="medicare-logo--logo"
+/>
+
+## Code
+
+### React
+
+<PropTable componentName="MedicaregovLogo" />
+

--- a/packages/docs/gatsby-config.ts
+++ b/packages/docs/gatsby-config.ts
@@ -34,6 +34,14 @@ const config: GatsbyConfig = {
       },
     },
     {
+      resolve: 'gatsby-source-filesystem',
+      // components to load prop data from
+      options: {
+        name: 'mgov-components',
+        path: '../ds-medicare-gov/src/components',
+      },
+    },
+    {
       resolve: 'gatsby-plugin-manifest',
       options: {
         name: 'CMS Design System',

--- a/packages/docs/src/components/InfoPage.tsx
+++ b/packages/docs/src/components/InfoPage.tsx
@@ -46,6 +46,8 @@ export const query = graphql`
         }
         medicare {
           sketchLink
+          storybookLink
+          githubLink
         }
       }
       slug

--- a/packages/docs/src/components/StorybookExample.tsx
+++ b/packages/docs/src/components/StorybookExample.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import classnames from 'classnames';
 import StorybookExampleFooter from './StorybookExampleFooter';
-import { ExternalLinkIcon, Spinner } from '@cmsgov/design-system';
-import { makeStorybookUrl } from '../helpers/urlUtils';
+import { Spinner } from '@cmsgov/design-system';
 import { withPrefix } from 'gatsby';
 
 interface StorybookExampleProps {

--- a/packages/ds-medicare-gov/src/components/Icons/icons.stories.tsx
+++ b/packages/ds-medicare-gov/src/components/Icons/icons.stories.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { RoundedStarIcon, PharmacyIcon, PiggyBankIcon, CheckShieldIcon, DrugsIcon } from './index';
+
+export default {
+  title: 'Medicare/Icons',
+  component: RoundedStarIcon,
+};
+
+const iconData = [
+  {
+    defaultTitle: 'Check with shield',
+    component: <CheckShieldIcon />,
+    name: 'CheckShieldIcon',
+  },
+  {
+    defaultTitle: 'Drugs',
+    component: <DrugsIcon />,
+    name: 'DrugsIcon',
+  },
+  {
+    defaultTitle: 'Pharmacy',
+    component: <PharmacyIcon />,
+    name: 'PharmacyIcon',
+  },
+  {
+    defaultTitle: 'Piggy Bank',
+    component: <PiggyBankIcon />,
+    name: 'PiggyBankIcon',
+  },
+  {
+    defaultTitle: '[variation] Star',
+    component: (
+      <>
+        <RoundedStarIcon />
+        <RoundedStarIcon variation="half" />
+        <RoundedStarIcon variation="filled" />
+      </>
+    ),
+    name: 'RoundedStarIcon',
+    notes:
+      'Takes a `variation` prop to determine if the star is fully filled, half filled, or just an outline.',
+  },
+];
+
+export const AvailableIcons = () => (
+  <>
+    <table className="ds-c-table">
+      <thead>
+        <tr>
+          <th>Icon Component</th>
+          <th>Example</th>
+          <th>
+            Default <code>title</code> attribute
+          </th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {iconData.map(({ defaultTitle, component, name, notes }) => (
+          <tr key={name}>
+            <td>
+              <code>{name}</code>
+            </td>
+            <td className="ds-u-text-align--center">{component}</td>
+            <td>{defaultTitle}</td>
+            <td dangerouslySetInnerHTML={{ __html: notes }} />
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </>
+);

--- a/packages/ds-medicare-gov/src/components/MedicaregovLogo/medicaregovLogo.stories.tsx
+++ b/packages/ds-medicare-gov/src/components/MedicaregovLogo/medicaregovLogo.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import MedicaregovLogo from './index';
+
+export default {
+  title: 'Medicare/Logo',
+  component: MedicaregovLogo,
+};
+
+export const Logo = () => <MedicaregovLogo />;


### PR DESCRIPTION
## Summary

Pt 1 of mgov-specific documentation includes adding docs for 

- HHS logo
- Mgov-specific icons
- Mgov logo

## How to test

`yarn build-storybook` `yarn build:gatsby` `yarn serve:gatsby`
