### PR TITLE
[WNMGDS-1869] Autocomplete, Dropdown/Select RTL Conversion

### DIFF
--- a/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Autocomplete renders a snapshot 1`] = `
+exports[`Autocomplete renders Autocomplete component 1`] = `
 <div
   class="ds-u-clearfix ds-c-autocomplete"
 >
@@ -9,8 +9,8 @@ exports[`Autocomplete renders a snapshot 1`] = `
   >
     <label
       class="ds-c-label"
-      for="autocomplete_60"
-      id="autocomplete_label_61"
+      for="autocomplete_1"
+      id="autocomplete_label_2"
     >
       <span
         class=""
@@ -20,12 +20,12 @@ exports[`Autocomplete renders a snapshot 1`] = `
     </label>
     <input
       aria-autocomplete="list"
-      aria-controls="autocomplete_owned_listbox_62"
+      aria-controls="autocomplete_owned_listbox_3"
       aria-expanded="false"
       aria-invalid="false"
       autocomplete="off"
       class="ds-c-field"
-      id="autocomplete_60"
+      id="autocomplete_1"
       name="autocomplete_field"
       role="combobox"
       type="text"
@@ -42,25 +42,81 @@ exports[`Autocomplete renders a snapshot 1`] = `
 </div>
 `;
 
-exports[`Autocomplete renders item with custom className 1`] = `"ds-c-autocomplete__list-item"`;
+exports[`Autocomplete renders a snapshot 1`] = `
+<div>
+  <div
+    class="ds-u-clearfix ds-c-autocomplete"
+  >
+    <div
+      class="ds-u-clearfix"
+    >
+      <label
+        class="ds-c-label"
+        for="autocomplete_55"
+        id="autocomplete_label_56"
+      >
+        <span
+          class=""
+        >
+          autocomplete
+        </span>
+      </label>
+      <input
+        aria-autocomplete="list"
+        aria-controls="autocomplete_owned_listbox_57"
+        aria-expanded="false"
+        aria-invalid="false"
+        autocomplete="off"
+        class="ds-c-field"
+        id="autocomplete_55"
+        name="autocomplete_field"
+        role="combobox"
+        type="text"
+        value=""
+      />
+    </div>
+    <button
+      aria-label="Clear search to try again"
+      class="ds-c-button ds-c-button--small ds-c-button--ghost ds-u-padding-right--0 ds-c-autocomplete__clear-btn"
+      type="button"
+    >
+      Clear search
+    </button>
+  </div>
+</div>
+`;
 
-exports[`Autocomplete renders item with custom className 2`] = `"custom-class ds-c-autocomplete__list-item"`;
+exports[`Autocomplete renders item with custom className 1`] = `
+Array [
+  <li
+    aria-selected="false"
+    class="ds-c-autocomplete__list-item"
+    id="downshift-3-item-0"
+    role="option"
+  >
+    Normal item
+  </li>,
+  <li
+    aria-selected="false"
+    class="custom-class ds-c-autocomplete__list-item"
+    id="downshift-3-item-1"
+    role="option"
+  >
+    Special item
+  </li>,
+]
+`;
 
 exports[`Autocomplete renders items with children property 1`] = `
 <ul
-  aria-labelledby={null}
-  className="ds-c-list--bare"
-  id="autocomplete_owned_listbox_14"
+  class="ds-c-list--bare"
+  id="autocomplete_owned_listbox_15"
   role="listbox"
 >
   <li
-    aria-selected={false}
-    className="ds-c-autocomplete__list-item"
-    id="downshift-1-item-0"
-    key="1"
-    onClick={[Function]}
-    onMouseDown={[Function]}
-    onMouseMove={[Function]}
+    aria-selected="false"
+    class="ds-c-autocomplete__list-item"
+    id="downshift-2-item-0"
     role="option"
   >
     Carrots 
@@ -69,13 +125,9 @@ exports[`Autocomplete renders items with children property 1`] = `
     </strong>
   </li>
   <li
-    aria-selected={false}
-    className="ds-c-autocomplete__list-item"
-    id="downshift-1-item-1"
-    key="2"
-    onClick={[Function]}
-    onMouseDown={[Function]}
-    onMouseMove={[Function]}
+    aria-selected="false"
+    class="ds-c-autocomplete__list-item"
+    id="downshift-2-item-1"
     role="option"
   >
     Cookies 
@@ -84,13 +136,9 @@ exports[`Autocomplete renders items with children property 1`] = `
     </strong>
   </li>
   <li
-    aria-selected={false}
-    className="ds-c-autocomplete__list-item"
-    id="downshift-1-item-2"
-    key="3"
-    onClick={[Function]}
-    onMouseDown={[Function]}
-    onMouseMove={[Function]}
+    aria-selected="false"
+    class="ds-c-autocomplete__list-item"
+    id="downshift-2-item-2"
     role="option"
   >
     Crackers 
@@ -99,13 +147,9 @@ exports[`Autocomplete renders items with children property 1`] = `
     </strong>
   </li>
   <li
-    aria-selected={false}
-    className="ds-c-autocomplete__list-item"
-    id="downshift-1-item-3"
-    key="4"
-    onClick={[Function]}
-    onMouseDown={[Function]}
-    onMouseMove={[Function]}
+    aria-selected="false"
+    class="ds-c-autocomplete__list-item"
+    id="downshift-2-item-3"
     role="option"
   >
     <a

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -25,8 +25,13 @@ function makeDropdown(customProps = {}, optionsCount = 1) {
 }
 
 describe('Dropdown', () => {
-  it('renders', () => {
-    const { container } = makeDropdown({ value: '1', label: '', ariaLabel: 'test aria label' });
+  it('dropdown matches snapshot', () => {
+    const { container } = makeDropdown({
+      value: '1',
+      label: '',
+      ariaLabel: 'test aria label',
+      readOnly: true,
+    });
 
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -1,4 +1,4 @@
-import { mount, shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import Dropdown from './Dropdown';
 import React from 'react';
 
@@ -17,19 +17,17 @@ export function generateOptions(count: number): { value: string; label: string }
   return options;
 }
 
-function render(customProps = {}, optionsCount = 1, deep = false) {
+function makeDropdown(customProps = {}, optionsCount = 1) {
   const props = { ...defaultProps, ...customProps };
   const component = <Dropdown {...props} options={generateOptions(optionsCount)} />;
 
-  return {
-    props: props,
-    wrapper: deep ? mount(component) : shallow(component),
-  };
+  return render(component);
 }
 
 describe('Dropdown', () => {
   it('renders', () => {
-    const data = render({ value: '1', label: '', ariaLabel: 'test aria label' });
-    expect(data.wrapper).toMatchSnapshot();
+    const { container } = makeDropdown({ value: '1', label: '', ariaLabel: 'test aria label' });
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/packages/design-system/src/components/Dropdown/Select.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Select.test.tsx
@@ -1,5 +1,6 @@
 import Select, { SelectProps } from './Select';
-import { mount, shallow } from 'enzyme';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { generateOptions } from './Dropdown.test';
 
@@ -13,118 +14,130 @@ const defaultProps: SelectProps = {
   options: [],
 };
 
-function render(customProps = {}, optionsCount = 1, deep = false) {
+function makeSelect(customProps = {}, optionsCount = 1) {
   const props = { ...defaultProps, ...customProps };
   const component = <Select {...props} options={generateOptions(optionsCount)} />;
 
-  return {
-    props: props,
-    wrapper: deep ? mount(component) : shallow(component),
-  };
+  return render(component);
 }
 
 describe('Select', () => {
   it('renders a select menu', () => {
-    const data = render({ value: '1', label: '', ariaLabel: 'test aria label' });
+    makeSelect({ value: '1', label: '', ariaLabel: 'test aria label' });
 
-    expect(data.wrapper.length).toBe(1);
-    expect(data.wrapper.children('option').length).toBe(1);
-    expect(data.wrapper).toMatchSnapshot();
+    const select = screen.getByRole('combobox');
+    const options = screen.queryAllByRole('option');
+    expect(select).toBeInTheDocument();
+    expect(options.length).toEqual(1);
+    expect(select).toMatchSnapshot();
   });
 
   it('renders options correctly', () => {
-    const data = render({ defaultValue: '1' }, 10);
+    makeSelect({ defaultValue: '1' }, 10);
 
-    expect(data.wrapper.length).toBe(1);
-    expect(data.wrapper.children('option').length).toBe(10);
-    expect(data.wrapper).toMatchSnapshot();
+    const select = screen.getByRole('combobox');
+    const options = screen.queryAllByRole('option');
+    expect(options.length).toBe(10);
+    expect(select).toMatchSnapshot();
   });
 
-  it('selects <option>', () => {
-    const controlledData = render({ value: '1' }, 4);
-    const uncontrolledData = render({ defaultValue: '2' }, 4);
+  it('controlled selects <option>', () => {
+    makeSelect({ value: '1' }, 4);
 
-    expect(controlledData.wrapper.prop('defaultValue')).toBe(controlledData.props.defaultValue);
-    expect(uncontrolledData.wrapper.prop('defaultValue')).toBe(uncontrolledData.props.defaultValue);
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveValue('1');
   });
 
-  it('has a selected <option>', () => {
-    const controlledData = render({ value: '1' }, 4);
-    const uncontrolledData = render({ defaultValue: '2' }, 4);
+  it('uncontrolled selects <option>', () => {
+    makeSelect({ defaultValue: '2' }, 4);
 
-    expect(controlledData.wrapper.prop('defaultValue')).toBe(controlledData.props.defaultValue);
-    expect(uncontrolledData.wrapper.prop('defaultValue')).toBe(uncontrolledData.props.defaultValue);
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveValue('2');
   });
 
   it('applies additional classNames to select element', () => {
-    const data = render({ fieldClassName: 'foo' });
+    makeSelect({ fieldClassName: 'foo' });
 
-    expect(data.wrapper.hasClass(data.props.fieldClassName)).toBe(true);
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveClass('foo');
     // Make sure we're not replacing the other class names
-    expect(data.wrapper.hasClass('ds-c-field')).toBe(true);
+    expect(select).toHaveClass('ds-c-field');
   });
 
-  it('adds size classes to select element', () => {
-    const mediumData = render({ size: 'medium' });
-    const smallData = render({ size: 'small' });
+  it('adds small size classes to select element', () => {
+    makeSelect({ size: 'small' });
 
-    expect(mediumData.wrapper.hasClass('ds-c-field--medium')).toBe(true);
-    expect(smallData.wrapper.hasClass('ds-c-field--small')).toBe(true);
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveClass('ds-c-field--small');
+  });
+
+  it('adds medium size classes to select element', () => {
+    makeSelect({ size: 'medium' });
+
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveClass('ds-c-field--medium');
   });
 
   it('is inversed', () => {
-    const data = render({ inversed: true });
+    makeSelect({ inversed: true });
 
-    expect(data.wrapper.hasClass('ds-c-field--inverse')).toBe(true);
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveClass('ds-c-field--inverse');
   });
 
   it('has error', () => {
-    const data = render({ errorMessage: 'Error' });
+    makeSelect({ errorMessage: 'Error' });
 
-    expect(data.wrapper.prop('aria-invalid')).toBe(true);
-    expect(data.wrapper.hasClass('ds-c-field--error')).toBe(true);
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveAttribute('aria-invalid', 'true');
+    expect(select).toHaveClass('ds-c-field--error');
   });
 
   it('handles bottom placed error', () => {
-    const data = render({
+    makeSelect({
       errorMessage: 'Error',
       errorPlacement: 'bottom',
       errorId: '1_error',
     });
 
-    expect(data.wrapper.prop('aria-invalid')).toBe(true);
-    expect(data.wrapper.prop('aria-describedby')).toBe('1_error');
-    expect(data.wrapper.hasClass('ds-c-field--error')).toBe(true);
-    expect(data.wrapper).toMatchSnapshot();
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveAttribute('aria-invalid', 'true');
+    expect(select).toHaveAttribute('aria-describedby', '1_error');
+    expect(select).toHaveClass('ds-c-field--error');
+    expect(select).toMatchSnapshot();
   });
 
   it('is disabled', () => {
-    const data = render({ disabled: true });
+    makeSelect({ disabled: true });
 
-    expect(data.wrapper.prop('disabled')).toBe(true);
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveAttribute('disabled');
   });
 
   it('is not disabled', () => {
-    const data = render();
+    makeSelect();
 
-    expect(data.wrapper.prop('disabled')).toBeUndefined();
+    const select = screen.getByRole('combobox');
+    expect(select).not.toHaveAttribute('disabled');
   });
 
-  describe('event handlers', () => {
-    const wrapper = render().wrapper;
+  describe('onChange and onBlur event handlers called appropriately', () => {
+    makeSelect({ defaultValue: '1' }, 10);
+    const select = screen.getByRole('combobox');
 
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
     it('calls the onChange handler', () => {
-      wrapper.simulate('change');
+      select.focus();
+      userEvent.keyboard('{Space}');
       expect(defaultProps.onBlur).not.toHaveBeenCalled();
       expect(defaultProps.onChange).toHaveBeenCalled();
     });
 
     it('calls the onBlur handler', () => {
-      wrapper.simulate('blur');
+      userEvent.hover(select);
       expect(defaultProps.onBlur).toHaveBeenCalled();
       expect(defaultProps.onChange).not.toHaveBeenCalled();
     });

--- a/packages/design-system/src/components/Dropdown/Select.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Select.test.tsx
@@ -22,6 +22,10 @@ function makeSelect(customProps = {}, optionsCount = 1) {
 }
 
 describe('Select', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders a select menu', () => {
     makeSelect({ value: '1', label: '', ariaLabel: 'test aria label' });
 
@@ -121,25 +125,20 @@ describe('Select', () => {
     expect(select).not.toHaveAttribute('disabled');
   });
 
-  describe('onChange and onBlur event handlers called appropriately', () => {
+  it('calls the onChange handler', () => {
     makeSelect({ defaultValue: '1' }, 10);
     const select = screen.getByRole('combobox');
+    userEvent.selectOptions(select, screen.getByRole('option', { name: '2' }));
+    expect(defaultProps.onBlur).not.toHaveBeenCalled();
+    expect(defaultProps.onChange).toHaveBeenCalled();
+  });
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-
-    it('calls the onChange handler', () => {
-      select.focus();
-      userEvent.keyboard('{Space}');
-      expect(defaultProps.onBlur).not.toHaveBeenCalled();
-      expect(defaultProps.onChange).toHaveBeenCalled();
-    });
-
-    it('calls the onBlur handler', () => {
-      userEvent.hover(select);
-      expect(defaultProps.onBlur).toHaveBeenCalled();
-      expect(defaultProps.onChange).not.toHaveBeenCalled();
-    });
+  it('calls the onBlur handler', () => {
+    makeSelect({ defaultValue: '1' }, 10);
+    const select = screen.getByRole('combobox');
+    userEvent.click(select);
+    userEvent.tab();
+    expect(defaultProps.onBlur).toHaveBeenCalled();
+    expect(defaultProps.onChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,10 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Dropdown renders 1`] = `
-<FormControl
-  component="div"
-  label=""
-  labelComponent="label"
-  render={[Function]}
-/>
+<div
+  class=""
+>
+  <label
+    class="ds-c-label"
+    for="field_1"
+    id="field_1-label"
+  >
+    <span
+      class=""
+    >
+      
+    </span>
+  </label>
+  <select
+    aria-invalid="false"
+    aria-label="test aria label"
+    class="ds-c-field"
+    id="field_1"
+    name="dropdown"
+  >
+    <option
+      value="1"
+    >
+      1
+    </option>
+  </select>
+</div>
 `;

--- a/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dropdown renders 1`] = `
+exports[`Dropdown dropdown matches snapshot 1`] = `
 <div
   class=""
 >
@@ -21,6 +21,7 @@ exports[`Dropdown renders 1`] = `
     class="ds-c-field"
     id="field_1"
     name="dropdown"
+    readonly=""
   >
     <option
       value="1"

--- a/packages/design-system/src/components/Dropdown/__snapshots__/Select.test.tsx.snap
+++ b/packages/design-system/src/components/Dropdown/__snapshots__/Select.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dropdown renders 1`] = `
+exports[`Dropdown dropdown matches snapshot 1`] = `
 <div
   class=""
 >
@@ -21,6 +21,7 @@ exports[`Dropdown renders 1`] = `
     class="ds-c-field"
     id="field_1"
     name="dropdown"
+    readonly=""
   >
     <option
       value="1"
@@ -34,15 +35,12 @@ exports[`Dropdown renders 1`] = `
 exports[`Select handles bottom placed error 1`] = `
 <select
   aria-describedby="1_error"
-  aria-invalid={true}
-  className="ds-c-field ds-c-field--error"
+  aria-invalid="true"
+  class="ds-c-field ds-c-field--error"
   id="1"
   name="Select"
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
 >
   <option
-    key="1"
     value="1"
   >
     1
@@ -52,18 +50,14 @@ exports[`Select handles bottom placed error 1`] = `
 
 exports[`Select renders a select menu 1`] = `
 <select
-  aria-invalid={false}
+  aria-invalid="false"
   aria-label="test aria label"
-  className="ds-c-field"
+  class="ds-c-field"
   id="1"
   label=""
   name="Select"
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
-  value="1"
 >
   <option
-    key="1"
     value="1"
   >
     1
@@ -73,70 +67,58 @@ exports[`Select renders a select menu 1`] = `
 
 exports[`Select renders options correctly 1`] = `
 <select
-  aria-invalid={false}
-  className="ds-c-field"
-  defaultValue="1"
+  aria-invalid="false"
+  class="ds-c-field"
   id="1"
   name="Select"
-  onBlur={[MockFunction]}
-  onChange={[MockFunction]}
 >
   <option
-    key="1"
+    selected=""
     value="1"
   >
     1
   </option>
   <option
-    key="2"
     value="2"
   >
     2
   </option>
   <option
-    key="3"
     value="3"
   >
     3
   </option>
   <option
-    key="4"
     value="4"
   >
     4
   </option>
   <option
-    key="5"
     value="5"
   >
     5
   </option>
   <option
-    key="6"
     value="6"
   >
     6
   </option>
   <option
-    key="7"
     value="7"
   >
     7
   </option>
   <option
-    key="8"
     value="8"
   >
     8
   </option>
   <option
-    key="9"
     value="9"
   >
     9
   </option>
   <option
-    key="10"
     value="10"
   >
     10

--- a/packages/design-system/src/components/Dropdown/__snapshots__/Select.test.tsx.snap
+++ b/packages/design-system/src/components/Dropdown/__snapshots__/Select.test.tsx.snap
@@ -1,12 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Dropdown renders 1`] = `
-<FormControl
-  component="div"
-  label=""
-  labelComponent="label"
-  render={[Function]}
-/>
+<div
+  class=""
+>
+  <label
+    class="ds-c-label"
+    for="field_1"
+    id="field_1-label"
+  >
+    <span
+      class=""
+    >
+      
+    </span>
+  </label>
+  <select
+    aria-invalid="false"
+    aria-label="test aria label"
+    class="ds-c-field"
+    id="field_1"
+    name="dropdown"
+  >
+    <option
+      value="1"
+    >
+      1
+    </option>
+  </select>
+</div>
 `;
 
 exports[`Select handles bottom placed error 1`] = `


### PR DESCRIPTION
## Summary

- Updated `Autocomplete` `Dropdown` and `Select` tests to RTL
- Still having a problem with `userEvent` in the Select tests @pwolfert @zarahzachz if you have time to take a look, will continue to investigate but not having a lot of luck, even tried upgrading jest, jest dom and the userEvent library.

## How to test

1. `yarn install && yarn test:unit`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`
- [x] Created or updated unit tests to cover the logic added
- [x] Updated unit test snapshots (`yarn update-snapshots`) and loki reference images **if necessary** (`yarn loki && yarn loki:healthcare && yarn loki:medicare`)