### PR TITLE
[WNMGDS-1897] Fix color swatch hex values not updating for non-core themes

### DIFF
--- a/packages/docs/content/foundation/color.mdx
+++ b/packages/docs/content/foundation/color.mdx
@@ -4,8 +4,6 @@ order: 20
 intro: The design system provides a flexible color palette that meets accessible color contrast requirements.
 ---
 
-import ColorSwatchList from '../../src/components/ColorSwatchList';
-
 <ThemeContent onlyThemes={['core', 'medicare']}>
 
 The palette is designed to support a range of distinct visual styles that continue to feel connected. The intent of the palette is to convey a warm and open American spirit, with bright saturated tints of blue, grounded in sophisticated deeper shades of cool blues and grays. These colors — combined with clear hierarchy, good information design, and ample white space — should leave users feeling welcomed and in good hands.

--- a/packages/docs/content/utilities/background-color.mdx
+++ b/packages/docs/content/utilities/background-color.mdx
@@ -2,7 +2,6 @@
 title: Background Color
 ---
 
-import ColorSwatchList from '../../src/components/ColorSwatchList';
 import { Alert } from '@cmsgov/design-system';
 
 Use the background color utility to change the default background color of an element.

--- a/packages/docs/src/components/ColorSwatchList.tsx
+++ b/packages/docs/src/components/ColorSwatchList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useLayoutEffect, useState } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import classNames from 'classnames';
 
 interface ColorSwatchListProps {
@@ -14,6 +14,10 @@ interface ColorSwatchListProps {
    * the start of the color name. Sometimes it is the variable preface (`$color`) or sometimes it is the css class name (`ds-u`)
    */
   preface: string;
+  /**
+   * Name of currently selected theme
+   */
+  theme: string;
 }
 
 // converts an rgb string 'rgb(15,24,128)' to a hex value '#0819A9'
@@ -27,12 +31,12 @@ export const rgbToHex = (r: number, g: number, b: number) => {
  * displays a list of color swatches with a sample of the color, the SCSS variable name & the hex value
  * @param colorNames {String[]} a list of color names - should be same as SCSS token
  */
-const ColorSwatchList = ({ backgroundClass, colorNames, preface }: ColorSwatchListProps) => {
+const ColorSwatchList = ({ backgroundClass, colorNames, preface, theme }: ColorSwatchListProps) => {
   const refList = useRef([]);
   const initialColors = colorNames.map((color) => ({ name: color, hex: '' }));
   const [colorList, setColorList] = useState(initialColors);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     // after swatch has been rendered once, pull rgb color from element styles & convert to hex
     const updatedColorList = colorList.map((colorItem, index) => {
       const styles = getComputedStyle(refList.current[index]);
@@ -53,7 +57,10 @@ const ColorSwatchList = ({ backgroundClass, colorNames, preface }: ColorSwatchLi
     });
 
     setColorList(updatedColorList);
-  }, []);
+  }, [
+    // If the theme changes, we need to recalculate our hex values
+    theme,
+  ]);
 
   return (
     <div className="c-swatch-list ds-u-border--1 ds-u-padding--2">

--- a/packages/docs/src/components/ContentRenderer.tsx
+++ b/packages/docs/src/components/ContentRenderer.tsx
@@ -12,6 +12,7 @@ import ComponentThemeOptions from './ComponentThemeOptions';
 import ThemeContent from './ThemeContent';
 import PropTable from './PropTable';
 import ResponsiveExample from './ResponsiveExample';
+import ColorSwatchList from './ColorSwatchList';
 
 // adds DS styling to tables from markdown
 const TableWithClassnames = (props) => {
@@ -70,6 +71,7 @@ const customComponents = (theme) => ({
   StorybookExample: (props) => <StorybookExample theme={theme} {...props} />,
   PropTable: (props) => <PropTable theme={theme} {...props} />,
   ResponsiveExample: (props) => <ResponsiveExample theme={theme} {...props} />,
+  ColorSwatchList: (props) => <ColorSwatchList theme={theme} {...props} />,
   ComponentThemeOptions: (props) => <ComponentThemeOptions theme={theme} {...props} />,
   ThemeContent: (props) => <ThemeContent theme={theme} {...props} />,
   ButtonMigrationTable: (props) => <ButtonMigrationTable theme={theme} {...props} />,


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-1897

- Make the color swatch component dependent on the current `theme` so it will re-render when the theme changes
- Switch from `useLayoutEffect` to `useEffect` because `useLayoutEffect` will always run before the DOM gets updated, which means it will never have a value other than what it gets from the default styles that are applied for the `core` theme before the frontend app hydrates

This is a quick fix and should make the theme dependency clearer in the code, but a better long-term solution would be to figure out a way to get static versions of each page for each theme as explained in https://jira.cms.gov/browse/WNMGDS-1899. I'm going to continue to look into that, but for now I want to get a fix up.

## How to test

`yarn build:docs && yarn serve:docs` and navigate to http://localhost:9000/foundation/color/?theme=core

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`
