### PR TITLE
[WNMGDS-2094] Fix centered containers shifting left when dialog opens

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -142,11 +142,11 @@ export const Dialog = (props: DialogProps) => {
   useLayoutEffect(() => {
     // https://css-tricks.com/prevent-page-scrolling-when-a-modal-is-open/
     const y = window.scrollY ?? 0;
-    document.body.style.position = 'fixed';
-    document.body.style.top = `-${y}px`;
+    const bodyClass = 'ds--dialog-open';
+    document.body.classList.add(bodyClass);
+    document.body.style.setProperty('--body_top--dialog-open', `-${y}px`);
     return () => {
-      document.body.style.position = '';
-      document.body.style.top = '';
+      document.body.classList.remove(bodyClass);
       window.scrollTo(0, y);
     };
   }, []);

--- a/packages/design-system/src/styles/components/_Dialog.scss
+++ b/packages/design-system/src/styles/components/_Dialog.scss
@@ -126,3 +126,10 @@ dialog.fixed {
     padding: $spacer-half $spacer-2;
   }
 }
+
+.ds--dialog-open {
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: var(--body_top--dialog-open, 0);
+}


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-2094

- The fix is setting a `left: 0` and `right: 0` on the body to make it fill the whole width of the screen when `position: fixed`, which makes an assumption about how the application wants its body element to be laid out
- Because that assumption could be wrong in some applications, we wanted to make it easy to override the behavior in applications, so we the body styles with a new CSS class

## How to test

1. Start storybook and navigate to http://localhost:6006/?path=/story/components-dialog--prevent-scroll-example
2. Find the `id="root"` element in the story iframe, and apply a `class="ds-l-container"` to mimic the layout of a standard application.
3. Click the button to open the dialog. In this branch, there should be no shift of the content. On the main branch, it will shift all the content to the left.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [ ] Created or updated unit tests to cover the logic added
- [ ] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)
