### PR TITLE
[WNMGDS-1864] Make the page id logic resilient to undefined slugs

### DIFF
--- a/packages/docs/src/components/Layout.tsx
+++ b/packages/docs/src/components/Layout.tsx
@@ -58,7 +58,7 @@ const Layout = ({
     ? `${frontmatter.title} - CMS Design System`
     : 'CMS Design System';
 
-  const pageId = `page--${slug.replace('/', '_')}`;
+  const pageId = slug ? `page--${slug.replace('/', '_')}` : null;
 
   return (
     <div className="ds-base" id={pageId}>


### PR DESCRIPTION
## Summary

- Building the doc site statically failed because apparently the `slug` is not always defined. Fix that
