### PR TITLE
[NO-TICKET] Adapt the background color of inverse stories to the selected theme in Storybook

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,3 +1,0 @@
-<script>
-  document.body.className += ' ds-base';
-</script>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -24,14 +24,6 @@ export const parameters = {
       date: /Date$/,
     },
   },
-  backgrounds: {
-    default: 'light',
-    values: [
-      { name: 'light', value: '#fff' },
-      { name: 'Hcgov dark', value: '#112e51' },
-      { name: 'Mgov dark', value: '#146a5d' },
-    ],
-  },
 };
 
 export const globalTypes = {
@@ -74,6 +66,17 @@ export const globalTypes = {
   },
 };
 
+const baseClassDecorator = (Story, context) => {
+  document.body.classList.add('ds-base');
+  if (context.parameters.baseInverse) {
+    document.body.classList.add('ds-base--inverse');
+  } else {
+    document.body.classList.remove('ds-base--inverse');
+  }
+
+  return <Story {...context} />;
+};
+
 const themeSettingDecorator = (Story, context) => {
   const { theme } = context.globals;
   document.documentElement.setAttribute('data-theme', theme);
@@ -110,6 +113,7 @@ const analyticsSettingsDecorator = (Story, context) => {
 };
 
 export const decorators = [
+  baseClassDecorator,
   languageSettingDecorator,
   analyticsSettingsDecorator,
   themeSettingDecorator,

--- a/packages/design-system/src/components/Button/Button.stories.jsx
+++ b/packages/design-system/src/components/Button/Button.stories.jsx
@@ -42,7 +42,7 @@ OnDark.args = {
   onDark: true,
 };
 OnDark.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };
 
 export const IconButton = Template.bind({});
@@ -84,7 +84,7 @@ export const VariationsOnDark = () => (
   </>
 );
 VariationsOnDark.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };
 VariationsOnDark.decorators = [
   (Story) => (

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.stories.jsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.stories.jsx
@@ -62,7 +62,7 @@ InverseOption.args = {
   inversed: true,
 };
 InverseOption.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };
 
 export const ChoiceChildren = Template.bind({});

--- a/packages/design-system/src/components/DateField/MultiInputDateField.stories.jsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.stories.jsx
@@ -57,5 +57,5 @@ InvertedMultiInputDateField.args = {
   inversed: true,
 };
 InvertedMultiInputDateField.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };

--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.jsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.jsx
@@ -85,5 +85,5 @@ InverseOption.args = {
   inversed: true,
 };
 InverseOption.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };

--- a/packages/design-system/src/components/FormLabel/FormLabel.stories.jsx
+++ b/packages/design-system/src/components/FormLabel/FormLabel.stories.jsx
@@ -41,5 +41,5 @@ InverseFormLabel.args = {
 };
 
 InverseFormLabel.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.stories.jsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.stories.jsx
@@ -65,7 +65,7 @@ InverseMonthPicker.args = {
   inversed: true,
 };
 InverseMonthPicker.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };
 
 export const InverseSelectedMonthPicker = Template.bind({});
@@ -77,7 +77,7 @@ InverseSelectedMonthPicker.args = {
   selectedMonths: [1, 2, 3, 4, 5, 6],
 };
 InverseSelectedMonthPicker.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };
 
 export const InverseDisabledMonthPicker = Template.bind({});
@@ -88,5 +88,5 @@ InverseDisabledMonthPicker.args = {
   disabledMonths: [7, 8, 9, 10, 11, 12],
 };
 InverseDisabledMonthPicker.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };

--- a/packages/design-system/src/components/Spinner/Spinner.stories.jsx
+++ b/packages/design-system/src/components/Spinner/Spinner.stories.jsx
@@ -42,7 +42,7 @@ FilledSpinner.args = {
   filled: true,
 };
 FilledSpinner.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };
 
 export const InverseFilledSpinner = Template.bind({});

--- a/packages/design-system/src/components/Tooltip/Tooltip.stories.jsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.stories.jsx
@@ -98,7 +98,7 @@ TooltipWithCloseButton.args = {
 
 export const InversedTrigger = Template.bind({});
 InversedTrigger.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };
 InversedTrigger.args = {
   data: <p className="ds-u-margin--0 ds-u-color--base-inverse">Tooltip with icon trigger</p>,

--- a/packages/ds-medicare-gov/src/components/HelpDrawer/HelpDrawer.stories.jsx
+++ b/packages/ds-medicare-gov/src/components/HelpDrawer/HelpDrawer.stories.jsx
@@ -112,7 +112,7 @@ export const HelpDrawerToggleOnDark = () => {
   );
 };
 HelpDrawerToggleOnDark.parameters = {
-  backgrounds: { default: process.env.STORYBOOK_DS === 'medicare' ? 'Mgov dark' : 'Hcgov dark' },
+  baseInverse: true,
 };
 HelpDrawerToggleOnDark.args = {
   onDark: true,


### PR DESCRIPTION

## Summary

The previous way of adding a dark background to Storybook stories had a few issues:
1. The background color had to be determined at the time of starting storybook, based on a `STORYBOOK_DS` environment variable and did not adapt to design-system theme changes done within storybook
    - This could be considered a doc-site bug
3. The background color was hard-coded rather than using the styles we already have
4. Logic was duplicated for every story that used it and was verbose

This change addresses those problems. You no longer need to use `storybook:medicare` or `storybook:healthcare` for a dark-background story to show the right color.

## How to test

1. Run `yarn storybook`
3. Navigate to http://localhost:6006/?path=/story/components-button--variations-on-dark
4. Change the theme between core, healthcare, and medicare, and see the background color change appropriately
