### PR TITLE
[NO-TICKET] Update the deploy-docs command with new sub-command names

### DIFF
--- a/scripts/deployDemo.ts
+++ b/scripts/deployDemo.ts
@@ -6,7 +6,7 @@ const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
 
 // Build the demo site
 execSync(`yarn --cwd ${join('packages', 'docs')} clean`, { stdio: 'inherit' });
-execSync('yarn build-storybook:gatsby', { stdio: 'inherit' });
+execSync('yarn build:storybook:docs', { stdio: 'inherit' });
 execSync('yarn build:docs', {
   env: {
     ...process.env,


### PR DESCRIPTION
## Summary

The storybook build command changed, so we need to update the `yarn deploy-docs` script.
