### PR TITLE
[WNMGDS-2153] Fix aria-disabled button styles

### DIFF
--- a/packages/design-system/src/components/Button/Button.stories.jsx
+++ b/packages/design-system/src/components/Button/Button.stories.jsx
@@ -396,11 +396,11 @@ export const AllButtons = () => {
           <Button size="small">Button</Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button size="big" disabled>
+          <Button size="big" aria-disabled>
             Button
           </Button>
-          <Button disabled>Button</Button>
-          <Button size="small" disabled>
+          <Button aria-disabled>Button</Button>
+          <Button size="small" aria-disabled>
             Button
           </Button>
         </div>
@@ -414,13 +414,13 @@ export const AllButtons = () => {
           </Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button size="big" disabled isAlternate>
+          <Button size="big" aria-disabled isAlternate>
             Alt button
           </Button>
-          <Button disabled isAlternate>
+          <Button aria-disabled isAlternate>
             Alt button
           </Button>
-          <Button size="small" disabled isAlternate>
+          <Button size="small" aria-disabled isAlternate>
             Alt button
           </Button>
         </div>
@@ -438,13 +438,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark size="big" disabled>
+            <Button onDark size="big" aria-disabled>
               Button on-dark
             </Button>
-            <Button onDark disabled>
+            <Button onDark aria-disabled>
               Button on-dark
             </Button>
-            <Button onDark size="small" disabled>
+            <Button onDark size="small" aria-disabled>
               Button on-dark
             </Button>
           </div>
@@ -460,13 +460,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark size="big" disabled isAlternate>
+            <Button onDark size="big" aria-disabled isAlternate>
               Alt button on-dark
             </Button>
-            <Button onDark disabled isAlternate>
+            <Button onDark aria-disabled isAlternate>
               Alt button on-dark
             </Button>
-            <Button onDark size="small" disabled isAlternate>
+            <Button onDark size="small" aria-disabled isAlternate>
               Alt button on-dark
             </Button>
           </div>
@@ -483,13 +483,13 @@ export const AllButtons = () => {
           </Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button variation="solid" size="big" disabled>
+          <Button variation="solid" size="big" aria-disabled>
             Solid button
           </Button>
-          <Button variation="solid" disabled>
+          <Button variation="solid" aria-disabled>
             Solid button
           </Button>
-          <Button variation="solid" size="small" disabled>
+          <Button variation="solid" size="small" aria-disabled>
             Solid button
           </Button>
         </div>
@@ -505,13 +505,13 @@ export const AllButtons = () => {
           </Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button variation="solid" size="big" disabled isAlternate>
+          <Button variation="solid" size="big" aria-disabled isAlternate>
             Solid alt button
           </Button>
-          <Button variation="solid" disabled isAlternate>
+          <Button variation="solid" aria-disabled isAlternate>
             Solid alt button
           </Button>
-          <Button variation="solid" size="small" disabled isAlternate>
+          <Button variation="solid" size="small" aria-disabled isAlternate>
             Solid alt button
           </Button>
         </div>
@@ -531,13 +531,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark variation="solid" size="big" disabled>
+            <Button onDark variation="solid" size="big" aria-disabled>
               Solid button on-dark
             </Button>
-            <Button onDark variation="solid" disabled>
+            <Button onDark variation="solid" aria-disabled>
               Solid button on-dark
             </Button>
-            <Button onDark variation="solid" size="small" disabled>
+            <Button onDark variation="solid" size="small" aria-disabled>
               Solid button on-dark
             </Button>
           </div>
@@ -553,13 +553,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark variation="solid" size="big" disabled isAlternate>
+            <Button onDark variation="solid" size="big" aria-disabled isAlternate>
               Solid alt button on-dark
             </Button>
-            <Button onDark variation="solid" disabled isAlternate>
+            <Button onDark variation="solid" aria-disabled isAlternate>
               Solid button on-dark
             </Button>
-            <Button onDark variation="solid" size="small" disabled isAlternate>
+            <Button onDark variation="solid" size="small" aria-disabled isAlternate>
               Solid alt button on-dark
             </Button>
           </div>
@@ -576,13 +576,13 @@ export const AllButtons = () => {
           </Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button variation="ghost" size="big" disabled>
+          <Button variation="ghost" size="big" aria-disabled>
             Ghost button
           </Button>
-          <Button variation="ghost" disabled>
+          <Button variation="ghost" aria-disabled>
             Ghost button
           </Button>
-          <Button variation="ghost" size="small" disabled>
+          <Button variation="ghost" size="small" aria-disabled>
             Ghost button
           </Button>
         </div>
@@ -598,13 +598,13 @@ export const AllButtons = () => {
           </Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button variation="ghost" size="big" disabled isAlternate>
+          <Button variation="ghost" size="big" aria-disabled isAlternate>
             Ghost alt button
           </Button>
-          <Button variation="ghost" disabled isAlternate>
+          <Button variation="ghost" aria-disabled isAlternate>
             Ghost alt button
           </Button>
-          <Button variation="ghost" size="small" disabled isAlternate>
+          <Button variation="ghost" size="small" aria-disabled isAlternate>
             Ghost alt button
           </Button>
         </div>
@@ -624,13 +624,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark variation="ghost" size="big" disabled>
+            <Button onDark variation="ghost" size="big" aria-disabled>
               Ghost button on-dark
             </Button>
-            <Button onDark variation="ghost" disabled>
+            <Button onDark variation="ghost" aria-disabled>
               Ghost button on-dark
             </Button>
-            <Button onDark variation="ghost" size="small" disabled>
+            <Button onDark variation="ghost" size="small" aria-disabled>
               Ghost button on-dark
             </Button>
           </div>
@@ -646,13 +646,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark variation="ghost" size="big" disabled isAlternate>
+            <Button onDark variation="ghost" size="big" aria-disabled isAlternate>
               Ghost alt button on-dark
             </Button>
-            <Button onDark variation="ghost" disabled isAlternate>
+            <Button onDark variation="ghost" aria-disabled isAlternate>
               Ghost alt button on-dark
             </Button>
-            <Button onDark variation="ghost" size="small" disabled isAlternate>
+            <Button onDark variation="ghost" size="small" aria-disabled isAlternate>
               Ghost alt button on-dark
             </Button>
           </div>

--- a/packages/design-system/src/components/Button/Button.stories.jsx
+++ b/packages/design-system/src/components/Button/Button.stories.jsx
@@ -396,11 +396,11 @@ export const AllButtons = () => {
           <Button size="small">Button</Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button size="big" aria-disabled>
+          <Button size="big" disabled>
             Button
           </Button>
-          <Button aria-disabled>Button</Button>
-          <Button size="small" aria-disabled>
+          <Button disabled>Button</Button>
+          <Button size="small" disabled>
             Button
           </Button>
         </div>
@@ -414,13 +414,13 @@ export const AllButtons = () => {
           </Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button size="big" aria-disabled isAlternate>
+          <Button size="big" disabled isAlternate>
             Alt button
           </Button>
-          <Button aria-disabled isAlternate>
+          <Button disabled isAlternate>
             Alt button
           </Button>
-          <Button size="small" aria-disabled isAlternate>
+          <Button size="small" disabled isAlternate>
             Alt button
           </Button>
         </div>
@@ -438,13 +438,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark size="big" aria-disabled>
+            <Button onDark size="big" disabled>
               Button on-dark
             </Button>
-            <Button onDark aria-disabled>
+            <Button onDark disabled>
               Button on-dark
             </Button>
-            <Button onDark size="small" aria-disabled>
+            <Button onDark size="small" disabled>
               Button on-dark
             </Button>
           </div>
@@ -460,13 +460,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark size="big" aria-disabled isAlternate>
+            <Button onDark size="big" disabled isAlternate>
               Alt button on-dark
             </Button>
-            <Button onDark aria-disabled isAlternate>
+            <Button onDark disabled isAlternate>
               Alt button on-dark
             </Button>
-            <Button onDark size="small" aria-disabled isAlternate>
+            <Button onDark size="small" disabled isAlternate>
               Alt button on-dark
             </Button>
           </div>
@@ -483,13 +483,13 @@ export const AllButtons = () => {
           </Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button variation="solid" size="big" aria-disabled>
+          <Button variation="solid" size="big" disabled>
             Solid button
           </Button>
-          <Button variation="solid" aria-disabled>
+          <Button variation="solid" disabled>
             Solid button
           </Button>
-          <Button variation="solid" size="small" aria-disabled>
+          <Button variation="solid" size="small" disabled>
             Solid button
           </Button>
         </div>
@@ -505,13 +505,13 @@ export const AllButtons = () => {
           </Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button variation="solid" size="big" aria-disabled isAlternate>
+          <Button variation="solid" size="big" disabled isAlternate>
             Solid alt button
           </Button>
-          <Button variation="solid" aria-disabled isAlternate>
+          <Button variation="solid" disabled isAlternate>
             Solid alt button
           </Button>
-          <Button variation="solid" size="small" aria-disabled isAlternate>
+          <Button variation="solid" size="small" disabled isAlternate>
             Solid alt button
           </Button>
         </div>
@@ -531,13 +531,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark variation="solid" size="big" aria-disabled>
+            <Button onDark variation="solid" size="big" disabled>
               Solid button on-dark
             </Button>
-            <Button onDark variation="solid" aria-disabled>
+            <Button onDark variation="solid" disabled>
               Solid button on-dark
             </Button>
-            <Button onDark variation="solid" size="small" aria-disabled>
+            <Button onDark variation="solid" size="small" disabled>
               Solid button on-dark
             </Button>
           </div>
@@ -553,13 +553,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark variation="solid" size="big" aria-disabled isAlternate>
+            <Button onDark variation="solid" size="big" disabled isAlternate>
               Solid alt button on-dark
             </Button>
-            <Button onDark variation="solid" aria-disabled isAlternate>
+            <Button onDark variation="solid" disabled isAlternate>
               Solid button on-dark
             </Button>
-            <Button onDark variation="solid" size="small" aria-disabled isAlternate>
+            <Button onDark variation="solid" size="small" disabled isAlternate>
               Solid alt button on-dark
             </Button>
           </div>
@@ -576,13 +576,13 @@ export const AllButtons = () => {
           </Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button variation="ghost" size="big" aria-disabled>
+          <Button variation="ghost" size="big" disabled>
             Ghost button
           </Button>
-          <Button variation="ghost" aria-disabled>
+          <Button variation="ghost" disabled>
             Ghost button
           </Button>
-          <Button variation="ghost" size="small" aria-disabled>
+          <Button variation="ghost" size="small" disabled>
             Ghost button
           </Button>
         </div>
@@ -598,13 +598,13 @@ export const AllButtons = () => {
           </Button>
         </div>
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-          <Button variation="ghost" size="big" aria-disabled isAlternate>
+          <Button variation="ghost" size="big" disabled isAlternate>
             Ghost alt button
           </Button>
-          <Button variation="ghost" aria-disabled isAlternate>
+          <Button variation="ghost" disabled isAlternate>
             Ghost alt button
           </Button>
-          <Button variation="ghost" size="small" aria-disabled isAlternate>
+          <Button variation="ghost" size="small" disabled isAlternate>
             Ghost alt button
           </Button>
         </div>
@@ -624,13 +624,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark variation="ghost" size="big" aria-disabled>
+            <Button onDark variation="ghost" size="big" disabled>
               Ghost button on-dark
             </Button>
-            <Button onDark variation="ghost" aria-disabled>
+            <Button onDark variation="ghost" disabled>
               Ghost button on-dark
             </Button>
-            <Button onDark variation="ghost" size="small" aria-disabled>
+            <Button onDark variation="ghost" size="small" disabled>
               Ghost button on-dark
             </Button>
           </div>
@@ -646,13 +646,13 @@ export const AllButtons = () => {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-            <Button onDark variation="ghost" size="big" aria-disabled isAlternate>
+            <Button onDark variation="ghost" size="big" disabled isAlternate>
               Ghost alt button on-dark
             </Button>
-            <Button onDark variation="ghost" aria-disabled isAlternate>
+            <Button onDark variation="ghost" disabled isAlternate>
               Ghost alt button on-dark
             </Button>
-            <Button onDark variation="ghost" size="small" aria-disabled isAlternate>
+            <Button onDark variation="ghost" size="small" disabled isAlternate>
               Ghost alt button on-dark
             </Button>
           </div>

--- a/packages/design-system/src/styles/components/_Button.scss
+++ b/packages/design-system/src/styles/components/_Button.scss
@@ -29,7 +29,7 @@
       text-decoration: none;
     }
 
-    &[aria-disabled] {
+    &[aria-disabled='true'] {
       pointer-events: none; // Needed to render disabled links correctly
     }
   }
@@ -62,7 +62,7 @@
   }
 
   &:disabled,
-  &[aria-disabled] {
+  &[aria-disabled='true'] {
     background-color: var(--backgroundColor--d, var(--button__background-color--disabled));
     border-color: var(--borderColor--d, var(--button__border-color--disabled));
     color: var(--color--d, var(--button__color--disabled));

--- a/packages/design-system/src/styles/components/_Button.scss
+++ b/packages/design-system/src/styles/components/_Button.scss
@@ -62,7 +62,8 @@
   }
 
   &:disabled,
-  &[aria-disabled='true'] {
+  &[aria-disabled='true'],
+  &[aria-disabled='true']:is(:hover, :hover:focus, :focus, :active, :active:focus) {
     background-color: var(--backgroundColor--d, var(--button__background-color--disabled));
     border-color: var(--borderColor--d, var(--button__border-color--disabled));
     color: var(--color--d, var(--button__color--disabled));


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-2153

- Fix `aria-disabled` button styles by qualifying the selector to only match `true` values, like `aria-disabled="true"`. Before those styles were being incorrectly applied to elements with `aria-disabled="false"`.
- Because an `aria-disabled` button can still be interacted with—unlike a `disabled` button—some interaction states like `:active:focus` were applying non-disabled styles to the button. To fix this, I increased the specificity of the disabled styles for those combinations

Fixes #2303

## How to test

1. Check out [Temporarily change a story for testing](https://github.com/CMSgov/design-system/commit/35ff6b296510dfdb7783b0b6a4c09cd8906d6a5b)
2. Start storybook
3. Navigate to the "All buttons" story
4. Interact with the disabled buttons with the keyboard and the mouse

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title`
