### PR TITLE
[WNMGDS-2112] Add accent colors to themes

### DIFF
--- a/.storybook/static/cmsgov-theme.css
+++ b/.storybook/static/cmsgov-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #3bcb7a;
 --color-secondary-darker: #2e9e5f;
 --color-secondary-darkest: #217144;
+--color-accent-primary-lightest: #fffce6;
+--color-accent-primary-lighter: #fff7b5;
+--color-accent-primary-light: #ffec52;
+--color-accent-primary: #ffe400;
+--color-accent-primary-dark: #e6cd07;
+--color-accent-primary-darker: #b3a006;
+--color-accent-primary-darkest: #807204;
 --color-info-lightest: #e7e9f5;
 --color-info-lighter: #b6bde0;
 --color-info-light: #5666b8;

--- a/.storybook/static/core-theme.css
+++ b/.storybook/static/core-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #107b0d;
 --color-secondary-darker: #0d600a;
 --color-secondary-darkest: #094507;
+--color-accent-primary-lightest: #fcebe6;
+--color-accent-primary-lighter: #f5c3b3;
+--color-accent-primary-light: #e7724f;
+--color-accent-primary: #dd3603;
+--color-accent-primary-dark: #c73103;
+--color-accent-primary-darker: #9b2602;
+--color-accent-primary-darkest: #6f1b02;
 --color-info-lightest: #e6f9fd;
 --color-info-lighter: #b3ecf8;
 --color-info-light: #4ed2ee;

--- a/.storybook/static/healthcare-theme.css
+++ b/.storybook/static/healthcare-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #107b0d;
 --color-secondary-darker: #0d600a;
 --color-secondary-darkest: #094507;
+--color-accent-primary-lightest: #fcebe6;
+--color-accent-primary-lighter: #f5c3b3;
+--color-accent-primary-light: #e7724f;
+--color-accent-primary: #dd3603;
+--color-accent-primary-dark: #c73103;
+--color-accent-primary-darker: #9b2602;
+--color-accent-primary-darkest: #6f1b02;
 --color-info-lightest: #ecf4fa;
 --color-info-lighter: #c5dff1;
 --color-info-light: #78b4dd;

--- a/.storybook/static/medicare-theme.css
+++ b/.storybook/static/medicare-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #1b3665;
 --color-secondary-darker: #152a4e;
 --color-secondary-darkest: #0f1e38;
+--color-accent-primary-lightest: #f7e6e6;
+--color-accent-primary-lighter: #e8b3b3;
+--color-accent-primary-light: #c94d4d;
+--color-accent-primary: #b20000;
+--color-accent-primary-dark: #a00000;
+--color-accent-primary-darker: #7d0000;
+--color-accent-primary-darkest: #590000;
 --color-info-lightest: #e9ecf1;
 --color-info-lighter: #bcc5d4;
 --color-info-light: #62779b;

--- a/packages/design-system-tokens/src/themes/cmsgov.ts
+++ b/packages/design-system-tokens/src/themes/cmsgov.ts
@@ -65,6 +65,14 @@ export const themeColors: ColorTokens = {
   'secondary-darker':           color['emerald-700'],
   'secondary-darkest':          color['emerald-800'],
   //
+  'accent-primary-lightest':    color['dandelion-50'],
+  'accent-primary-lighter':     color['dandelion-100'],
+  'accent-primary-light':       color['dandelion-300'],
+  'accent-primary':             color['dandelion-500'],
+  'accent-primary-dark':        color['dandelion-600'],
+  'accent-primary-darker':      color['dandelion-700'],
+  'accent-primary-darkest':     color['dandelion-800'],
+  //
   'info-lightest':             color['deepsea-50'],
   'info-lighter':              color['deepsea-100'],
   'info-light':                color['deepsea-300'],

--- a/packages/design-system-tokens/src/themes/core.ts
+++ b/packages/design-system-tokens/src/themes/core.ts
@@ -65,6 +65,14 @@ export const themeColors: ColorTokens = {
   'secondary-darker':           color['spring-700'],
   'secondary-darkest':          color['spring-800'],
   //
+  'accent-primary-lightest':    color['persimmon-50'],
+  'accent-primary-lighter':     color['persimmon-100'],
+  'accent-primary-light':       color['persimmon-300'],
+  'accent-primary':             color['persimmon-500'],
+  'accent-primary-dark':        color['persimmon-600'],
+  'accent-primary-darker':      color['persimmon-700'],
+  'accent-primary-darkest':     color['persimmon-800'],
+  //
   'info-lightest':              color['sky-50'],
   'info-lighter':               color['sky-100'],
   'info-light':                 color['sky-300'],

--- a/packages/design-system-tokens/src/themes/healthcare.ts
+++ b/packages/design-system-tokens/src/themes/healthcare.ts
@@ -65,6 +65,14 @@ export const themeColors: ColorTokens = {
   'secondary-darker':           color['spring-700'],
   'secondary-darkest':          color['spring-800'],
   //
+  'accent-primary-lightest':    color['persimmon-50'],
+  'accent-primary-lighter':     color['persimmon-100'],
+  'accent-primary-light':       color['persimmon-300'],
+  'accent-primary':             color['persimmon-500'],
+  'accent-primary-dark':        color['persimmon-600'],
+  'accent-primary-darker':      color['persimmon-700'],
+  'accent-primary-darkest':     color['persimmon-800'],
+  //
   'info-lightest':              color['darksky-50'],
   'info-lighter':               color['darksky-100'],
   'info-light':                 color['darksky-300'],

--- a/packages/design-system-tokens/src/themes/medicare.ts
+++ b/packages/design-system-tokens/src/themes/medicare.ts
@@ -65,6 +65,14 @@ export const themeColors: ColorTokens = {
   'secondary-darker':           color['lapis-700'],
   'secondary-darkest':          color['lapis-800'],
   //
+  'accent-primary-lightest':    color['crimson-50'],
+  'accent-primary-lighter':     color['crimson-100'],
+  'accent-primary-light':       color['crimson-300'],
+  'accent-primary':             color['crimson-500'],
+  'accent-primary-dark':        color['crimson-600'],
+  'accent-primary-darker':      color['crimson-700'],
+  'accent-primary-darkest':     color['crimson-800'],
+  //
   'info-lightest':              color['lapis-50'],
   'info-lighter':               color['lapis-100'],
   'info-light':                 color['lapis-300'],

--- a/packages/design-system/src/styles/core-theme.css
+++ b/packages/design-system/src/styles/core-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #107b0d;
 --color-secondary-darker: #0d600a;
 --color-secondary-darkest: #094507;
+--color-accent-primary-lightest: #fcebe6;
+--color-accent-primary-lighter: #f5c3b3;
+--color-accent-primary-light: #e7724f;
+--color-accent-primary: #dd3603;
+--color-accent-primary-dark: #c73103;
+--color-accent-primary-darker: #9b2602;
+--color-accent-primary-darkest: #6f1b02;
 --color-info-lightest: #e6f9fd;
 --color-info-lighter: #b3ecf8;
 --color-info-light: #4ed2ee;

--- a/packages/design-system/src/styles/utilities/_background-color.scss
+++ b/packages/design-system/src/styles/utilities/_background-color.scss
@@ -60,6 +60,36 @@
   background-color: var(--color-secondary-darkest) !important;
 }
 
+// accent - primary
+
+.ds-u-fill--accent-primary-lightest {
+  background-color: var(--color-accent-primary-lightest) !important;
+}
+
+.ds-u-fill--accent-primary-lighter {
+  background-color: var(--color-accent-primary-lighter) !important;
+}
+
+.ds-u-fill--accent-primary-light {
+  background-color: var(--color-accent-primary-light) !important;
+}
+
+.ds-u-fill--accent-primary {
+  background-color: var(--color-accent-primary) !important;
+}
+
+.ds-u-fill--accent-primary-dark {
+  background-color: var(--color-accent-primary-dark) !important;
+}
+
+.ds-u-fill--accent-primary-darker {
+  background-color: var(--color-accent-primary-darker) !important;
+}
+
+.ds-u-fill--accent-primary-darkest {
+  background-color: var(--color-accent-primary-darkest) !important;
+}
+
 // gray
 .ds-u-fill--gray {
   background-color: var(--color-gray) !important;

--- a/packages/docs/content/foundation/theme-colors.mdx
+++ b/packages/docs/content/foundation/theme-colors.mdx
@@ -90,6 +90,25 @@ These are accent colors to provide additional lightness and style to pages looki
   preface="--color-"
 />
 
+## Accent colors
+
+Accent colors are used sparingly to support primary and secondary colors in designs and illustrations. 
+
+### Primary accent colors
+
+<ColorExampleList
+  colorNames={[
+    'accent-primary-lightest',
+    'accent-primary-lighter',
+    'accent-primary-light',
+    'accent-primary',
+    'accent-primary-dark',
+    'accent-primary-darker',
+    'accent-primary-darkest',
+  ]}
+  preface="--color-"
+/>
+
 ## Neutral colors
 
 <ColorExampleList

--- a/packages/docs/content/utilities/background-color.mdx
+++ b/packages/docs/content/utilities/background-color.mdx
@@ -40,6 +40,23 @@ Use the background color utility to change the default background color of an el
   preface=".ds-u-fill--"
 />
 
+## Accent colors
+
+### Primary accent colors
+
+<ColorExampleList
+  colorNames={[
+    'accent-primary-lightest',
+    'accent-primary-lighter',
+    'accent-primary-light',
+    'accent-primary',
+    'accent-primary-dark',
+    'accent-primary-darker',
+    'accent-primary-darkest',
+  ]}
+  preface=".ds-u-fill--"
+/>
+
 ## Neutral colors
 
 <ColorExampleList

--- a/packages/docs/static/themes/cmsgov-theme.css
+++ b/packages/docs/static/themes/cmsgov-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #3bcb7a;
 --color-secondary-darker: #2e9e5f;
 --color-secondary-darkest: #217144;
+--color-accent-primary-lightest: #fffce6;
+--color-accent-primary-lighter: #fff7b5;
+--color-accent-primary-light: #ffec52;
+--color-accent-primary: #ffe400;
+--color-accent-primary-dark: #e6cd07;
+--color-accent-primary-darker: #b3a006;
+--color-accent-primary-darkest: #807204;
 --color-info-lightest: #e7e9f5;
 --color-info-lighter: #b6bde0;
 --color-info-light: #5666b8;

--- a/packages/docs/static/themes/core-theme.css
+++ b/packages/docs/static/themes/core-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #107b0d;
 --color-secondary-darker: #0d600a;
 --color-secondary-darkest: #094507;
+--color-accent-primary-lightest: #fcebe6;
+--color-accent-primary-lighter: #f5c3b3;
+--color-accent-primary-light: #e7724f;
+--color-accent-primary: #dd3603;
+--color-accent-primary-dark: #c73103;
+--color-accent-primary-darker: #9b2602;
+--color-accent-primary-darkest: #6f1b02;
 --color-info-lightest: #e6f9fd;
 --color-info-lighter: #b3ecf8;
 --color-info-light: #4ed2ee;

--- a/packages/docs/static/themes/healthcare-theme.css
+++ b/packages/docs/static/themes/healthcare-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #107b0d;
 --color-secondary-darker: #0d600a;
 --color-secondary-darkest: #094507;
+--color-accent-primary-lightest: #fcebe6;
+--color-accent-primary-lighter: #f5c3b3;
+--color-accent-primary-light: #e7724f;
+--color-accent-primary: #dd3603;
+--color-accent-primary-dark: #c73103;
+--color-accent-primary-darker: #9b2602;
+--color-accent-primary-darkest: #6f1b02;
 --color-info-lightest: #ecf4fa;
 --color-info-lighter: #c5dff1;
 --color-info-light: #78b4dd;

--- a/packages/docs/static/themes/medicare-theme.css
+++ b/packages/docs/static/themes/medicare-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #1b3665;
 --color-secondary-darker: #152a4e;
 --color-secondary-darkest: #0f1e38;
+--color-accent-primary-lightest: #f7e6e6;
+--color-accent-primary-lighter: #e8b3b3;
+--color-accent-primary-light: #c94d4d;
+--color-accent-primary: #b20000;
+--color-accent-primary-dark: #a00000;
+--color-accent-primary-darker: #7d0000;
+--color-accent-primary-darkest: #590000;
 --color-info-lightest: #e9ecf1;
 --color-info-lighter: #bcc5d4;
 --color-info-light: #62779b;

--- a/packages/ds-cms-gov/src/styles/cmsgov-theme.css
+++ b/packages/ds-cms-gov/src/styles/cmsgov-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #3bcb7a;
 --color-secondary-darker: #2e9e5f;
 --color-secondary-darkest: #217144;
+--color-accent-primary-lightest: #fffce6;
+--color-accent-primary-lighter: #fff7b5;
+--color-accent-primary-light: #ffec52;
+--color-accent-primary: #ffe400;
+--color-accent-primary-dark: #e6cd07;
+--color-accent-primary-darker: #b3a006;
+--color-accent-primary-darkest: #807204;
 --color-info-lightest: #e7e9f5;
 --color-info-lighter: #b6bde0;
 --color-info-light: #5666b8;

--- a/packages/ds-healthcare-gov/src/styles/healthcare-theme.css
+++ b/packages/ds-healthcare-gov/src/styles/healthcare-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #107b0d;
 --color-secondary-darker: #0d600a;
 --color-secondary-darkest: #094507;
+--color-accent-primary-lightest: #fcebe6;
+--color-accent-primary-lighter: #f5c3b3;
+--color-accent-primary-light: #e7724f;
+--color-accent-primary: #dd3603;
+--color-accent-primary-dark: #c73103;
+--color-accent-primary-darker: #9b2602;
+--color-accent-primary-darkest: #6f1b02;
 --color-info-lightest: #ecf4fa;
 --color-info-lighter: #c5dff1;
 --color-info-light: #78b4dd;

--- a/packages/ds-medicare-gov/src/styles/medicare-theme.css
+++ b/packages/ds-medicare-gov/src/styles/medicare-theme.css
@@ -53,6 +53,13 @@
 --color-secondary-dark: #1b3665;
 --color-secondary-darker: #152a4e;
 --color-secondary-darkest: #0f1e38;
+--color-accent-primary-lightest: #f7e6e6;
+--color-accent-primary-lighter: #e8b3b3;
+--color-accent-primary-light: #c94d4d;
+--color-accent-primary: #b20000;
+--color-accent-primary-dark: #a00000;
+--color-accent-primary-darker: #7d0000;
+--color-accent-primary-darkest: #590000;
 --color-info-lightest: #e9ecf1;
 --color-info-lighter: #bcc5d4;
 --color-info-light: #62779b;


### PR DESCRIPTION
## Summary

- Added tokens for --color-accent-primary for all themes
- Updated doc site page to add color swatches for  --color-accent-primary
- Added styles for using --color-accent-primary for background colors
- **Did not** add accent color for text-color utilities at this time b/c I don't think it would be needed 

## How to test

1. Run doc site with `yarn start` and visit the theme file page to see accent color content on the page
2. Then visit the background color page to see the bg color examples 

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [ ] Created or updated unit tests to cover any new or modified code
- [ ] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)

### If this is a change to documentation:

- [ ] Checked for spelling and grammatical errors
