### PR TITLE
[NO-TICKET] Don't delete dist/scss folder during build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,12 +37,14 @@ const fontsCorePath = path.join(corePackageFiles, 'fonts');
  * clean up dist folder if it exists
  */
 const cleanDist = (cb) => {
-  fs.readdirSync(distPath, (err, files) => {
-    files.forEach((f) => {
-      // don't clean out the scss folder that was just created
-      if (f !== 'scss') fs.rm(f, { recursive: true });
+  if (fs.existsSync(distPath)) {
+    fs.readdirSync(distPath, (err, files) => {
+      files.forEach((f) => {
+        // don't clean out the scss folder that was just created
+        if (f !== 'scss') fs.rm(f, { recursive: true });
+      });
     });
-  });
+  }
   cb();
 };
 cleanDist.displayName = '🧹 cleaning up dist path';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,9 +37,13 @@ const fontsCorePath = path.join(corePackageFiles, 'fonts');
  * clean up dist folder if it exists
  */
 const cleanDist = (cb) => {
-  fs.rm(distPath, { recursive: true }, () => {
-    cb();
+  fs.readdirSync(distPath, (err, files) => {
+    files.forEach((f) => {
+      // don't clean out the scss folder that was just created
+      if (f !== 'scss') fs.rm(f, { recursive: true });
+    });
   });
+  cb();
 };
 cleanDist.displayName = '🧹 cleaning up dist path';
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "build:tokens": "yarn --cwd ./packages/design-system-tokens build:all",
     "build:docs": "yarn build:storybook:docs && yarn build:prop-data && yarn --cwd ./packages/docs build",
     "build:prop-data": "node ./scripts/extractPropData.js",
-    "build:tokens": "yarn --cwd ./packages/design-system-tokens build themes scss && yarn --cwd ./packages/design-system-tokens build themes css-vars && yarn --cwd ./packages/design-system-tokens dist",
     "check:maturity": "./scripts/maturityCheck.sh",
     "clean": "yarn clean:cache && yarn clean:modules",
     "clean:cache": "rm -rf packages/docs/.cache",

--- a/packages/design-system-tokens/package.json
+++ b/packages/design-system-tokens/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "ts-node ./src/index.ts",
     "build:all": "yarn clean && yarn build themes css-vars && yarn build themes scss && yarn dist",
-    "clean": "rm -f dist/*",
+    "clean": "rm -rf dist/*",
     "dist": "./src/copy_themes.sh"
   },
   "dependencies": {}


### PR DESCRIPTION
## Summary

This will be cherry picked into the 6.0 release for another beta.

- Adds some logic to gulp build to leave the dist/scss folder alone so it doesn't clean it out during build.
- Removes extra `build:tokens` script from package.json
- Removing subdirectories as well in token dist folder in cases where subfolders may be there

## How to test

1. `yarn build` - check for existence of `dist/scss` for each child system, should be there now.