### PR TITLE
[WNMGDS-2262] Improve side nav a11y

### DIFF
--- a/packages/docs/src/components/layout/DocSiteNavigation.tsx
+++ b/packages/docs/src/components/layout/DocSiteNavigation.tsx
@@ -96,14 +96,11 @@ const DocSiteNavigation = ({ location }: DocSiteNavProps) => {
 
   return (
     <div
-      className={classnames(
-        'ds-u-padding--0 ds-u-md-padding--2 ds-u-md-padding-top--4 c-navigation',
-        {
-          'c-navigation--open': isMobile && isMobileNavOpen,
-        }
-      )}
+      className={classnames('ds-u-padding--0 ds-u-md-padding--2 c-navigation', {
+        'c-navigation--open': isMobile && isMobileNavOpen,
+      })}
     >
-      <header className="c-navigation__header">
+      <header className="c-navigation__header ds-u-md-padding-top--4">
         <Button
           className="ds-u-md-display--none ds-u-padding-left--0 ds-u-padding-right--1"
           variation="ghost"
@@ -117,9 +114,12 @@ const DocSiteNavigation = ({ location }: DocSiteNavProps) => {
             <MenuIconThin className="ds-u-font-size--xl" />
           )}
         </Button>
-        <a className="c-navigation__title" href="/">
-          CMS Design System
-        </a>
+        <div>
+          <a className="c-navigation__title" href="/">
+            CMS Design System
+          </a>
+          <ThemeSwitcher />
+        </div>
       </header>
 
       <div
@@ -128,7 +128,6 @@ const DocSiteNavigation = ({ location }: DocSiteNavProps) => {
         hidden={isMobile && !isMobileNavOpen}
         className="ds-u-padding--2 ds-u-md-padding--0"
       >
-        <ThemeSwitcher />
         <VerticalNav
           className="c-navigation__link-list"
           items={navItems}

--- a/packages/docs/src/styles/components/navigation.scss
+++ b/packages/docs/src/styles/components/navigation.scss
@@ -6,7 +6,6 @@
   .c-navigation__header {
     align-items: flex-start;
     background-color: var(--color-primary);
-    // flex-direction: column;
     color: var(--color-white);
     display: flex;
     gap: $spacer-2;

--- a/packages/docs/src/styles/components/navigation.scss
+++ b/packages/docs/src/styles/components/navigation.scss
@@ -4,7 +4,7 @@
   width: 100%;
 
   .c-navigation__header {
-    align-items: center;
+    align-items: flex-start;
     background-color: var(--color-primary);
     // flex-direction: column;
     color: var(--color-white);

--- a/packages/docs/src/styles/components/navigation.scss
+++ b/packages/docs/src/styles/components/navigation.scss
@@ -5,7 +5,9 @@
 
   .c-navigation__header {
     align-items: center;
-    background-color: var(--color-primary-lightest);
+    background-color: var(--color-primary);
+    // flex-direction: column;
+    color: var(--color-white);
     display: flex;
     gap: $spacer-2;
     padding: $spacer-2;
@@ -60,7 +62,7 @@
 // Desktop
 @media (min-width: $media-width-md) {
   .c-navigation {
-    background-color: var(--color-primary-lightest);
+    background-color: var(--color-gray-lightest);
     // Set it to a fixed width that is wide enough for most links so that it
     // doesn't jump around when we open and close subsections.
     width: 13rem;

--- a/packages/docs/src/styles/components/themeSwitcher.scss
+++ b/packages/docs/src/styles/components/themeSwitcher.scss
@@ -1,5 +1,0 @@
-.c-theme-switcher {
-  .ds-c-label {
-    margin-top: 0;
-  }
-}

--- a/packages/docs/src/styles/index.scss
+++ b/packages/docs/src/styles/index.scss
@@ -25,7 +25,6 @@
 @import 'components/storybookExample.scss';
 @import 'components/syntaxHighlighting.scss';
 @import 'components/textColorList.scss';
-@import 'components/themeSwitcher.scss';
 @import 'components/tableOfContents.scss';
 @import 'components/spacingUtilityExampleList.scss';
 @import 'components/video.scss';


### PR DESCRIPTION
## Summary

- Updated side nav background to gray-lightest to fix a11y contrast issues for links
- Updated top of side nav to use brand primary color for accent and use white text color 

## How to test

1. run the doc site with `yarn start` see that their ar no longer color contrast issues with the left navigtaion

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [ ] Created or updated unit tests to cover any new or modified code
- [ ] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)

### If this is a change to documentation:

- [x] Checked for spelling and grammatical errors
