### PR TITLE
[WNMGDS-2282] Fix `labelId` leaking through `TextField` into the DOM

### DIFF
--- a/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/design-system/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -28,7 +28,6 @@ exports[`Autocomplete renders Autocomplete component 1`] = `
       autocomplete="off"
       class="ds-c-field"
       id="autocomplete__input--1"
-      labelid="autocomplete__label--2"
       name="autocomplete_field"
       role="combobox"
       type="text"

--- a/packages/design-system/src/components/FormLabel/useFormLabel.tsx
+++ b/packages/design-system/src/components/FormLabel/useFormLabel.tsx
@@ -102,6 +102,8 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
     label,
     labelClassName,
     labelComponent,
+    // Throw away this value and don't pass it to `fieldProps`
+    labelId: _labelId,
     errorMessage,
     errorMessageClassName,
     errorPlacement = errorPlacementDefault(),

--- a/packages/design-system/src/components/TextField/TextField.test.tsx
+++ b/packages/design-system/src/components/TextField/TextField.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import TextField from './TextField';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { DATE_MASK } from './useLabelMask';
+import userEvent from '@testing-library/user-event';
 
 const defaultProps = {
   label: 'Foo',
@@ -23,5 +24,34 @@ describe('TextField', function () {
 
   it('renders with a mask', () => {
     expect(renderTextField({ mask: 'currency' }).asFragment()).toMatchSnapshot();
+  });
+
+  it('can accept custom ids', () => {
+    const id = 'custom-id';
+    const labelId = 'custom-label-id';
+    const { container } = renderTextField({ id, labelId });
+    expect(container.querySelector('input').id).toEqual(id);
+    expect(container.querySelector('label').id).toEqual(labelId);
+  });
+
+  it('calls onChange when user types', () => {
+    const onChange = jest.fn();
+    renderTextField({ onChange });
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    userEvent.click(input);
+    userEvent.type(input, 'c');
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ target: expect.objectContaining({ value: 'c' }) })
+    );
+  });
+
+  it('calls onBlur when input loses focus', () => {
+    const onBlur = jest.fn();
+    renderTextField({ onBlur });
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    userEvent.click(input);
+    expect(onBlur).not.toHaveBeenCalled();
+    userEvent.tab();
+    expect(onBlur).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

https://jira.cms.gov/browse/WNMGDS-2282

Fixes the following error coming from the use of `labelId` on `TextField`:
```
console.error
    Warning: React does not recognize the `labelId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `labelid` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

## How to test

Run the unit tests. There should be no console errors related to `labelId`.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)
