### PR TITLE
[NO-TICKET] Moving ds-scripts dependencies into devDependencies

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -56,22 +56,24 @@
     "@types/react": "^17.0.10",
     "@types/react-dom": "^17.0.10",
     "@types/react-transition-group": "^4.4.5",
-    "chalk": "^5.0.1",
     "classnames": "^2.2.5",
     "core-js": "^3.6.5",
     "date-fns": "^2.28.0",
     "downshift": "^7.6.0",
     "ev-emitter": "^1.1.1",
     "focus-trap-react": "^10.0.0",
-    "globby": "^13.1.2",
-    "inquirer": "^9.0.2",
     "lodash": "^4.17.21",
-    "ora": "^6.1.2",
     "preactement": "1.8.4",
     "prop-types": "^15.8.1",
     "react-day-picker": "^8.0.5",
-    "react-transition-group": "^4.4.5",
-    "yargs": "^17.5.1"
+    "react-transition-group": "^4.4.5"
+  },
+  "devDependencies": {
+    "ora": "^6.1.2",
+    "yargs": "^17.5.1",
+    "globby": "^13.1.2",
+    "inquirer": "^9.0.2",
+    "chalk": "^5.0.1"
   },
   "peerDependencies": {
     "react": ">=17.0.0",


### PR DESCRIPTION
## Summary

- These dependencies should be in devDependencies so to not load up package size for users of the ds

## How to test

1. `yarn clean && yarn install && yarn build && yarn cmsds-migrate`, everything should work the same

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.