### PR TITLE
[WNMGDS-2050] Pagination page list fix

### DIFF
--- a/packages/design-system/src/components/Pagination/Ellipses.tsx
+++ b/packages/design-system/src/components/Pagination/Ellipses.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 const Ellipses: React.FC<unknown> = () => {
-  return (
-    <li>
-      <span className="ds-c-pagination__overflow">&hellip;</span>
-    </li>
-  );
+  return <span className="ds-c-pagination__overflow">&hellip;</span>;
 };
 
 export default Ellipses;

--- a/packages/design-system/src/components/Pagination/Page.tsx
+++ b/packages/design-system/src/components/Pagination/Page.tsx
@@ -27,7 +27,7 @@ export default function Page({
   onPageChange,
 }: PageProps): React.ReactElement {
   return (
-    <li>
+    <>
       {isActive ? (
         <span
           className="ds-c-button ds-c-button--ghost ds-c-pagination__current-page"
@@ -40,6 +40,6 @@ export default function Page({
           {index}
         </Button>
       )}
-    </li>
+    </>
   );
 }

--- a/packages/design-system/src/components/Pagination/Pagination.test.tsx
+++ b/packages/design-system/src/components/Pagination/Pagination.test.tsx
@@ -31,8 +31,7 @@ function queryNextLink() {
 }
 
 function hasEllipsis() {
-  const items = screen.getAllByRole('listitem');
-  return items.some((item) => item.querySelector('.ds-c-pagination__overflow'));
+  return document.querySelector('.ds-c-pagination__overflow');
 }
 
 describe('Pagination', () => {
@@ -153,14 +152,14 @@ describe('Pagination', () => {
   describe('pagination slot behavior', () => {
     it('should begin page count with 1', () => {
       renderPagination({ currentPage: 1 });
-      const items = screen.getAllByRole('listitem');
+      const items = document.querySelector('.ds-c-pagination__pages').childNodes;
       expect(items[0].textContent).toContain('1');
     });
 
     it('should end page count with page total', () => {
       const lastPageNum = 3;
       renderPagination({ currentPage: 1, totalPages: lastPageNum });
-      const items = screen.getAllByRole('listitem');
+      const items = document.querySelector('.ds-c-pagination__pages').childNodes;
       expect(items[items.length - 1].textContent).toContain(`${lastPageNum}`);
     });
 
@@ -175,14 +174,14 @@ describe('Pagination', () => {
       it('should show all pages', () => {
         const totalPageNum = 5;
         renderPagination({ currentPage: 1, totalPages: totalPageNum });
-        const items = screen.getAllByRole('listitem');
+        const items = document.querySelector('.ds-c-pagination__pages').childNodes;
         expect(items.length).toEqual(totalPageNum);
         expect(items).toMatchSnapshot();
       });
 
       it('should not show ellipses', () => {
         renderPagination({ totalPages: 6 });
-        expect(hasEllipsis()).toBe(false);
+        expect(hasEllipsis()).toBeNull();
       });
     });
 
@@ -192,7 +191,7 @@ describe('Pagination', () => {
           screen.getAllByText('1')[1];
           screen.getAllByText('2')[1];
           screen.getAllByText('3')[1];
-          expect(screen.getAllByRole('listitem').length).toBe(7);
+          expect(document.querySelector('.ds-c-pagination__pages').childNodes.length).toBe(7);
         }
 
         it('for page 1', () => {
@@ -216,7 +215,7 @@ describe('Pagination', () => {
           screen.getAllByText('33')[1];
           screen.getAllByText('34')[1];
           screen.getAllByText('35')[1];
-          expect(screen.getAllByRole('listitem').length).toBe(7);
+          expect(document.querySelector('.ds-c-pagination__pages').childNodes.length).toBe(7);
         }
 
         it('for page 33', () => {
@@ -238,12 +237,12 @@ describe('Pagination', () => {
       describe('should show ellipses for number in middle', () => {
         it('for page 10', () => {
           renderPagination({ currentPage: 10, totalPages: 35 });
-          expect(hasEllipsis()).toBe(true);
+          expect(hasEllipsis()).toBeTruthy();
         });
 
         it('for page 30', () => {
           renderPagination({ currentPage: 30, totalPages: 35 });
-          expect(hasEllipsis()).toBe(true);
+          expect(hasEllipsis()).toBeTruthy();
         });
       });
     });

--- a/packages/design-system/src/components/Pagination/Pagination.tsx
+++ b/packages/design-system/src/components/Pagination/Pagination.tsx
@@ -272,7 +272,7 @@ function Pagination({
         }}
       />
 
-      <ul role="list">{pages}</ul>
+      <div className="ds-c-pagination__pages">{pages}</div>
 
       <Button
         variation="ghost"

--- a/packages/design-system/src/components/Pagination/__snapshots__/Page.test.tsx.snap
+++ b/packages/design-system/src/components/Pagination/__snapshots__/Page.test.tsx.snap
@@ -1,26 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Page should render interactive el if not current 1`] = `
-<li>
-  <a
-    aria-label="page 1"
-    class="ds-c-button ds-c-button--ghost"
-    href="/#1"
-  >
-    1
-  </a>
-</li>
-`;
+exports[`Page should render interactive el if not current 1`] = `null`;
 
 exports[`Page should render static el if current 1`] = `
 <div>
-  <li>
-    <span
-      aria-current="page"
-      class="ds-c-button ds-c-button--ghost ds-c-pagination__current-page"
-    >
-      1
-    </span>
-  </li>
+  <span
+    aria-current="page"
+    class="ds-c-button ds-c-button--ghost ds-c-pagination__current-page"
+  >
+    1
+  </span>
 </div>
 `;

--- a/packages/design-system/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/design-system/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1,51 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Pagination pagination slot behavior less than 7 pages should show all pages 1`] = `
-Array [
-  <li>
-    <span
-      aria-current="page"
-      class="ds-c-button ds-c-button--ghost ds-c-pagination__current-page"
-    >
-      1
-    </span>
-  </li>,
-  <li>
-    <a
-      aria-label="page 2"
-      class="ds-c-button ds-c-button--ghost"
-      href="#2"
-    >
-      2
-    </a>
-  </li>,
-  <li>
-    <a
-      aria-label="page 3"
-      class="ds-c-button ds-c-button--ghost"
-      href="#3"
-    >
-      3
-    </a>
-  </li>,
-  <li>
-    <a
-      aria-label="page 4"
-      class="ds-c-button ds-c-button--ghost"
-      href="#4"
-    >
-      4
-    </a>
-  </li>,
-  <li>
-    <a
-      aria-label="page 5"
-      class="ds-c-button ds-c-button--ghost"
-      href="#5"
-    >
-      5
-    </a>
-  </li>,
+NodeList [
+  <span
+    aria-current="page"
+    class="ds-c-button ds-c-button--ghost ds-c-pagination__current-page"
+  >
+    1
+  </span>,
+  <a
+    aria-label="page 2"
+    class="ds-c-button ds-c-button--ghost"
+    href="#2"
+  >
+    2
+  </a>,
+  <a
+    aria-label="page 3"
+    class="ds-c-button ds-c-button--ghost"
+    href="#3"
+  >
+    3
+  </a>,
+  <a
+    aria-label="page 4"
+    class="ds-c-button ds-c-button--ghost"
+    href="#4"
+  >
+    4
+  </a>,
+  <a
+    aria-label="page 5"
+    class="ds-c-button ds-c-button--ghost"
+    href="#5"
+  >
+    5
+  </a>,
 ]
 `;
 
@@ -105,36 +95,30 @@ exports[`Pagination should render component 1`] = `
         3
       </strong>
     </span>
-    <ul
-      role="list"
+    <div
+      class="ds-c-pagination__pages"
     >
-      <li>
-        <a
-          aria-label="page 1"
-          class="ds-c-button ds-c-button--ghost"
-          href="#1"
-        >
-          1
-        </a>
-      </li>
-      <li>
-        <span
-          aria-current="page"
-          class="ds-c-button ds-c-button--ghost ds-c-pagination__current-page"
-        >
-          2
-        </span>
-      </li>
-      <li>
-        <a
-          aria-label="page 3"
-          class="ds-c-button ds-c-button--ghost"
-          href="#3"
-        >
-          3
-        </a>
-      </li>
-    </ul>
+      <a
+        aria-label="page 1"
+        class="ds-c-button ds-c-button--ghost"
+        href="#1"
+      >
+        1
+      </a>
+      <span
+        aria-current="page"
+        class="ds-c-button ds-c-button--ghost ds-c-pagination__current-page"
+      >
+        2
+      </span>
+      <a
+        aria-label="page 3"
+        class="ds-c-button ds-c-button--ghost"
+        href="#3"
+      >
+        3
+      </a>
+    </div>
     <a
       aria-hidden="false"
       aria-label="Next Page"
@@ -222,8 +206,8 @@ exports[`Pagination with compact prop enabled should render compact variant 1`] 
         3
       </strong>
     </span>
-    <ul
-      role="list"
+    <div
+      class="ds-c-pagination__pages"
     />
     <a
       aria-hidden="false"

--- a/packages/design-system/src/styles/components/_Pagination.scss
+++ b/packages/design-system/src/styles/components/_Pagination.scss
@@ -5,9 +5,8 @@
   align-items: center;
   display: flex;
   justify-content: space-between;
-  ul {
+  .ds-c-pagination__pages {
     display: none;
-    list-style: none;
     margin: 0;
 
     @media (-ms-high-contrast: active), (forced-colors: active) {
@@ -18,9 +17,6 @@
     @media (min-width: $media-width-sm + 1) {
       display: inline-block;
     }
-  }
-  li {
-    display: inline-block;
   }
   .ds-c-button {
     color: var(--pagination-link__color);
@@ -154,7 +150,7 @@
     .ds-c-pagination__page-count {
       display: inline;
     }
-    ul {
+    .ds-c-pagination__pages {
       display: none;
     }
   }


### PR DESCRIPTION
## Summary

WNMGDS-2050

Pagination's list of pages gives incorrect context to screen reader users. E.g., if a page set has 15 pages the readout will still say listitem X of 7 because there are 7 &lt;li> tags on the screen.

To fix this, the solution was to remove the list markup in favor of something more generic that won't confuse SR users.

To test, visit [demo url](https://cmsgov.github.io/design-system/branch/WNMGDS-2050/pagination-page-list-fix/components/pagination/?theme=core) and confirm no list markup exists. Test with a screen reader to confirm the readout is as expected (no confusion around number of items in a list vs actual number of pages).