### PR TITLE
[NO-TICKET] Refine look of doc site switchers

### DIFF
--- a/packages/docs/src/components/layout/ThemeSwitcher.tsx
+++ b/packages/docs/src/components/layout/ThemeSwitcher.tsx
@@ -26,6 +26,7 @@ const ThemeSwitcher = () => {
       label="Selected theme"
       name="theme-switcher"
       className="c-theme-switcher"
+      labelClassName="ds-u-margin-top--0"
       options={themeOptions}
       value={currentTheme}
       onChange={onThemeChange}


### PR DESCRIPTION
## Summary

Remove the top margin from the theme switcher so there's no awkward gap

Before

<img width="746" alt="Screenshot 2023-06-14 at 2 51 42 PM" src="https://github.com/CMSgov/design-system/assets/7595652/7e245c1b-1ac0-43ae-b961-78eec24d0080">

After

<img width="787" alt="Screenshot 2023-06-14 at 2 51 27 PM" src="https://github.com/CMSgov/design-system/assets/7595652/127554ee-a005-49fe-9e91-24ee951063db">
