### PR TITLE
[NO-TICKET] Remove use of deprecated prop in example

### DIFF
--- a/examples/create-react-app-typescript/src/components/Examples/UsaBannerExample.tsx
+++ b/examples/create-react-app-typescript/src/components/Examples/UsaBannerExample.tsx
@@ -6,7 +6,6 @@ function UsaBannerExample(): React.ReactElement {
     <div>
       <h2>Usa Banner Example</h2>
       <UsaBanner />
-      <UsaBanner locale="es" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Remove the use of the `locale` prop that is now deprecated
