### PR TITLE
[NO-TICKET] Add viewport sizes to storybook to match doc site and remove light/dark background options from storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -13,8 +13,47 @@ import { setLanguage as setLanguageFromPackage } from '@cmsgov/design-system';
 // Rewire analytics events to log to the console
 window.utag = { link: console.log };
 
+const customViewports = {
+  ExtraSmall: {
+    name: 'Extra Small - 320px',
+    styles: {
+      width: '320px',
+      height: '800px',
+    },
+  },
+  Small: {
+    name: 'Small - 544px',
+    styles: {
+      width: '544px',
+      height: '800px',
+    },
+  },
+  Medium: {
+    name: 'Medium - 768px',
+    styles: {
+      width: '768px',
+      height: '800px',
+    },
+  },
+  Large: {
+    name: 'Large - 1024px',
+    styles: {
+      width: '1024px',
+      height: '800px',
+    },
+  },
+  ExtraLarge: {
+    name: 'Extra Large - 1280px',
+    styles: {
+      width: '1280px',
+      height: '800px',
+    },
+  },
+};
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
+  viewport: { viewports: customViewports },
   controls: {
     expanded: true,
     matchers: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -61,6 +61,7 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  backgrounds: { disable: true },
 };
 
 export const globalTypes = {


### PR DESCRIPTION
## Summary

- Updated our storybook viewport sizes to [match doc site](https://design.cms.gov/foundation/layout-grid/responsive-design?theme=core) 
- Added Xsmall, small, medium, large and Xlarge

## How to test

1. run `yarn storybook` see that the viewports are available and that light/dark backgrounds are not available in the storybook top toolbar

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover the logic added
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)

### If this is a change to documentation:

- [x] Checked for spelling and grammatical errors

### Example

https://user-images.githubusercontent.com/1449852/195638406-a53d93d8-7097-48b7-87d8-366782971159.mov

