### PR TITLE
[WNMGDS-2122] Revert use of sass:math to restore support for LibSass in 5.0

### DIFF
--- a/packages/design-system/src/styles/settings/mixins/_layout.scss
+++ b/packages/design-system/src/styles/settings/mixins/_layout.scss
@@ -1,5 +1,3 @@
-@use 'sass:math';
-
 @mixin clearfix {
   &::before {
     content: '';
@@ -14,8 +12,8 @@
 }
 
 @mixin flexbox-col($size) {
-  flex: 0 0 percentage(math.div($size, $grid-columns));
-  max-width: percentage(math.div($size, $grid-columns)); // IE10+ and Firefox
+  flex: 0 0 percentage($size / $grid-columns);
+  max-width: percentage($size / $grid-columns); // IE10+ and Firefox
 }
 
 @mixin equal-width-flexbox-col() {


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-2122

Amid some delinting changes, we accidentally introduced [some Sass code](https://github.com/CMSgov/design-system/commit/f209b1611e94205e0bf83bcd2bf0930b1f373f83#diff-b18f80412afbfbae4bd03e27ba4b4df438eaa1a8874560b8d0d59855bfde619c) that [isn’t supported by LibSass](https://sass-lang.com/documentation/modules/math). Reverts use of `sass:math` only in the `release/5.0` branch.
