### PR TITLE
[WNMGDS-1879] TableCaption & TableCell test updates to RTL

### DIFF
--- a/packages/design-system/src/components/Table/TableCaption.test.tsx
+++ b/packages/design-system/src/components/Table/TableCaption.test.tsx
@@ -1,35 +1,30 @@
 import React from 'react';
 import TableCaption from './TableCaption';
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 const defaultCaptionChildren = 'Foo';
 
-function render(customProps = {}) {
+function renderCaption(customProps = {}) {
   const props = Object.assign({}, customProps);
   const children = <TableCaption {...props}>{defaultCaptionChildren}</TableCaption>;
 
   return {
     props: props,
-    wrapper: mount(<table>{children}</table>),
+    view: render(<table>{children}</table>),
   };
 }
 
 describe('TableCaption', function () {
   it('renders a table caption', () => {
-    const { wrapper } = render();
-    const caption = wrapper.find('caption');
-
-    expect(caption).toHaveLength(1);
-    expect(caption.hasClass('ds-c-table__caption')).toBe(true);
-    expect(caption.text()).toBe(defaultCaptionChildren);
+    renderCaption();
+    const caption = screen.getByText(defaultCaptionChildren);
+    expect(caption).toHaveClass('ds-c-table__caption');
   });
 
   it('applies additional classNames to caption', () => {
-    const { wrapper } = render({ className: 'foo-caption' });
-    const caption = wrapper.find('caption');
-
-    expect(caption.hasClass('foo-caption')).toBe(true);
-
-    expect(wrapper).toMatchSnapshot();
+    const view = renderCaption({ className: 'foo-caption' });
+    const caption = screen.getByText(defaultCaptionChildren);
+    expect(caption).toHaveClass('foo-caption');
+    expect(view).toMatchSnapshot();
   });
 });

--- a/packages/design-system/src/components/Table/TableCell.test.tsx
+++ b/packages/design-system/src/components/Table/TableCell.test.tsx
@@ -3,110 +3,67 @@ import TableBody from './TableBody';
 import TableCell from './TableCell';
 import TableHead from './TableHead';
 import TableRow from './TableRow';
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
-function renderHead(customProps = {}) {
-  const props = Object.assign({}, customProps);
-  const children = (
-    <TableHead>
-      <TableRow>
-        <TableCell>Column a</TableCell>
-        <TableCell>Column b</TableCell>
-      </TableRow>
-    </TableHead>
+const renderHead = () =>
+  render(
+    <table>
+      <TableHead>
+        <TableRow>
+          <TableCell>Column a</TableCell>
+          <TableCell>Column b</TableCell>
+        </TableRow>
+      </TableHead>
+    </table>
   );
 
-  return {
-    props: props,
-    wrapper: mount(<table>{children}</table>),
-  };
-}
-
-function renderBody(customProps = {}) {
-  const props = Object.assign({}, customProps);
-  const children = (
-    <TableBody>
-      <TableRow>
-        <TableCell component="th">Cell a</TableCell>
-        <TableCell>Cell b</TableCell>
-      </TableRow>
-    </TableBody>
+const renderBody = () =>
+  render(
+    <table>
+      <TableBody>
+        <TableRow>
+          <TableCell component="th">Cell a</TableCell>
+          <TableCell>Cell b</TableCell>
+        </TableRow>
+      </TableBody>
+    </table>
   );
-
-  return {
-    props: props,
-    wrapper: mount(<table>{children}</table>),
-  };
-}
 
 describe('TableCell', function () {
   describe('TableHead wrap: <th> header cell - default props', () => {
-    it('renders a table <th> element', () => {
-      const { wrapper } = renderHead();
-      const table = wrapper.find('th');
-
-      expect(table).toHaveLength(2);
-
-      expect(wrapper).toMatchSnapshot();
+    it('renders a table <th> element with correct role', () => {
+      const view = renderHead();
+      expect(screen.getAllByRole('columnheader')).toHaveLength(2);
+      expect(view).toMatchSnapshot();
     });
 
-    it('sets <th> align="left"', () => {
-      const { wrapper } = renderHead();
-      const table = wrapper.find('TableCell');
-
-      expect(table.first().prop('align')).toBe('left');
+    it('sets correct <th> alignment class', () => {
+      renderHead();
+      screen.getAllByRole('columnheader').forEach((th) => {
+        expect(th).toHaveClass('ds-c-table__cell--align-left');
+      });
     });
 
-    it('sets <th> role="columnheader"', () => {
-      const { wrapper } = renderHead();
-      const table = wrapper.find('th');
-
-      expect(table.first().prop('role')).toBe('columnheader');
-    });
-
-    it('sets <th> scope="col"', () => {
-      const { wrapper } = renderHead();
-      const table = wrapper.find('th');
-
-      expect(table.first().prop('scope')).toBe('col');
+    it('sets <th> scope to col', () => {
+      renderHead();
+      screen.getAllByRole('columnheader').forEach((th) => {
+        expect(th).toHaveAttribute('scope', 'col');
+      });
     });
   });
 
   describe('TableBody wrap: <td> data cell - default props', () => {
-    it('renders TableCell component', () => {
-      const { wrapper } = renderBody();
-      const table = wrapper.find('TableCell');
-
-      expect(table).toHaveLength(2);
-      expect(wrapper).toMatchSnapshot();
+    it('renders TableCell component which has the role cell', () => {
+      const view = renderBody();
+      const cells = screen.getAllByRole('cell');
+      expect(cells).toHaveLength(1);
+      expect(view).toMatchSnapshot();
     });
 
-    it('renders a table <th> row header element which overwrites default header row component to <th>', () => {
-      const { wrapper } = renderBody();
-      const table = wrapper.find('th');
-
-      expect(table).toHaveLength(1);
-    });
-
-    it('sets a table <th> role="rowheader" which overwrites default role value "cell"', () => {
-      const { wrapper } = renderBody();
-      const table = wrapper.find('th');
-
-      expect(table.prop('role')).toBe('rowheader');
-    });
-
-    it('renders a table <td> row data element', () => {
-      const { wrapper } = renderBody();
-      const table = wrapper.find('td');
-
-      expect(table).toHaveLength(1);
-    });
-
-    it('sets a table <td> role="cell"', () => {
-      const { wrapper } = renderBody();
-      const table = wrapper.find('td');
-
-      expect(table.prop('role')).toBe('cell');
+    it('renders a <th> row header element which overwrites default header row component to <th> and has the correct role of rowheader', () => {
+      renderBody();
+      const tableHeaders = screen.getAllByRole('rowheader');
+      expect(tableHeaders).toHaveLength(1);
     });
   });
 });

--- a/packages/design-system/src/components/Table/__snapshots__/TableCaption.test.tsx.snap
+++ b/packages/design-system/src/components/Table/__snapshots__/TableCaption.test.tsx.snap
@@ -1,15 +1,83 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TableCaption applies additional classNames to caption 1`] = `
-<table>
-  <TableCaption
-    className="foo-caption"
-  >
-    <caption
-      className="ds-c-table__caption foo-caption"
-    >
-      Foo
-    </caption>
-  </TableCaption>
-</table>
+Object {
+  "props": Object {
+    "className": "foo-caption",
+  },
+  "view": Object {
+    "asFragment": [Function],
+    "baseElement": <body>
+      <div>
+        <table>
+          <caption
+            class="ds-c-table__caption foo-caption"
+          >
+            Foo
+          </caption>
+        </table>
+      </div>
+    </body>,
+    "container": <div>
+      <table>
+        <caption
+          class="ds-c-table__caption foo-caption"
+        >
+          Foo
+        </caption>
+      </table>
+    </div>,
+    "debug": [Function],
+    "findAllByAltText": [Function],
+    "findAllByDisplayValue": [Function],
+    "findAllByLabelText": [Function],
+    "findAllByPlaceholderText": [Function],
+    "findAllByRole": [Function],
+    "findAllByTestId": [Function],
+    "findAllByText": [Function],
+    "findAllByTitle": [Function],
+    "findByAltText": [Function],
+    "findByDisplayValue": [Function],
+    "findByLabelText": [Function],
+    "findByPlaceholderText": [Function],
+    "findByRole": [Function],
+    "findByTestId": [Function],
+    "findByText": [Function],
+    "findByTitle": [Function],
+    "getAllByAltText": [Function],
+    "getAllByDisplayValue": [Function],
+    "getAllByLabelText": [Function],
+    "getAllByPlaceholderText": [Function],
+    "getAllByRole": [Function],
+    "getAllByTestId": [Function],
+    "getAllByText": [Function],
+    "getAllByTitle": [Function],
+    "getByAltText": [Function],
+    "getByDisplayValue": [Function],
+    "getByLabelText": [Function],
+    "getByPlaceholderText": [Function],
+    "getByRole": [Function],
+    "getByTestId": [Function],
+    "getByText": [Function],
+    "getByTitle": [Function],
+    "queryAllByAltText": [Function],
+    "queryAllByDisplayValue": [Function],
+    "queryAllByLabelText": [Function],
+    "queryAllByPlaceholderText": [Function],
+    "queryAllByRole": [Function],
+    "queryAllByTestId": [Function],
+    "queryAllByText": [Function],
+    "queryAllByTitle": [Function],
+    "queryByAltText": [Function],
+    "queryByDisplayValue": [Function],
+    "queryByLabelText": [Function],
+    "queryByPlaceholderText": [Function],
+    "queryByRole": [Function],
+    "queryByTestId": [Function],
+    "queryByText": [Function],
+    "queryByTitle": [Function],
+    "rerender": [Function],
+    "unmount": [Function],
+  },
+}
 `;

--- a/packages/design-system/src/components/Table/__snapshots__/TableCell.test.tsx.snap
+++ b/packages/design-system/src/components/Table/__snapshots__/TableCell.test.tsx.snap
@@ -1,85 +1,219 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableCell TableBody wrap: <td> data cell - default props renders TableCell component 1`] = `
-<table>
-  <TableBody>
-    <tbody
-      role="rowgroup"
-    >
-      <TableRow>
-        <tr
-          role="row"
+exports[`TableCell TableBody wrap: <td> data cell - default props renders TableCell component which has the role cell 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <table>
+        <tbody
+          role="rowgroup"
         >
-          <TableCell
-            align="left"
-            component="th"
+          <tr
+            role="row"
           >
             <th
-              className="ds-c-table__cell--align-left"
+              class="ds-c-table__cell--align-left"
               role="rowheader"
             >
               Cell a
             </th>
-          </TableCell>
-          <TableCell
-            align="left"
-          >
             <td
-              className="ds-c-table__cell--align-left"
+              class="ds-c-table__cell--align-left"
               role="cell"
             >
               Cell b
             </td>
-          </TableCell>
-        </tr>
-      </TableRow>
-    </tbody>
-  </TableBody>
-</table>
-`;
-
-exports[`TableCell TableHead wrap: <th> header cell - default props renders a table <th> element 1`] = `
-<table>
-  <TableHead>
-    <thead
-      role="rowgroup"
-    >
-      <TableRow
-        _isTableHeadChild={true}
-        key=".0"
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </body>,
+  "container": <div>
+    <table>
+      <tbody
+        role="rowgroup"
       >
         <tr
           role="row"
         >
-          <TableCell
-            _isTableHeadChild={true}
-            align="left"
-            key=".0"
+          <th
+            class="ds-c-table__cell--align-left"
+            role="rowheader"
+          >
+            Cell a
+          </th>
+          <td
+            class="ds-c-table__cell--align-left"
+            role="cell"
+          >
+            Cell b
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`TableCell TableHead wrap: <th> header cell - default props renders a table <th> element with correct role 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <table>
+        <thead
+          role="rowgroup"
+        >
+          <tr
+            role="row"
           >
             <th
-              className="ds-c-table__cell--align-left"
+              class="ds-c-table__cell--align-left"
               role="columnheader"
               scope="col"
             >
               Column a
             </th>
-          </TableCell>
-          <TableCell
-            _isTableHeadChild={true}
-            align="left"
-            key=".1"
-          >
             <th
-              className="ds-c-table__cell--align-left"
+              class="ds-c-table__cell--align-left"
               role="columnheader"
               scope="col"
             >
               Column b
             </th>
-          </TableCell>
+          </tr>
+        </thead>
+      </table>
+    </div>
+  </body>,
+  "container": <div>
+    <table>
+      <thead
+        role="rowgroup"
+      >
+        <tr
+          role="row"
+        >
+          <th
+            class="ds-c-table__cell--align-left"
+            role="columnheader"
+            scope="col"
+          >
+            Column a
+          </th>
+          <th
+            class="ds-c-table__cell--align-left"
+            role="columnheader"
+            scope="col"
+          >
+            Column b
+          </th>
         </tr>
-      </TableRow>
-    </thead>
-  </TableHead>
-</table>
+      </thead>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;


### PR DESCRIPTION
## Summary

- Converted tests for `TableCaption` and `TableCell` to RTL from enzyme

I don't know if I'm doing this right :) I removed several tests from these as they were redundant under the RTL model of selecting by role.

## How to test

`yarn install && yarn test:unit`

### If this is a change to code:

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[ticket] title`
- [x] Ran `yarn type-check && yarn lint && yarn test` with no errors
- [x] Updated unit test snapshots and loki reference images **if necessary** with `yarn loki` && `yarn update-snapshots`