### PR TITLE
[no-ticket] Removing tsconfig settings which are no longer needed

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,23 +8,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "baseUrl": ".",
-    "skipLibCheck": true,
-    // Allows `*.example.tsx` files in `docs` to import directly from the design system source root
-    // TODO: Remove this once we get rid of the example files in favor of Storybook stories
-    "paths": {
-      "@design-system": [
-        "packages/design-system/src",
-        "packages/ds-medicare-gov/src",
-        "packages/ds-healthcare-gov/src"
-      ]
-    }
+    "skipLibCheck": true
   },
-  "include": ["packages/**/src/**/*"],
-  // TODO: Remove this once all our TypeScript definitions are generated from source
-  "exclude": [
-    "packages/**/src/types/**/*",
-    "packages/design-system-docs/src/**/*",
-    "packages/ds-healthcare-gov/docs/src/**/*",
-    "packages/ds-medicare-gov/docs/src/**/*"
-  ]
+  "include": ["packages/**/src/**/*"]
 }


### PR DESCRIPTION
## Summary

- Removes outdated `.tsconfig` settings which seem to no longer be needed

## How to test

1. `yarn type-check` - used to fail because of these, but it seems they are no longer needed, thoughts @pwolfert ?