### PR TITLE
[WNMGDS-1911] Fix anchor styles overriding anchor-button styles when keyboard focusing

### DIFF
--- a/packages/design-system/src/styles/components/_Button.scss
+++ b/packages/design-system/src/styles/components/_Button.scss
@@ -21,6 +21,7 @@
 
     &:focus {
       background-color: var(--backgroundColor, $button__background-color);
+      color: var(--color, $button__color);
       text-decoration: none;
     }
 


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-1911

Other rules for button interaction states were setting the color property, but this particular rule didn't. This meant that while the local CSS variable in charge of the text color had the correct value, that value wasn't being applied by a rule that had higher specificity than the rule that applies focus styles for plain anchor elements. When focusing on the link buttons with a keyboard only, the plain anchor rule was winning out, which resulted in a text color that didn't match.

Fixes #2110 

## How to test

1. Start Storybook and view http://localhost:6006/?path=/story/components-button--all-anchor-buttons

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Updated unit test snapshots (`yarn update-snapshots`) and loki reference images **if necessary** (`yarn loki && yarn loki:healthcare && yarn loki:medicare`)
