### PR TITLE
[LHDM-1387] Expose Privacy Settings Modal for standalone usage

### DIFF
--- a/packages/ds-healthcare-gov/src/components/Footer/InlineLinkLists.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/InlineLinkLists.tsx
@@ -51,7 +51,7 @@ const InlineLinkLists = function (props: InlineLinkListsProps) {
     'footer.nondiscriminationAndA11y':
       'http://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/CMSNondiscriminationNotice.html',
     'footer.privacyPolicy': `${primaryDomain}/privacy`,
-    'footer.privacySettings': <PrivacySettingsLink t={props.t} />,
+    'footer.privacySettings': <PrivacySettingsLink />,
     'footer.linkingPolicy': `${primaryDomain}/privacy/#links`,
     'footer.usingThisSite': `${primaryDomain}/using-this-site`,
     'footer.plainWriting': 'http://www.hhs.gov/open/plain-writing/index.html',

--- a/packages/ds-healthcare-gov/src/components/Footer/PrivacySettingsLink.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/PrivacySettingsLink.tsx
@@ -5,6 +5,7 @@ import { TFunction } from '@cmsgov/design-system';
 
 interface PrivacySettingsLinkProps {
   t: TFunction;
+  className?: string;
 }
 
 export const PrivacySettingsLink = (props: PrivacySettingsLinkProps) => {
@@ -16,7 +17,9 @@ export const PrivacySettingsLink = (props: PrivacySettingsLinkProps) => {
 
   return (
     <>
-      <button onClick={openDialog}>{props.t('footer.privacySettings')}</button>
+      <button className={props.className ?? ''} onClick={openDialog}>
+        {props.t('footer.privacySettings')}
+      </button>
       {showDialog && <PrivacySettingsDialog onExit={closeDialog} t={props.t} />}
     </>
   );

--- a/packages/ds-healthcare-gov/src/components/Footer/PrivacySettingsLink.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/PrivacySettingsLink.tsx
@@ -19,7 +19,7 @@ export const PrivacySettingsLink = (props: PrivacySettingsLinkProps) => {
 
   return (
     <>
-      <button className={props.className ?? ''} onClick={openDialog}>
+      <button className={props.className} onClick={openDialog}>
         {t('footer.privacySettings')}
       </button>
       {showDialog && <PrivacySettingsDialog onExit={closeDialog} t={t} />}

--- a/packages/ds-healthcare-gov/src/components/Footer/PrivacySettingsLink.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/PrivacySettingsLink.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import PrivacySettingsDialog from '../PrivacySettings/PrivacySettingsDialog';
 import { useState } from 'react';
-import { TFunction } from '@cmsgov/design-system';
+
+import { tWithLanguage } from '../i18n';
 
 interface PrivacySettingsLinkProps {
-  t: TFunction;
   className?: string;
 }
 
 export const PrivacySettingsLink = (props: PrivacySettingsLinkProps) => {
   const [showDialog, setShowDialog] = useState(false);
+
+  const t = tWithLanguage();
 
   const openDialog = () => setShowDialog(true);
 
@@ -18,9 +20,9 @@ export const PrivacySettingsLink = (props: PrivacySettingsLinkProps) => {
   return (
     <>
       <button className={props.className ?? ''} onClick={openDialog}>
-        {props.t('footer.privacySettings')}
+        {t('footer.privacySettings')}
       </button>
-      {showDialog && <PrivacySettingsDialog onExit={closeDialog} t={props.t} />}
+      {showDialog && <PrivacySettingsDialog onExit={closeDialog} t={t} />}
     </>
   );
 };

--- a/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/InlineLinkLists.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/InlineLinkLists.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`InlineLinkLists renders lists of links 1`] = `
         class="hc-c-footer__inline-item ds-u-margin-y--0 ds-u-display--inline-block"
       >
         <button>
-          footer.privacySettings
+          Privacy Settings
         </button>
       </li>
       <li
@@ -359,7 +359,7 @@ exports[`InlineLinkLists renders lists of links with absolute URLs 1`] = `
         class="hc-c-footer__inline-item ds-u-margin-y--0 ds-u-display--inline-block"
       >
         <button>
-          footer.privacySettings
+          Privacy Settings
         </button>
       </li>
       <li

--- a/packages/ds-healthcare-gov/src/components/Footer/index.ts
+++ b/packages/ds-healthcare-gov/src/components/Footer/index.ts
@@ -1,1 +1,2 @@
 export * from './Footer';
+export * from './PrivacySettingsLink';


### PR DESCRIPTION
## Summary

- Exporting the `PrivacySettingsLink` component so it can be consumed alone, outside of its usage in the footer.
- https://jira.cms.gov/browse/LHDM-1387

## How to test

For testing, I'd mostly done so in the consuming application to ensure the changes would work for my use case. However, the `PrivacySettingsLink` component should be able to be added in any other storybook component instance and work on its own.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [ ] Created or updated unit tests to cover the logic added
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)
