### PR TITLE
[NO-TICKET] Fix a bad link in our 5.0 blog article

### DIFF
--- a/packages/docs/content/blog/index.mdx
+++ b/packages/docs/content/blog/index.mdx
@@ -22,7 +22,7 @@ Hey everyone, we're doing something new! We've saved up a program increment's wo
 
 #### Component maturity checklist
 
-We established a checklist that measures each component's path toward maturity and stability through [well-defined and repeatable processes](https://github.com/CMSgov/design-system/blob/pwolfert/blog/COMPONENT_MATURITY.md). This _maturity model_ evaluates a component's accessibility, code, Sketch assets, and use of design tokens as a series of checklist items that have a complete, incomplete, or not-applicable status. This checklist helps us track progress on components and also helps application teams make informed decisions about when to use certain components, when to wait, or when to contribute.
+We established a checklist that measures each component's path toward maturity and stability through [well-defined and repeatable processes](https://github.com/CMSgov/design-system/blob/main/COMPONENT_MATURITY.md). This _maturity model_ evaluates a component's accessibility, code, Sketch assets, and use of design tokens as a series of checklist items that have a complete, incomplete, or not-applicable status. This checklist helps us track progress on components and also helps application teams make informed decisions about when to use certain components, when to wait, or when to contribute.
 
 <div className="ds-u-measure--wide ds-u-margin-top--2">
   <Video name="component-maturity-demo" />


### PR DESCRIPTION
## Summary

- Fixes a link to the maturity checklist documentation, which pointed to a branch that no longer exists

## How to test

1. `yarn start`
2. Go to http://localhost:8000/blog
