### PR TITLE
[WNMGDS-2348] Remove react props table from docs site

### DIFF
--- a/packages/docs/content/components/accordion.mdx
+++ b/packages/docs/content/components/accordion.mdx
@@ -4,7 +4,7 @@ intro: An accordion is a list of headers that hide or reveal additional content 
 core:
   githubLink: design-system/src/components/Accordion
   sketchLink: ygDKPRA
-  storybookLink: components-accordion--default
+  storybookLink: components-accordion--docs
 healthcare:
   githubLink: ds-healthcare-gov/src/components/Accordion
   sketchLink: zxJDbdo

--- a/packages/docs/content/components/accordion.mdx
+++ b/packages/docs/content/components/accordion.mdx
@@ -13,20 +13,13 @@ medicare:
   sketchLink: R1zwwm2
 ---
 
-
 ## Examples
 
 <ThemeContent neverThemes={['healthcare']}>
-  <StorybookExample
-    componentName="accordion"
-    storyId="components-accordion--default"
-  />
+  <StorybookExample componentName="accordion" storyId="components-accordion--default" />
 </ThemeContent>
 <ThemeContent onlyThemes={['healthcare']}>
-  <StorybookExample
-    componentName="accordion"
-    storyId="healthcare-accordion--default"
-  />
+  <StorybookExample componentName="accordion" storyId="healthcare-accordion--default" />
 </ThemeContent>
 
 ## Code

--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -4,13 +4,14 @@ intro: Alerts give feedback to users, provide critical information, and/or offer
 core:
   githubLink: design-system/src/components/Alert
   sketchLink: 9P3rvwn
-  storybookLink: components-alert--default
+  storybookLink: components-alert--docs
 healthcare:
   sketchLink: nRKbw3z
 medicare:
   sketchLink: 1K9gg0y
 ---
 
+import { SeeStorybookForReactGuidance } from '../../src/components/content/SeeStorybookForReactGuidance.tsx';
 import { Badge } from '@cmsgov/design-system';
 
 ## Examples
@@ -125,9 +126,7 @@ Used to show important but not as urgent messages as standard alerts.
 
 ### React
 
-<PropTable componentName="Alert" hasAnalytics>
-  <PropTableHtmlElementRow elements={['div']} />
-</PropTable>
+<SeeStorybookForReactGuidance storyId={'components-alert--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -11,7 +11,6 @@ medicare:
   sketchLink: 1K9gg0y
 ---
 
-import { SeeStorybookForReactGuidance } from '../../src/components/content/SeeStorybookForReactGuidance.tsx';
 import { Badge } from '@cmsgov/design-system';
 
 ## Examples

--- a/packages/docs/content/components/autocomplete.mdx
+++ b/packages/docs/content/components/autocomplete.mdx
@@ -4,7 +4,7 @@ intro: Autocompletes allow users to enter any combination of letters, numbers, o
 core:
   githubLink: design-system/src/components/Autocomplete
   sketchLink: 7y3WZY8
-  storybookLink: components-autocomplete--default
+  storybookLink: components-autocomplete--docs
 healthcare:
   sketchLink: ZOZk4rx
 ---
@@ -41,18 +41,13 @@ An `<Autocomplete>` component accepts a list of items (JavaScript objects) that 
 
 The following CSS variables can be overridden to customize Autocomplete components:
 
-<ComponentThemeOptions
-  componentname="autocomplete"
-/>
+<ComponentThemeOptions componentname="autocomplete" />
 
 #### Text Input Options
 
 The `<Autocomplete>` component also makes use of a text field, which can be customized by the following variables:
 
-<ComponentThemeOptions
-  componentname="text-input"
-/>
-
+<ComponentThemeOptions componentname="text-input" />
 
 ## Guidance
 

--- a/packages/docs/content/components/autocomplete.mdx
+++ b/packages/docs/content/components/autocomplete.mdx
@@ -23,7 +23,7 @@ The `Autocomplete` component is a parent component that adds autocomplete functi
 
 ### React
 
-<PropTable componentName="Autocomplete" />
+<SeeStorybookForReactGuidance storyId={'components-autocomplete--docs'} />
 
 #### Autocomplete items
 

--- a/packages/docs/content/components/badge.mdx
+++ b/packages/docs/content/components/badge.mdx
@@ -11,8 +11,6 @@ medicare:
   sketchLink: paz00rp
 ---
 
-import { SeeStorybookForReactGuidance } from '../../src/components/content/SeeStorybookForReactGuidance.tsx';
-
 ## Examples
 
 ### Default

--- a/packages/docs/content/components/badge.mdx
+++ b/packages/docs/content/components/badge.mdx
@@ -4,12 +4,14 @@ intro: Badges hold small amounts of information and draw attention to new or imp
 core:
   githubLink: design-system/src/components/Badge
   sketchLink: PGjYyaQ
-  storybookLink: components-badge--default
+  storybookLink: components-badge--docs
 healthcare:
   sketchLink: JnRjWEG
 medicare:
   sketchLink: paz00rp
 ---
+
+import { SeeStorybookForReactGuidance } from '../../src/components/content/SeeStorybookForReactGuidance.tsx';
 
 ## Examples
 
@@ -37,7 +39,7 @@ medicare:
 
 ### React
 
-<PropTable componentName="Badge" htmlElementName="span" />
+<SeeStorybookForReactGuidance storyId={'components-badge--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/button.mdx
+++ b/packages/docs/content/components/button.mdx
@@ -4,7 +4,7 @@ intro: Buttons allow users to take actions from a current state to a future stat
 core:
   githubLink: design-system/src/components/Button
   sketchLink: zx4Ybra
-  storybookLink: components-button--default
+  storybookLink: components-button--docs
 healthcare:
   sketchLink: bgkyK0V
 medicare:

--- a/packages/docs/content/components/button.mdx
+++ b/packages/docs/content/components/button.mdx
@@ -15,8 +15,8 @@ import { Alert, Badge, ArrowIcon, Button, CloseIconThin } from '@cmsgov/design-s
 
 <Alert heading="Are you upgrading to v4 (healthcare v8, medicare v6)?">
 
-  [Take a look at our v4 buttons migration guide](/getting-started/migrating-to-new-buttons) to get started.
-  
+[Take a look at our v4 buttons migration guide](/getting-started/migrating-to-new-buttons) to get started.
+
 </Alert>
 
 ## Examples
@@ -47,13 +47,11 @@ Use solid buttons for the primary actions we want users to take. These actions a
   storyId="components-button--default&args=children:Solid;variation:solid"
 />
 
-
 #### Outline button
 
 <ThemeContent onlyThemes={['healthcare']}>
 
 Use outline buttons for actions available but not the primary action we want users to take (example: Plan details). There doesn't have to be a primary button on the page to use the secondary button.
-
 
 </ThemeContent>
 
@@ -62,8 +60,6 @@ Use outline buttons for actions available but not the primary action we want use
   sourceFilePath="components/Button/Button.tsx"
   storyId="components-button--default&args=children:Outline"
 />
-
-
 
 #### Ghost button
 
@@ -84,7 +80,7 @@ Use ghost buttons for actions available but do not take priority over a primary 
 <ThemeContent onlyThemes={['healthcare']}>
 
 <Badge variation="alert">
-<CloseIconThin /> Unused by Healthcare.
+  <CloseIconThin /> Unused by Healthcare.
 </Badge>
 
 </ThemeContent>
@@ -93,8 +89,8 @@ Each button variation (outline, solid, ghost) has an alternate option. Alternate
 
 <ThemeContent neverThemes={['healthcare']}>
 
-  #### Alternate solid button
-  
+#### Alternate solid button
+
   <StorybookExample
     componentName="solid-alt-button"
     sourceFilePath="components/Button/Button.tsx"
@@ -111,7 +107,7 @@ Each button variation (outline, solid, ghost) has an alternate option. Alternate
 <ThemeContent onlyThemes={['medicare']}>
 
 <Badge variation="alert">
-<CloseIconThin /> Unused by Medicare.
+  <CloseIconThin /> Unused by Medicare.
 </Badge>
 
 </ThemeContent>
@@ -134,7 +130,7 @@ Each button variation (outline, solid, ghost) has an alternate option. Alternate
 <ThemeContent onlyThemes={['medicare']}>
 
 <Badge variation="alert">
-<CloseIconThin /> Unused by Medicare.
+  <CloseIconThin /> Unused by Medicare.
 </Badge>
 
 </ThemeContent>
@@ -148,13 +144,12 @@ Each button variation (outline, solid, ghost) has an alternate option. Alternate
   />
 </ThemeContent>
 
+### On dark background
 
-### On dark background 
-
-<ThemeContent onlyThemes={['healthcare']}> 
+<ThemeContent onlyThemes={['healthcare']}>
 
 <Badge variation="alert">
-<CloseIconThin /> Unused by Healthcare.
+  <CloseIconThin /> Unused by Healthcare.
 </Badge>
 
 </ThemeContent>
@@ -177,7 +172,7 @@ Buttons can exist in two sizes other than default: "big" or "small".
 <ThemeContent onlyThemes={['healthcare']}>
 
 <Badge variation="alert">
-<CloseIconThin /> Unused by Healthcare.
+  <CloseIconThin /> Unused by Healthcare.
 </Badge>
 
 </ThemeContent>
@@ -186,9 +181,7 @@ Buttons can exist in two sizes other than default: "big" or "small".
 
 <EmbeddedExample>
   <div>
-    <Button size="big">
-      Big
-    </Button>
+    <Button size="big">Big</Button>
   </div>
 </EmbeddedExample>
 
@@ -202,12 +195,9 @@ Small outline buttons are used for utility buttons on a page with other primary 
 
 </ThemeContent>
 
-
 <EmbeddedExample>
   <div>
-    <Button size="small">
-      Small
-    </Button>
+    <Button size="small">Small</Button>
   </div>
 </EmbeddedExample>
 
@@ -242,9 +232,7 @@ In addition to the supported props listed, you can also pass in additional
 props, which will be passed to the rendered root component. For example,
 you could pass in a `target` prop to pass to the rendered anchor element.
 
-<PropTable componentName="Button" hasAnalytics hasParentAnalytics>
-  <PropTableHtmlElementRow elements={['button', 'a']} />
-</PropTable>
+<SeeStorybookForReactGuidance storyId={'components-button--docs'} />
 
 ### Styles
 
@@ -262,13 +250,15 @@ Buttons are promises to the user; they must deliver the promise they offer by do
 
 <ThemeContent onlyThemes={['medicare']}>
 
-- Action buttons do NOT include icons. 
-<br/> <i>Exception:</i> Can include icons in buttons in mobile for CTAs outlining functionality.<br /> Examples: Filter, Sort, Map, and Menu. 
+- Action buttons do NOT include icons.
+  <br /> <i>Exception:</i> Can include icons in buttons in mobile for CTAs outlining functionality.
+  <br /> Examples: Filter, Sort, Map, and Menu.{' '}
 - Other exceptions require advance and separate approval than mock-ups by product teams. See [Exception process](../../guidelines/exceptions/?theme=medicare)" in Foundations.
 - Buttons use title case. Example: Join Plan or Find Doctors.
 - Note that clickable cards are sentence case. See that component for more information.
 
 When pairing 2 CTAs:
+
 - In forms/decision trees: Have the preferred action be on the right. Example: Back/Next or Cancel/Submit.
 - All other cases: Have the preferred action be on the left. Example: Create Account/Return to Home or Change My Account/Stop Easy Pay.
 
@@ -293,7 +283,7 @@ When pairing 2 CTAs:
 
 #### Don't
 
-- Use buttons for navigational elements like going to a new page. 
+- Use buttons for navigational elements like going to a new page.
 
 </ThemeContent>
 
@@ -318,17 +308,17 @@ Disabling a "button" to act as a guide to the level of form completion is a comm
 - They don’t provide feedback and tell the user why they're disabled. They communicate that something is off, but very often that is not enough information. As a result, users are left wondering what’s actually missing, and consequently are locked out entirely.
 - Assistive technologies like [screen readers](https://www.nngroup.com/articles/touchscreen-screen-readers/) and [switches](https://en.wikipedia.org/wiki/Switch_access) are usually not even able to navigate to disabled buttons.
 
-For these reasons, disabled buttons can be frustrating for all users but especially those with cognitive disabilities and those who use assistive technologies. 
+For these reasons, disabled buttons can be frustrating for all users but especially those with cognitive disabilities and those who use assistive technologies.
 
 <ThemeContent onlyThemes={['healthcare']}>
 
 ### Design guidelines
 
 - Buttons are used for actions; links are used for navigation
-- Buttons do NOT include icons. 
+- Buttons do NOT include icons.
   - Exception: Can include icons in buttons for utility actions like print and save and branded buttons like Facebook, Twitter, and YouTube used in the Footer
 - When pairing 2 buttons the preferred/main action is placed on the left.
-- Ghost buttons are typically used when paired with a Solid or Outline button or to indicate lower priority actions. 
+- Ghost buttons are typically used when paired with a Solid or Outline button or to indicate lower priority actions.
 
 </ThemeContent>
 
@@ -336,20 +326,17 @@ For these reasons, disabled buttons can be frustrating for all users but especia
 
 <ThemeContent onlyThemes={['healthcare']}>
 
-Consider when to use links vs. when to use buttons. Links and buttons are read differently using a screen readers. For screen readers buttons can be triggered by pressing the space bar or the enter key while links are only triggered by the enter key. This makes a difference to a screen reader user's flow. 
+Consider when to use links vs. when to use buttons. Links and buttons are read differently using a screen readers. For screen readers buttons can be triggered by pressing the space bar or the enter key while links are only triggered by the enter key. This makes a difference to a screen reader user's flow.
 
 </ThemeContent>
-
 
 - Buttons should display a visible focus state when users tab to them.
 - Create a button with a `<button>` or `<a>` element to retain the native click functionality. Avoid using `<div>` or `<img>` tags to create buttons. Screen readers don't automatically know either is a usable button.
 - When styling links to look like buttons, remember that screen readers handle links slightly differently than they do buttons. Pressing the `Space` key triggers a button, but pressing the `Enter` key triggers a link.
-- Dimmed or unavailable buttons using the `<a>` tag must have the `aria-disabled` attribute set to true and its `href` attribute removed. 
-    - Unlike the `<button>`, `disabled` is not a valid attribute for `<a>`. To describe the disabled state to screen reader users, use the `aria-disabled` attribute instead.
-    - The `href` attribute is not required on `<a>`, and when it's absent it doesn't create a hyperlink.
+- Dimmed or unavailable buttons using the `<a>` tag must have the `aria-disabled` attribute set to true and its `href` attribute removed.
+  - Unlike the `<button>`, `disabled` is not a valid attribute for `<a>`. To describe the disabled state to screen reader users, use the `aria-disabled` attribute instead.
+  - The `href` attribute is not required on `<a>`, and when it's absent it doesn't create a hyperlink.
 - Dimmed or unavailable buttons using the `<button>` tag should have the `disabled` attribute applied. This removes native click and keypress events from the button. It also prevents automated scanners from logging a low contrast error. Finally, it announces the button as "dimmed" or "disabled" to screen readers, offering users additional context.
-
-
 
 <ThemeContent onlyThemes={['medicare']}>
 
@@ -359,24 +346,23 @@ Consider when to use links vs. when to use buttons. Links and buttons are read d
 - Use buttons for javascript triggers that have a clickable element tied to javascript functionality.
 - Use links for navigational elements. `<a>` tags are reserved for navigation.
 
-
 #### Don't
 
 - Use buttons for navigational elements like going to a new page.
 
-
 </ThemeContent>
 
 ### Content
-- Describe what will happen, not the current state. 
-- Buttons always start with an action word describing the main thing users will do once selected. 
+
+- Describe what will happen, not the current state.
+- Buttons always start with an action word describing the main thing users will do once selected.
   - Pair it with a noun to help it be clearer. Example: Get tips.
   - If in a form, it can be just the action word if it's navigating between steps. Example: Cancel, Back, Next.
 - Use the least amount of words possible (no more than 6 with 2-4 being ideal).
 
 <ThemeContent onlyThemes={['healthcare']}>
 
-- Use sentence case for buttons. This conveys a friendlier tone. Note: Some tools and the homepage are using ALL CAPS. There are also a few examples of Title Case. We should change to sentence case for consistency across the site. 
+- Use sentence case for buttons. This conveys a friendlier tone. Note: Some tools and the homepage are using ALL CAPS. There are also a few examples of Title Case. We should change to sentence case for consistency across the site.
 
 </ThemeContent>
 
@@ -389,8 +375,9 @@ Consider when to use links vs. when to use buttons. Links and buttons are read d
 <ThemeContent onlyThemes={['healthcare', 'medicare']}>
 
 #### Writing content
+
 - Remove articles and use '&' instead of 'and'
-- Do not capitalize articles. 
+- Do not capitalize articles.
 - Avoid all caps unless the word is an acronym, like ZIP.
 - Avoid pronouns unless the future state provides the user with customized information. Example: "Get my results"
 - Limit branded terms, like tool names. As a general rule, we don't use tool names in web content or flow. Rather, content should outline what the user will get/can do when they click the button.
@@ -414,19 +401,11 @@ Generally better to use specific verbs to confirm what the user is starting. For
   </thead>
   <tbody role="rowgroup">
     <tr role="row">
-      <td
-        role="cell"
-        data-title="Document title"
-        width="50%"
-      >
-       Start
+      <td role="cell" data-title="Document title" width="50%">
+        Start
       </td>
-      <td
-        role="cell"
-        data-title="Description"
-        width="50%"
-      >
-     Begin, Go, Enter, or Submit
+      <td role="cell" data-title="Description" width="50%">
+        Begin, Go, Enter, or Submit
       </td>
     </tr>
   </tbody>
@@ -453,18 +432,10 @@ For forward movement to the next page or step.
   </thead>
   <tbody role="rowgroup">
     <tr role="row">
-      <td
-        role="cell"
-        data-title="Document title"
-        width="50%"
-      >
-       Continue
+      <td role="cell" data-title="Document title" width="50%">
+        Continue
       </td>
-      <td
-        role="cell"
-        data-title="Description"
-        width="50%"
-      >
+      <td role="cell" data-title="Description" width="50%">
         Next
       </td>
     </tr>
@@ -488,18 +459,10 @@ For forward movement to the next page or step.
   </thead>
   <tbody role="rowgroup">
     <tr role="row">
-      <td
-        role="cell"
-        data-title="Document title"
-        width="50%"
-      >
-       Next
+      <td role="cell" data-title="Document title" width="50%">
+        Next
       </td>
-      <td
-        role="cell"
-        data-title="Description"
-        width="50%"
-      >
+      <td role="cell" data-title="Description" width="50%">
         Continue
       </td>
     </tr>
@@ -525,18 +488,10 @@ For backward movement to the previous step in the process.
   </thead>
   <tbody role="rowgroup">
     <tr role="row">
-      <td
-        role="cell"
-        data-title="Document title"
-        width="50%"
-      >
-       Back or Go Back
+      <td role="cell" data-title="Document title" width="50%">
+        Back or Go Back
       </td>
-      <td
-        role="cell"
-        data-title="Description"
-        width="50%"
-      >
+      <td role="cell" data-title="Description" width="50%">
         Undo or Cancel
       </td>
     </tr>
@@ -558,18 +513,10 @@ For backward movement to the previous step in the process.
   </thead>
   <tbody role="rowgroup">
     <tr role="row">
-      <td
-        role="cell"
-        data-title="Document title"
-        width="50%"
-      >
-       Cancel
+      <td role="cell" data-title="Document title" width="50%">
+        Cancel
       </td>
-      <td
-        role="cell"
-        data-title="Description"
-        width="50%"
-      >
+      <td role="cell" data-title="Description" width="50%">
         X
       </td>
     </tr>
@@ -578,7 +525,7 @@ For backward movement to the previous step in the process.
 
 ##### Submiting information or completing a process
 
-Generally better to use specific verbs if appropriate to confirm an action. 
+Generally better to use specific verbs if appropriate to confirm an action.
 
 <table class="ds-c-table ds-c-table--compact ds-c-md-table--stacked" role="table" width="100%">
   <thead role="rowgroup">
@@ -593,18 +540,10 @@ Generally better to use specific verbs if appropriate to confirm an action.
   </thead>
   <tbody role="rowgroup">
     <tr role="row">
-      <td
-        role="cell"
-        data-title="Document title"
-        width="50%"
-      >
-       Enter, Go, or Submit
+      <td role="cell" data-title="Document title" width="50%">
+        Enter, Go, or Submit
       </td>
-      <td
-        role="cell"
-        data-title="Description"
-        width="50%"
-      >
+      <td role="cell" data-title="Description" width="50%">
         Fill in, Tell us, Done, or Select
       </td>
     </tr>
@@ -626,56 +565,32 @@ Generally better to use specific verbs if appropriate to confirm an action.
   </thead>
   <tbody role="rowgroup">
     <tr role="row">
-      <td
-        role="cell"
-        data-title="Document title"
-        width="50%"
-      >
-      <ul>
-       <li>Log in - MUST be 2 words and "in" is lowercase when it's an action.</li>
-       <li>Login - Used as 1 word when it's a noun or adjective.</li>
-       </ul>
+      <td role="cell" data-title="Document title" width="50%">
+        <ul>
+          <li>Log in - MUST be 2 words and "in" is lowercase when it's an action.</li>
+          <li>Login - Used as 1 word when it's a noun or adjective.</li>
+        </ul>
       </td>
-      <td
-        role="cell"
-        data-title="Description"
-        width="50%"
-      >
+      <td role="cell" data-title="Description" width="50%">
         Sign in, or Signin
       </td>
     </tr>
     <tr role="row">
-      <td
-        role="cell"
-        data-title="Document title"
-        width="50%"
-      >
-       <ul>
-       <li>Log out - MUST be 2 words and "out" is lowercase when it's an action.</li>
-       <li>Logout - Used as 1 word when it's a noun or adjective.</li>
-       </ul>
+      <td role="cell" data-title="Document title" width="50%">
+        <ul>
+          <li>Log out - MUST be 2 words and "out" is lowercase when it's an action.</li>
+          <li>Logout - Used as 1 word when it's a noun or adjective.</li>
+        </ul>
       </td>
-      <td
-        role="cell"
-        data-title="Description"
-        width="50%"
-      >
+      <td role="cell" data-title="Description" width="50%">
         Logoff, Log off, Signout, or Sign out
       </td>
     </tr>
     <tr role="row">
-      <td
-        role="cell"
-        data-title="Document title"
-        width="50%"
-      >
-       Username - MUST be 1 word.
+      <td role="cell" data-title="Document title" width="50%">
+        Username - MUST be 1 word.
       </td>
-      <td
-        role="cell"
-        data-title="Description"
-        width="50%"
-      >
+      <td role="cell" data-title="Description" width="50%">
         User name
       </td>
     </tr>
@@ -683,7 +598,6 @@ Generally better to use specific verbs if appropriate to confirm an action.
 </table>
 
 </ThemeContent>
-
 
 ## Learn more
 

--- a/packages/docs/content/components/card.mdx
+++ b/packages/docs/content/components/card.mdx
@@ -24,7 +24,7 @@ import { Alert } from '@cmsgov/design-system';
 
 ### React
 
-<PropTable componentName="Card" />
+<SeeStorybookForReactGuidance storyId={'medicare-card--docs'} />
 
 ## Component maturity
 

--- a/packages/docs/content/components/card.mdx
+++ b/packages/docs/content/components/card.mdx
@@ -2,24 +2,23 @@
 title: Card (M.gov)
 medicare:
   githubLink: ds-medicare-gov/src/components/Card
-  storybookLink: medicare-card--default
+  storybookLink: medicare-card--docs
 ---
+
 import { Alert } from '@cmsgov/design-system';
 
 <ThemeContent neverThemes={['medicare']}>
   <Alert variation="error">
-     <p class="ds-c-alert__text">
-        This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.
+    <p class="ds-c-alert__text">
+      This component is only used for Medicare. Please use the theme switcher to view the component
+      with Medicare styles.
     </p>
   </Alert>
 </ThemeContent>
 
 ## Examples
 
-<StorybookExample
-    componentName="card"
-    storyId="medicare-card--default"
-/>
+<StorybookExample componentName="card" storyId="medicare-card--default" />
 
 ## Code
 

--- a/packages/docs/content/components/checkbox.mdx
+++ b/packages/docs/content/components/checkbox.mdx
@@ -4,7 +4,7 @@ intro: Checkboxes allow users to select one or more options from a list.
 core:
   githubLink: design-system/src/components/ChoiceList
   sketchLink: 8yn3JK7
-  storybookLink: components-choicelist--default-checkbox
+  storybookLink: components-choicelist--docs
 healthcare:
   sketchLink: 4a7lxP3
 ---
@@ -53,17 +53,13 @@ Note that each of the items in the `choices` array represents props that will be
 
 The following CSS variables can be overridden to customize choice fields:
 
-<ComponentThemeOptions
-  componentname="choice"
-/>
+<ComponentThemeOptions componentname="choice" />
 
 #### Form components
 
 This component also makes use of form field styles, which can be customized by the following variables:
 
-<ComponentThemeOptions
-  componentname="form"
-/>
+<ComponentThemeOptions componentname="form" />
 
 ## Guidance
 

--- a/packages/docs/content/components/date-field/date-picker.mdx
+++ b/packages/docs/content/components/date-field/date-picker.mdx
@@ -4,7 +4,6 @@ intro: Date field (with calendar picker), also known as "date picker", provides 
 core:
   githubLink: design-system/src/components/DateField
   sketchLink: nRja1ed
-  storybookLink: components-singleinputdatefield--with-picker
 healthcare:
   sketchLink: Kv3oKMn
 medicare:
@@ -30,17 +29,13 @@ The calendar picker is another name for the `<SingleInputDateField>` with a cale
 
 The following CSS variables can be overridden to customize Input/Form components:
 
-<ComponentThemeOptions
-  componentname="text-input"
-/>
+<ComponentThemeOptions componentname="text-input" />
 
 #### Form components
 
 This component also makes use of form field styles, which can be customized by the following variables:
 
-<ComponentThemeOptions
-  componentname="form"
-/>
+<ComponentThemeOptions componentname="form" />
 
 ## Guidance
 
@@ -56,8 +51,9 @@ This component also makes use of form field styles, which can be customized by t
 ### Usage
 
 Allow users to have flexibility in entering the date, such as allowing one-digit numbers with or without "0" prior to the number, or entering a date with or without slashes to separate month, day, and year.
-  - Example: "1" as well as "01" for a month or day.
-  - Example: "05/18/2022" as well as "05182022".
+
+- Example: "1" as well as "01" for a month or day.
+- Example: "05/18/2022" as well as "05182022".
 
 ### Accessibility
 

--- a/packages/docs/content/components/date-field/multi-input-date-field.mdx
+++ b/packages/docs/content/components/date-field/multi-input-date-field.mdx
@@ -22,7 +22,7 @@ medicare:
 
 ### React
 
-<PropTable componentName="MultiInputDateField" />
+<SeeStorybookForReactGuidance storyId={'components-multiinputdatefield--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/date-field/multi-input-date-field.mdx
+++ b/packages/docs/content/components/date-field/multi-input-date-field.mdx
@@ -4,7 +4,7 @@ intro: Date field (multi-input) provides date entry, spaced over three separate 
 core:
   githubLink: design-system/src/components/DateField
   sketchLink: xrmY9oJ
-  storybookLink: components-multiinputdatefield--multi-input-date-field-default
+  storybookLink: components-multiinputdatefield--docs
 healthcare:
   sketchLink: wLOVybw
 medicare:
@@ -28,23 +28,20 @@ medicare:
 
 The following CSS variables can be overridden to customize Input/Form components:
 
-<ComponentThemeOptions
-  componentname="text-input"
-/>
+<ComponentThemeOptions componentname="text-input" />
 
 #### Form components
 
 This component also makes use of form field styles, which can be customized by the following variables:
 
-<ComponentThemeOptions
-  componentname="form"
-/>
+<ComponentThemeOptions componentname="form" />
 
 ## Guidance
 
 ### When to use
 
 Use this date field when:
+
 - User flow requires inputs be separated
 - Functionality/back-end systems can't support a single date field entry
 
@@ -64,6 +61,7 @@ Generally used for more memorable dates like date of birth, marriage date, or in
 - Do not use JavaScript to auto advance the focus from one field to the next. This makes it difficult for keyboard-only users to navigate and correct mistakes.
 
 ### Related patterns
+
 - [Date field (single-input)](/components/single-input-date-field/)
 - [Date field (with calendar)](/components/date-picker/)
 

--- a/packages/docs/content/components/date-field/single-input-date-field.mdx
+++ b/packages/docs/content/components/date-field/single-input-date-field.mdx
@@ -22,7 +22,7 @@ medicare:
 
 ### React
 
-<PropTable componentName="SingleInputDateField" />
+<SeeStorybookForReactGuidance storyId={'components-singleinputdatefield--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/date-field/single-input-date-field.mdx
+++ b/packages/docs/content/components/date-field/single-input-date-field.mdx
@@ -4,7 +4,7 @@ intro: Date field (single-input) provides date entry, using a text field, in a s
 core:
   githubLink: design-system/src/components/DateField
   sketchLink: jgLGlZm
-  storybookLink: components-singleinputdatefield--default
+  storybookLink: components-singleinputdatefield--docs
 healthcare:
   sketchLink: L03Rw5W
 medicare:
@@ -28,17 +28,13 @@ medicare:
 
 The following CSS variables can be overridden to customize Input/Form components:
 
-<ComponentThemeOptions
-  componentname="text-input"
-/>
+<ComponentThemeOptions componentname="text-input" />
 
 #### Form components
 
 This component also makes use of form field styles, which can be customized by the following variables:
 
-<ComponentThemeOptions
-  componentname="form"
-/>
+<ComponentThemeOptions componentname="form" />
 
 ## Guidance
 
@@ -54,8 +50,9 @@ This component also makes use of form field styles, which can be customized by t
 ### Usage
 
 Allow users to have flexibility in entering the date, such as allowing one-digit numbers with or without "0" prior to the number, or entering a date with or without slashes to separate month, day, and year.
-  - Example: "1" as well as "01" for a month or day.
-  - Example: "05/01/2022" as well as "05012022".
+
+- Example: "1" as well as "01" for a month or day.
+- Example: "05/01/2022" as well as "05012022".
 
 ### Accessibility
 

--- a/packages/docs/content/components/drawer.mdx
+++ b/packages/docs/content/components/drawer.mdx
@@ -4,7 +4,7 @@ intro: A drawer provides a space for medium to long-form help content — conten
 core:
   githubLink: design-system/src/components/Drawer
   sketchLink: zxawg1M
-  storybookLink: components-drawer--drawer-default
+  storybookLink: components-drawer--docs
 healthcare:
   sketchLink: GmlMnkL
 medicare:

--- a/packages/docs/content/components/dropdown.mdx
+++ b/packages/docs/content/components/dropdown.mdx
@@ -11,11 +11,7 @@ healthcare:
 
 ## Examples
 
-<StorybookExample
-  componentName="dropdown"
-  storyId="components-dropdown--default"
-  minHeight={250}
-/>
+<StorybookExample componentName="dropdown" storyId="components-dropdown--default" minHeight={250} />
 
 ## Code
 
@@ -23,23 +19,19 @@ healthcare:
 
 Note that any _undocumented_ props that you pass to this component will be passed to the `select` element, so you can use this to set additional attributes if necessary.
 
-<PropTable componentName="Dropdown" />
+<SeeStorybookForReactGuidance storyId={'components-dropdown--docs'} />
 
 ### Styles
 
 The following CSS variables can be overridden to customize Dropdown components:
 
-<ComponentThemeOptions
-  componentname="dropdown"
-/>
+<ComponentThemeOptions componentname="dropdown" />
 
 #### Text Input Options
 
 This component also makes use of some text input styles, which can be customized by the following variables:
 
-<ComponentThemeOptions
-  componentname="text-input"
-/>
+<ComponentThemeOptions componentname="text-input" />
 
 ## Guidance
 

--- a/packages/docs/content/components/filter-chip.mdx
+++ b/packages/docs/content/components/filter-chip.mdx
@@ -3,15 +3,12 @@ title: Filter Chip
 intro: Filter Chips are used to display dismissible filter chips.
 core:
   githubLink: design-system/src/components/FilterChip
-  storybookLink: components-filter-chip--multiple-chips
+  storybookLink: components-filter-chip--docs
 ---
 
 ## Examples
 
-<StorybookExample
-  componentName="filterChip"
-  storyId="components-filter-chip--multiple-chips"
-/>
+<StorybookExample componentName="filterChip" storyId="components-filter-chip--multiple-chips" />
 
 ## Code
 
@@ -23,9 +20,7 @@ core:
 
 The following CSS variables can be overridden to customize FilterChip components:
 
-<ComponentThemeOptions
-  componentname="filter-chip"
-/>
+<ComponentThemeOptions componentname="filter-chip" />
 
 ## Guidance
 

--- a/packages/docs/content/components/filter-chip.mdx
+++ b/packages/docs/content/components/filter-chip.mdx
@@ -14,7 +14,7 @@ core:
 
 ### React
 
-<PropTable componentName="FilterChip" />
+<SeeStorybookForReactGuidance storyId={'components-filter-chip--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/footer/healthcare-footer.mdx
+++ b/packages/docs/content/components/footer/healthcare-footer.mdx
@@ -3,24 +3,23 @@ title: Healthcare.gov Footer
 healthcare:
   githubLink: ds-healthcare-gov/src/components/Footer
   sketchLink: 52ykDvL
+  storybookLink: healthcare-footer--docs
 ---
 
 import { Alert } from '@cmsgov/design-system';
 
 <ThemeContent neverThemes={['healthcare']}>
   <Alert variation="error">
-     <p class="ds-c-alert__text">
-        This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.
+    <p class="ds-c-alert__text">
+      This component is only used for HealthCare. Please use the theme switcher to view the
+      component with HealthCare styles.
     </p>
   </Alert>
 </ThemeContent>
 
 ## Examples
 
-<StorybookExample
-    componentName="footer"
-    storyId="healthcare-footer--basic-footer"
-/>
+<StorybookExample componentName="footer" storyId="healthcare-footer--basic-footer" />
 
 ## Code
 
@@ -43,4 +42,4 @@ import { Alert } from '@cmsgov/design-system';
   responsiveUiKit={false}
   tokensInCode={true}
   tokensInSketch={true}
-/>  
+/>{' '}

--- a/packages/docs/content/components/footer/healthcare-footer.mdx
+++ b/packages/docs/content/components/footer/healthcare-footer.mdx
@@ -25,7 +25,7 @@ import { Alert } from '@cmsgov/design-system';
 
 ### React
 
-<PropTable componentName="Footer" />
+<SeeStorybookForReactGuidance storyId={'healthcare-footer--docs'} />
 
 ## Component maturity
 

--- a/packages/docs/content/components/footer/medicare-footer.mdx
+++ b/packages/docs/content/components/footer/medicare-footer.mdx
@@ -25,7 +25,7 @@ import { Alert } from '@cmsgov/design-system';
 
 ### React
 
-<PropTable componentName="SimpleFooter" />
+<SeeStorybookForReactGuidance storyId={'medicare-simplefooter--docs'} />
 
 ## Component maturity
 

--- a/packages/docs/content/components/footer/medicare-footer.mdx
+++ b/packages/docs/content/components/footer/medicare-footer.mdx
@@ -3,25 +3,23 @@ title: Medicare.gov Footer
 medicare:
   githubLink: ds-medicare-gov/src/components/SimpleFooter
   sketchLink: oYZ3yn2
-  storybookLink: medicare-simplefooter--default
+  storybookLink: medicare-simplefooter--docs
 ---
 
 import { Alert } from '@cmsgov/design-system';
 
 <ThemeContent neverThemes={['medicare']}>
   <Alert variation="error">
-     <p class="ds-c-alert__text">
-        This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.
+    <p class="ds-c-alert__text">
+      This component is only used for Medicare. Please use the theme switcher to view the component
+      with Medicare styles.
     </p>
   </Alert>
 </ThemeContent>
 
 ## Examples
 
-<StorybookExample
-    componentName="footer"
-    storyId="medicare-simplefooter--default"
-/>
+<StorybookExample componentName="footer" storyId="medicare-simplefooter--default" />
 
 ## Code
 

--- a/packages/docs/content/components/form-label.mdx
+++ b/packages/docs/content/components/form-label.mdx
@@ -3,7 +3,7 @@ title: Form Label & Legend
 intro: Form Labels & Legends are used with form inputs to provide labels, hints, and errors that help the user enter information.
 core:
   githubLink: design-system/src/components/FormLabel
-  storybookLink: components-formlabel--form-label-with-hint
+  storybookLink: components-formlabel--docs
 ---
 
 ## Examples
@@ -28,9 +28,7 @@ The `FormLabel` component provides the `label` (or `legend`) for a field, along 
 
 The following CSS variables can be overridden to customize Form components:
 
-<ComponentThemeOptions
-  componentname="form"
-/>
+<ComponentThemeOptions componentname="form" />
 
 ## Guidance
 
@@ -38,7 +36,6 @@ The following CSS variables can be overridden to customize Form components:
 
 - Use a single legend for fieldset (this is required). One example of a common use of fieldset and legend is a question with radio button options for answers. The question text and radio buttons are wrapped in a fieldset, with the question itself being inside the legend tag.
 - Avoid links in legends when possible. Links inside legends are not read by some screen readers, namely JAWS. If you need a pattern like this, put the link outside of the legend element, but keep all other useful hint text in the legend.
-
 
 ### Form label
 
@@ -66,7 +63,7 @@ The following CSS variables can be overridden to customize Form components:
 - Place hint text where appropriate depending on what content it's helping to explain
 - Use hint text for supporting contextual help, which will always be shown.
 - Hint text should sit between a form label and the input.
-- Use lower visual style (i.e., lighter gray than the form label or the input option) so it won't compete for users' attention with the field label. 
+- Use lower visual style (i.e., lighter gray than the form label or the input option) so it won't compete for users' attention with the field label.
 - Use hint text to indicate which inputs are optional when there are more required fields than optional.
 - Hint text can also appear after an input box when the text is being used to show the value someone should be entering in the field (e.g., income amount input box displays text after the input box to highlight the amount should be "monthly income".)
 

--- a/packages/docs/content/components/form-label.mdx
+++ b/packages/docs/content/components/form-label.mdx
@@ -20,9 +20,7 @@ The `FormLabel` component provides the `label` (or `legend`) for a field, along 
 
 ### React
 
-<PropTable componentName="FormLabel">
-  <PropTableHtmlElementRow elements={['label', 'legend']} />
-</PropTable>
+<SeeStorybookForReactGuidance storyId={'components-formlabel--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/header/healthcare-header.mdx
+++ b/packages/docs/content/components/header/healthcare-header.mdx
@@ -37,7 +37,7 @@ The HealthCare.gov header component varies depending on the user's state (ie. lo
 
 ### React
 
-<PropTable componentName="Header" />
+<SeeStorybookForReactGuidance storyId={'healthcare-header--docs'} />
 
 ### Google Analytics
 

--- a/packages/docs/content/components/header/healthcare-header.mdx
+++ b/packages/docs/content/components/header/healthcare-header.mdx
@@ -3,38 +3,35 @@ title: Healthcare.gov Header
 healthcare:
   githubLink: ds-healthcare-gov/src/components/Header
   sketchLink: bgDE8k4
+  storybookLink: healthcare-header--docs
 ---
 
 import { Alert } from '@cmsgov/design-system';
 
 <ThemeContent neverThemes={['healthcare']}>
   <Alert variation="error">
-     <p class="ds-c-alert__text">
-        This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.
+    <p class="ds-c-alert__text">
+      This component is only used for HealthCare. Please use the theme switcher to view the
+      component with HealthCare styles.
     </p>
   </Alert>
 </ThemeContent>
 
 ## Examples
+
 The HealthCare.gov header component varies depending on the user's state (ie. logged-in) and context (ie. what page the user is on).
 
 ### Logged-In
-<StorybookExample
-    componentName="loggedin-header"
-    storyId="healthcare-header--logged-in-header"
-/>
+
+<StorybookExample componentName="loggedin-header" storyId="healthcare-header--logged-in-header" />
 
 ### Logged-Out
-<StorybookExample
-    componentName="loggedout-header"
-    storyId="healthcare-header--logged-out-header"
-/>
+
+<StorybookExample componentName="loggedout-header" storyId="healthcare-header--logged-out-header" />
 
 ### Minimal
-<StorybookExample
-    componentName="minimal-header"
-    storyId="healthcare-header--minimal-header"
-/>
+
+<StorybookExample componentName="minimal-header" storyId="healthcare-header--minimal-header" />
 
 ## Code
 
@@ -53,7 +50,7 @@ On applications where the page has `utag` loaded, the data goes to Tealium which
 Import and set the `setHeaderSendsAnalytics` feature flag to `false` in your application's entry file:
 
 ```js
-import { setHeaderSendsAnalytics } from "@cmsgov/<design-system-package>";
+import { setHeaderSendsAnalytics } from '@cmsgov/<design-system-package>';
 setHeaderSendsAnalytics(false);
 ```
 

--- a/packages/docs/content/components/header/medicare-header.mdx
+++ b/packages/docs/content/components/header/medicare-header.mdx
@@ -17,11 +17,11 @@ import consistentHeaderPageLevelImg from '../../../src/images/consistent-header/
 import consistentHeaderSlideOutDrawerImg from '../../../src/images/consistent-header/consistent-header-slide-out-drawers.png';
 import consistentHeaderToastImg from '../../../src/images/consistent-header/consistent-header-toast.png';
 
-
 <ThemeContent neverThemes={['medicare']}>
   <Alert variation="error">
-     <p class="ds-c-alert__text">
-        This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.
+    <p class="ds-c-alert__text">
+      This component is only used for Medicare. Please use the theme switcher to view the component
+      with Medicare styles.
     </p>
   </Alert>
 </ThemeContent>
@@ -29,10 +29,18 @@ import consistentHeaderToastImg from '../../../src/images/consistent-header/cons
 ## Code
 
 ### HTML
+
 The following example shows what the div element should look like before importing the scripts:
 
 ```html
-<div id="root" lang="en" lang-toggle-link="your-language-toggle-link-here" login-url="login-url" logout-url="logout-url" enable-live-chat="true">
+<div
+  id="root"
+  lang="en"
+  lang-toggle-link="your-language-toggle-link-here"
+  login-url="login-url"
+  logout-url="logout-url"
+  enable-live-chat="true"
+></div>
 ```
 
 ### JS
@@ -44,42 +52,40 @@ loadFilesFromManifest('https://frontend.imp.medicare.gov/', 'asset-manifest.json
 
 //Gets and parses the entrypoints node of the asset manifest file
 function loadFilesFromManifest(rootURL, manifest) {
-	var manifestURL = rootURL + manifest;
-	$.getJSON(manifestURL, function(json) {
-		importFilesFromArray(json.entrypoints, rootURL);
-	});
+  var manifestURL = rootURL + manifest;
+  $.getJSON(manifestURL, function (json) {
+    importFilesFromArray(json.entrypoints, rootURL);
+  });
 }
 
 //Takes the provided array, parses it and loads
 // all of the JS and CSS files based on their file extension
 function importFilesFromArray(files, rootURL) {
-	for (var i = 0; i < files.length; i++) {
-		if (files[i].endsWith('.js'))
-			importJSFile(rootURL + files[i]);
-		else if (files[i].endsWith('.css'))
-			importCSSFile(rootURL + files[i]);
-	}
+  for (var i = 0; i < files.length; i++) {
+    if (files[i].endsWith('.js')) importJSFile(rootURL + files[i]);
+    else if (files[i].endsWith('.css')) importCSSFile(rootURL + files[i]);
+  }
 }
 
 //Imports a single JS file
 function importJSFile(url) {
-	var jsElement = document.createElement('script');
-	jsElement.src = url;
-	jsElement.type = 'text/javascript';
+  var jsElement = document.createElement('script');
+  jsElement.src = url;
+  jsElement.type = 'text/javascript';
 
-	var head = document.head;
-	head.insertBefore(jsElement, head.childNodes[0]);
+  var head = document.head;
+  head.insertBefore(jsElement, head.childNodes[0]);
 }
 
 //Imports a single CSS file
 function importCSSFile(url) {
-	var cssElement = document.createElement('link');
-	cssElement.href = url;
-	cssElement.rel = 'stylesheet';
-	cssElement.type = 'text/css';
+  var cssElement = document.createElement('link');
+  cssElement.href = url;
+  cssElement.rel = 'stylesheet';
+  cssElement.type = 'text/css';
 
-	var head = document.head;
-	head.insertBefore(cssElement, head.childNodes[0]);
+  var head = document.head;
+  head.insertBefore(cssElement, head.childNodes[0]);
 }
 ```
 
@@ -90,9 +96,10 @@ For detailed information on the header contents, see [this Confluence page](http
 For guidance on how to use the consistent header in a variety of scenarios, see the [Additional Guidelines](https://cms.invisionapp.com/dsm/cms/mgov-design-system/nav/5fa7da3f7044bd0018240ddb/asset/5fa15ef85296b21c9eb14293/tab/design?mode=preview).
 
 ### Usage
+
 Implementers should create a `div` with the id of `root` and supply it with the required attributes(listed below), and import the correct Javascript and CSS files, which will attach the header to the div. A list of resources to import can be found in the `entrypoints` section of the `asset-manifest.json` file for each environment.
 
-### Authenticated and Guest Headers 
+### Authenticated and Guest Headers
 
 Use the authenticated headers – named "Auth Headers" in the symbols – for scenarios where a user is logged in. The user's first name should appear in the menu item listed as "First name." Only the first letter of their name is capitalized.
 
@@ -100,7 +107,7 @@ Use the authenticated headers – named "Auth Headers" in the symbols – for sc
   <img src={consistentHeaderLoggedInImg} alt="" class="ds-u-border--1" />
 </div>
 
-Use the guest headers – named "Guest Headers" in the symbols – for scenarios where a user is not logged in. This is no customization when 
+Use the guest headers – named "Guest Headers" in the symbols – for scenarios where a user is not logged in. This is no customization when
 
 <div className="ds-u-measure--wide ds-u-margin-top--2">
   <img src={consistentHeaderGuestImg} alt="" class="ds-u-border--1" />
@@ -174,7 +181,7 @@ Based on where a user is on the site, an underline will display below the sectio
   <img src={consistentHeaderCurrentSectionImg} alt="" class="ds-u-border--1" />
 </div>
 
-### Slide-out Menus (Tablet and Mobile Only) 
+### Slide-out Menus (Tablet and Mobile Only)
 
 Each of the slide-out menu symbols for tablet and mobile include the dark background and will scale to any screen size.
 
@@ -182,14 +189,13 @@ Each of the slide-out menu symbols for tablet and mobile include the dark backgr
   <img src={consistentHeaderSlideOutImg} alt="" class="ds-u-border--1" />
 </div>
 
-
 ### Z-index
 
 To ensure users always have, you'll need consider the z-index for the header. Components like modals and slide-out menus should display in front of the Consistent Header. While components like page-level banners, sub-navigation should display behind the Consistent Header. Most of the sections below show examples of how the header should render relative to other elements.
 
 ### Sub-navigation
 
-Sub-navigation menu items should display below and behind the Consistent Header. 
+Sub-navigation menu items should display below and behind the Consistent Header.
 
 <div className="ds-u-measure--wide ds-u-margin-top--2">
   <img src={consistentHeaderSubNavImg} alt="" class="ds-u-border--1" />
@@ -218,8 +224,6 @@ Toast notifications should appear below the Medicare Header with a 10px top marg
 <div className="ds-u-measure--wide ds-u-margin-top--2">
   <img src={consistentHeaderToastImg} alt="" class="ds-u-border--1" />
 </div>
-
-
 
 ### FAQ
 

--- a/packages/docs/content/components/icon.mdx
+++ b/packages/docs/content/components/icon.mdx
@@ -11,11 +11,9 @@ medicare:
 
 import { CloseIcon, SvgIcon } from '@cmsgov/design-system';
 
-
 <ThemeContent onlyThemes={['healthcare']}>
 
 Icons are a key part of the user interface. They are language-independent and can help users efficiently navigate and perform desired tasks. They can describe an action better than words alone; communicating concepts faster and in less space than text, reducing cognitive load.
-
 
 They require a careful balance when applied. When used thoughtfully, icons help users understand your interface quickly and easily. When icons are overdone, they crowd the interface and add unnecessary complexity and confuse users instead of guiding them.
 
@@ -92,15 +90,13 @@ In the example below, the `<SvgIcon>` component is used with a custom path.
 
 ### React
 
-<PropTable componentName="SvgIcon" />
+<SeeStorybookForReactGuidance storyId={'components-icons--docs'} />
 
 ### Styles
 
 The following CSS variables can be overridden to customize Icon components:
 
-<ComponentThemeOptions
-  componentname="icon"
-/>
+<ComponentThemeOptions componentname="icon" />
 
 ## Guidance
 
@@ -108,15 +104,22 @@ The following CSS variables can be overridden to customize Icon components:
 
 ## Guidance
 
-- <b>Use icons sparingly</b> - Only use if they add value/meaning for the user. Too many icons = users stop paying attention.
-- <b>Use the approved icon for similar actions/purpose</b> - Consistency across the entire site is key for user recognition and trust. 
+- <b>Use icons sparingly</b> - Only use if they add value/meaning for the user. Too many icons = users
+  stop paying attention.
+- <b>Use the approved icon for similar actions/purpose</b> - Consistency across the entire site is key
+  for user recognition and trust.{' '}
 - <b>Include a text label with most icons</b> - Users need text to overcome ambiguity.
-- <b>Any new icons or changes in use case need prior approval</b> - Contact the internal CMS Design Guild early in your design process. (See "Foundations" page for process.)
--- Specialty icons for similar use cases are rare. Requests will be considered on a case-by-case basis. In reviewing requests, we'll consider use case, similar icons already approved, and impact to users (UX, consistency, Medicare brand, purpose, and accompanying message impact - like immediate & severe bene harm).
-- <b>Icons can be teal, navy, or black (following approved M.gov DS color swatches) unless stated in the use case notes below.</b>
+- <b>Any new icons or changes in use case need prior approval</b> - Contact the internal CMS Design Guild
+  early in your design process. (See "Foundations" page for process.) -- Specialty icons for similar
+  use cases are rare. Requests will be considered on a case-by-case basis. In reviewing requests, we'll
+  consider use case, similar icons already approved, and impact to users (UX, consistency, Medicare brand,
+  purpose, and accompanying message impact - like immediate & severe bene harm).
+- <b>
+    Icons can be teal, navy, or black (following approved M.gov DS color swatches) unless stated in
+    the use case notes below.
+  </b>
 
 </ThemeContent>
-
 
 ### Accessibility
 

--- a/packages/docs/content/components/icon.mdx
+++ b/packages/docs/content/components/icon.mdx
@@ -4,7 +4,7 @@ intro: Icons help communicate meaning, actions, status, or feedback.
 core:
   githubLink: design-system/src/components/Icons
   sketchLink: ZOm83Y3
-  storybookLink: components-icons--available-icons
+  storybookLink: components-icons--docs
 medicare:
   githubLink: ds-medicare-gov/src/components/Icons
 ---

--- a/packages/docs/content/components/idle-timeout.mdx
+++ b/packages/docs/content/components/idle-timeout.mdx
@@ -3,7 +3,7 @@ title: Idle Timeout
 intro: A component that counts down to the end of a session (behind the scenes) and shows a warning message after a set amount of time of inactivity.
 core:
   githubLink: design-system/src/components/IdleTimeout
-  storybookLink: components-idle-timeout--default
+  storybookLink: components-idle-timeout--docs
 ---
 
 ## Examples
@@ -24,9 +24,7 @@ core:
 
 The following CSS variables can be overridden to customize Dialog components:
 
-<ComponentThemeOptions
-  componentname="dialog"
-/>
+<ComponentThemeOptions componentname="dialog" />
 
 ## Guidance
 

--- a/packages/docs/content/components/idle-timeout.mdx
+++ b/packages/docs/content/components/idle-timeout.mdx
@@ -18,7 +18,7 @@ core:
 
 ### React
 
-<PropTable componentName="IdleTimeout" />
+<SeeStorybookForReactGuidance storyId={'components-idle-timeout--docs'} />
 
 ### Customization
 

--- a/packages/docs/content/components/inset.mdx
+++ b/packages/docs/content/components/inset.mdx
@@ -4,13 +4,15 @@ intro: The Inset component is meant to draw attention to important content, or t
 healthcare:
   githubLink: ds-healthcare-gov/src/styles/components/_Inset.scss
 ---
+
 import loremIpsumGenerator from '../../src/helpers/loremIpsumGenerator';
 import { Alert } from '@cmsgov/design-system';
 
 <ThemeContent neverThemes={['healthcare']}>
   <Alert variation="error">
-     <p class="ds-c-alert__text">
-        This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.
+    <p class="ds-c-alert__text">
+      This component is only used for HealthCare. Please use the theme switcher to view the
+      component with HealthCare styles.
     </p>
   </Alert>
 </ThemeContent>
@@ -18,9 +20,9 @@ import { Alert } from '@cmsgov/design-system';
 ## Examples
 
 <EmbeddedExample>
-    <p class="ds-text">{loremIpsumGenerator('m')}</p>
-    <p class="hc-c-inset ds-text">{loremIpsumGenerator('l')}</p>
-    <p class="ds-text">{loremIpsumGenerator('m')}</p>
+  <p class="ds-text">{loremIpsumGenerator('m')}</p>
+  <p class="hc-c-inset ds-text">{loremIpsumGenerator('l')}</p>
+  <p class="ds-text">{loremIpsumGenerator('m')}</p>
 </EmbeddedExample>
 
 ## Guidance

--- a/packages/docs/content/components/logos/healthcare-logo.mdx
+++ b/packages/docs/content/components/logos/healthcare-logo.mdx
@@ -1,9 +1,10 @@
 ---
 title: Healthcare.gov Logo
-intro: Renders the HealthCare.gov logo in English (default) or Spanish. 
+intro: Renders the HealthCare.gov logo in English (default) or Spanish.
 healthcare:
   githubLink: ds-healthcare-gov/src/components/Logo
   sketchLink: g0k9E3J
+  storybookLink: healthcare-logo--docs
 ---
 
 import { Alert } from '@cmsgov/design-system';
@@ -21,45 +22,43 @@ import greyLogoTag from '../../../src/images/HCgov-logo/GreyLogoTag.png';
 
 <ThemeContent neverThemes={['healthcare']}>
   <Alert variation="error">
-     <p class="ds-c-alert__text">
-        This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.
+    <p class="ds-c-alert__text">
+      This component is only used for HealthCare. Please use the theme switcher to view the
+      component with HealthCare styles.
     </p>
   </Alert>
 </ThemeContent>
 
 In keeping with our theme of trust, the HealthCare.gov identity marker establishes a universal signature across all HealthCare.gov communications. We treat the marker the same across all media. See the rules to follow when using the HealthCare.gov identity marker below.
 
-The Health Insurance Marketplace, the authenticated application where consumers buy insurance, uses a separate and distinct logo. This logo appears in the HealthCare.gov footer. 
+The Health Insurance Marketplace, the authenticated application where consumers buy insurance, uses a separate and distinct logo. This logo appears in the HealthCare.gov footer.
 
 To ensure that our identity marker is clearly discernable, it requires space as shown below, free of type, graphics, and other elements that might cause visual clutter. There is also a Spanish version of the marker.
 
 ## Examples
 
 ### English
-<StorybookExample
-    componentName="hgovLogo"
-    storyId="healthcare-logo--english-logo"
-/>
+
+<StorybookExample componentName="hgovLogo" storyId="healthcare-logo--english-logo" />
 
 ### Spanish
-<StorybookExample
-    componentName="hgovLogoSpanish"
-    storyId="healthcare-logo--spanish-logo"
-/>
 
+<StorybookExample componentName="hgovLogoSpanish" storyId="healthcare-logo--spanish-logo" />
 
 ### Variations
 
 There are two variations of the HealthCare.gov identity marker that should be used sparingly. The first is a white logo against black. The second is a gray version. Both are intended to be used as "tags" in areas such as a footer where subtle use of the mark is appropriate.
 
 #### White logo on black
+
 <EmbeddedExample>
-<img src={blackLogoTag} />
+  <img src={blackLogoTag} />
 </EmbeddedExample>
 
 #### Grey logo
+
 <EmbeddedExample>
-<img src={greyLogoTag} />
+  <img src={greyLogoTag} />
 </EmbeddedExample>
 
 ### Favicon
@@ -67,7 +66,7 @@ There are two variations of the HealthCare.gov identity marker that should be us
 A dark blue HealthCare.gov favicon appears on all HealthCare.gov web pages.
 
 <EmbeddedExample>
-<img src={hcgovFavicon} />
+  <img src={hcgovFavicon} />
 </EmbeddedExample>
 
 ## Code
@@ -86,7 +85,6 @@ Available classes:
 - `.hc-c-logo__care`
 - `.hc-c-logo__gov`
 
-
 ## Guidance
 
 ### Usage
@@ -95,16 +93,15 @@ Available classes:
 
 ### Incorrect usage
 
-| Style        | Example                                   |
-| ----------- | ----------------------------------------- |
-| <CloseIconThin class='ds-c-icon-color--error' /> Color background        | <img src={colorBackground} alt="Healthcage.gov logo incorrectly used on a blue background"/> |
-| <CloseIconThin class='ds-c-icon-color--error' /> Photographic background        | <img src={photoBackground} alt="Healthcage.gov logo incorrectly used on a photographic background"/> |
-| <CloseIconThin class='ds-c-icon-color--error' /> White against color        |   <img src={reversed} alt="White Healthcage.gov logo incorrectly used on a blue background"/> |
-| <CloseIconThin class='ds-c-icon-color--error' /> Drop shadow        |   <img src={dropshadow} alt="Healthcage.gov logo incorrectly used with a drop shadow"/> |
-| <CloseIconThin class='ds-c-icon-color--error' /> Other colors        | <img src={differentColors} alt="Healthcage.gov logo incorrectly used with tan and teal colors"/> |
-| <CloseIconThin class='ds-c-icon-color--error' /> Outlined        | <img src={outlined} alt="Healthcage.gov logo incorrectly used with a blue outline of the logo"/> |
-| <CloseIconThin class='ds-c-icon-color--error' /> Squeezed        | <img src={squeezed} alt="Healthcage.gov logo incorrectly used with the logo squeezed"/> |
-
+| Style                                                                    | Example                                                                                              |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| <CloseIconThin class='ds-c-icon-color--error' /> Color background        | <img src={colorBackground} alt="Healthcage.gov logo incorrectly used on a blue background"/>         |
+| <CloseIconThin class='ds-c-icon-color--error' /> Photographic background | <img src={photoBackground} alt="Healthcage.gov logo incorrectly used on a photographic background"/> |
+| <CloseIconThin class='ds-c-icon-color--error' /> White against color     | <img src={reversed} alt="White Healthcage.gov logo incorrectly used on a blue background"/>          |
+| <CloseIconThin class='ds-c-icon-color--error' /> Drop shadow             | <img src={dropshadow} alt="Healthcage.gov logo incorrectly used with a drop shadow"/>                |
+| <CloseIconThin class='ds-c-icon-color--error' /> Other colors            | <img src={differentColors} alt="Healthcage.gov logo incorrectly used with tan and teal colors"/>     |
+| <CloseIconThin class='ds-c-icon-color--error' /> Outlined                | <img src={outlined} alt="Healthcage.gov logo incorrectly used with a blue outline of the logo"/>     |
+| <CloseIconThin class='ds-c-icon-color--error' /> Squeezed                | <img src={squeezed} alt="Healthcage.gov logo incorrectly used with the logo squeezed"/>              |
 
 ## Component maturity
 
@@ -122,4 +119,3 @@ Available classes:
   tokensInCode={true}
   tokensInSketch={true}
 />
-

--- a/packages/docs/content/components/logos/healthcare-logo.mdx
+++ b/packages/docs/content/components/logos/healthcare-logo.mdx
@@ -73,7 +73,7 @@ A dark blue HealthCare.gov favicon appears on all HealthCare.gov web pages.
 
 ### React
 
-<PropTable componentName="Logo" />
+<SeeStorybookForReactGuidance storyId={'healthcare-logo--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/logos/hhs-logo.mdx
+++ b/packages/docs/content/components/logos/hhs-logo.mdx
@@ -3,22 +3,18 @@ title: HHS Logo
 intro: Renders the HHS logo.
 core:
   githubLink: design-system/src/components/Icons/HhsLogo.tsx
-  storybookLink: components-icons--hhs-logo
+  storybookLink: components-icons--docs
 ---
 
 ## Examples
 
-<StorybookExample
-    componentName="hhsLogo"
-    storyId="components-icons--hhs-logo"
-/>
+<StorybookExample componentName="hhsLogo" storyId="components-icons--hhs-logo" />
 
 ## Code
 
 ### React
 
 <PropTable componentName="SvgIcon" />
-
 
 ## Component maturity
 

--- a/packages/docs/content/components/logos/hhs-logo.mdx
+++ b/packages/docs/content/components/logos/hhs-logo.mdx
@@ -14,7 +14,7 @@ core:
 
 ### React
 
-<PropTable componentName="SvgIcon" />
+<SeeStorybookForReactGuidance storyId={'components-icons--docs'} />
 
 ## Component maturity
 

--- a/packages/docs/content/components/logos/medicare-logo.mdx
+++ b/packages/docs/content/components/logos/medicare-logo.mdx
@@ -4,31 +4,29 @@ intro: Renders the Medicare.gov logo.
 medicare:
   githubLink: ds-medicare-gov/src/components/MedicaregovLogo
   sketchLink: nRzKJna
-  storybookLink: medicare-logo--logo
+  storybookLink: medicare-logo--docs
 ---
+
 import { Alert } from '@cmsgov/design-system';
 
 <ThemeContent neverThemes={['medicare']}>
   <Alert variation="error">
-     <p class="ds-c-alert__text">
-        This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.
+    <p class="ds-c-alert__text">
+      This component is only used for Medicare. Please use the theme switcher to view the component
+      with Medicare styles.
     </p>
   </Alert>
 </ThemeContent>
 
 ## Examples
 
-<StorybookExample
-    componentName="medicareLogo"
-    storyId="medicare-logo--logo"
-/>
+<StorybookExample componentName="medicareLogo" storyId="medicare-logo--logo" />
 
 ## Code
 
 ### React
 
 <PropTable componentName="MedicaregovLogo" />
-
 
 ## Component maturity
 

--- a/packages/docs/content/components/logos/medicare-logo.mdx
+++ b/packages/docs/content/components/logos/medicare-logo.mdx
@@ -26,7 +26,7 @@ import { Alert } from '@cmsgov/design-system';
 
 ### React
 
-<PropTable componentName="MedicaregovLogo" />
+<SeeStorybookForReactGuidance storyId={'medicare-logo--docs'} />
 
 ## Component maturity
 

--- a/packages/docs/content/components/modal-dialog.mdx
+++ b/packages/docs/content/components/modal-dialog.mdx
@@ -41,7 +41,7 @@ Apply one of the size modifier classes to the `ds-c-dialog` element to change th
 
 ### React
 
-<PropTable componentName="Dialog" hasAnalytics />
+<SeeStorybookForReactGuidance storyId={'components-dialog--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/modal-dialog.mdx
+++ b/packages/docs/content/components/modal-dialog.mdx
@@ -4,12 +4,12 @@ intro: The dialog component can be used to focus a user's attention on a single 
 core:
   githubLink: design-system/src/components/Dialog
   sketchLink: Jn3kY4k
-  storybookLink: components-dialog--dialog-example
+  storybookLink: components-dialog--docs
 healthcare:
   sketchLink: m1Y5wQ7
 medicare:
   sketchLink: YGOggo0
-  storybookLink: medicare-dialog--dialog-example
+  storybookLink: medicare-dialog--docs
 ---
 
 ## Examples
@@ -47,9 +47,7 @@ Apply one of the size modifier classes to the `ds-c-dialog` element to change th
 
 The following CSS variables can be overridden to customize Dialog components:
 
-<ComponentThemeOptions
-  componentname="dialog"
-/>
+<ComponentThemeOptions componentname="dialog" />
 
 ### Analytics
 

--- a/packages/docs/content/components/month-picker.mdx
+++ b/packages/docs/content/components/month-picker.mdx
@@ -23,7 +23,7 @@ The Month Picker component renders a grid of checkboxes with shortened month nam
 
 ### React
 
-<PropTable componentName="MonthPicker" />
+<SeeStorybookForReactGuidance storyId={'components-month-picker--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/month-picker.mdx
+++ b/packages/docs/content/components/month-picker.mdx
@@ -3,7 +3,7 @@ title: Month Picker
 core:
   githubLink: design-system/src/components/MonthPicker
   sketchLink: v8Gp7l4
-  storybookLink: components-month-picker--default-month-picker
+  storybookLink: components-month-picker--docs
 healthcare:
   sketchLink: DPag8Aj
 medicare:
@@ -29,17 +29,13 @@ The Month Picker component renders a grid of checkboxes with shortened month nam
 
 The following CSS variables can be overridden to customize MonthPicker fields:
 
-<ComponentThemeOptions
-  componentname="choice"
-/>
+<ComponentThemeOptions componentname="choice" />
 
 ### Form components
 
 This component also makes use of form field styles, which can be customized by the following variables:
 
-<ComponentThemeOptions
-  componentname="form"
-/>
+<ComponentThemeOptions componentname="form" />
 
 ## Component maturity
 

--- a/packages/docs/content/components/pagination.mdx
+++ b/packages/docs/content/components/pagination.mdx
@@ -4,7 +4,7 @@ intro: Pagination is navigation for paginated content.
 core:
   githubLink: design-system/src/components/Pagination
   sketchLink: 4a3Mj1D
-  storybookLink: components-pagination--default
+  storybookLink: components-pagination--docs
 healthcare:
   sketchLink: agmKV3d
 medicare:
@@ -13,10 +13,7 @@ medicare:
 
 ## Examples
 
-<StorybookExample
-  componentName="pagination"
-  storyId="components-pagination--default"
-/>
+<StorybookExample componentName="pagination" storyId="components-pagination--default" />
 
 ## Code
 
@@ -32,9 +29,7 @@ Pagination also comes in two styles: default, which is compact on mobile viewpor
 
 The following CSS variables can be overridden to customize Pagination components:
 
-<ComponentThemeOptions
-  componentname="pagination"
-/>
+<ComponentThemeOptions componentname="pagination" />
 
 ## Guidance
 

--- a/packages/docs/content/components/pagination.mdx
+++ b/packages/docs/content/components/pagination.mdx
@@ -23,7 +23,7 @@ Pagination requires three properties: `totalPages`, which is the total number of
 
 Pagination also comes in two styles: default, which is compact on mobile viewports and expands to reveal individual pages on larger viewports, and `compact`, which maintains the compact layout regardless of viewport size.
 
-<PropTable componentName="Pagination" />
+<SeeStorybookForReactGuidance storyId={'components-pagination--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/radio.mdx
+++ b/packages/docs/content/components/radio.mdx
@@ -4,7 +4,7 @@ intro: Radio buttons allow users to select exactly one choice from a group.
 core:
   githubLink: design-system/src/components/ChoiceList
   sketchLink: eKVZm2P
-  storybookLink: components-choicelist--default-radio
+  storybookLink: components-choicelist--docs
 healthcare:
   sketchLink: paqdxPr
 medicare:
@@ -55,17 +55,13 @@ Note that each of the items in the `choices` array represents props that will be
 
 The following CSS variables can be overridden to customize choice fields:
 
-<ComponentThemeOptions
-  componentname="choice"
-/>
+<ComponentThemeOptions componentname="choice" />
 
 #### Form components
 
 This component also makes use of form field styles, which can be customized by the following variables:
 
-<ComponentThemeOptions
-  componentname="form"
-/>
+<ComponentThemeOptions componentname="form" />
 
 ## Guidance
 

--- a/packages/docs/content/components/review.mdx
+++ b/packages/docs/content/components/review.mdx
@@ -19,7 +19,7 @@ The `Review` component wraps up the styles and markup required to make a single 
 
 ### React
 
-<PropTable componentName="Review" />
+<SeeStorybookForReactGuidance storyId={'components-review--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/review.mdx
+++ b/packages/docs/content/components/review.mdx
@@ -4,7 +4,7 @@ intro: The review pattern is used for listing a summary of information entered b
 core:
   githubLink: design-system/src/components/Review
   sketchLink: YGOgW9L
-  storybookLink: components-review--multiple-reviews
+  storybookLink: components-review--docs
 healthcare:
   sketchLink: WKjAZvw
 ---

--- a/packages/docs/content/components/skip-nav.mdx
+++ b/packages/docs/content/components/skip-nav.mdx
@@ -19,7 +19,7 @@ Make sure you include an `id` at the beginning of your main content and that it 
 
 ### React
 
-<PropTable componentName="SkipNav" />
+<SeeStorybookForReactGuidance storyId={'components-skip-nav--docs'} />
 
 ## Guidance
 

--- a/packages/docs/content/components/skip-nav.mdx
+++ b/packages/docs/content/components/skip-nav.mdx
@@ -4,17 +4,14 @@ intro: Skip navigation links allow users with screen readers to bypass long navi
 core:
   githubLink: design-system/src/components/SkipNav
   sketchLink: Gm3E1DO
-  storybookLink: components-skip-nav--skip-nav-example
+  storybookLink: components-skip-nav--docs
 healthcare:
   sketchLink: VrPazJr
 ---
 
 ## Examples
 
-<StorybookExample
-  componentName="pagination"
-  storyId="components-skip-nav--skip-nav-example"
-/>
+<StorybookExample componentName="pagination" storyId="components-skip-nav--skip-nav-example" />
 
 ## Code
 

--- a/packages/docs/content/components/spinner.mdx
+++ b/packages/docs/content/components/spinner.mdx
@@ -73,7 +73,7 @@ To provide more contrast when being rendered over other content, the `.ds-c-spin
 
 ### React
 
-<PropTable componentName="Spinner" />
+<SeeStorybookForReactGuidance storyId={'components-spinner--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/spinner.mdx
+++ b/packages/docs/content/components/spinner.mdx
@@ -4,7 +4,7 @@ intro: Spinners signify that the application is waiting for an asynchronous oper
 core:
   githubLink: design-system/src/components/Spinner
   sketchLink: OmxV71m
-  storybookLink: components-spinner--default-spinner
+  storybookLink: components-spinner--docs
 healthcare:
   sketchLink: YGzlveZ
 ---
@@ -14,10 +14,7 @@ import loremIpsumGenerator from '../../src/helpers/loremIpsumGenerator';
 
 ## Examples
 
-<StorybookExample
-  componentName="spinner"
-  storyId="components-spinner--default-spinner"
-/>
+<StorybookExample componentName="spinner" storyId="components-spinner--default-spinner" />
 
 ### Changing the spinner color
 
@@ -82,9 +79,7 @@ To provide more contrast when being rendered over other content, the `.ds-c-spin
 
 The following CSS variables can be overridden to customize Spinner components:
 
-<ComponentThemeOptions
-  componentname="spinner"
-/>
+<ComponentThemeOptions componentname="spinner" />
 
 ## Guidance
 

--- a/packages/docs/content/components/stars.mdx
+++ b/packages/docs/content/components/stars.mdx
@@ -2,24 +2,23 @@
 title: Stars (M.gov)
 medicare:
   githubLink: ds-medicare-gov/src/components/Stars
-  storybookLink: medicare-stars--default
+  storybookLink: medicare-stars--docs
 ---
+
 import { Alert } from '@cmsgov/design-system';
 
 <ThemeContent neverThemes={['medicare']}>
   <Alert variation="error">
-     <p class="ds-c-alert__text">
-        This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.
+    <p class="ds-c-alert__text">
+      This component is only used for Medicare. Please use the theme switcher to view the component
+      with Medicare styles.
     </p>
   </Alert>
 </ThemeContent>
 
 ## Examples
 
-<StorybookExample
-    componentName="stars"
-    storyId="medicare-stars--default"
-/>
+<StorybookExample componentName="stars" storyId="medicare-stars--default" />
 
 ## Code
 

--- a/packages/docs/content/components/stars.mdx
+++ b/packages/docs/content/components/stars.mdx
@@ -24,7 +24,7 @@ import { Alert } from '@cmsgov/design-system';
 
 ### React
 
-<PropTable componentName="Stars" />
+<SeeStorybookForReactGuidance storyId={'medicare-stars--docs'} />
 
 ## Component maturity
 

--- a/packages/docs/content/components/step-list.mdx
+++ b/packages/docs/content/components/step-list.mdx
@@ -4,7 +4,7 @@ intro: A step list represents a user's progression through an application or mul
 core:
   githubLink: design-system/src/components/StepList
   sketchLink: Kv3oKlr
-  storybookLink: patterns-step-list--step-list-example
+  storybookLink: patterns-step-list--docs
 healthcare:
   sketchLink: 3OL0DZa
 ---
@@ -15,10 +15,7 @@ import { Badge } from '@cmsgov/design-system';
 
 The `StepList` component is the preferred method for building a step list, since it handles all the state logic necessary to produce its markup. A step is represented by an object with text, progress, and routing information and can optionally include an array of substeps as well as a description.
 
-<StorybookExample
-  componentName="step-list"
-  storyId="patterns-step-list--step-list-example"
-/>
+<StorybookExample componentName="step-list" storyId="patterns-step-list--step-list-example" />
 
 ## Code
 
@@ -34,9 +31,7 @@ The `StepList` component is the preferred method for building a step list, since
 
 The following CSS variables can be overridden to customize StepList patterns:
 
-<ComponentThemeOptions
-  componentname="steplist"
-/>
+<ComponentThemeOptions componentname="steplist" />
 
 #### Step Object
 

--- a/packages/docs/content/components/table.mdx
+++ b/packages/docs/content/components/table.mdx
@@ -4,7 +4,7 @@ intro: Tables show tabular data in columns and rows.
 core:
   githubLink: design-system/src/components/Table
   sketchLink: m19DRAP
-  storybookLink: components-table--scrollable-table
+  storybookLink: components-table--docs
 healthcare:
   sketchLink: L0pzWyl
 medicare:
@@ -20,26 +20,11 @@ import {
   TableRow,
 } from '@cmsgov/design-system';
 
-
 ## Examples
 
 ### Table with multi headers and a caption
 
-<StorybookExample
-  componentName="table"
-  storyId="components-table--multi-header-table"
-/>
-
-### Scrollable Table
-
-<ResponsiveExample title="Scrollable table example" storyId="components-table--scrollable-table" />
-
-### Stackable Table
-
-<ResponsiveExample
-  componentName="stackable table example"
-  storyId="components-table--stackable-table"
-/>
+<StorybookExample componentName="table" storyId="components-table--multi-header-table" />
 
 ## Code
 
@@ -85,9 +70,7 @@ responsive features including horizontal scrolling and vertically stacked rows.
 
 The following CSS variables can be overridden to customize Table components:
 
-<ComponentThemeOptions
-  componentname="table"
-/>
+<ComponentThemeOptions componentname="table" />
 
 ## Guidance
 

--- a/packages/docs/content/components/tabs.mdx
+++ b/packages/docs/content/components/tabs.mdx
@@ -4,7 +4,7 @@ intro: Tabs are a secondary navigation pattern, allowing a user to view only the
 core:
   githubLink: design-system/src/components/Tabs
   sketchLink: DPQmkG4
-  storybookLink: components-tabs--default-tabs
+  storybookLink: components-tabs--docs
 healthcare:
   sketchLink: 7yPRdeb
 medicare:
@@ -13,11 +13,7 @@ medicare:
 
 ## Examples
 
-<StorybookExample
-  componentName="tabs"
-  storyId="components-tabs--default-tabs"
-  minHeight={400}
-/>
+<StorybookExample componentName="tabs" storyId="components-tabs--default-tabs" minHeight={400} />
 
 ## Code
 
@@ -39,9 +35,7 @@ A `TabPanel` is a presentational component which accepts a tab's content as its 
 
 The following CSS variables can be overridden to customize Tab components:
 
-<ComponentThemeOptions
-  componentname="tabs"
-/>
+<ComponentThemeOptions componentname="tabs" />
 
 ## Guidance
 

--- a/packages/docs/content/components/text-field/label-masked-field.mdx
+++ b/packages/docs/content/components/text-field/label-masked-field.mdx
@@ -36,7 +36,7 @@ The label-mask currently has five built-in implementations: _currency_, _phone n
 
 Passing a `labelMask` prop into a [`TextField`](/components/text-field/) component with a valid masking function will turn it into a label mask. You can either import one of the named, built-in mask functions (`SSN_MASK`, `ZIP_MASK`, `PHONE_MASK`, or `CURRENCY_MASK`), or you can provide a custom mask function. The following table shows the `TextField` prop that is specific to label masks:
 
-<PropTable componentName="TextField" subset={['labelMask']} />
+<SeeStorybookForReactGuidance storyId={'components-text-field--docs'} />
 
 #### Handling input changes
 

--- a/packages/docs/content/components/text-field/label-masked-field.mdx
+++ b/packages/docs/content/components/text-field/label-masked-field.mdx
@@ -3,7 +3,7 @@ title: Label-Masked Field
 intro: A label-masked field is a text-field pattern that provides instant, visual feedback about how inputed data is being interpreted without creating a noisy aural experience.
 core:
   githubLink: design-system/src/components/LabelMask
-  storybookLink: components-text-field--label-masked-currency
+  storybookLink: components-text-field--docs
 ---
 
 ## Examples
@@ -16,39 +16,27 @@ The label-mask currently has five built-in implementations: _currency_, _phone n
 
 ### Currency
 
-<StorybookExample
-  componentName="currency"
-  storyId="components-text-field--label-masked-currency"
-/>
+<StorybookExample componentName="currency" storyId="components-text-field--label-masked-currency" />
 
 ### Phone number
 
-<StorybookExample
-  componentName="phone"
-  storyId="components-text-field--label-masked-phone"
-/>
+<StorybookExample componentName="phone" storyId="components-text-field--label-masked-phone" />
 
 ### Social Security number
 
-<StorybookExample
-  componentName="ssn"
-  storyId="components-text-field--label-masked-ssn"
-/>
+<StorybookExample componentName="ssn" storyId="components-text-field--label-masked-ssn" />
 
 ### ZIP code
 
-<StorybookExample
-  componentName="zip"
-  storyId="components-text-field--label-masked-postal-code"
-/>
+<StorybookExample componentName="zip" storyId="components-text-field--label-masked-postal-code" />
 
-## Code 
+## Code
 
 ### React
 
 Passing a `labelMask` prop into a [`TextField`](/components/text-field/) component with a valid masking function will turn it into a label mask. You can either import one of the named, built-in mask functions (`SSN_MASK`, `ZIP_MASK`, `PHONE_MASK`, or `CURRENCY_MASK`), or you can provide a custom mask function. The following table shows the `TextField` prop that is specific to label masks:
 
-<PropTable componentName="TextField" subset={["labelMask"]} />
+<PropTable componentName="TextField" subset={['labelMask']} />
 
 #### Handling input changes
 

--- a/packages/docs/content/components/text-field/masked-field.mdx
+++ b/packages/docs/content/components/text-field/masked-field.mdx
@@ -22,7 +22,7 @@ Passing a `mask` prop into the `TextField` component with a valid value will
 enable formatting to occur when the field is blurred. To "unmask" the
 value, you can import and call the `unmaskValue` method.
 
-<PropTable componentName="TextField" />
+<SeeStorybookForReactGuidance storyId={'components-text-field--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/text-field/masked-field.mdx
+++ b/packages/docs/content/components/text-field/masked-field.mdx
@@ -3,7 +3,7 @@ title: Masked Field
 intro: A masked field is an enhanced input field that improves readability by providing visual and non-visual cues to a user about the expected value.
 core:
   githubLink: design-system/src/components/TextField
-  storybookLink: components-text-field--all-masked-fields
+  storybookLink: components-text-field--docs
 ---
 
 import { TextField, unmaskValue } from '@cmsgov/design-system';
@@ -12,12 +12,9 @@ import { TextField, unmaskValue } from '@cmsgov/design-system';
 
 A Mask component renders a controlled input field that applies formatting to the input value when the field is blurred.
 
-<StorybookExample
-  componentName="text-field"
-  storyId="components-text-field--all-masked-fields"
-/>
+<StorybookExample componentName="text-field" storyId="components-text-field--all-masked-fields" />
 
-## Code 
+## Code
 
 ### React
 
@@ -31,17 +28,13 @@ value, you can import and call the `unmaskValue` method.
 
 The following CSS variables can be overridden to customize Input/Form components:
 
-<ComponentThemeOptions
-  componentname="text-input"
-/>
+<ComponentThemeOptions componentname="text-input" />
 
 #### Form components
 
 This component uses a text field and its styles, which can be customized by the following variables:
 
-<ComponentThemeOptions
-  componentname="form"
-/>
+<ComponentThemeOptions componentname="form" />
 
 ## Component maturity
 

--- a/packages/docs/content/components/text-field/text-field.mdx
+++ b/packages/docs/content/components/text-field/text-field.mdx
@@ -4,13 +4,12 @@ intro: Text fields allow users to enter any combination of letters, numbers, or 
 core:
   githubLink: design-system/src/components/TextField
   sketchLink: oYdAplL
-  storybookLink: components-text-field--single-line-field
+  storybookLink: components-text-field--docs
 healthcare:
   sketchLink: 9PdpZOx
 medicare:
   sketchLink: 9P3rrEM
 ---
-
 
 ## Examples
 
@@ -55,17 +54,13 @@ A `TextField` component renders an input field as well as supporting UI elements
 
 The following CSS variables can be overridden to customize Input/Form components:
 
-<ComponentThemeOptions
-  componentname="text-input"
-/>
+<ComponentThemeOptions componentname="text-input" />
 
 #### Form components
 
 This component also makes use of form field styles, which can be customized by the following variables:
 
-<ComponentThemeOptions
-  componentname="form"
-/>
+<ComponentThemeOptions componentname="form" />
 
 ## Guidance
 

--- a/packages/docs/content/components/text-field/text-field.mdx
+++ b/packages/docs/content/components/text-field/text-field.mdx
@@ -48,7 +48,7 @@ medicare:
 
 A `TextField` component renders an input field as well as supporting UI elements like a label, error message, and hint text.
 
-<PropTable componentName="TextField" />
+<SeeStorybookForReactGuidance storyId={'components-text-field--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/third-party-external-link.mdx
+++ b/packages/docs/content/components/third-party-external-link.mdx
@@ -16,7 +16,7 @@ core:
 
 ### React
 
-<PropTable componentName="ThirdPartyExternalLink" hasAnalytics />
+<SeeStorybookForReactGuidance storyId={'components-thirdpartyexternallink--docs'} />
 
 ### Analytics
 

--- a/packages/docs/content/components/third-party-external-link.mdx
+++ b/packages/docs/content/components/third-party-external-link.mdx
@@ -3,7 +3,7 @@ title: Third Party External Link
 intro: The third party external link component is used to notify a user that the action they are taking will take them to a new external website.
 core:
   githubLink: design-system/src/components/ThirdPartyExternalLink
-  storybookLink: components-thirdpartyexternallink--default
+  storybookLink: components-thirdpartyexternallink--docs
 ---
 
 ## Examples

--- a/packages/docs/content/components/tooltip.mdx
+++ b/packages/docs/content/components/tooltip.mdx
@@ -4,7 +4,7 @@ intro: Tooltips provide additional information upon hover, focus or click. The i
 core:
   githubLink: design-system/src/components/Tooltip
   sketchLink: R1zwPYW
-  storybookLink: components-tooltip--icon-trigger
+  storybookLink: components-tooltip--docs
 healthcare:
   sketchLink: g0k9EVJ
 medicare:
@@ -69,9 +69,7 @@ When using the `<TooltipIcon>` as the only child of `<Tooltip>`, be sure to prov
 
 The following CSS variables can be overridden to customize Tooltip fields:
 
-<ComponentThemeOptions
-  componentname="tooltip"
-/>
+<ComponentThemeOptions componentname="tooltip" />
 
 ## Guidance
 
@@ -83,7 +81,7 @@ The following CSS variables can be overridden to customize Tooltip fields:
 - Words inside a tooltip won't break over lines for legibility.
 - A tooltip link can break over lines, if needed.
 - When the tooltip defines a term: Repeat the linked term at the top of the tool tip (bold styling).<br />
- Have space for next line of text be a soft-return (single line spacing).
+  Have space for next line of text be a soft-return (single line spacing).
 - When the tooltip is just contextual help: Don't include the linked term at the top of the tooltip.
 
 ### Content guidelines

--- a/packages/docs/content/components/usa-banner.mdx
+++ b/packages/docs/content/components/usa-banner.mdx
@@ -32,7 +32,7 @@ healthcare:
 
 ### React
 
-<PropTable componentName="UsaBanner" />
+<SeeStorybookForReactGuidance storyId={'components-usa-banner--docs'} />
 
 ### Styles
 

--- a/packages/docs/content/components/usa-banner.mdx
+++ b/packages/docs/content/components/usa-banner.mdx
@@ -4,7 +4,7 @@ intro: The USA banner identifies official websites of government organizations i
 core:
   githubLink: design-system/src/components/UsaBanner
   sketchLink: paz0Vko
-  storybookLink: components-usa-banner--english-banner
+  storybookLink: components-usa-banner--docs
 healthcare:
   sketchLink: 25qAbzl
 ---
@@ -38,9 +38,7 @@ healthcare:
 
 The following CSS variables can be overridden to customize UsaBanner components:
 
-<ComponentThemeOptions
-  componentname="usa-banner"
-/>
+<ComponentThemeOptions componentname="usa-banner" />
 
 ## Guidance
 

--- a/packages/docs/content/components/vertical-navigation.mdx
+++ b/packages/docs/content/components/vertical-navigation.mdx
@@ -4,11 +4,10 @@ intro: Hierarchical, vertical navigation.
 core:
   githubLink: design-system/src/components/VerticalNav
   sketchLink: 1K9gbq5
-  storybookLink: components-vertical-nav--default-vertical-nav
+  storybookLink: components-vertical-nav--docs
 healthcare:
   sketchLink: 8yj1zGO
 ---
-
 
 ## Examples
 
@@ -33,9 +32,7 @@ A `VerticalNav` component accepts list items as a JSON object and includes addit
 
 The following CSS variables can be overridden to customize VerticalNav components:
 
-<ComponentThemeOptions
-  componentname="vertical-nav"
-/>
+<ComponentThemeOptions componentname="vertical-nav" />
 
 ## Guidance
 
@@ -84,7 +81,7 @@ The following CSS variables can be overridden to customize VerticalNav component
   a11yStandards={true}
   color={true}
   forcedColors={false}
-  screenReaders={true}  
+  screenReaders={true}
   keyboardNavigable={true}
   storybook={true}
   responsive={true}

--- a/packages/docs/src/components/content/ContentRenderer.tsx
+++ b/packages/docs/src/components/content/ContentRenderer.tsx
@@ -6,18 +6,19 @@ import { MDXProvider } from '@mdx-js/react';
 
 import ButtonMigrationTable from './ButtonMigrationTable';
 import ButtonVariationsTable from './ButtonVariationsTable';
-import EmbeddedExample from './EmbeddedExample';
-import StorybookExample from './StorybookExample';
+import ColorExampleList from './ColorExampleList';
+import ColorRamps from './ColorRamps';
 import ComponentThemeOptions from './ComponentThemeOptions';
-import ThemeContent from './ThemeContent';
+import EmbeddedExample from './EmbeddedExample';
+import MaturityChecklist from './MaturityChecklist';
 import PropTable from './PropTable';
 import PropTableHtmlElementRow from './PropTableHtmlElementRow';
 import ResponsiveExample from './ResponsiveExample';
-import ColorExampleList from './ColorExampleList';
-import ColorRamps from './ColorRamps';
-import MaturityChecklist from './MaturityChecklist';
+import SeeStorybookForReactGuidance from './SeeStorybookForReactGuidance';
 import SpacingUtilityExampleList from './SpacingUtilityExampleList';
+import StorybookExample from './StorybookExample';
 import TextColorList from './TextColorList';
+import ThemeContent from './ThemeContent';
 
 // adds DS styling to tables from markdown
 const TableWithClassnames = (props) => {
@@ -66,26 +67,29 @@ const TextWithMaxWidth = (props: any, Component) => {
  * Each mapping has a key with the element name and a value of a functional component to be used for that element
  */
 const customComponents = (theme) => ({
-  table: TableWithClassnames,
+  ButtonMigrationTable: (props) => <ButtonMigrationTable theme={theme} {...props} />,
+  ButtonVariationsTable: (props) => <ButtonVariationsTable theme={theme} {...props} />,
   code: CodeWithSyntaxHighlighting,
-  pre: PreformattedWithLanguageClass,
-  p: (props) => TextWithMaxWidth(props, 'p'),
-  ul: (props) => TextWithMaxWidth(props, 'ul'),
-  ol: (props) => TextWithMaxWidth(props, 'ol'),
+  ColorExampleList: (props) => <ColorExampleList theme={theme} {...props} />,
+  ColorRamps,
+  ComponentThemeOptions: (props) => <ComponentThemeOptions theme={theme} {...props} />,
   EmbeddedExample,
   MaturityChecklist,
-  ColorRamps,
-  StorybookExample: (props) => <StorybookExample theme={theme} {...props} />,
+  ol: (props) => TextWithMaxWidth(props, 'ol'),
+  p: (props) => TextWithMaxWidth(props, 'p'),
+  pre: PreformattedWithLanguageClass,
   PropTable: (props) => <PropTable theme={theme} {...props} />,
   PropTableHtmlElementRow: (props) => <PropTableHtmlElementRow theme={theme} {...props} />,
   ResponsiveExample: (props) => <ResponsiveExample theme={theme} {...props} />,
-  ColorExampleList: (props) => <ColorExampleList theme={theme} {...props} />,
-  TextColorList: (props) => <TextColorList theme={theme} {...props} />,
+  SeeStorybookForReactGuidance: (props) => (
+    <SeeStorybookForReactGuidance theme={theme} {...props} />
+  ),
   SpacingUtilityExampleList: (props) => <SpacingUtilityExampleList theme={theme} {...props} />,
-  ComponentThemeOptions: (props) => <ComponentThemeOptions theme={theme} {...props} />,
+  StorybookExample: (props) => <StorybookExample theme={theme} {...props} />,
+  table: TableWithClassnames,
+  TextColorList: (props) => <TextColorList theme={theme} {...props} />,
   ThemeContent: (props) => <ThemeContent theme={theme} {...props} />,
-  ButtonMigrationTable: (props) => <ButtonMigrationTable theme={theme} {...props} />,
-  ButtonVariationsTable: (props) => <ButtonVariationsTable theme={theme} {...props} />,
+  ul: (props) => TextWithMaxWidth(props, 'ul'),
 });
 
 interface ContentRendererProps {

--- a/packages/docs/src/components/content/EmbeddedExample.tsx
+++ b/packages/docs/src/components/content/EmbeddedExample.tsx
@@ -19,7 +19,7 @@ const EmbeddedExample = ({ children }: EmbeddedExampleProps) => {
   return (
     <section className="c-embedded-example">
       <div className="ds-u-border--1 ds-u-padding--2">{children}</div>
-      <ExampleFooter html={html} />
+      <ExampleFooter />
     </section>
   );
 };

--- a/packages/docs/src/components/content/ExampleFooter.tsx
+++ b/packages/docs/src/components/content/ExampleFooter.tsx
@@ -1,25 +1,6 @@
 import React from 'react';
-/* eslint-disable react/no-danger */
-import { useRef, useState } from 'react';
-import uniqueId from 'lodash/uniqueId';
-import { ArrowIcon, Button } from '@cmsgov/design-system';
-import { highlightHtmlSyntax } from '../../helpers/syntaxHighlighting';
-
-enum SnippetState {
-  CLOSED = 'closed',
-  HTML = 'html',
-  JSX = 'jsx',
-}
 
 interface ExampleFooterProps {
-  /**
-   * html string to prettify, highlight and display
-   */
-  html: string;
-  /**
-   * pre-highlighted jsx html as a string, because we gather it by scraping
-   */
-  highlightedJsx?: string;
   /**
    * A link or something to render to the right of the code button(s)
    */
@@ -29,68 +10,8 @@ interface ExampleFooterProps {
 /**
  * HTML code snippet. This component will prettify an html string and do syntax highlighting
  */
-const ExampleFooter = ({ html, highlightedJsx, sourceLink }: ExampleFooterProps) => {
-  const [snippetState, setSnippetState] = useState<SnippetState>(SnippetState.CLOSED);
-  const highlightedHtml = html && highlightHtmlSyntax(html);
-
-  const snippetIdPrefix = useRef(uniqueId('example-snippet-')).current;
-  const getButtonId = (snippetState: SnippetState) => `${snippetIdPrefix}-${snippetState}-toggle`;
-  const getSnippetId = (snippetState: SnippetState) => `${snippetIdPrefix}-${snippetState}`;
-
-  const buttons = [{ snippetState: SnippetState.HTML, text: 'HTML code' }];
-  const snippets = [{ snippetState: SnippetState.HTML, code: highlightedHtml }];
-
-  if (highlightedJsx) {
-    buttons.unshift({ snippetState: SnippetState.JSX, text: 'React code' });
-    snippets.unshift({ snippetState: SnippetState.JSX, code: highlightedJsx });
-  }
-
-  const codeToggles = buttons.map((buttonConfig) => (
-    <Button
-      key={buttonConfig.snippetState}
-      variation="ghost"
-      size="small"
-      className="c-code-snippet-toggle ds-u-margin-right--2"
-      aria-expanded={buttonConfig.snippetState === snippetState}
-      aria-controls={getSnippetId(buttonConfig.snippetState)}
-      id={getButtonId(buttonConfig.snippetState)}
-      onClick={() =>
-        setSnippetState(
-          buttonConfig.snippetState === snippetState
-            ? SnippetState.CLOSED
-            : buttonConfig.snippetState
-        )
-      }
-    >
-      <ArrowIcon direction="right" /> {buttonConfig.text}
-    </Button>
-  ));
-
-  const codeSnippets = snippets.map((snippetConfig) => (
-    <div
-      key={snippetConfig.snippetState}
-      aria-labelledby={getButtonId(snippetConfig.snippetState)}
-      id={getSnippetId(snippetConfig.snippetState)}
-      hidden={snippetConfig.snippetState !== snippetState}
-    >
-      <pre className="ds-u-margin-bottom--4 ds-u-overflow--auto ds-u-padding--2">
-        <code
-          dangerouslySetInnerHTML={{ __html: snippetConfig.code }}
-          className={`language-${snippetConfig.snippetState}`}
-        />
-      </pre>
-    </div>
-  ));
-
-  return (
-    <div className="c-example-footer">
-      <div className="ds-u-display--flex ds-u-justify-content--between">
-        <div>{codeToggles}</div>
-        <div>{sourceLink}</div>
-      </div>
-      {codeSnippets}
-    </div>
-  );
+const ExampleFooter = ({ sourceLink }: ExampleFooterProps) => {
+  return <div className="c-example-footer">{sourceLink}</div>;
 };
 
 export default ExampleFooter;

--- a/packages/docs/src/components/content/SeeStorybookForReactGuidance.tsx
+++ b/packages/docs/src/components/content/SeeStorybookForReactGuidance.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { makeStorybookUrl } from '../../helpers/urlUtils';
+
+// Create a link component that uses urlUtils to create the link
+// to the storybook page for the component
+
+interface StorybookExampleFooterProps {
+  /**
+   * ID of the component's doc page in Storybook.
+   */
+  storyId: string;
+  /**
+   * Current theme name.
+   */
+  theme: string;
+}
+
+const SeeStorybookForReactGuidance = ({ theme, storyId }: StorybookExampleFooterProps) => {
+  return (
+    <p>
+      See <a href={makeStorybookUrl(storyId, theme, 'docs')}>Storybook</a> for React guidance of
+      this component.
+    </p>
+  );
+};
+
+export default SeeStorybookForReactGuidance;

--- a/packages/docs/src/components/content/StorybookExample.tsx
+++ b/packages/docs/src/components/content/StorybookExample.tsx
@@ -43,27 +43,43 @@ const StorybookExample = ({ theme, componentName, minHeight, storyId }: Storyboo
   useEffect(() => {
     if (window) {
       // when window resizes, recalculate the height of the iframe
-      window.addEventListener('resize', setIframeHeight);
+      window.addEventListener('resize', updateIframeHeight);
 
       return () => {
-        window.removeEventListener('resize', setIframeHeight);
+        window.removeEventListener('resize', updateIframeHeight);
       };
     }
   }, []);
 
-  // when the iframe content resizes, recalculate the height at which it should be shown
-  const setIframeHeight = () => {
-    if (iframeRef.current) {
-      const height = iframeRef.current.contentDocument.body.offsetHeight;
+  /**
+   * Calculate the new height of the iframe based on the content resizes.
+   * Returns true if it detects height and resizes.
+   */
+  const updateIframeHeight = () => {
+    const height = iframeRef?.current.contentDocument.body.offsetHeight;
+    if (height > 0) {
       setiFrameHeight(height);
+      return true;
     }
+    return false;
   };
 
   // when the iframe's content loads, calculate height of iframe & set html
   const onIframeLoad = () => {
-    if (iframeRef.current) {
-      setIframeHeight();
-    }
+    const attemptToUpdateHeight = (millisecondsWaited = 0) => {
+      if (updateIframeHeight()) {
+        // Job well done
+        return;
+      }
+
+      if (millisecondsWaited > 2000) {
+        console.error(`Timed out waiting for content from ${iframeUrl} to have readable height`);
+      } else {
+        setTimeout(() => attemptToUpdateHeight(millisecondsWaited + 200), 200);
+      }
+    };
+
+    attemptToUpdateHeight();
     setIsLoading(false);
   };
 

--- a/packages/docs/src/components/content/StorybookExampleFooter.tsx
+++ b/packages/docs/src/components/content/StorybookExampleFooter.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { useRef, useState } from 'react';
-import { Button, ExternalLinkIcon } from '@cmsgov/design-system';
+import { Button } from '@cmsgov/design-system';
 import { makeStorybookUrl } from '../../helpers/urlUtils';
-import { withPrefix } from 'gatsby';
 import ExampleFooter from './ExampleFooter';
 
 interface StorybookExampleFooterProps {
@@ -18,96 +16,13 @@ interface StorybookExampleFooterProps {
 }
 
 /**
- * Goes below storybook-based examples and allows people to view React and HTML source or
- * to click a link to go directly to the story within Storybook. Fetches the source code
- * by loading the component's Storybook docs page in an iframe and scraping the page.
+ * Goes below storybook-based examples and allows people to click a link to go directly
+ * to the story within Storybook.
  */
 const StorybookExampleFooter = ({ theme, storyId }: StorybookExampleFooterProps) => {
-  const [htmlCode, setHtmlCode] = useState<string>('Loading...');
-  const [reactCode, setReactCode] = useState<string>('Loading...');
-  const iframeRef = useRef<HTMLIFrameElement>();
-  const iframeUrl = withPrefix(
-    `/storybook/iframe.html?id=${storyId}&viewMode=docs&globals=theme:${theme}`
-  );
-
-  const onIframeLoad = () => {
-    const errorLoadingReactCode = () => setReactCode('Error loading React source');
-    const errorLoadingHtmlCode = () => setHtmlCode('Error loading HTML source');
-
-    if (!iframeRef.current) {
-      errorLoadingReactCode();
-      errorLoadingHtmlCode();
-      return;
-    }
-
-    const normalizedStoryId = storyId.split('&')[0]; // Omit additional args
-    const storyBlockSelector = `#anchor--${normalizedStoryId}`;
-    const storyRootSelector = `#story--${normalizedStoryId}`;
-    const codeButtonSelector = `${storyBlockSelector} .docblock-code-toggle`;
-    const codeBlockSelector = `${storyBlockSelector} .language-jsx`;
-    const body = iframeRef.current.contentDocument.body;
-
-    const storyRootEl = body.querySelector(storyRootSelector);
-    if (storyRootEl) {
-      setHtmlCode(storyRootEl.innerHTML);
-    } else {
-      errorLoadingHtmlCode();
-    }
-
-    // Find the 'Show code' button and click it so we can access the code
-    const showCodeButton = body.querySelector(codeButtonSelector);
-    if (!(showCodeButton && (showCodeButton as HTMLButtonElement).click)) {
-      console.error(
-        `Code button missing or invalid using this selector: '${codeButtonSelector}'`,
-        showCodeButton
-      );
-      errorLoadingReactCode();
-      return;
-    }
-    // Hide the iframe first so that clicking the button doesn't scroll us to it. We can't
-    // do this when we first render the iframe or it will never load.
-    iframeRef.current.hidden = true;
-    iframeRef.current.style.display = 'none';
-    (showCodeButton as HTMLButtonElement).click();
-
-    // Read the code out of the resulting code block after waiting for it to be generated
-    let retries = 0;
-    const MAX_RETRIES = 3;
-    function readCode() {
-      setTimeout(() => {
-        const codeEl = body.querySelector(codeBlockSelector);
-        if (codeEl) {
-          setReactCode(codeEl.innerHTML);
-        } else if (retries < MAX_RETRIES) {
-          retries++;
-          readCode();
-        } else {
-          console.error(`Code block not found: ${codeBlockSelector}`, codeEl);
-          errorLoadingReactCode();
-        }
-      }, 1000);
-    }
-    readCode();
-  };
-
-  const iframe = (
-    <iframe
-      className="c-storybook-example-footer__iframe"
-      referrerPolicy="no-referrer"
-      src={iframeUrl}
-      ref={iframeRef}
-      loading="lazy"
-      onLoad={onIframeLoad}
-      tabIndex={-1}
-    />
-  );
-
   return (
     <div className="c-storybook-example-footer">
-      {iframe}
       <ExampleFooter
-        html={htmlCode}
-        highlightedJsx={reactCode}
         sourceLink={
           <Button
             href={makeStorybookUrl(storyId, theme)}
@@ -115,7 +30,7 @@ const StorybookExampleFooter = ({ theme, storyId }: StorybookExampleFooterProps)
             variation="ghost"
             size="small"
           >
-            Open in Storybook
+            View interactive React examples in Storybook
           </Button>
         }
       />

--- a/packages/docs/src/components/layout/PageHeader.tsx
+++ b/packages/docs/src/components/layout/PageHeader.tsx
@@ -46,7 +46,7 @@ const PageHeader = ({ frontmatter = { title: '' }, theme }: PageHeaderProps) => 
             </a>
           )}
           {storyId && (
-            <a href={makeStorybookUrl(storyId, theme)} className="c-page-header__link">
+            <a href={makeStorybookUrl(storyId, theme, 'docs')} className="c-page-header__link">
               <img
                 alt="Storybook logo"
                 src={withPrefix('/images/storybook-icon.png')}

--- a/packages/docs/src/helpers/urlUtils.ts
+++ b/packages/docs/src/helpers/urlUtils.ts
@@ -21,8 +21,8 @@ export function makeSketchUrl(pathname = '', theme) {
 }
 
 // creates links to storybook story
-export function makeStorybookUrl(storyId, theme) {
-  return withPrefix(`/storybook/?path=/story/${storyId}&globals=theme:${theme}`);
+export function makeStorybookUrl(storyId, theme, storyType = 'story') {
+  return withPrefix(`/storybook/?path=/${storyType}/${storyId}&globals=theme:${theme}`);
 }
 
 export function makePageUrl(fileRelativePath, location: LocationInterface) {


### PR DESCRIPTION
WNMGDS-2348

- Update Storybook link in component header to point to the Docs story in Storybook
- Update code examples in docs site
    - Remove React/HTML dropdown
    - Replace stuff under examples with link to corresponding Storybook
    - Remove React props tables from docs site*

*Can't really remove all React props tables until components have been updated with new Storybook syntax. Seeing some components with props tables for multiple components (e.g., Accordion, Table, etc.). Removing props tables where I can.