### PR TITLE
[NO-TICKET] Clean out unneeded `Alert` analytics logic

### DIFF
--- a/packages/design-system/src/components/Alert/Alert.test.tsx
+++ b/packages/design-system/src/components/Alert/Alert.test.tsx
@@ -127,8 +127,8 @@ describe('Alert', function () {
       ga_eventValue: '',
       ga_eventCategory: 'ui components',
       ga_eventAction: 'alert impression',
-      ga_eventLabel: defaultText,
-      heading: defaultText,
+      ga_eventLabel: `Warning: ${defaultText}`,
+      heading: `Warning: ${defaultText}`,
       type: 'warn',
     };
 

--- a/packages/design-system/src/components/Alert/Alert.test.tsx
+++ b/packages/design-system/src/components/Alert/Alert.test.tsx
@@ -150,8 +150,8 @@ describe('Alert', function () {
       renderAlert({ heading, variation: 'error' });
       expect(tealiumMock).toBeCalledWith({
         ...defaultEvent,
-        ga_eventLabel: heading,
-        heading,
+        ga_eventLabel: `Alert: ${heading}`,
+        heading: `Alert: ${heading}`,
         type: 'error',
       });
       expect(tealiumMock).toHaveBeenCalledTimes(1);

--- a/packages/design-system/src/components/Alert/Alert.tsx
+++ b/packages/design-system/src/components/Alert/Alert.tsx
@@ -103,11 +103,7 @@ export const Alert: React.FC<AlertProps> = (props: AlertProps) => {
   let headingElement;
   if (heading) {
     const Heading = `h${headingLevel}` as const;
-    headingElement = (
-      <Heading className="ds-c-alert__heading" ref={headingRef}>
-        {heading}
-      </Heading>
-    );
+    headingElement = <Heading className="ds-c-alert__heading">{heading}</Heading>;
   }
 
   const classes = classNames(
@@ -155,7 +151,7 @@ export const Alert: React.FC<AlertProps> = (props: AlertProps) => {
       {getIcon()}
       <div className="ds-c-alert__body" id={headingId} ref={bodyRef}>
         {heading ? (
-          <div className="ds-c-alert__header ds-c-alert__heading">
+          <div className="ds-c-alert__header ds-c-alert__heading" ref={headingRef}>
             {a11yLabel}
             {headingElement}
           </div>

--- a/packages/design-system/src/components/Alert/useAlertAnalytics.ts
+++ b/packages/design-system/src/components/Alert/useAlertAnalytics.ts
@@ -5,8 +5,6 @@ import { alertSendsAnalytics } from '../flags';
 export default function useAlertAnalytics({
   analytics,
   analyticsLabelOverride,
-  children,
-  heading,
   variation,
 }: AlertProps) {
   // Order matters! Content comes from the heading first and falls back to body if heading doesn't exist

--- a/packages/design-system/src/components/Alert/useAlertAnalytics.ts
+++ b/packages/design-system/src/components/Alert/useAlertAnalytics.ts
@@ -22,16 +22,7 @@ export default function useAlertAnalytics({
         return;
       }
 
-      // This is complicated but allows us to match the old behavior exactly, where if heading or
-      // children are strings, those strings will take priority over the content that we scrape
-      // from the DOM.
-      // TODO: Remove it during a breaking change after warning stakeholders that a11y labels
-      // will start to appear in the analytics content where they might not have before.
-      const rawPropsContent = heading ?? children;
-      const rawPropsContentString =
-        typeof rawPropsContent === 'string' ? rawPropsContent : undefined;
-
-      const eventHeadingText = analyticsLabelOverride ?? (rawPropsContentString || content);
+      const eventHeadingText = analyticsLabelOverride ?? content;
       if (!eventHeadingText) {
         console.error('No content found for Dialog analytics event');
         return;


### PR DESCRIPTION

## Summary

Removes logic that made the event content always match what was being sent before. We've been given the go-ahead to update and simplify this analytics logic in the next breaking change. It will now always include the a11y-label prefix because that always exists in the DOM, and we're always pulling from the DOM now.

## How to test

`yarn test:unit`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover the logic added
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)