### PR TITLE
[NO-TICKET] Implemented stricter tsc checking with noUnusedLocals & noUnusedParameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:browser:smoke": "docker run --rm --network host -v $(pwd):/work/ -w /work/ --env SMOKE=true mcr.microsoft.com/playwright:v1.31.0-focal yarn playwright test --config tests/browser/playwright.config.ts",
     "test:browser:interaction": "docker run --rm --network host -v $(pwd):/work/ -w /work/ mcr.microsoft.com/playwright:v1.31.0-focal yarn playwright test --config tests/browser/interaction.config.ts",
     "test:browser:update": "yarn build:storybook && yarn test:browser -u && yarn test:browser:interaction -u",
-    "type-check": "yarn tsc --noEmit"
+    "type-check": "yarn tsc --noEmit --alwaysStrict --diagnostics --noUnusedLocals --noUnusedParameters"
   },
   "husky": {
     "hooks": {

--- a/packages/design-system/src/components/Alert/useAlertAnalytics.ts
+++ b/packages/design-system/src/components/Alert/useAlertAnalytics.ts
@@ -16,7 +16,6 @@ export default function useAlertAnalytics({
 }: AlertProps) {
   // Order matters! Content comes from the heading first and falls back to body if heading doesn't exist
   const [headingRef, bodyRef] = useAnalyticsContent({
-    componentName: 'Alert',
     onMount: (content: string | undefined) => {
       if (analytics !== true && (!alertSendsAnalytics() || analytics === false)) {
         return;

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -188,8 +188,6 @@ export class Autocomplete extends React.Component<AutocompleteProps, any> {
 
   filterItems(
     items: AutocompleteItems[],
-    inputValue: string,
-    getInputProps: (...args: any[]) => any,
     getItemProps: (...args: any[]) => any,
     highlightedIndex: number
   ): React.ReactNode {
@@ -328,7 +326,6 @@ export class Autocomplete extends React.Component<AutocompleteProps, any> {
           getItemProps,
           getRootProps,
           highlightedIndex,
-          inputValue,
           isOpen,
         }) => (
           <WrapperDiv
@@ -359,13 +356,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, any> {
                   id={this.listboxId}
                   role="listbox"
                 >
-                  {this.filterItems(
-                    items,
-                    inputValue,
-                    getInputProps,
-                    getItemProps,
-                    highlightedIndex
-                  )}
+                  {this.filterItems(items, getItemProps, highlightedIndex)}
                 </ul>
               </div>
             ) : null}

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
@@ -100,7 +100,7 @@ export const ChoiceList: React.FC<ChoiceListProps> = (props: ChoiceListProps) =>
     }, 20);
   };
 
-  const { labelProps, fieldProps, wrapperProps, bottomError } = useFormLabel({
+  const { labelProps, wrapperProps, bottomError } = useFormLabel({
     ...listProps,
     labelComponent: 'legend',
     wrapperIsFieldset: true,

--- a/packages/design-system/src/components/Dialog/useDialogAnalytics.ts
+++ b/packages/design-system/src/components/Dialog/useDialogAnalytics.ts
@@ -39,7 +39,6 @@ export function useDialogAnalytics({
   }
 
   const [headingRef] = useAnalyticsContent({
-    componentName: 'Dialog',
     onMount: (content: string | undefined) => {
       sendDialogEvent(content, {
         event_name: 'modal_impression',

--- a/packages/design-system/src/components/HelpDrawer/useHelpDrawerAnalytics.ts
+++ b/packages/design-system/src/components/HelpDrawer/useHelpDrawerAnalytics.ts
@@ -39,7 +39,6 @@ export default function useHelpDrawerAnalytics({
   }
 
   const [headingRef] = useAnalyticsContent({
-    componentName: 'Dialog',
     onMount: (content: string | undefined) => {
       sendHelpDrawerEvent(content, {
         event_name: 'help_drawer_opened',

--- a/packages/design-system/src/components/Pagination/Pagination.tsx
+++ b/packages/design-system/src/components/Pagination/Pagination.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Button from '../Button/Button';
 import Ellipses from './Ellipses';
 import Page from './Page';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import classNames from 'classnames';
 import { ArrowIcon } from '../Icons';
 import { t } from '../i18n';

--- a/packages/design-system/src/components/analytics/getAnalyticsContentFromRefs.ts
+++ b/packages/design-system/src/components/analytics/getAnalyticsContentFromRefs.ts
@@ -1,9 +1,6 @@
 import { RefObject } from 'react';
 
-export function getAnalyticsContentFromRefs(
-  refs: RefObject<any>[],
-  componentName?: string
-): string | undefined {
+export function getAnalyticsContentFromRefs(refs: RefObject<any>[]): string | undefined {
   return refs.map((ref) => ref.current?.textContent).find((textContent) => textContent);
 }
 

--- a/packages/design-system/src/components/analytics/useAnalyticsContent.ts
+++ b/packages/design-system/src/components/analytics/useAnalyticsContent.ts
@@ -5,7 +5,6 @@ export interface UseAnalyticsContentProps {
   /**
    * Optional name of component for error messages
    */
-  componentName?: string;
   onMount: (content?: string) => any;
   onUnmount?: (content?: string) => any;
 }
@@ -45,11 +44,7 @@ export interface UseAnalyticsContentProps {
  *   </div>
  * )
  */
-export function useAnalyticsContent({
-  componentName,
-  onMount,
-  onUnmount,
-}: UseAnalyticsContentProps) {
+export function useAnalyticsContent({ onMount, onUnmount }: UseAnalyticsContentProps) {
   // Three refs should be enough to support fallback content. Add more in the future if needed
   const refs: RefObject<any>[] = [useRef(), useRef(), useRef()];
 
@@ -61,7 +56,7 @@ export function useAnalyticsContent({
   // have dependencies that should be listed but are unknown. This assumes that the onMount and
   // onUnmount do not have a reason to change between renders.
   useEffect(() => {
-    const content = getAnalyticsContentFromRefs(refs, componentName);
+    const content = getAnalyticsContentFromRefs(refs);
     onMount(content);
     return () => {
       if (onUnmount) onUnmount(content);

--- a/packages/docs/src/components/content/StorybookExampleFooter.tsx
+++ b/packages/docs/src/components/content/StorybookExampleFooter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useRef, useState } from 'react';
-import { Button, ExternalLinkIcon } from '@cmsgov/design-system';
+import { Button } from '@cmsgov/design-system';
 import { makeStorybookUrl } from '../../helpers/urlUtils';
 import { withPrefix } from 'gatsby';
 import ExampleFooter from './ExampleFooter';

--- a/packages/ds-healthcare-gov/src/components/Accordion/index.tsx
+++ b/packages/ds-healthcare-gov/src/components/Accordion/index.tsx
@@ -1,2 +1,1 @@
-import React from 'react';
 export * from './AccordionItem';


### PR DESCRIPTION
## Summary

- Updated `yarn type-check` with more flags: `--alwaysStrict --diagnostics --noUnusedLocals --noUnusedParameters`
- After updating these, found several places where we have unused locals and unused parameters which I then removed.
- Validated these changes and found no difference in effect between local storybook & design.cms.gov/storybook

## How to test

1. `yarn clean && yarn install && yarn build && yarn type-check && yarn test`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [ ] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [ ] Selected appropriate `Impacts`, multiple can be selected.