### PR TITLE
[NO-TICKET] Fix contact link pointing to old `feedback` route

### DIFF
--- a/packages/docs/src/components/TableOfContents.tsx
+++ b/packages/docs/src/components/TableOfContents.tsx
@@ -58,7 +58,7 @@ export const TableOfContentsFeedback = ({ slug }: TableOfContentsFeedbackProps) 
     </h2>
     <ul role="list" className="ds-c-list ds-c-list--bare ds-u-md-margin-y--2">
       <li>
-        <a href="/feedback">Contact the team</a>
+        <a href="/contact">Contact the team</a>
       </li>
       <li>
         <a href="https://github.com/CMSgov/design-system/discussions">


### PR DESCRIPTION
## Summary

In https://github.com/CMSgov/design-system/pull/2076 we renamed the `feedback` page to `contact`, but [I forgot to change the link that pointed to it]((https://github.com/CMSgov/design-system/commit/7aff2011e5a4e47d043ab8b252e13042ccef46f5#diff-2b42bc3c6f340eb687c4f3b560ae8a7bba5a306ecc42ad1d2b56ff6e4975678dL57))

## How to test

1. `yarn start`
2. Click on the link in the side bar under `Have ideas?` that says `Contact the team`
3. It should take you to the contact page
