### PR TITLE
[NO-TICKET] Mask interaction test update

### DIFF
--- a/packages/design-system/src/components/TextField/Mask.test.interaction.ts
+++ b/packages/design-system/src/components/TextField/Mask.test.interaction.ts
@@ -17,7 +17,7 @@ Object.keys(themes).forEach((theme) => {
   test(`Mask partial text entry and exit: ${theme}`, async ({ page }) => {
     await page.goto(`${storyUrl}&globals=theme:${theme}`);
     const elem = page.locator('input.ds-c-field');
-    await elem.type('221');
+    await elem.type('221', { delay: 220 });
     await elem.press('Tab');
     await expect(page).toHaveScreenshot(`mask--text-entry-and-exit--${theme}.png`, {
       fullPage: true,


### PR DESCRIPTION
## Summary

- Updates mask interaction test to add slight delay during `elem.type` which ensures 3 characters are typed
- Occasionally only two characters were being typed before this.

## How to test

1. `yarn clean && yarn install && yarn build && yarn test:browser:all`

## Checklist
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)
