### PR TITLE
[WNMGDS-2133] Make currentPage required, update docs

### DIFF
--- a/packages/design-system/src/components/Pagination/Pagination.test.tsx
+++ b/packages/design-system/src/components/Pagination/Pagination.test.tsx
@@ -37,6 +37,7 @@ describe('Pagination', () => {
   function renderPagination(overrideProps = {}) {
     const props = {
       totalPages: 3,
+      currentPage: 1,
       onPageChange: onPageChange,
       renderHref: (currentPage) => `#${currentPage}`,
       ...overrideProps,

--- a/packages/design-system/src/components/Pagination/Pagination.tsx
+++ b/packages/design-system/src/components/Pagination/Pagination.tsx
@@ -21,9 +21,9 @@ export interface PaginationProps {
    */
   compact?: boolean;
   /**
-   * Defines active page in Pagination. Optional.
+   * Defines active page in Pagination.
    */
-  currentPage?: number;
+  currentPage: number;
   /**
    * Determines if navigation is hidden when current page is the first or last of Pagination page set. Optional.
    */
@@ -321,7 +321,6 @@ function Pagination({
 
 Pagination.defaultProps = {
   compact: false,
-  currentPage: 1,
   isNavigationHidden: false,
 };
 

--- a/packages/docs/content/components/pagination.mdx
+++ b/packages/docs/content/components/pagination.mdx
@@ -22,7 +22,7 @@ medicare:
 
 ### React
 
-Pagination requires two properties: `totalPages`, which is the total number of pages, and `onPageChange`, which is a function used to handle state changes when the user clicks a page.
+Pagination requires three properties: `totalPages`, which is the total number of pages, `currentPage`, which acts a means to track the current page, and `onPageChange`, which is a function used to handle state changes when the user clicks a page.
 
 Pagination also comes in two styles: default, which is compact on mobile viewports and expands to reveal individual pages on larger viewports, and `compact`, which maintains the compact layout regardless of viewport size.
 


### PR DESCRIPTION
## Summary

WNMGDS-2133

Made `currentPage` a required prop, removed default value (this will undoubtedly cause issues for users - worth calling out in release notes), updated docs with change.

### Test
- View [demo site](https://cmsgov.github.io/design-system/branch/WNMGDS-2133/pagination-currentpage-bug) or build locally if demo unavailable
- Props table on docs site and Storybook should show `currentPage` as required