### PR TITLE
[no-ticket] [bugfix] Missing export on mgov logo caused build to fail 

### DIFF
--- a/packages/design-system-scripts/gulp/build.js
+++ b/packages/design-system-scripts/gulp/build.js
@@ -23,6 +23,7 @@ const getSrcGlob = (src, changedPath) =>
     ? [changedPath]
     : [
         `${src}/**/*.{js,jsx,ts,tsx}`,
+        `!${src}/**/*.stories.{js,jsx,ts,tsx}`,
         `!${src}/setupTests.{js,jsx,ts,tsx}`,
         `!${src}/**/*{.test,.spec,.d}.{js,jsx,ts,tsx}`,
         `!${src}/**/{__mocks__,__tests__}/**/*`,

--- a/packages/design-system-scripts/gulp/build.js
+++ b/packages/design-system-scripts/gulp/build.js
@@ -68,7 +68,7 @@ function copyMisc(dir) {
         `!${src}/images/**`,
         `!${src}/styles/**`,
         `!${src}/setupTests.{js,jsx,ts,tsx}`,
-        `!${src}/**/*{.test,.spec}.{js,jsx,ts,tsx}`,
+        `!${src}/**/*{.test,.spec,.stories}.{js,jsx,ts,tsx}`,
         `!${src}/**/{__mocks__,__tests__,helpers}/**/*`,
       ])
       .pipe(gulp.dest(path.join(dir, 'dist')))
@@ -110,7 +110,7 @@ async function generateTypeDefinitions(dir, changedPath) {
         `${src}/**/*.{ts,tsx}`,
         `!${src}/**/*.{js,jsx}`,
         `!${src}/setupTests.{js,jsx,ts,tsx}`,
-        `!${src}/**/*{.test,.spec,.d}.{js,jsx,ts,tsx}`,
+        `!${src}/**/*{.test,.spec,.d,.stories}.{js,jsx,ts,tsx}`,
         `!${src}/**/{__mocks__,__tests__,helpers}/**/*`,
       ];
 

--- a/packages/design-system-scripts/gulp/build.js
+++ b/packages/design-system-scripts/gulp/build.js
@@ -23,9 +23,8 @@ const getSrcGlob = (src, changedPath) =>
     ? [changedPath]
     : [
         `${src}/**/*.{js,jsx,ts,tsx}`,
-        `!${src}/**/*.stories.{js,jsx,ts,tsx}`,
+        `!${src}/**/*{.test,.spec,.d,.stories}.{js,jsx,ts,tsx}`,
         `!${src}/setupTests.{js,jsx,ts,tsx}`,
-        `!${src}/**/*{.test,.spec,.d}.{js,jsx,ts,tsx}`,
         `!${src}/**/{__mocks__,__tests__}/**/*`,
       ];
 

--- a/packages/ds-medicare-gov/src/components/MedicaregovLogo/MedicaregovLogo.tsx
+++ b/packages/ds-medicare-gov/src/components/MedicaregovLogo/MedicaregovLogo.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import uniqueId from 'lodash/uniqueId';
 
-interface MedicaregovLogoProps {
+export interface MedicaregovLogoProps {
   width?: string;
   height?: string;
   className?: string;


### PR DESCRIPTION
## Summary

`yarn build:medicare` is currently failing in master because of a missing export on a props interface for `MedicaregovLogo`

## How to test

`yarn install && yarn build && yarn build:medicare`

### If this is a change to code:

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[ticket] title`
- [x] Ran `yarn type-check && yarn lint && yarn test` with no errors
- [x] Updated unit test snapshots and loki reference images **if necessary** with `yarn loki` && `yarn update-snapshots`