### PR TITLE
[NO-TICKET] Remove unused flag for error icons

### DIFF
--- a/packages/design-system/src/components/flags.ts
+++ b/packages/design-system/src/components/flags.ts
@@ -6,7 +6,6 @@ interface flagsType {
   BUTTON_SENDS_ANALYTICS: boolean;
   DIALOG_SENDS_ANALYTICS: boolean;
   HELP_DRAWER_SENDS_ANALYTICS: boolean;
-  DISPLAY_INLINE_ERROR_ICON: boolean;
 }
 
 // featureFlags.js
@@ -16,12 +15,7 @@ const flags: flagsType = {
   BUTTON_SENDS_ANALYTICS: false,
   DIALOG_SENDS_ANALYTICS: false,
   HELP_DRAWER_SENDS_ANALYTICS: false,
-  DISPLAY_INLINE_ERROR_ICON: false,
 };
-
-export function setInlineErrorIconDisplay(value: boolean): void {
-  flags.DISPLAY_INLINE_ERROR_ICON = value;
-}
 
 export function errorPlacementDefault(): errorPlacementValue {
   return flags.ERROR_PLACEMENT_DEFAULT;

--- a/packages/ds-healthcare-gov/src/components/index.ts
+++ b/packages/ds-healthcare-gov/src/components/index.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { setInlineErrorIconDisplay, setErrorPlacementDefault } from '@cmsgov/design-system';
+import { setErrorPlacementDefault } from '@cmsgov/design-system';
 
 export * from '@cmsgov/design-system';
 export * from './Accordion';
@@ -28,6 +28,4 @@ export * from './flags';
 /**
  * Healthcare.gov Flags
  */
-
-setInlineErrorIconDisplay(true);
 setErrorPlacementDefault('bottom');


### PR DESCRIPTION
## Summary

I noticed that we don't pay attention to this flag anymore. All inline errors use the error icon. This unnecessarily complicates `ds-healthcare-gov` and adds a side-effect.
