### PR TITLE
[WNMGDS-2150] Refactor nav link to remove H1 tag, preserve styles

### DIFF
--- a/packages/docs/src/components/layout/DocSiteNavigation.tsx
+++ b/packages/docs/src/components/layout/DocSiteNavigation.tsx
@@ -122,9 +122,9 @@ const DocSiteNavigation = ({ location }: DocSiteNavProps) => {
             <MenuIconThin className="ds-u-font-size--xl" />
           )}
         </Button>
-        <h1 className="c-navigation__title">
-          <a href="/">CMS Design System</a>
-        </h1>
+        <a className="c-navigation__title" href="/">
+          CMS Design System
+        </a>
       </header>
 
       <div

--- a/packages/docs/src/styles/components/navigation.scss
+++ b/packages/docs/src/styles/components/navigation.scss
@@ -16,15 +16,11 @@
   }
 
   .c-navigation__title {
-    color: var(--color-base);
+    background-color: transparent;
+    color: currentColor;
     font-size: var(--font-size-xl);
-    margin: 0;
-
-    a {
-      background-color: transparent;
-      color: currentColor;
-      text-decoration: none;
-    }
+    font-weight: var(--font-weight-bold);
+    text-decoration: none;
   }
 
   .c-navigation__link-list {


### PR DESCRIPTION
## Summary

WNMGDS-2150

## To test
1. Run demo docs site (or build locally if link isn't working)
2. Open the dev tools and search for "<h1" - you should only see one result
3. (Optional) Open VoiceOver and open Rotor - Headings - you should only see one heading for "1"