### PR TITLE
[WNMGDS-2009] Document pass-through props

### DIFF
--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -141,11 +141,7 @@ Used to show important but not as urgent messages as standard alerts.
 ### React
 
 <PropTable componentName="Alert">
-  <PropTableHtmlElementRow
-    elements={[
-      { name: 'div', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div' },
-    ]}
-  />
+  <PropTableHtmlElementRow elements={['div']} />
 </PropTable>
 
 ### Styles

--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -140,7 +140,13 @@ Used to show important but not as urgent messages as standard alerts.
 
 ### React
 
-<PropTable componentName="Alert" htmlElementName="div" />
+<PropTable componentName="Alert">
+  <PropTableHtmlElementRow
+    elements={[
+      { name: 'div', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div' },
+    ]}
+  />
+</PropTable>
 
 ### Styles
 

--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -140,7 +140,7 @@ Used to show important but not as urgent messages as standard alerts.
 
 ### React
 
-<PropTable componentName="Alert" />
+<PropTable componentName="Alert" htmlElementName="div" />
 
 ### Styles
 

--- a/packages/docs/content/components/badge.mdx
+++ b/packages/docs/content/components/badge.mdx
@@ -52,7 +52,7 @@ medicare:
 
 ### React
 
-<PropTable componentName="Badge" />
+<PropTable componentName="Badge" htmlElementName="span" />
 
 ### Styles
 

--- a/packages/docs/content/components/button.mdx
+++ b/packages/docs/content/components/button.mdx
@@ -242,7 +242,7 @@ In addition to the supported props listed, you can also pass in additional
 props, which will be passed to the rendered root component. For example,
 you could pass in a `target` prop to pass to the rendered anchor element.
 
-<PropTable componentName="Button" />
+<PropTable componentName="Button" htmlElementName="button" />
 
 ### Styles
 

--- a/packages/docs/content/components/button.mdx
+++ b/packages/docs/content/components/button.mdx
@@ -243,12 +243,7 @@ props, which will be passed to the rendered root component. For example,
 you could pass in a `target` prop to pass to the rendered anchor element.
 
 <PropTable componentName="Button">
-  <PropTableHtmlElementRow
-    elements={[
-      { name: 'button', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button' },
-      { name: 'a', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a' },
-    ]}
-  />
+  <PropTableHtmlElementRow elements={['button', 'a']} />
 </PropTable>
 
 ### Styles

--- a/packages/docs/content/components/button.mdx
+++ b/packages/docs/content/components/button.mdx
@@ -242,7 +242,14 @@ In addition to the supported props listed, you can also pass in additional
 props, which will be passed to the rendered root component. For example,
 you could pass in a `target` prop to pass to the rendered anchor element.
 
-<PropTable componentName="Button" htmlElementName="button" />
+<PropTable componentName="Button">
+  <PropTableHtmlElementRow
+    elements={[
+      { name: 'button', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button' },
+      { name: 'a', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a' },
+    ]}
+  />
+</PropTable>
 
 ### Styles
 

--- a/packages/docs/content/components/checkbox.mdx
+++ b/packages/docs/content/components/checkbox.mdx
@@ -45,7 +45,13 @@ Note that any _undocumented_ props that you pass to a `<Choice>` or `choices` wi
 
 #### `<Choice>` component
 
-<PropTable componentName="Choice" />
+<PropTable componentName="Choice">
+  <PropTableHtmlElementRow
+    elements={[
+      { name: 'input', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input' },
+    ]}
+  />
+</PropTable>
 
 ### Styles
 

--- a/packages/docs/content/components/checkbox.mdx
+++ b/packages/docs/content/components/checkbox.mdx
@@ -37,7 +37,7 @@ Checkboxes can have optional checked or unchecked children that are conditionall
 
 Checkboxes can be managed as a group using `<ChoiceList>` or individually using `<Choice>`.
 
-Note that any _undocumented_ props that you pass to a `<Choice>` or `choices` will be passed to the `input` element, so you can use this to set additional attributes if necessary.
+Note that each of the items in the `choices` array represents props that will be passed to an individual `<Choice>` component. You can therefore define any of the props listed in the <strong>`<Choice>` component</strong> table below, including all valid attributes of the [HTML input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
 
 #### `<ChoiceList>` component
 
@@ -46,11 +46,7 @@ Note that any _undocumented_ props that you pass to a `<Choice>` or `choices` wi
 #### `<Choice>` component
 
 <PropTable componentName="Choice">
-  <PropTableHtmlElementRow
-    elements={[
-      { name: 'input', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input' },
-    ]}
-  />
+  <PropTableHtmlElementRow elements={['input']} />
 </PropTable>
 
 ### Styles

--- a/packages/docs/content/components/form-label.mdx
+++ b/packages/docs/content/components/form-label.mdx
@@ -21,12 +21,7 @@ The `FormLabel` component provides the `label` (or `legend`) for a field, along 
 ### React
 
 <PropTable componentName="FormLabel">
-  <PropTableHtmlElementRow
-    elements={[
-      { name: 'label', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label' },
-      { name: 'legend', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend' },
-    ]}
-  />
+  <PropTableHtmlElementRow elements={['label', 'legend']} />
 </PropTable>
 
 ### Styles

--- a/packages/docs/content/components/form-label.mdx
+++ b/packages/docs/content/components/form-label.mdx
@@ -20,7 +20,14 @@ The `FormLabel` component provides the `label` (or `legend`) for a field, along 
 
 ### React
 
-<PropTable componentName="ChoiceList" />
+<PropTable componentName="FormLabel">
+  <PropTableHtmlElementRow
+    elements={[
+      { name: 'label', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label' },
+      { name: 'legend', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend' },
+    ]}
+  />
+</PropTable>
 
 ### Styles
 

--- a/packages/docs/content/components/radio.mdx
+++ b/packages/docs/content/components/radio.mdx
@@ -47,7 +47,13 @@ Note that any _undocumented_ props that you pass to a `<Choice>` or `choices` wi
 
 #### `<Choice>` component
 
-<PropTable componentName="Choice" />
+<PropTable componentName="Choice">
+  <PropTableHtmlElementRow
+    elements={[
+      { name: 'input', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input' },
+    ]}
+  />
+</PropTable>
 
 ### Styles
 

--- a/packages/docs/content/components/radio.mdx
+++ b/packages/docs/content/components/radio.mdx
@@ -39,7 +39,7 @@ Radio buttons can have optional checked or unchecked children that are condition
 
 Radio buttons can be managed as a group using `<ChoiceList>` or individually using `<Choice>`.
 
-Note that any _undocumented_ props that you pass to a `<Choice>` or `choices` will be passed to the `input` element, so you can use this to set additional attributes if necessary.
+Note that each of the items in the `choices` array represents props that will be passed to an individual `<Choice>` component. You can therefore define any of the props listed in the <strong>`<Choice>` component</strong> table below, including all valid attributes of the [HTML input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
 
 #### `<ChoiceList>` component
 
@@ -48,11 +48,7 @@ Note that any _undocumented_ props that you pass to a `<Choice>` or `choices` wi
 #### `<Choice>` component
 
 <PropTable componentName="Choice">
-  <PropTableHtmlElementRow
-    elements={[
-      { name: 'input', link: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input' },
-    ]}
-  />
+  <PropTableHtmlElementRow elements={['input']} />
 </PropTable>
 
 ### Styles

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -33,6 +33,7 @@
     "gatsby-remark-autolink-headers": "^5.19.0",
     "gatsby-source-filesystem": "^4.11.1",
     "gatsby-transformer-react-docgen": "^7.13.0",
+    "humanize-react": "1.0.0",
     "lodash.sortby": "^4.7.0",
     "prettier": "^2.6.2",
     "prismjs": "^1.11.0",

--- a/packages/docs/src/components/content/ContentRenderer.tsx
+++ b/packages/docs/src/components/content/ContentRenderer.tsx
@@ -10,6 +10,7 @@ import StorybookExample from './StorybookExample';
 import ComponentThemeOptions from './ComponentThemeOptions';
 import ThemeContent from './ThemeContent';
 import PropTable from './PropTable';
+import PropTableHtmlElementRow from './PropTableHtmlElementRow';
 import ResponsiveExample from './ResponsiveExample';
 import ColorSwatchList from './ColorSwatchList';
 import MaturityChecklist from './MaturityChecklist';
@@ -72,6 +73,7 @@ const customComponents = (theme) => ({
   MaturityChecklist,
   StorybookExample: (props) => <StorybookExample theme={theme} {...props} />,
   PropTable: (props) => <PropTable theme={theme} {...props} />,
+  PropTableHtmlElementRow: (props) => <PropTableHtmlElementRow theme={theme} {...props} />,
   ResponsiveExample: (props) => <ResponsiveExample theme={theme} {...props} />,
   ColorSwatchList: (props) => <ColorSwatchList theme={theme} {...props} />,
   SpacingUtilityExampleList: (props) => <SpacingUtilityExampleList theme={theme} {...props} />,

--- a/packages/docs/src/components/content/PropTable.tsx
+++ b/packages/docs/src/components/content/PropTable.tsx
@@ -96,6 +96,10 @@ const PropTable = ({ componentName, theme, htmlElementName, htmlElementLink }: P
     []
   );
 
+  const formattedHtmlElementName = htmlElementName ? (
+    <code>{`<${htmlElementName}>`}</code>
+  ) : undefined;
+
   return (
     <Table className="c-prop-table" stackable scrollable borderless>
       <TableCaption>
@@ -137,20 +141,10 @@ const PropTable = ({ componentName, theme, htmlElementName, htmlElementLink }: P
         ))}
         {htmlElementName && (
           <TableRow>
-            <TableCell colSpan={2}>
+            <TableCell colSpan={4}>
               This component passes any additional props to its underlying{' '}
-              <code>
-                {'<'}
-                {htmlElementName}
-                {'>'}`
-              </code>{' '}
-              element as attributes. It will accept poop any props that are valid attributes of
-              <code>
-                {'<'}
-                {htmlElementName}
-                {'>'}`
-              </code>{' '}
-              .{' '}
+              {formattedHtmlElementName} element as attributes. It will accept any props that are
+              valid attributes of {formattedHtmlElementName}.{' '}
               {htmlElementLink && (
                 <>
                   Please see <a href={htmlElementLink}>MDN documentation</a> for a list of those

--- a/packages/docs/src/components/content/PropTable.tsx
+++ b/packages/docs/src/components/content/PropTable.tsx
@@ -21,26 +21,19 @@ export interface PropTableDataItem {
 }
 
 interface PropTableProps {
+  children: React.ReactNode;
   componentName: string;
   /**
    * Name of currently selected theme
    */
   theme: string;
-  /**
-   * If the component we're documenting passes extra props through to an HTML element,
-   * setting this prop will show additional documentation about that behavior. Use
-   * this in combination with `htmlElementLink`, which is a link to MDN documentation
-   * about that element and the attributes it accepts.
-   */
-  htmlElementName?: string;
-  htmlElementLink?: string;
 }
 
 /**
  * A component to display a Design System component's prop table
  * It loads all props for all components and then finds the appropriate props for the passed in `componentName`
  */
-const PropTable = ({ componentName, theme, htmlElementName, htmlElementLink }: PropTableProps) => {
+const PropTable = ({ children, componentName, theme }: PropTableProps) => {
   // load all props for all components
   const allPropData: ComponentPropQuery = useStaticQuery(graphql`
     query loadComponentPropsQuery {
@@ -96,10 +89,6 @@ const PropTable = ({ componentName, theme, htmlElementName, htmlElementLink }: P
     []
   );
 
-  const formattedHtmlElementName = htmlElementName ? (
-    <code>{`<${htmlElementName}>`}</code>
-  ) : undefined;
-
   return (
     <Table className="c-prop-table" stackable scrollable borderless>
       <TableCaption>
@@ -139,21 +128,7 @@ const PropTable = ({ componentName, theme, htmlElementName, htmlElementLink }: P
             </TableCell>
           </TableRow>
         ))}
-        {htmlElementName && (
-          <TableRow>
-            <TableCell colSpan={4}>
-              This component passes any additional props to its underlying{' '}
-              {formattedHtmlElementName} element as attributes. It will accept any props that are
-              valid attributes of {formattedHtmlElementName}.{' '}
-              {htmlElementLink && (
-                <>
-                  Please see <a href={htmlElementLink}>MDN documentation</a> for a list of those
-                  attributes.
-                </>
-              )}
-            </TableCell>
-          </TableRow>
-        )}
+        {children}
       </TableBody>
     </Table>
   );

--- a/packages/docs/src/components/content/PropTable.tsx
+++ b/packages/docs/src/components/content/PropTable.tsx
@@ -22,13 +22,25 @@ export interface PropTableDataItem {
 
 interface PropTableProps {
   componentName: string;
+  /**
+   * Name of currently selected theme
+   */
+  theme: string;
+  /**
+   * If the component we're documenting passes extra props through to an HTML element,
+   * setting this prop will show additional documentation about that behavior. Use
+   * this in combination with `htmlElementLink`, which is a link to MDN documentation
+   * about that element and the attributes it accepts.
+   */
+  htmlElementName?: string;
+  htmlElementLink?: string;
 }
 
 /**
  * A component to display a Design System component's prop table
  * It loads all props for all components and then finds the appropriate props for the passed in `componentName`
  */
-const PropTable = ({ componentName }: PropTableProps, theme: string) => {
+const PropTable = ({ componentName, theme, htmlElementName, htmlElementLink }: PropTableProps) => {
   // load all props for all components
   const allPropData: ComponentPropQuery = useStaticQuery(graphql`
     query loadComponentPropsQuery {
@@ -123,6 +135,31 @@ const PropTable = ({ componentName }: PropTableProps, theme: string) => {
             </TableCell>
           </TableRow>
         ))}
+        {htmlElementName && (
+          <TableRow>
+            <TableCell colSpan={2}>
+              This component passes any additional props to its underlying{' '}
+              <code>
+                {'<'}
+                {htmlElementName}
+                {'>'}`
+              </code>{' '}
+              element as attributes. It will accept poop any props that are valid attributes of
+              <code>
+                {'<'}
+                {htmlElementName}
+                {'>'}`
+              </code>{' '}
+              .{' '}
+              {htmlElementLink && (
+                <>
+                  Please see <a href={htmlElementLink}>MDN documentation</a> for a list of those
+                  attributes.
+                </>
+              )}
+            </TableCell>
+          </TableRow>
+        )}
       </TableBody>
     </Table>
   );

--- a/packages/docs/src/components/content/PropTableHtmlElementRow.tsx
+++ b/packages/docs/src/components/content/PropTableHtmlElementRow.tsx
@@ -16,19 +16,21 @@ export interface PropTableHtmlElementRowProps {
  * table.
  */
 const PropsTableHtmlElementRow = ({ elements }: PropTableHtmlElementRowProps) => {
+  const elementNames = elements.map((name) => <code key={name}>{`<${name}>`}</code>);
   const elementLinks = elements.map((name) => (
     <a href={`https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${name}`} key={name}>
-      {`<${name}>`}
+      {name}
     </a>
   ));
-  const formattedElementLinks = humanizeList(elementLinks, { conjunction: 'or' });
+  const formattedElementNames = humanizeList(elementNames, { conjunction: 'or' });
+  const formattedElementLinks = humanizeList(elementLinks, { conjunction: 'and' });
 
   return (
     <TableRow>
       <TableCell colSpan={4}>
-        This component passes any additional props to its underlying {formattedElementLinks} element
-        as attributes. It will accept any props that are valid attributes of {formattedElementLinks}
-        .
+        This component passes any additional props to its underlying {formattedElementNames} element
+        as attributes. See the corresponding MDN documentation for {formattedElementLinks} for a
+        list of valid attributes.
       </TableCell>
     </TableRow>
   );

--- a/packages/docs/src/components/content/PropTableHtmlElementRow.tsx
+++ b/packages/docs/src/components/content/PropTableHtmlElementRow.tsx
@@ -3,9 +3,9 @@ import { TableRow, TableCell } from '@cmsgov/design-system';
 
 export interface PropsTableHtmlElementRowProps {
   /**
-   * List of element names and the URL to documentation
+   * List of element names
    */
-  elements: Array<{ name: string; link: string }>;
+  elements: string[];
 }
 
 /**
@@ -16,9 +16,9 @@ export interface PropsTableHtmlElementRowProps {
  * table.
  */
 const PropsTableHtmlElementRow = ({ elements }: PropsTableHtmlElementRowProps) => {
-  const elementLinks = elements.map(({ name, link }) => (
-    <a href={link} key={name}>
-      <code>{`<${name}>`}</code>
+  const elementLinks = elements.map((name) => (
+    <a href={`https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${name}`} key={name}>
+      {`<${name}>`}
     </a>
   ));
   const formattedElementLinks = humanizeList(elementLinks, { conjunction: 'or' });

--- a/packages/docs/src/components/content/PropTableHtmlElementRow.tsx
+++ b/packages/docs/src/components/content/PropTableHtmlElementRow.tsx
@@ -1,7 +1,7 @@
 import humanizeList from 'humanize-react';
 import { TableRow, TableCell } from '@cmsgov/design-system';
 
-export interface PropsTableHtmlElementRowProps {
+export interface PropTableHtmlElementRowProps {
   /**
    * List of element names
    */
@@ -15,7 +15,7 @@ export interface PropsTableHtmlElementRowProps {
  * some explanatory text with MDN documentation links to the bottom of our props
  * table.
  */
-const PropsTableHtmlElementRow = ({ elements }: PropsTableHtmlElementRowProps) => {
+const PropsTableHtmlElementRow = ({ elements }: PropTableHtmlElementRowProps) => {
   const elementLinks = elements.map((name) => (
     <a href={`https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${name}`} key={name}>
       {`<${name}>`}

--- a/packages/docs/src/components/content/PropTableHtmlElementRow.tsx
+++ b/packages/docs/src/components/content/PropTableHtmlElementRow.tsx
@@ -1,0 +1,37 @@
+import humanizeList from 'humanize-react';
+import { TableRow, TableCell } from '@cmsgov/design-system';
+
+export interface PropsTableHtmlElementRowProps {
+  /**
+   * List of element names and the URL to documentation
+   */
+  elements: Array<{ name: string; link: string }>;
+}
+
+/**
+ * If the component we're documenting passes extra props through to an HTML element,
+ * we want to include documentation about that. Rather than listing out all the
+ * additional attributes for those HTML elements in our props table, we will add
+ * some explanatory text with MDN documentation links to the bottom of our props
+ * table.
+ */
+const PropsTableHtmlElementRow = ({ elements }: PropsTableHtmlElementRowProps) => {
+  const elementLinks = elements.map(({ name, link }) => (
+    <a href={link} key={name}>
+      <code>{`<${name}>`}</code>
+    </a>
+  ));
+  const formattedElementLinks = humanizeList(elementLinks, { conjunction: 'or' });
+
+  return (
+    <TableRow>
+      <TableCell colSpan={4}>
+        This component passes any additional props to its underlying {formattedElementLinks} element
+        as attributes. It will accept any props that are valid attributes of {formattedElementLinks}
+        .
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default PropsTableHtmlElementRow;

--- a/packages/docs/src/components/content/PropTableHtmlElementRow.tsx
+++ b/packages/docs/src/components/content/PropTableHtmlElementRow.tsx
@@ -19,7 +19,7 @@ const PropsTableHtmlElementRow = ({ elements }: PropTableHtmlElementRowProps) =>
   const elementNames = elements.map((name) => <code key={name}>{`<${name}>`}</code>);
   const elementLinks = elements.map((name) => (
     <a href={`https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${name}`} key={name}>
-      {name}
+      <code key={name}>{`<${name}>`}</code>
     </a>
   ));
   const formattedElementNames = humanizeList(elementNames, { conjunction: 'or' });

--- a/packages/docs/src/styles/components/propTable.scss
+++ b/packages/docs/src/styles/components/propTable.scss
@@ -1,6 +1,0 @@
-.c-prop-table {
-  code {
-    background-color: $color-gray-lightest;
-    padding: $spacer-half;
-  }
-}

--- a/packages/docs/src/styles/components/syntaxHighlighting.scss
+++ b/packages/docs/src/styles/components/syntaxHighlighting.scss
@@ -14,12 +14,12 @@ code {
   display: inline-block;
   font-size: 0.9em;
   margin: 1px;
-  padding: $spacer-half;
+  padding: 0 $spacer-half;
 }
 
-p code {
-  padding-bottom: 0;
-  padding-top: 0;
+a code {
+  color: $link__color;
+  text-decoration: underline;
 }
 
 /**

--- a/packages/docs/src/styles/index.scss
+++ b/packages/docs/src/styles/index.scss
@@ -37,7 +37,6 @@ $font-path: '@cmsgov/ds-medicare-gov/dist/fonts';
 @import 'components/maturityChecklist.scss';
 @import 'components/navigation.scss';
 @import 'components/pageHeader.scss';
-@import 'components/propTable.scss';
 @import 'components/responsiveExample.scss';
 @import 'components/storybookExample.scss';
 @import 'components/syntaxHighlighting.scss';

--- a/yarn.lock
+++ b/yarn.lock
@@ -15066,6 +15066,11 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+humanize-react@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/humanize-react/-/humanize-react-1.0.0.tgz#542c78db7c919b9b8e8c095487469c8868b8c26f"
+  integrity sha512-d68v6HGH4EnYgH/YgbRKj1+4KYi3TLkMXlZgk4On1ee18XbCQO1Eb/ur0BOZvmEgu8TES5G9Cqu7a4lQng4Sig==
+
 husky@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.1.tgz#579f4180b5da4520263e8713cc832942b48e1f1c"


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-2009

If the component we're documenting passes extra props through to an HTML element, we want to include documentation about that. Rather than listing out all the additional attributes for those HTML elements in our props table, I figured we could add some explanatory text with MDN documentation links to the bottom of our props table [like Primer does](https://primer.style/react/Button#props).

- Adds a `PropsTableHtmlElementRow` component
- Modifies `PropsTable` to accept `children`, which it renders at the bottom

## How to test

`yarn start` and visit one of the updated pages

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`

### If this is a change to documentation:

- [x] Checked for spelling and grammatical errors

## Requested feedback

1. I figured putting that information in the table would be helpful to people who use screen readers, but is there a better way?
2. Ideas for a better way to explain this?