### PR TITLE
[WNMGDS-2291] Remove max-width for doc site theme and version switchers

### DIFF
--- a/packages/docs/src/components/layout/ThemeSwitcher.tsx
+++ b/packages/docs/src/components/layout/ThemeSwitcher.tsx
@@ -25,8 +25,8 @@ const ThemeSwitcher = () => {
     <Dropdown
       label="Selected theme"
       name="theme-switcher"
-      options={themeOptions}
       className="c-theme-switcher"
+      options={themeOptions}
       value={currentTheme}
       onChange={onThemeChange}
     />

--- a/packages/docs/src/components/layout/VersionSwitcher.tsx
+++ b/packages/docs/src/components/layout/VersionSwitcher.tsx
@@ -53,6 +53,7 @@ const VersionSwitcher = () => {
     <Dropdown
       label="Documentation version"
       name="version-switcher"
+      className="c-version-switcher"
       options={getVersionOptions(themeVersions)}
       value={currentVersion}
       onChange={onVersionChange}

--- a/packages/docs/src/styles/components/navigation.scss
+++ b/packages/docs/src/styles/components/navigation.scss
@@ -62,6 +62,11 @@
   margin-block-start: 0;
 }
 
+.c-theme-switcher .ds-c-field,
+.c-version-switcher .ds-c-field {
+  max-width: none;
+}
+
 .c-navigation--open {
   inset: 0;
   overflow-y: auto;


### PR DESCRIPTION
# Summary

Follow-up to https://github.com/CMSgov/design-system/pull/2474

Take the form max width off of the switchers so they don't look weird in the mobile menu on wider screens
