### PR TITLE
[WNMGDS-965] Add aria-label to header nav elements.

### DIFF
--- a/packages/ds-healthcare-gov/src/components/Header/Header.tsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.tsx
@@ -228,6 +228,7 @@ export const Header = (props: HeaderProps) => {
           </a>
 
           <nav
+            aria-label="action"
             id="hc-c-header__actions"
             className="hc-c-header__actions ds-l-col ds-l-col--auto ds-u-margin-left--auto ds-u-font-weight--bold"
           >

--- a/packages/ds-healthcare-gov/src/components/Header/Menu.tsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Menu.tsx
@@ -24,12 +24,17 @@ const Menu = (props: MenuProps) => {
   });
 
   return (
-    <div id="hc-c-menu" hidden={!props.open} className={classes}>
+    <nav
+      aria-label="Profile and application"
+      id="hc-c-menu"
+      hidden={!props.open}
+      className={classes}
+    >
       {props.submenuTop}
       {props.beforeLinks}
       {props.links && <MenuLinks links={props.links} />}
       {props.submenuBottom}
-    </div>
+    </nav>
   );
 };
 

--- a/packages/ds-healthcare-gov/src/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Header/__snapshots__/Header.test.tsx.snap
@@ -98,6 +98,7 @@ exports[`Header renders Direct Enrollment banner 1`] = `
           </span>
         </a>
         <nav
+          aria-label="action"
           class="hc-c-header__actions ds-l-col ds-l-col--auto ds-u-margin-left--auto ds-u-font-weight--bold"
           id="hc-c-header__actions"
         >
@@ -147,7 +148,8 @@ exports[`Header renders Direct Enrollment banner 1`] = `
             </svg>
             Menu
           </button>
-          <div
+          <nav
+            aria-label="Profile and application"
             class="hc-c-menu"
             hidden=""
             id="hc-c-menu"
@@ -176,7 +178,7 @@ exports[`Header renders Direct Enrollment banner 1`] = `
                 </a>
               </li>
             </ul>
-          </div>
+          </nav>
         </nav>
       </div>
     </div>
@@ -307,6 +309,7 @@ exports[`Header renders Spanish header 1`] = `
           </span>
         </a>
         <nav
+          aria-label="action"
           class="hc-c-header__actions ds-l-col ds-l-col--auto ds-u-margin-left--auto ds-u-font-weight--bold"
           id="hc-c-header__actions"
         >
@@ -356,7 +359,8 @@ exports[`Header renders Spanish header 1`] = `
             </svg>
             Menú
           </button>
-          <div
+          <nav
+            aria-label="Profile and application"
             class="hc-c-menu"
             hidden=""
             id="hc-c-menu"
@@ -385,7 +389,7 @@ exports[`Header renders Spanish header 1`] = `
                 </a>
               </li>
             </ul>
-          </div>
+          </nav>
         </nav>
       </div>
     </div>
@@ -491,6 +495,7 @@ exports[`Header renders full/homepage header 1`] = `
           </span>
         </a>
         <nav
+          aria-label="action"
           class="hc-c-header__actions ds-l-col ds-l-col--auto ds-u-margin-left--auto ds-u-font-weight--bold"
           id="hc-c-header__actions"
         >
@@ -540,7 +545,8 @@ exports[`Header renders full/homepage header 1`] = `
             </svg>
             Menu
           </button>
-          <div
+          <nav
+            aria-label="Profile and application"
             class="hc-c-menu"
             hidden=""
             id="hc-c-menu"
@@ -569,7 +575,7 @@ exports[`Header renders full/homepage header 1`] = `
                 </a>
               </li>
             </ul>
-          </div>
+          </nav>
         </nav>
       </div>
     </div>
@@ -675,6 +681,7 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
           </span>
         </a>
         <nav
+          aria-label="action"
           class="hc-c-header__actions ds-l-col ds-l-col--auto ds-u-margin-left--auto ds-u-font-weight--bold"
           id="hc-c-header__actions"
         >
@@ -724,7 +731,8 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
             </svg>
             Menu
           </button>
-          <div
+          <nav
+            aria-label="Profile and application"
             class="hc-c-menu"
             hidden=""
             id="hc-c-menu"
@@ -753,7 +761,7 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
                 </a>
               </li>
             </ul>
-          </div>
+          </nav>
         </nav>
       </div>
     </div>
@@ -859,6 +867,7 @@ exports[`Header renders logged-in header with firstName 1`] = `
           </span>
         </a>
         <nav
+          aria-label="action"
           class="hc-c-header__actions ds-l-col ds-l-col--auto ds-u-margin-left--auto ds-u-font-weight--bold"
           id="hc-c-header__actions"
         >
@@ -889,7 +898,8 @@ exports[`Header renders logged-in header with firstName 1`] = `
             </svg>
             Menu
           </button>
-          <div
+          <nav
+            aria-label="Profile and application"
             class="hc-c-menu"
             hidden=""
             id="hc-c-menu"
@@ -943,7 +953,7 @@ exports[`Header renders logged-in header with firstName 1`] = `
                 </a>
               </li>
             </ul>
-          </div>
+          </nav>
         </nav>
       </div>
     </div>
@@ -1049,6 +1059,7 @@ exports[`Header renders logged-in header without firstName 1`] = `
           </span>
         </a>
         <nav
+          aria-label="action"
           class="hc-c-header__actions ds-l-col ds-l-col--auto ds-u-margin-left--auto ds-u-font-weight--bold"
           id="hc-c-header__actions"
         >
@@ -1074,7 +1085,8 @@ exports[`Header renders logged-in header without firstName 1`] = `
             </svg>
             Menu
           </button>
-          <div
+          <nav
+            aria-label="Profile and application"
             class="hc-c-menu"
             hidden=""
             id="hc-c-menu"
@@ -1123,7 +1135,7 @@ exports[`Header renders logged-in header without firstName 1`] = `
                 </a>
               </li>
             </ul>
-          </div>
+          </nav>
         </nav>
       </div>
     </div>

--- a/packages/ds-healthcare-gov/src/components/Header/__snapshots__/Menu.test.jsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Header/__snapshots__/Menu.test.jsx.snap
@@ -2,7 +2,8 @@
 
 exports[`Menu removes hidden state 1`] = `
 <div>
-  <div
+  <nav
+    aria-label="Profile and application"
     class="hc-c-menu hc-c-menu--open"
     id="hc-c-menu"
   >
@@ -30,13 +31,14 @@ exports[`Menu removes hidden state 1`] = `
         </a>
       </li>
     </ul>
-  </div>
+  </nav>
 </div>
 `;
 
 exports[`Menu renders MenuList 1`] = `
 <div>
-  <div
+  <nav
+    aria-label="Profile and application"
     class="hc-c-menu"
     hidden=""
     id="hc-c-menu"
@@ -65,6 +67,6 @@ exports[`Menu renders MenuList 1`] = `
         </a>
       </li>
     </ul>
-  </div>
+  </nav>
 </div>
 `;


### PR DESCRIPTION
## Summary

WNMGDS-965

- Add `aria-label` to `<nav>` elements in HCgov header
- Replace `<div>` with semantic `<nav>` element in HCgov header

## How to test

Review a11y tree of Healthcare header (building)