### PR TITLE
[WNMGDS-2371] Wrap highlightitem args in if statement to prevent undefined

### DIFF
--- a/packages/design-system/src/components/Dropdown/useHighlightStatusMessageFn.ts
+++ b/packages/design-system/src/components/Dropdown/useHighlightStatusMessageFn.ts
@@ -24,10 +24,12 @@ export default function useHighlightStatusMessageFn(
   return (args: A11yStatusMessageOptions<any>) => {
     if (prevHighlightedIndexRef.current !== args.highlightedIndex) {
       prevHighlightedIndexRef.current = args.highlightedIndex;
-      const label = args.highlightedItem.label;
-      const position = args.highlightedIndex + 1;
-      const total = args.resultCount;
-      return `${label}, (${position} of ${total})`;
+      if (args.highlightedItem) {
+        const label = args.highlightedItem.label;
+        const position = args.highlightedIndex + 1;
+        const total = args.resultCount;
+        return `${label}, (${position} of ${total})`;
+      }
     }
     return originalGetA11yStatusMessage(args);
   };


### PR DESCRIPTION
## Summary

WNMGDS-2371

If you open the dropdown without hovering/selecting a new item, you receive `Uncaught TypeError: Cannot read properties of undefined (reading 'label')`

This was resolved by wrapping the highlightItem args in an if statement to see if they exist before assigning them to a const.
 