### PR TITLE
[no-ticket] [bugfix] Update cmsds-migrate to convert 'transparent' to 'ghost'

### DIFF
--- a/packages/design-system/scripts/cmsds-migrate/configs/html-button-migration.mjs
+++ b/packages/design-system/scripts/cmsds-migrate/configs/html-button-migration.mjs
@@ -5,28 +5,28 @@ export default {
   expressions: [
     {
       from: new RegExp(
-        /(<\s*?button[\s\S]*?class=[\"\'][\s\S]*?)(ds-c-button--primary|ds-c-button--success)([\s\S]*?[\"\'][\s\S]*?\/?>+)/,
+        /(<\s*?button[\s\S]*?class=["'][\s\S]*?)(ds-c-button--primary|ds-c-button--success)([\s\S]*?["'][\s\S]*?\/?>+)/,
         'gi'
       ),
       to: '$1ds-c-button--solid$3',
     },
     {
       from: new RegExp(
-        /(<\s*?button[\s\S]*?class=[\"\'][\s\S]*?)(ds-c-button--transparent)([\s\S]*?[\"\'][\s\S]*?\/?>+)/,
+        /(<\s*?button[\s\S]*?class=["'][\s\S]*?)(ds-c-button--transparent)([\s\S]*?["'][\s\S]*?\/?>+)/,
         'gi'
       ),
-      to: '$1ds-c-button--link$3',
+      to: '$1ds-c-button--ghost$3',
     },
     {
       from: new RegExp(
-        /(<\s*?button[\s\S]*?class=[\"\'][\s\S]*?)(ds-c-button--inverse)([\s\S]*?[\"\'][\s\S]*?\/?>+)/,
+        /(<\s*?button[\s\S]*?class=["'][\s\S]*?)(ds-c-button--inverse)([\s\S]*?["'][\s\S]*?\/?>+)/,
         'gi'
       ),
       to: '$1ds-c-button--on-dark$3',
     },
     {
       from: new RegExp(
-        /(<\s*?button[\s\S]*?class=[\"\'][\s\S]*?)(ds-c-button|ds-c-button--hover|ds-c-button--active|ds-c-button--focus)([\s\S]*?[\"\'][\s\S]*?\/?>+)/,
+        /(<\s*?button[\s\S]*?class=["'][\s\S]*?)(ds-c-button|ds-c-button--hover|ds-c-button--active|ds-c-button--focus)([\s\S]*?["'][\s\S]*?\/?>+)/,
         'gi'
       ),
       to: '$& <!-- CMSDS-MIGRATE: ds-c-button and ds-c-button--active/focus/hover will be deprecated in upcoming DS releases -->',

--- a/packages/design-system/scripts/cmsds-migrate/configs/react-button-migration.mjs
+++ b/packages/design-system/scripts/cmsds-migrate/configs/react-button-migration.mjs
@@ -4,19 +4,19 @@ export default {
   patterns: ['**/*.{jsx,tsx}'],
   expressions: [
     {
-      from: new RegExp(/(<\s*?button[\s\S]*?variation=[\"\'])(primary)([\"\'][\s\S]*?\/?>+)/, 'gi'),
+      from: new RegExp(/(<\s*?button[\s\S]*?variation=["'])(primary)(["'][\s\S]*?\/?>+)/, 'gi'),
       to: '$1solid$3',
     },
     {
       from: new RegExp(
-        /(<\s*?button[\s\S]*?variation=[\"\'])(transparent)([\"\'][\s\S]*?\/?>+)/,
+        /(<\s*?button[\s\S]*?variation=["'])(transparent)(["'][\s\S]*?\/?>+)/,
         'gi'
       ),
-      to: "$1link$3 {/* CMSDS-MIGRATE: possible visual difference between 'transparent' and 'link' */}",
+      to: "$1ghost$3 {/* CMSDS-MIGRATE: possible visual difference between 'transparent' and 'ghost' */}",
     },
     {
       from: new RegExp(
-        /(<\s*?button[\s\S]*?variation=[\"\'])(danger|success)([\"\'][\s\S]*?\/?>+)/,
+        /(<\s*?button[\s\S]*?variation=["'])(danger|success)(["'][\s\S]*?\/?>+)/,
         'gi'
       ),
       to: '$1solid$3 {/* CMSDS-MIGRATE: $2 variation will be deprecated */}',


### PR DESCRIPTION
## Summary

- `transparent` is now converted to `ghost`
- removed a couple escape backslashes that linter marked as un-necessary

## How to test

1. `yarn install && yarn cmsds-migrate` - run it using button && react configs, should update appropriately

### If this is a change to code:

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[ticket] title`
- [x] Ran `yarn type-check && yarn lint && yarn test` with no errors
