### PR TITLE
[NO-TICKET] Sorting tags by committerdate in release:notes

### DIFF
--- a/scripts/notes.ts
+++ b/scripts/notes.ts
@@ -73,7 +73,9 @@ export const getLatestVersions = () => {
   const versions: { [key: string]: string } = {};
   Object.entries(themes).forEach((theme) => {
     const pkgn = theme[1].packageName;
-    const vers = execSync(`git ls-remote --tags --sort tag origin | grep "${pkgn}" | tail -1`)
+    const vers = execSync(
+      `git ls-remote --tags --sort committerdate origin | grep "${pkgn}" | tail -1`
+    )
       .toString()
       .trim();
     versions[theme[0]] = vers.replace(/\w+\s+refs\/tags\/@cmsgov\/.*@(.*)$/, '$1');


### PR DESCRIPTION
## Summary

- Previously sorting by `tag` was wrapping numbers higher than 9 back around to the 1's, not ideal, made latest release number for healthcare 9.0.0 instead of 11.0.0-beta.1
- Sorting by `committerdate` get's the latest tag which is more in line with what we're looking for

## How to test

1. try the command that is now run: `git ls-remote --tags --sort committerdate origin | grep "design-system" | tail -1`
2. or `git ls-remote --tags --sort committerdate origin | grep "ds-healthcare-gov" | tail -1`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
