### PR TITLE
[NO-TICKET] getting rid of defaultProps in stories

### DIFF
--- a/packages/design-system/src/components/DateField/SingleInputDateField.stories.jsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.stories.jsx
@@ -11,7 +11,6 @@ export default {
       control: { type: 'text' },
     },
     errorPlacement: {
-      defaultValue: 'top',
       control: {
         type: 'radio',
       },
@@ -28,8 +27,9 @@ export default {
     },
   },
   args: {
-    label: 'Birthday',
+    errorPlacement: 'top',
     hint: 'Please enter your birthday',
+    label: 'Birthday',
     name: 'single-input-date-field',
   },
 };

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.stories.jsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.stories.jsx
@@ -18,10 +18,6 @@ export default {
     inversed: {
       control: 'radio',
       options: [true, false],
-      defaultValue: false,
-    },
-    errorPlacement: {
-      defaultValue: 'top',
     },
     locale: {
       description:
@@ -30,7 +26,9 @@ export default {
   },
   args: {
     hint: "Month Picker can receive optional help text, giving the user additional information of what's required.",
+    inversed: false,
     errorMessage: 'Please meet form requirements.',
+    errorPlacement: 'top',
   },
 };
 

--- a/packages/design-system/src/components/Review/Review.stories.jsx
+++ b/packages/design-system/src/components/Review/Review.stories.jsx
@@ -10,11 +10,13 @@ export default {
         type: 'select',
       },
       options: ['1', '2', '3', '4', '5', '6'],
-      defaultValue: '3',
     },
     editContent: { control: false },
     editText: { control: 'text' },
     heading: { control: 'text' },
+  },
+  args: {
+    headingLevel: '3',
   },
 };
 

--- a/packages/design-system/src/components/Spinner/Spinner.stories.jsx
+++ b/packages/design-system/src/components/Spinner/Spinner.stories.jsx
@@ -10,15 +10,17 @@ export default {
       options: ['small', 'big'],
     },
     inversed: {
-      defaultValue: false,
       control: 'radio',
       options: [true, false],
     },
     filled: {
-      defaultValue: false,
       control: 'radio',
       options: [true, false],
     },
+  },
+  args: {
+    inversed: false,
+    filled: false,
   },
 };
 

--- a/packages/design-system/src/components/VerticalNav/VerticalNav.stories.jsx
+++ b/packages/design-system/src/components/VerticalNav/VerticalNav.stories.jsx
@@ -12,13 +12,15 @@ export default {
     collapsed: {
       control: 'radio',
       options: [true, false],
-      defaultValue: false,
     },
     nested: {
       control: 'radio',
       options: [true, false],
-      defaultValue: false,
     },
+  },
+  args: {
+    collapsed: false,
+    nested: false,
   },
   subcomponents: { VerticalNavItem, VerticalNavItemLabel },
 };


### PR DESCRIPTION
## Summary

- Was getting a bunch of warnings in storybook about `defaultProps` deprecation so figured I'd clean it up
- Removes `defaultProps` in any stories which use them, instead setting them manually with `args`

**Information on the deprecation here:**
[https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#no-longer-inferring-default-values-of-args](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#no-longer-inferring-default-values-of-args
)

## How to test

1. `yarn clean && yarn install && yarn storybook`
2. Shouldn't see any more warnings about this deprecation