### PR TITLE
[WNMGDS-2364] Fix JAWS issue caused by empty `aria-activedescendant` attribute

### DIFF
--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -230,6 +230,10 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     'aria-labelledby': `${buttonContentId} ${labelId}`,
   });
 
+  if (!buttonProps['aria-activedescendant']) {
+    delete buttonProps['aria-activedescendant'];
+  }
+
   const menuProps = getMenuProps({
     className: classNames(
       'ds-c-dropdown__menu',

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -231,6 +231,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
   });
 
   if (!buttonProps['aria-activedescendant']) {
+    // This attribute being empty causes unexpected behavior in JAWS, so remove it
     delete buttonProps['aria-activedescendant'];
   }
 


### PR DESCRIPTION
_Combine this with other dropdown items in the release notes._

## Summary

WNMGDS-2364

When an item has been selected and focus on the button is regained after being elsewhere, JAWS reads "Select an option" instead of the selected item, so my guess was that the empty `aria-activedescendant` attribute is causing JAWS to look for the first element to read. We it in JAWS again with this change, and it seemed to fix it.

## How to test

1. Instructions on how to test the changes in this PR.

## Checklist

- [ ] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [ ] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [ ] Selected appropriate `Impacts`, multiple can be selected.

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [ ] Created or updated unit tests to cover any new or modified code
- [ ] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)

### If this is a change to documentation:

- [ ] Checked for spelling and grammatical errors
