### PR TITLE
[WNMGDS-2126] Single source of truth for list of themes

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,6 +9,7 @@ import {
 import { setHeaderSendsAnalytics } from '../packages/ds-healthcare-gov/src/components/flags';
 import { setLanguage } from '../packages/design-system/src/components/i18n';
 import { setLanguage as setLanguageFromPackage } from '@cmsgov/design-system';
+import themes from '../themes.json';
 
 // Rewire analytics events to log to the console
 window.utag = { link: console.log };
@@ -95,12 +96,10 @@ export const globalTypes = {
     defaultValue: 'core',
     toolbar: {
       icon: 'paintbrush',
-      items: [
-        { value: 'core', left: 'Core', title: 'Core CMSDS Theme' },
-        { value: 'healthcare', left: 'Healthcare', title: 'Healthcare Theme' },
-        { value: 'medicare', left: 'Medicare', title: 'Medicare Theme' },
-        { value: 'cmsgov', left: 'CMS Gov', title: 'CMS Gov Theme' },
-      ],
+      items: Object.keys(themes).map((key) => ({
+        value: key,
+        title: `${themes[key].displayName} theme`,
+      })),
     },
   },
 };

--- a/.storybook/static/cmsgov-theme.css
+++ b/.storybook/static/cmsgov-theme.css
@@ -1,4 +1,4 @@
-/* Last modified on Thu Jan 19 09:21:33 CST 2023 */
+/* Last modified on Thu Jan 26 16:26:52 PST 2023 */
 :root, ::before, ::after, ::backdrop {
 --animation-ease-in-out-expo: cubic-bezier(1, 0, 0, 1);
 --animation-speed-base: 1;

--- a/packages/design-system-tokens/src/copy_themes.sh
+++ b/packages/design-system-tokens/src/copy_themes.sh
@@ -4,7 +4,7 @@ declare -A PATHS
 PATHS[core]="../../design-system"
 PATHS[healthcare]="../../ds-healthcare-gov"
 PATHS[medicare]="../../ds-medicare-gov"
-PATHS[cmsgov]="../../cms-gov"
+PATHS[cmsgov]="../../ds-cms-gov"
 
 cd dist
 

--- a/packages/docs/src/components/content/ThemeContent.tsx
+++ b/packages/docs/src/components/content/ThemeContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-type ThemeName = 'core' | 'healthcare' | 'medicare';
+import themes from '../../../../../themes.json';
+type ThemeName = keyof typeof themes;
 
 export interface ThemeContentProps {
   children: React.ReactElement;

--- a/packages/docs/src/components/layout/ThemeSwitcher.tsx
+++ b/packages/docs/src/components/layout/ThemeSwitcher.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Dropdown } from '@cmsgov/design-system';
+import themes from '../../../../../themes.json';
 import useTheme from '../../helpers/useTheme';
+import { Dropdown } from '@cmsgov/design-system';
 import { setQueryParam } from '../../helpers/urlUtils';
 
-const themeOptions = [
-  { label: 'Core', value: 'core' },
-  { label: 'Healthcare', value: 'healthcare' },
-  { label: 'Medicare', value: 'medicare' },
-  { label: 'CMS Gov', value: 'cmsgov' },
-];
+const themeOptions = Object.keys(themes).map((key) => ({
+  label: themes[key].displayName,
+  value: key,
+}));
+
 /**
  * Theme Switcher
  * The dropdown component to switch the theme of the documentation site

--- a/packages/docs/static/themes/cmsgov-theme.css
+++ b/packages/docs/static/themes/cmsgov-theme.css
@@ -1,4 +1,4 @@
-/* Last modified on Thu Jan 19 09:21:33 CST 2023 */
+/* Last modified on Thu Jan 26 16:26:52 PST 2023 */
 :root, ::before, ::after, ::backdrop {
 --animation-ease-in-out-expo: cubic-bezier(1, 0, 0, 1);
 --animation-speed-base: 1;

--- a/themes.json
+++ b/themes.json
@@ -1,0 +1,18 @@
+{
+  "core": {
+    "displayName": "Core",
+    "packageName": "design-system"
+  },
+  "cms": {
+    "displayName": "CMS.gov",
+    "packageName": "ds-cms-gov"
+  },
+  "healthcare": {
+    "displayName": "HealthCare.gov",
+    "packageName": "ds-healthcare-gov"
+  },
+  "medicare": {
+    "displayName": "Medicare.gov",
+    "packageName": "ds-medicare-gov"
+  }
+}

--- a/themes.json
+++ b/themes.json
@@ -3,7 +3,7 @@
     "displayName": "Core",
     "packageName": "design-system"
   },
-  "cms": {
+  "cmsgov": {
     "displayName": "CMS.gov",
     "packageName": "ds-cms-gov"
   },


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-2126

- Create a `themes.json` in the root with useful info about themes
- Use it in Storybook
- Use it in the doc site
- TO DO in a follow-up ticket: Use it in tests. I've got the code ready, but we may want to wait to take the initial visual regression reference images until the new CMS.gov theme has stabilized. Otherwise we'll be running those a lot.

## How to test
