### PR TITLE
[NO-TICKET] Focus colors in theme color list had incorrect identifier

### DIFF
--- a/packages/docs/content/foundation/theme-colors.mdx
+++ b/packages/docs/content/foundation/theme-colors.mdx
@@ -151,7 +151,7 @@ Status colors can also be used with these aliases where `green`, `gold`, and `re
 
 ## Focus colors
 
-<ColorSwatchList colorNames={['focus-color-light', 'focus-color-dark']} preface="--color-" />
+<ColorSwatchList colorNames={['focus-light', 'focus-dark']} preface="--color-" />
 
 ## Additional colors
 


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/783820/214606981-6b11df74-c64d-416f-8959-289da7b0d96e.png)

- Focus color swatches had the wrong token name