### PR TITLE
[WNMGDS-1855] Add box-sizing rule. Remove focus sizing styles - unneeded.

### DIFF
--- a/packages/design-system/src/styles/components/_Choice.scss
+++ b/packages/design-system/src/styles/components/_Choice.scss
@@ -79,6 +79,11 @@ label,
     width: $choice__size;
   }
 
+  &::before,
+  &::after {
+    box-sizing: content-box;
+  }
+
   // Error
   @if $ds-include-choice-error-highlight {
     &.ds-c-choice--error {
@@ -139,12 +144,6 @@ label,
   &:checked {
     &::after {
       opacity: 1;
-    }
-
-    &:focus::before {
-      // have to do a mix of calc & sass interpolation in order to accommodate values being css vars in internal tools
-      height: calc(#{$choice__size} - (#{$choice__border-width} * 2));
-      width: calc(#{$choice__size} - (#{$choice__border-width} * 2));
     }
   }
 }

--- a/packages/ds-medicare-gov/src/styles/components/_override.choice.scss
+++ b/packages/ds-medicare-gov/src/styles/components/_override.choice.scss
@@ -16,11 +16,6 @@
     &::before {
       border-radius: $choice__border-radius;
     }
-
-    &:focus::before {
-      height: $choice__size;
-      width: $choice__size;
-    }
   }
 }
 


### PR DESCRIPTION
## Summary

This work folds in a local style from the Windowshop/Enroll app where small checkbox icons weren't displaying correctly. 

It turned out that app's CSS reseat included a `box-sizing: initial` for all elements, (`*, *::before, *::after { box-sizing: initial; }`) that was breaking the layout of our CSS. They fixed it by adding a local `box-sizing: content-box` to the checkbox styles. I migrated this style into our design system.

While testing this change, I discovered another bug:
![Screen Shot 2022-10-17 at 11 05 43 AM](https://user-images.githubusercontent.com/5159392/196214611-3d9709ad-788a-4dac-851a-009d9082beae.png)

Small checkboxes increase in size on focus. After playing around with the style causing this, I was able to determine we could safely remove the offending CSS. Tested in Chrome, Firefox, and Safari and removing this style had no impact on any checkboxes in our design system.

## How to test

Run Storybook locally and navigate to: http://localhost:6006/?path=/story/components-choicelist--small-option&args=type:checkbox

Clicking new checkboxes (moving focus around) should persist the small sizing.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [ ] Created or updated unit tests to cover the logic added
- [ ] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)

### If this is a change to documentation:

- [ ] Checked for spelling and grammatical errors
