### PR TITLE
[WNMGDS-2040] CDN Index build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "yarn build:tokens && yarn build:core && yarn build:healthcare && yarn build:medicare && yarn build:prop-data",
+    "build": "yarn build:tokens && yarn build:core && yarn build:healthcare && yarn build:medicare && yarn build:prop-data && yarn build:cdn-index",
     "build:core": "yarn gulp build",
     "build:healthcare": "yarn gulp build --package packages/ds-healthcare-gov",
     "build:medicare": "yarn gulp build --package packages/ds-medicare-gov",
@@ -15,6 +15,7 @@
     "build:storybook": "./scripts/build-storybook.sh",
     "build:storybook:docs": "./scripts/build-storybook.sh docs",
     "build:tokens": "yarn --cwd ./packages/design-system-tokens build:all",
+    "build:cdn-index": "ts-node ./scripts/build-cdn-indexes.ts",
     "build:docs": "yarn build:storybook:docs && yarn build:prop-data && yarn --cwd ./packages/docs build",
     "build:prop-data": "node ./scripts/extractPropData.js",
     "check:maturity": "./scripts/maturityCheck.sh",

--- a/scripts/build-cdn-indexes.ts
+++ b/scripts/build-cdn-indexes.ts
@@ -58,6 +58,11 @@ getSystems().forEach((sysinfo) => {
             <li>DS CSS:<br> <code class="ds-u-fill--gray-lightest ds-u-padding--1 ds-u-margin--1 ds-u-display--inline-block"><a href="https://design.cms.gov/cdn/${system}/${version}/css/index.css">https://design.cms.gov/cdn/${system}/${version}/css/index.css</a></code></li>
             <li>Theme:<br> <code class="ds-u-fill--gray-lightest ds-u-padding--1 ds-u-margin--1 ds-u-display--inline-block"><a href="https://design.cms.gov/cdn/${themeCssPath}">https://design.cms.gov/cdn/${themeCssPath}</a></code></li>
           </ul>
+        <h3 class="ds-text-heading--md">The following assets are also available for this version:</h3> 
+          <ul>
+            <li>Preact JS Bundle:<br> <code class="ds-u-fill--gray-lightest ds-u-padding--1 ds-u-margin--1 ds-u-display--inline-block"><a href="https://design.cms.gov/cdn/${system}/${version}/js/preact-components.js">https://design.cms.gov/cdn/${system}/${version}/js/preact-components.js</a></code></li>
+            <li>Web Components JS Bundle:<br> <code class="ds-u-fill--gray-lightest ds-u-padding--1 ds-u-margin--1 ds-u-display--inline-block"><a href="https://design.cms.gov/cdn/${system}/${version}/js/web-components.js">https://design.cms.gov/cdn/${system}/${version}/js/web-components.js</a></code></li>
+          </ul>
       </div>
     </div>
   </body>

--- a/scripts/build-cdn-indexes.ts
+++ b/scripts/build-cdn-indexes.ts
@@ -5,16 +5,13 @@ import c from 'chalk';
 
 const getSystems = () => {
   const result: string[][] = [];
-  Object.entries(themes).forEach((theme) => {
-    const config = theme[1];
-    if ('incomplete' in config) return;
+  Object.entries(themes).forEach(([themeName, themeInfo]) => {
+    if ('incomplete' in themeInfo) return;
 
-    const shortname =
-      config.packageName.split('-')[0] === 'design' ? 'core' : config.packageName.split('-')[1];
-    const packageFile = path.join('packages', config.packageName, 'package.json');
+    const packageFile = path.join('packages', themeInfo.packageName, 'package.json');
     const version = JSON.parse(fs.readFileSync(packageFile, 'utf8')).version;
 
-    result.push([config.packageName, version, shortname]);
+    result.push([themeInfo.packageName, version, themeName]);
   });
   return result;
 };

--- a/scripts/build-cdn-indexes.ts
+++ b/scripts/build-cdn-indexes.ts
@@ -1,0 +1,69 @@
+import path from 'path';
+import themes from '../themes.json';
+import fs from 'node:fs';
+import c from 'chalk';
+
+const getSystems = () => {
+  const result: string[][] = [];
+  Object.entries(themes).forEach((theme) => {
+    const config = theme[1];
+    if ('incomplete' in config) return;
+
+    const shortname =
+      config.packageName.split('-')[0] === 'design' ? 'core' : config.packageName.split('-')[1];
+    const packageFile = path.join('packages', config.packageName, 'package.json');
+    const version = JSON.parse(fs.readFileSync(packageFile, 'utf8')).version;
+
+    result.push([config.packageName, version, shortname]);
+  });
+  return result;
+};
+
+getSystems().forEach((sysinfo) => {
+  const [system, version, shortname] = sysinfo;
+
+  const distPath = path.join('packages', system, 'dist');
+  const themeCssPath = `${distPath}/css/${shortname}-theme.css`;
+  const htmlDoc = `<!DOCTYPE html>
+<html lang="en">
+  <meta charset="utf-8" />
+  <head>
+    <meta name=“viewport” content=“width=device-width, initial-scale=1, shrink-to-fit=no”>
+<title>CMSDS CDN Version Index</title>
+    <link rel="stylesheet" href="https://design.cms.gov/cdn/${system}/${version}/css/index.css" />
+    <link rel="stylesheet" href="https://design.cms.gov/cdn/${system}/${version}/css/${shortname}-theme.css" />
+    <script type="text/javascript" src="https://design.cms.gov/cdn/${system}/${version}/js/react.production.min.js"></script>
+    <script type="text/javascript" src="https://design.cms.gov/cdn/${system}/${version}/js/react-dom.production.min.js"></script>
+    <script type="text/javascript" src="https://design.cms.gov/cdn/${system}/${version}/js/bundle.js"></script>
+  </head>
+  <body class="ds-base" style="margin: 0">
+    <div id="usa-banner"></div>
+    <script>
+      ReactDOM.render(
+        React.createElement(DesignSystem.UsaBanner),
+        document.getElementById('usa-banner')
+      );
+    </script>
+    <header class="ds-base--inverse ds-u-padding-y--3">
+      <div class="ds-l-container">
+        <h1 class="ds-text-heading--2xl">CMSDS CDN Assets for v${version} of the <a href="https://npmjs.com/package/@cmsgov/${system}/v/${version}">@cmsgov/${system} package</a>.</h1>
+      </div>
+    </header>
+    <div class="ds-l-container ds-u-padding-top--4">
+      <div>
+        <h3 class="ds-text-heading--md">The following assets are available for use, and are currently loaded on this page:</h3>
+        <p>See the <a href="https://design.cms.gov">CMSDS documentation site</a> for  <a href="https://design.cms.gov/getting-started/for-developers/#option-2-reference-assets-from-the-cdn">instructions</a> regarding utilization of these assets.</p>
+          <ul>
+            <li>Main JS Bundle:<br> <code class="ds-u-fill--gray-lightest ds-u-padding--1 ds-u-margin--1 ds-u-display--inline-block"><a href="https://design.cms.gov/cdn/${system}/${version}/js/bundle.js">https://design.cms.gov/cdn/${system}/${version}/js/bundle.js</a></code></li>
+            <li>DS CSS:<br> <code class="ds-u-fill--gray-lightest ds-u-padding--1 ds-u-margin--1 ds-u-display--inline-block"><a href="https://design.cms.gov/cdn/${system}/${version}/css/index.css">https://design.cms.gov/cdn/${system}/${version}/css/index.css</a></code></li>
+            <li>Theme:<br> <code class="ds-u-fill--gray-lightest ds-u-padding--1 ds-u-margin--1 ds-u-display--inline-block"><a href="https://design.cms.gov/cdn/${themeCssPath}">https://design.cms.gov/cdn/${themeCssPath}</a></code></li>
+          </ul>
+      </div>
+    </div>
+  </body>
+</html>`;
+  console.log(
+    `${c.green('+')} Writing CDN index for ${c.yellow(system)} version ${c.cyan(version)} to dist.`
+  );
+  fs.writeFileSync(distPath + '/index.html', htmlDoc, 'utf8');
+});


### PR DESCRIPTION
## Summary

- Adds a script to build `index.html` files in the `dist` folders during build utilizing the latest version data from each child systems `package.json`
- Since this will only be updated live when we publish with jenkins, the versions will be up to date and correct/different.
- This is 1/3rd of this total ticket, the other 2/3rd's have been pushed live at [design.cms.gov/cdn](https://design.cms.gov/cdn) for browsing.
- @pwolfert I think the jenkins work needs another ticket, to keep it organized. I can create it. The only jenkins work that needs done is ensuring the `version/index.html` file is copied and the main `cdn/index.html` is updated with latest versions after a successful publish. Or maybe not another ticket, I'll be working on it, shouldn't bee too difficult, I've tested the main index with the append method and it works.

## How to test

1. visit [design.cms.gov/cdn](https://design.cms.gov/cdn), you can `wget https://design.cms.gov/cdn/` to see the actual source, the browser automatically fills in some fields that don't exist in the actual file.
2. `yarn clean && yarn install && yarn build`, inspect dist folders new index.html files

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.