### PR TITLE
[WNMGDS-1837] updating tab title with page name

### DIFF
--- a/packages/docs/src/components/Layout.tsx
+++ b/packages/docs/src/components/Layout.tsx
@@ -57,7 +57,7 @@ const Layout = ({
   return (
     <div className="ds-base">
       <Helmet
-        title="CMS Design System"
+        title={`${frontmatter?.title || ''} - CMS Design System`}
         htmlAttributes={{
           lang: 'en',
         }}


### PR DESCRIPTION
## Summary

Updating the browser tab title with the page name to help with history navigation.

## How to test

`yarn start:gatsby`. Click around the site and confirm that the tab title updates.
