### PR TITLE
[WNMGDS-1921] Fix styles for anchor buttons inside alerts

### DIFF
--- a/packages/design-system/src/components/Alert/Alert.stories.jsx
+++ b/packages/design-system/src/components/Alert/Alert.stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from '../Button';
 
 import Alert from './Alert';
 
@@ -62,4 +63,38 @@ export const LightWeight = Template.bind({});
 LightWeight.args = {
   heading: 'A lightweight heading',
   weight: 'lightweight',
+};
+
+export const AlertWithButtons = (args) => {
+  return (
+    <div className="ds-u-measure--base">
+      <Alert {...args}>
+        <p className="ds-c-alert__text">
+          Lorem ipsum dolor sit <a href="https://design.cms.gov/">link text</a>, consectetur
+          adipiscing elit, sed do eiusmod. Alerts can have chidren, or they can be left off and used
+          with just a heading prop.
+        </p>
+        <div className="ds-u-margin-top--2">
+          <Button variation="solid">Primary action</Button>
+          <Button className="ds-u-margin-left--1">Secondary action</Button>
+        </div>
+      </Alert>
+
+      <Alert {...args} className="ds-u-margin-top--3">
+        <p className="ds-c-alert__text">
+          Lorem ipsum dolor sit <a href="https://design.cms.gov/">link text</a>, consectetur
+          adipiscing elit, sed do eiusmod. Alerts can have chidren, or they can be left off and used
+          with just a heading prop.
+        </p>
+        <div className="ds-u-margin-top--2">
+          <Button variation="solid" href="#">
+            Primary action (link)
+          </Button>
+          <Button className="ds-u-margin-left--1" href="#">
+            Secondary action (link)
+          </Button>
+        </div>
+      </Alert>
+    </div>
+  );
 };

--- a/packages/design-system/src/styles/components/_Alert.scss
+++ b/packages/design-system/src/styles/components/_Alert.scss
@@ -10,7 +10,7 @@
   padding: $alert__padding;
   position: relative;
 
-  a,
+  a:not(.ds-c-button),
   .ds-c-link {
     color: $alert-link__font-color;
 


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-1921

- Adds a Storybook story that shows buttons and anchor-buttons inside alerts
- Fixes anchor buttons having incorrect styles applied inside alerts

## How to test

1. Start storybook
2. Navigate to http://localhost:6006/?path=/story/components-alert--alert-with-buttons

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- ~Updated unit test snapshots (`yarn update-snapshots`) and loki reference images **if necessary** (`yarn loki && yarn loki:healthcare && yarn loki:medicare`)~ Purposefully leaving loki out of this for now until we have a fix for VRTs

