### PR TITLE
[WNMGDS-2235] Revert to using `info` color in drawer footers

### DIFF
--- a/.storybook/static/core-theme.css
+++ b/.storybook/static/core-theme.css
@@ -381,7 +381,7 @@
 --drawer__border-color: #d9d9d9;
 --drawer-close__color: #000000;
 --drawer-header__background-color: #f2f2f2;
---drawer-footer__background-color: #e6f1f8;
+--drawer-footer__background-color: #e6f9fd;
 --drawer-toggle__background-color--hover: #02bfe7;
 --drawer-toggle__color--hover: #ffffff;
 --drawer-toggle__background-color--hover--inverse: #ffffff;

--- a/.storybook/static/healthcare-theme.css
+++ b/.storybook/static/healthcare-theme.css
@@ -381,7 +381,7 @@
 --drawer__border-color: #d9d9d9;
 --drawer-close__color: #000000;
 --drawer-header__background-color: #f2f2f2;
---drawer-footer__background-color: #e6f0f4;
+--drawer-footer__background-color: #ecf4fa;
 --drawer-toggle__background-color--hover: #3e94cf;
 --drawer-toggle__color--hover: #ffffff;
 --drawer-toggle__background-color--hover--inverse: #ffffff;

--- a/packages/design-system-tokens/src/themes/cmsgov-component.ts
+++ b/packages/design-system-tokens/src/themes/cmsgov-component.ts
@@ -288,7 +288,7 @@ export const components: AnyTokenValues = {
     '__border-color':                             t.color['border'],
     '-close__color':                              t.color['black'],
     '-header__background-color':                  t.color['gray-lightest'],
-    '-footer__background-color':                  t.color['primary-lightest'],
+    '-footer__background-color':                  t.color['info-lightest'],
     '-toggle__background-color--hover':           t.color['info'],
     '-toggle__color--hover':                      t.color['white'],
     '-toggle__background-color--hover--inverse':  t.color['white'],

--- a/packages/design-system-tokens/src/themes/core-component.ts
+++ b/packages/design-system-tokens/src/themes/core-component.ts
@@ -288,7 +288,7 @@ export const components: AnyTokenValues = {
     '__border-color':                             t.color['border'],
     '-close__color':                              t.color['black'],
     '-header__background-color':                  t.color['gray-lightest'],
-    '-footer__background-color':                  t.color['primary-lightest'],
+    '-footer__background-color':                  t.color['info-lightest'],
     '-toggle__background-color--hover':           t.color['info'],
     '-toggle__color--hover':                      t.color['white'],
     '-toggle__background-color--hover--inverse':  t.color['white'],

--- a/packages/design-system-tokens/src/themes/healthcare-component.ts
+++ b/packages/design-system-tokens/src/themes/healthcare-component.ts
@@ -288,7 +288,7 @@ export const components: AnyTokenValues = {
     '__border-color':                             t.color['border'],
     '-close__color':                              t.color['black'],
     '-header__background-color':                  t.color['gray-lightest'],
-    '-footer__background-color':                  t.color['primary-lightest'],
+    '-footer__background-color':                  t.color['info-lightest'],
     '-toggle__background-color--hover':           t.color['info'],
     '-toggle__color--hover':                      t.color['white'],
     '-toggle__background-color--hover--inverse':  t.color['white'],

--- a/packages/design-system/src/styles/core-theme.css
+++ b/packages/design-system/src/styles/core-theme.css
@@ -381,7 +381,7 @@
 --drawer__border-color: #d9d9d9;
 --drawer-close__color: #000000;
 --drawer-header__background-color: #f2f2f2;
---drawer-footer__background-color: #e6f1f8;
+--drawer-footer__background-color: #e6f9fd;
 --drawer-toggle__background-color--hover: #02bfe7;
 --drawer-toggle__color--hover: #ffffff;
 --drawer-toggle__background-color--hover--inverse: #ffffff;

--- a/packages/docs/static/themes/core-theme.css
+++ b/packages/docs/static/themes/core-theme.css
@@ -381,7 +381,7 @@
 --drawer__border-color: #d9d9d9;
 --drawer-close__color: #000000;
 --drawer-header__background-color: #f2f2f2;
---drawer-footer__background-color: #e6f1f8;
+--drawer-footer__background-color: #e6f9fd;
 --drawer-toggle__background-color--hover: #02bfe7;
 --drawer-toggle__color--hover: #ffffff;
 --drawer-toggle__background-color--hover--inverse: #ffffff;

--- a/packages/docs/static/themes/healthcare-theme.css
+++ b/packages/docs/static/themes/healthcare-theme.css
@@ -381,7 +381,7 @@
 --drawer__border-color: #d9d9d9;
 --drawer-close__color: #000000;
 --drawer-header__background-color: #f2f2f2;
---drawer-footer__background-color: #e6f0f4;
+--drawer-footer__background-color: #ecf4fa;
 --drawer-toggle__background-color--hover: #3e94cf;
 --drawer-toggle__color--hover: #ffffff;
 --drawer-toggle__background-color--hover--inverse: #ffffff;

--- a/packages/ds-healthcare-gov/src/styles/healthcare-theme.css
+++ b/packages/ds-healthcare-gov/src/styles/healthcare-theme.css
@@ -381,7 +381,7 @@
 --drawer__border-color: #d9d9d9;
 --drawer-close__color: #000000;
 --drawer-header__background-color: #f2f2f2;
---drawer-footer__background-color: #e6f0f4;
+--drawer-footer__background-color: #ecf4fa;
 --drawer-toggle__background-color--hover: #3e94cf;
 --drawer-toggle__color--hover: #ffffff;
 --drawer-toggle__background-color--hover--inverse: #ffffff;


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-2235

Reverts earlier color change (https://github.com/CMSgov/design-system/pull/2384) after rethinking the role of the footer. I had originally changed this from `secondary` to `primary` when `secondary` colors moved into `info` because I thought a primary background would be more appropriate for the brand. However, this might have been an unnecessary color change for the component, especially considering that the footer may actually be used in an informational role, like an info alert. I'm not sure if that's true, but I'm proposing we don't actually change this value if we haven't figured out what our alternative background color palette looks like yet.