### PR TITLE
[WNMGDS-1942] Fix color swatch hex values not updating for non-core themes in Firefox

### DIFF
--- a/packages/docs/src/components/content/ColorSwatchList.tsx
+++ b/packages/docs/src/components/content/ColorSwatchList.tsx
@@ -36,13 +36,6 @@ const ColorSwatchList = ({ backgroundClass, colorNames, preface, theme }: ColorS
   const initialColors = colorNames.map((color) => ({ name: color, hex: '' }));
   const [colorList, setColorList] = useState(initialColors);
 
-  if (colorList[0].name === 'primary') console.log(theme, colorList[0].hex);
-  // Recalculate hex values every time we render, because there's a chance the browser could
-  // have rendered with the old colors even though we already switched to the current theme.
-  // It may have to do with the fact that Helmet doesn't make its changes during render but
-  // by manipulating the DOM directly. This means that even if we change `theme` in Layout,
-  // the DOM might not have been updated by the time this renders. Before this, I had [theme]
-  // as the dependency array, but it didn't work on Firefox - PW
   useEffect(() => {
     // after swatch has been rendered once, pull rgb color from element styles & convert to hex
     const updatedColorList = colorList.map((colorItem, index) => {
@@ -67,7 +60,10 @@ const ColorSwatchList = ({ backgroundClass, colorNames, preface, theme }: ColorS
     if (colorList.some((item, index) => item.hex !== updatedColorList[index].hex)) {
       setColorList(updatedColorList);
     }
-  });
+  }, [
+    // If the theme changes, we need to recalculate our hex values
+    theme,
+  ]);
 
   return (
     <div className="c-swatch-list ds-u-border--1 ds-u-padding--2">

--- a/packages/docs/src/components/content/ColorSwatchList.tsx
+++ b/packages/docs/src/components/content/ColorSwatchList.tsx
@@ -36,6 +36,13 @@ const ColorSwatchList = ({ backgroundClass, colorNames, preface, theme }: ColorS
   const initialColors = colorNames.map((color) => ({ name: color, hex: '' }));
   const [colorList, setColorList] = useState(initialColors);
 
+  if (colorList[0].name === 'primary') console.log(theme, colorList[0].hex);
+  // Recalculate hex values every time we render, because there's a chance the browser could
+  // have rendered with the old colors even though we already switched to the current theme.
+  // It may have to do with the fact that Helmet doesn't make its changes during render but
+  // by manipulating the DOM directly. This means that even if we change `theme` in Layout,
+  // the DOM might not have been updated by the time this renders. Before this, I had [theme]
+  // as the dependency array, but it didn't work on Firefox - PW
   useEffect(() => {
     // after swatch has been rendered once, pull rgb color from element styles & convert to hex
     const updatedColorList = colorList.map((colorItem, index) => {
@@ -56,11 +63,11 @@ const ColorSwatchList = ({ backgroundClass, colorNames, preface, theme }: ColorS
       };
     });
 
-    setColorList(updatedColorList);
-  }, [
-    // If the theme changes, we need to recalculate our hex values
-    theme,
-  ]);
+    // Only update and re-render if a hex value changed
+    if (colorList.some((item, index) => item.hex !== updatedColorList[index].hex)) {
+      setColorList(updatedColorList);
+    }
+  });
 
   return (
     <div className="c-swatch-list ds-u-border--1 ds-u-padding--2">

--- a/packages/docs/src/components/layout/Layout.tsx
+++ b/packages/docs/src/components/layout/Layout.tsx
@@ -61,14 +61,11 @@ const Layout = ({
   const pageId = slug ? `page--${slug.replace('/', '_')}` : null;
 
   return (
-    <div className="ds-base" id={pageId}>
+    <div className="ds-base" data-theme={theme} id={pageId}>
       <Helmet
         title={tabTitle}
         htmlAttributes={{
           lang: 'en',
-        }}
-        bodyAttributes={{
-          'data-theme': theme,
         }}
       >
         <script>{`window.tealiumEnvironment = "${env}";`}</script>


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-1942

Our theming CSS is controlled by a `data-theme` attribute that we apply to the body element through a library component called `Helmet`. Helmet allows us to render a `<Helmet>` component anywhere in our render tree and have changes applied to the `head` of our document or the `body` element. It's a handy tool, but the changes it makes are necessarily out of the normal React rendering lifecycle. When we apply a new theme by changing our top-level `theme` prop it trickles down and causes re-renders for components that rely on it. But because the actual DOM update for `data-theme` happens out of band, there's no guarantee that the styles for the theme will have been applied by the browser by the time our `ColorSwatchList` component expects to be re-calculating its color hex values. While the old fix worked for me on Chrome, it didn't work in Firefox. It was a race condition. This new fix should address the root of the issue and help avoid similar bugs in the future.

- Apply the `data-theme` attribute to an element that we control with our render functions, rather than using `Helmet` which makes DOM upates out of band
- Avoid re-rendering the `ColorSwatchList` when no hex values changed (not really related, but it's an improvement, and it was part of an earlier attempt at a fix)

Fixes #2090 

## How to test

1. `yarn start`
2. In Firefox, open http://localhost:8000/foundation/color/?theme=healthcare
3. The hex value for the first one (color-primary) will be wrong on `main` because it will have the hex value for the core theme. On this branch it should be fixed. If you can't reproduce it, try switching between themes and looking at the hex value after coming from core.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`
