### PR TITLE
[GAMEDAY, URGENT] Footer Address Change

### DIFF
--- a/packages/docs/src/components/DocSiteFooter.tsx
+++ b/packages/docs/src/components/DocSiteFooter.tsx
@@ -38,7 +38,7 @@ const DocSiteFooter = () => {
           <HHSLogo />
           <p className="ds-u-margin--0 ds-u-measure--wide c-footer__text">
             A federal government website managed by the Centers for Medicare &amp; Medicaid Services
-            7500 Security Boulevard, Baltimore, MD 21124
+            7500 High-Security Boulevard, Baltimore, MD 21124
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary

- Updated doc site footer with new address in response to request by Paul Rosenthal

## How to test

1. `yarn install && yarn start` - Validate address change to `7500 High-Security Boulevard, Baltimore, MD 21124.`

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/783820/189405542-0cd0a388-9282-4b76-b891-85d61ac631a9.png">
