### PR TITLE
[WNMGDS-1940] Changing Choice wrapper max-width

### DIFF
--- a/packages/design-system/src/styles/components/_Choice.scss
+++ b/packages/design-system/src/styles/components/_Choice.scss
@@ -11,7 +11,7 @@
   display: flex;
   gap: 0.5rem;
   margin: 0.5rem 0;
-  max-width: $form__max-width;
+  max-width: $measure-wide;
 }
 
 // Styles for label


### PR DESCRIPTION
## Summary

- Updated choice wrapper max width to use `$measure-wide` which is `80ex` (https://design.cms.gov/utilities/text/measure)

## Feedback requested

Should this also apply to `Autocomplete`'s `ds-c-autocomplete` and `TextField`'s `ds-c-field` or do those remain constrained by the `$form__max-width` of `470px`?

## How to test

1. Instructions on how to test the changes in this PR.

## Checklist

- [ ] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`