### PR TITLE
[NO-TICKET] Use code formatting for CSS variables on spacing page

### DIFF
--- a/packages/docs/content/foundation/spacing.mdx
+++ b/packages/docs/content/foundation/spacing.mdx
@@ -14,13 +14,13 @@ The design system uses multiples of `8px` for all spacing values: dimensions, pa
 
 - [The 8-Point Grid](https://spec.fm/specifics/8-pt-grid)
 
-| Variable     | Value | Example                                                      |
-| ------------ | ----- | --------------------------------------------------------------
-| --spacer-half | 4px   | <div class="ds-u-fill--secondary example-spacer-half"></div> |
-| --spacer-1    | 8px   | <div class="ds-u-fill--secondary example-spacer-1"></div>    |
-| --spacer-2    | 16px  | <div class="ds-u-fill--secondary example-spacer-2"></div>    |
-| --spacer-3    | 24px  | <div class="ds-u-fill--secondary example-spacer-3"></div>    |
-| --spacer-4    | 32px  | <div class="ds-u-fill--secondary example-spacer-4"></div>    |
-| --spacer-5    | 40px  | <div class="ds-u-fill--secondary example-spacer-5"></div>    |
-| --spacer-6    | 48px  | <div class="ds-u-fill--secondary example-spacer-6"></div>    |
-| --spacer-7    | 56px  | <div class="ds-u-fill--secondary example-spacer-7"></div>    |
+| Variable        | Value | Example                                                      |
+| --------------- | ----- | ------------------------------------------------------------ |
+| `--spacer-half` | 4px   | <div class="ds-u-fill--secondary example-spacer-half"></div> |
+| `--spacer-1`    | 8px   | <div class="ds-u-fill--secondary example-spacer-1"></div>    |
+| `--spacer-2`    | 16px  | <div class="ds-u-fill--secondary example-spacer-2"></div>    |
+| `--spacer-3`    | 24px  | <div class="ds-u-fill--secondary example-spacer-3"></div>    |
+| `--spacer-4`    | 32px  | <div class="ds-u-fill--secondary example-spacer-4"></div>    |
+| `--spacer-5`    | 40px  | <div class="ds-u-fill--secondary example-spacer-5"></div>    |
+| `--spacer-6`    | 48px  | <div class="ds-u-fill--secondary example-spacer-6"></div>    |
+| `--spacer-7`    | 56px  | <div class="ds-u-fill--secondary example-spacer-7"></div>    |


### PR DESCRIPTION
## Summary

Found a table that wasn't consistent with our other presentations of variable names

## How to test

`yarn start` and visit http://localhost:8000/foundation/spacing/
