### PR TITLE
[WNMGDS-2099] Obfuscate SSNs in label masked TextField

### DIFF
--- a/packages/design-system/src/components/TextField/useLabelMask.test.tsx
+++ b/packages/design-system/src/components/TextField/useLabelMask.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import useLabelMask, {
   DATE_MASK,
   SSN_MASK,
+  SSN_MASK_OBFUSCATED,
   PHONE_MASK,
   ZIP_MASK,
   CURRENCY_MASK,
@@ -33,6 +34,31 @@ describe('SSN_MASK', () => {
     expect(SSN_MASK('123', true)).toEqual('123');
     expect(SSN_MASK('12345', true)).toEqual('123-45');
     expect(SSN_MASK('1234567', true)).toEqual('123-45-67');
+  });
+});
+
+describe('SSN_MASK_OBFUSCATED', () => {
+  it('returns just the mask when given no input', () => {
+    expect(SSN_MASK_OBFUSCATED('')).toEqual('###-##-####');
+  });
+
+  it('masks complete social security numbers', () => {
+    expect(SSN_MASK_OBFUSCATED('123-45-6789')).toEqual('***-**-6789');
+    expect(SSN_MASK_OBFUSCATED('123 45 6789')).toEqual('***-**-6789');
+    expect(SSN_MASK_OBFUSCATED('123456789')).toEqual('***-**-6789');
+    expect(SSN_MASK_OBFUSCATED('123.45.6789')).toEqual('***-**-6789');
+  });
+
+  it('masks incomplete social security numbers', () => {
+    expect(SSN_MASK_OBFUSCATED('123')).toEqual('***-##-####');
+    expect(SSN_MASK_OBFUSCATED('1234')).toEqual('***-*#-####');
+    expect(SSN_MASK_OBFUSCATED('1234567')).toEqual('***-**-67##');
+  });
+
+  it('handles valueOnly parameter', () => {
+    expect(SSN_MASK_OBFUSCATED('123', true)).toEqual('***');
+    expect(SSN_MASK_OBFUSCATED('12345', true)).toEqual('***-**');
+    expect(SSN_MASK_OBFUSCATED('1234567', true)).toEqual('***-**-67');
   });
 });
 

--- a/packages/design-system/src/components/TextField/useLabelMask.tsx
+++ b/packages/design-system/src/components/TextField/useLabelMask.tsx
@@ -99,7 +99,7 @@ export const CURRENCY_MASK = makeMask(RE_CURRENCY, '$', (match) => {
   const clipped = stripped.includes('.') ? stripped.slice(0, stripped.indexOf('.') + 3) : stripped;
   const USDollar = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
   const formatted = USDollar.format(Number(clipped)).replace(/\.00/, '');
-  
+
   if (Number(clipped) > 0) {
     return signed ? '-' + formatted : formatted;
   } else {
@@ -122,6 +122,7 @@ export function useLabelMask(maskFn: MaskFunction, originalInputProps: TextInput
   const inputProps = {
     ...originalInputProps,
     defaultValue: undefined,
+    value: currentValue,
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
       setCurrentValue(e.currentTarget.value);
 

--- a/packages/design-system/src/components/TextField/useLabelMask.tsx
+++ b/packages/design-system/src/components/TextField/useLabelMask.tsx
@@ -89,6 +89,9 @@ export const SSN_MASK: MaskFunction = makeMask(RE_SSN, '###-##-####', (match) =>
     .join('-');
 });
 
+/**
+ * Does the same thing as SSN_MASK except that it obfuscates the first five digits
+ */
 export const SSN_MASK_OBFUSCATED: MaskFunction = (rawInput: string, valueOnly?: boolean) => {
   // Use the normal SSN_MASK function just to clean the raw input and format it
   const formatted = SSN_MASK(rawInput, true);

--- a/packages/design-system/src/components/TextField/useLabelMask.tsx
+++ b/packages/design-system/src/components/TextField/useLabelMask.tsx
@@ -147,8 +147,6 @@ export function useLabelMask(maskFn: MaskFunction, originalInputProps: TextInput
       }
     },
     onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
-      setCurrentValue(e.currentTarget.value);
-
       if (onFocus) {
         onFocus(e);
       }
@@ -186,7 +184,7 @@ export function useLabelMask(maskFn: MaskFunction, originalInputProps: TextInput
   // SSN mask needs to obfuscate the SSN when not focused
   if (maskFn === SSN_MASK && !focused && currentValue !== '') {
     currentMask = SSN_MASK_OBFUSCATED(currentValue);
-    // inputProps.value = '***-**-****';
+    inputProps.value = SSN_MASK_OBFUSCATED(currentValue, true);
   }
 
   return {

--- a/packages/design-system/src/components/TextField/useLabelMask.tsx
+++ b/packages/design-system/src/components/TextField/useLabelMask.tsx
@@ -90,24 +90,19 @@ export const SSN_MASK: MaskFunction = makeMask(RE_SSN, '###-##-####', (match) =>
 });
 
 export const SSN_MASK_OBFUSCATED: MaskFunction = (rawInput: string, valueOnly?: boolean) => {
+  // Use the normal SSN_MASK function just to clean the raw input and format it
   const formatted = SSN_MASK(rawInput, true);
+  // We only hide the first five digits of the SSNs
   const obfuscation = '***-**';
+
   let obfuscated: string;
   if (formatted.length < obfuscation.length) {
     obfuscated = obfuscation.substring(0, formatted.length);
   } else {
     obfuscated = obfuscation + formatted.substring(obfuscation.length);
   }
-  return SSN_MASK(obfuscated, valueOnly);
 
-  // const masked = SSN_MASK(rawInput, valueOnly);
-  // // Actually, this will obfuscate `#` values from the above, so we need to start by passing `true` for `valueOnly`
-  // const obfuscation = '***-**';
-  // if (masked.length < obfuscation.length) {
-  //   return obfuscation.substring(0, masked.length);
-  // } else {
-  //   return obfuscation + masked.substring(obfuscation.length);
-  // }
+  return SSN_MASK(obfuscated, valueOnly);
 };
 
 /**


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-2099

- Obfuscates social security numbers when the input doesn't have focus by replacing the first five digits with asterisks
- As a side effect of implementing this, we no longer have the cursor-jump problem for label-masked TextFields, but the problem still exists for other TextFields

## How to test

1. Start Storybook
2. Navigate to http://localhost:6006/?path=/story/components-text-field--label-masked-ssn
3. The input should display the full social security number that you input while you're typing, but it will hide the first five digits whenever the input doesn't have focus

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover the logic added
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)

### If this is a change to documentation:

- [x] Checked for spelling and grammatical errors
