### PR TITLE
[NO-TICKET] Adding child system scss back to doc site build

### DIFF
--- a/packages/docs/src/styles/index.scss
+++ b/packages/docs/src/styles/index.scss
@@ -25,3 +25,11 @@
 @import 'components/tableOfContents.scss';
 @import 'components/spacingUtilityExampleList.scss';
 @import 'components/video.scss';
+
+[data-theme='healthcare'] {
+  @import '@cmsgov/ds-healthcare-gov/src/styles/index';
+}
+
+[data-theme='medicare'] {
+  @import '@cmsgov/ds-medicare-gov/src/styles/index';
+}

--- a/packages/docs/src/styles/index.scss
+++ b/packages/docs/src/styles/index.scss
@@ -27,9 +27,9 @@
 @import 'components/video.scss';
 
 [data-theme='healthcare'] {
-  @import '@cmsgov/ds-healthcare-gov/src/styles/index';
+  @import '@cmsgov/ds-healthcare-gov/src/styles/components/index';
 }
 
 [data-theme='medicare'] {
-  @import '@cmsgov/ds-medicare-gov/src/styles/index';
+  @import '@cmsgov/ds-medicare-gov/src/styles/components/index';
 }

--- a/packages/ds-healthcare-gov/src/styles/components/index.scss
+++ b/packages/ds-healthcare-gov/src/styles/components/index.scss
@@ -1,0 +1,7 @@
+@use 'Accordion';
+@use 'Footer';
+@use 'FormLabel';
+@use 'Header';
+@use 'Inset';
+@use 'Logo';
+@use 'PrivacySettingsTable';

--- a/packages/ds-healthcare-gov/src/styles/index.scss
+++ b/packages/ds-healthcare-gov/src/styles/index.scss
@@ -9,11 +9,4 @@
 
 @use '../../../design-system/src/styles/index';
 @use 'layout';
-
-@use 'components/Accordion';
-@use 'components/Footer';
-@use 'components/FormLabel';
-@use 'components/Header';
-@use 'components/Inset';
-@use 'components/Logo';
-@use 'components/PrivacySettingsTable';
+@use 'components/index' as *;

--- a/packages/ds-medicare-gov/src/styles/components/index.scss
+++ b/packages/ds-medicare-gov/src/styles/components/index.scss
@@ -1,0 +1,9 @@
+@use 'ChoiceList';
+@use 'Dialog';
+@use 'Forms';
+@use 'HelpDrawer';
+@use 'Other';
+@use 'Tooltip';
+@use 'Icons';
+@use 'SimpleFooter';
+@use 'Card';

--- a/packages/ds-medicare-gov/src/styles/index.scss
+++ b/packages/ds-medicare-gov/src/styles/index.scss
@@ -11,13 +11,4 @@
 @use 'layout';
 @use 'base';
 @use 'fonts';
-
-@use 'components/ChoiceList';
-@use 'components/Dialog';
-@use 'components/Forms';
-@use 'components/HelpDrawer';
-@use 'components/Other';
-@use 'components/Tooltip';
-@use 'components/Icons';
-@use 'components/SimpleFooter';
-@use 'components/Card';
+@use 'components/index' as *;


### PR DESCRIPTION
## Summary

- Doc site wasn't adding the child systems styles where they needed to be.
- This was removed in the epic css branch and shouldn't have been

## How to test

1. `yarn clean && yarn install && yarn start`