### PR TITLE
[WNMGDS-2135] Fix language detection bug

### DIFF
--- a/packages/design-system/src/components/i18n.test.ts
+++ b/packages/design-system/src/components/i18n.test.ts
@@ -1,4 +1,5 @@
 import {
+  _detectDocumentLanguage,
   getLanguage,
   setLanguage,
   getTranslations,
@@ -13,6 +14,23 @@ import {
 describe('i18n', () => {
   afterEach(() => {
     setLanguage('en');
+  });
+
+  describe('_detectDocumentLanguage', () => {
+    it('detects lang="en"', () => {
+      document.documentElement.setAttribute('lang', 'en');
+      expect(_detectDocumentLanguage()).toEqual('en');
+    });
+
+    it('detects lang="es"', () => {
+      document.documentElement.setAttribute('lang', 'es');
+      expect(_detectDocumentLanguage()).toEqual('es');
+    });
+
+    it('returns undefined for lang="de"', () => {
+      document.documentElement.setAttribute('lang', 'de');
+      expect(_detectDocumentLanguage()).toBeUndefined();
+    });
   });
 
   describe('getLanguage and setLanguage', () => {

--- a/packages/design-system/src/components/i18n.test.ts
+++ b/packages/design-system/src/components/i18n.test.ts
@@ -31,6 +31,16 @@ describe('i18n', () => {
       document.documentElement.setAttribute('lang', 'de');
       expect(_detectDocumentLanguage()).toBeUndefined();
     });
+
+    it('detects lang="en-US" by returning "en"', () => {
+      document.documentElement.setAttribute('lang', 'en-US');
+      expect(_detectDocumentLanguage()).toEqual('en');
+    });
+
+    it('detects lang="es-US" by returning "es"', () => {
+      document.documentElement.setAttribute('lang', 'es-US');
+      expect(_detectDocumentLanguage()).toEqual('es');
+    });
   });
 
   describe('getLanguage and setLanguage', () => {

--- a/packages/design-system/src/components/i18n.ts
+++ b/packages/design-system/src/components/i18n.ts
@@ -9,11 +9,13 @@ export function _detectDocumentLanguage(): Language | undefined {
     return undefined;
   }
   const detectedLang = document.querySelector('html')?.lang ?? '';
-  if (['en', 'es'].some((lang) => languageMatches(lang, detectedLang))) {
-    return detectedLang as Language;
-  } else {
-    return undefined;
+  const validLangs: Language[] = ['en', 'es'];
+  for (const lang of validLangs) {
+    if (languageMatches(lang, detectedLang)) {
+      return lang;
+    }
   }
+  return undefined;
 }
 
 let language: Language = _detectDocumentLanguage() ?? 'en';

--- a/packages/design-system/src/components/i18n.ts
+++ b/packages/design-system/src/components/i18n.ts
@@ -4,7 +4,7 @@ import get from 'lodash/get';
 
 export type Language = 'en' | 'es';
 
-function detectDocumentLanguage(): Language | undefined {
+export function _detectDocumentLanguage(): Language | undefined {
   if (typeof document === 'undefined') {
     return undefined;
   }
@@ -16,7 +16,7 @@ function detectDocumentLanguage(): Language | undefined {
   }
 }
 
-let language: Language = detectDocumentLanguage() ?? 'en';
+let language: Language = _detectDocumentLanguage() ?? 'en';
 
 export function getLanguage() {
   return language;


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-2135

Fixes bug where language is detected and stored with its full [Unicode BCP 47 locale identifier](https://www.unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers) instead of only the language tag, which our `i18n` module expects elsewhere.

## How to test

I modified the `examples/cdn` example to test this. I changed the HTML `lang` attribute to `en-US` and to `es-US`. I added the healthcare.gov header and witnessed the bug using the code from `main` and then saw it fixed when switching to a bundle built from this branch.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover the logic added
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)