### PR TITLE
[LHDM-953] Remove Accordion max height and y overflow

### DIFF
--- a/packages/design-system/src/styles/components/_Accordion.scss
+++ b/packages/design-system/src/styles/components/_Accordion.scss
@@ -83,9 +83,7 @@ $accordion-header-font-family: $font-sans;
   font-size: $font-size-base;
   line-height: $font-line-height-base;
   margin-top: 0;
-  max-height: 16rem;
   overflow: auto;
-  overflow-y: auto;
   padding: $spacer-2 $spacer-3 $spacer-1 $spacer-4;
 
   // Not sure why this first-child last-child is not working


### PR DESCRIPTION
## Summary

- Removing max height and y overflow settings for Accordion, per [a recent conversation around the current behavior](https://adhoc.slack.com/archives/C645GLLNN/p1664397928811549?thread_ts=1664386875.605169&cid=C645GLLNN).
- [LHDM-953](https://jira.cms.gov/browse/LHDM-953) is the ticket our team has used to track changes. If references to this ticket need to be swapped out for another on the Experience board let me know and I'll update everything here.

## How to test

1. View updates on Storybook Accordion page

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [ ] Created or updated unit tests to cover the logic added
- [ ] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)

<img width="1920" alt="Screen Shot 2022-09-29 at 10 15 54 AM" src="https://user-images.githubusercontent.com/16626560/193099672-cb648359-7e65-401c-8fdd-4bfcf9fd80de.png">
