### PR TITLE
[NO-TICKET] Fix outdated story id on layout grid page

### DIFF
--- a/packages/docs/content/foundation/layout-grid/layout-grid.mdx
+++ b/packages/docs/content/foundation/layout-grid/layout-grid.mdx
@@ -230,7 +230,7 @@ In the example below, the cells span:
 - The entire width of the row on viewports smaller than the `sm` breakpoint, using `.ds-l-col--12`
 
 <ResponsiveExample
-  storyId="utilities-layout-grid--responsive-columns"
+  storyId="foundations-layout-grid--responsive-columns"
   title="Responsive layout grid example"
 />
 


### PR DESCRIPTION
## Summary

That story id didn't exist anymore, so this embedded story was broken

## How to test

`yarn start` and visit http://localhost:8000/foundation/layout-grid/layout-grid/