### PR TITLE
[NO-TICKET] Add some notes about importing css to dev docs

### DIFF
--- a/packages/docs/content/getting-started/for-developers.mdx
+++ b/packages/docs/content/getting-started/for-developers.mdx
@@ -273,7 +273,7 @@ These custom properties allow for a degree of customization of the design system
 }
 ```
 
-This allows these classes to apply globally to the entire page their loaded on. By re-defining these variables in this same scope or defining a variable in a custom scope, such as a specific class, you can overwrite these variables:
+This allows these classes to apply globally to the entire page they're loaded on. By re-defining these variables in this same scope or defining a variable in a custom scope, such as a specific class, you can overwrite these variables:
 
 ```css
 .ds-c-button {

--- a/packages/docs/content/getting-started/for-developers.mdx
+++ b/packages/docs/content/getting-started/for-developers.mdx
@@ -255,7 +255,11 @@ import '@cmsgov/ds-medicare-gov/dist/css/medicare-theme.css';
 
 </ThemeContent>
 
-Note that some bundlers have trouble finding the font and image files when the CSS files are imported through Sass. In those cases, we recommend either adding the `.css` extension to the imports or importing the CSS files directly from JavaScript to avoid limitations of the Sass compiler and/or the WebPack configuration.
+<Alert heading="Issues with fonts and images" variation="warn">
+
+  Note that some bundlers have trouble finding the font and image files when the CSS files are imported through Sass. In those cases, we recommend either adding the `.css` extension to the imports or importing the CSS files directly from JavaScript to avoid limitations of the Sass compiler and/or the WebPack configuration.
+
+</Alert>
 
 ### CSS Custom Properties
 
@@ -433,11 +437,11 @@ console.log(getLanguage());
   variation="warn"
   className="ds-u-margin-top--3"
 >
-  <p class="ds-c-alert__text">
-    You may notice that some components accept an older `language` or `locale` prop to set the
-    language of the content on a per-component basis, but these per-component props have been
-    deprecated and will be removed in a future breaking-change release.
-  </p>
+
+  You may notice that some components accept an older `language` or `locale` prop to set the
+  language of the content on a per-component basis, but these per-component props have been
+  deprecated and will be removed in a future breaking-change release.
+
 </Alert>
 
 ## Further resources

--- a/packages/docs/content/getting-started/for-developers.mdx
+++ b/packages/docs/content/getting-started/for-developers.mdx
@@ -255,6 +255,8 @@ import '@cmsgov/ds-medicare-gov/dist/css/medicare-theme.css';
 
 </ThemeContent>
 
+Note that some bundlers have trouble finding the font and image files when the CSS files are imported through Sass. In those cases, we recommend either adding the `.css` extension to the imports or importing the CSS files directly from JavaScript to avoid limitations of the Sass compiler and/or the WebPack configuration.
+
 ### CSS Custom Properties
 
 The CMSDS utilizes [CSS Custom Properties](https://www.w3.org/TR/css-variables-1/) to allow for flexible styling of components, layout, animation, typography and color. Lists of variables and their values can be found throughout this documentation.  

--- a/packages/docs/src/styles/components/syntaxHighlighting.scss
+++ b/packages/docs/src/styles/components/syntaxHighlighting.scss
@@ -22,6 +22,11 @@ a code {
   text-decoration: underline;
 }
 
+.ds-c-alert code {
+  // Semi-transparent so it matches the color of the alert better
+  background-color: #c4c4c44f;
+}
+
 /**
  * a11y-light theme for JavaScript, CSS, and HTML
  * Based on the okaidia theme: https://github.com/PrismJS/prism/blob/gh-pages/themes/prism-okaidia.css


### PR DESCRIPTION
## Summary

See the added note for details. This isn't really an option for some teams, but for teams that don't need it to be interpreted as Sass, it could help.