### PR TITLE
[WNMGDS-1918] Add z-index fix to Drawer

### DIFF
--- a/packages/design-system/src/styles/components/_Drawer.scss
+++ b/packages/design-system/src/styles/components/_Drawer.scss
@@ -54,6 +54,7 @@ $drawer-toggle-space: 0;
   width: 100%;
   max-height: 100%;
   height: 100%;
+  z-index: $drawer-elevation;
 
   // If `hasFocusTrap` enabled, `background` should
   // not be visible.


### PR DESCRIPTION
## Summary

[Jira ticket](https://jira.cms.gov/browse/WNMGDS-1918)

Reimplement 500 z-index on Drawer component. Using the Sass var/token that I accidentally forgot to delete the last time I refactored (thanks Past Sarah!).

## How to test

Run `yarn storybook` on this branch to see the z-index was applied

