### PR TITLE
[NO-TICKET] Fix responsive examples

### DIFF
--- a/packages/docs/src/components/content/ResponsiveExample.tsx
+++ b/packages/docs/src/components/content/ResponsiveExample.tsx
@@ -133,6 +133,9 @@ const ResponsiveExample = ({ storyId, title, theme }: ResponsiveExample) => {
             width={iframeWidth}
             style={{ transform: `scale(${iframeScale})` }}
           />
+          {iframeScale < 1 && (
+            <div className="c-responsive-example__scale">Scale: {iframeScale.toFixed(2)}</div>
+          )}
         </div>
       </div>
       <StorybookExampleFooter storyId={storyId} theme={theme} />

--- a/packages/docs/src/components/content/ResponsiveExample.tsx
+++ b/packages/docs/src/components/content/ResponsiveExample.tsx
@@ -1,17 +1,19 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import { useState, useRef, useEffect } from 'react';
 import { withPrefix } from 'gatsby';
 import classnames from 'classnames';
 import StorybookExampleFooter from './StorybookExampleFooter';
 
 // @TODO: grab these from tokens
-const breakpointOpts = {
-  xs: '360',
-  sm: '544',
-  md: '768',
-  lg: '1024',
-  xl: '1280',
-};
+const breakpoints = {
+  xs: 360,
+  sm: 544,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+} as const;
+
+const examplePadding = 16;
 
 interface ResponsiveExample {
   /**
@@ -36,65 +38,57 @@ interface ResponsiveExample {
  * To use this example, you must have a corresponding storybook story to reference
  */
 const ResponsiveExample = ({ storyId, title, theme }: ResponsiveExample) => {
-  const [iframeBreakpoint, setIframeBreakpoint] = useState<string>('xl');
-  const [iframeHeight, setiFrameHeight] = useState<number>(0);
-  const [exampleWrapperWidth, setExampleWrapperWidth] = useState<number>(0);
-  const iframeRef = useRef<HTMLIFrameElement>();
+  const rootRef = useRef<HTMLDivElement>();
   const exampleWrapperRef = useRef<HTMLDivElement>();
+  const [exampleWrapperWidth, setExampleWrapperWidth] = useState<number>(200);
+  const [iframeBreakpoint, setIframeBreakpoint] = useState<keyof typeof breakpoints>('md');
+  const [iframeHeight, setIFrameHeight] = useState<number>(200);
+  const iframeRef = useRef<HTMLIFrameElement>();
   const iframeUrl = withPrefix(
     `/storybook/iframe.html?id=${storyId}&viewMode=story&globals=theme:${theme}`
   );
 
+  const availableWidth = exampleWrapperWidth - 2 * examplePadding;
+  const iframeWidth = breakpoints[iframeBreakpoint];
+  const iframeScale = Math.min(1, availableWidth / iframeWidth);
+  const exampleWrapperHeight = iframeHeight * iframeScale + 2 * examplePadding;
+
+  function calcExampleWidth() {
+    setTimeout(() => {
+      if (rootRef.current) {
+        setExampleWrapperWidth(rootRef.current.offsetWidth);
+      }
+    }, 50);
+  }
+
+  useEffect(calcExampleWidth, [rootRef.current]);
+
   useEffect(() => {
     if (window) {
-      // on window resize, re-calculate the width of the wrapper
-      window.addEventListener('resize', handleWindowResize);
+      window.addEventListener('resize', calcExampleWidth);
     }
-    handleWindowResize();
-
-    const contentWindow = iframeRef.current.contentWindow;
 
     return () => {
-      if (contentWindow) {
-        contentWindow.removeEventListener('resize', handleIframeResize);
+      window.removeEventListener('resize', calcExampleWidth);
+      // Remove resize listener set in the onIFrameLoad handler
+      if (iframeRef.current?.contentWindow) {
+        iframeRef.current.contentWindow.removeEventListener('resize', handleIframeResize);
       }
-      window.removeEventListener('resize', handleWindowResize);
     };
   }, []);
-
-  // get & set the width of the example wrapper
-  const handleWindowResize = () => {
-    if (exampleWrapperRef.current) {
-      setExampleWrapperWidth(exampleWrapperRef.current.offsetWidth);
-    }
-  };
-
-  // calculate the scale at which the example should be shown
-  const getScale = () => {
-    if (exampleWrapperRef.current) {
-      return Math.min(1, exampleWrapperWidth / breakpointOpts[iframeBreakpoint]);
-    }
-  };
-
-  // calculate css height with fallback
-  const getHeight = () => {
-    const heightCalc = getScale() * iframeHeight;
-    return heightCalc ? heightCalc : '0';
-  };
 
   // when the iframe content resizes, recalculate the height at which it should be shown
   const handleIframeResize = () => {
     if (iframeRef.current) {
       const height = iframeRef.current.contentDocument.body.offsetHeight;
-      setiFrameHeight(height);
+      setIFrameHeight(height);
     }
   };
 
   // when the iframe's content loads, set up listener and calculate height of iframe
-  const onIframeLoad = () => {
+  const onIFrameLoad = () => {
     if (iframeRef.current) {
-      const contentWindow = iframeRef.current.contentWindow;
-      contentWindow.addEventListener('resize', handleIframeResize);
+      iframeRef.current.contentWindow.addEventListener('resize', handleIframeResize);
       iframeRef.current.contentDocument.documentElement.classList.add('ds-u-overflow--hidden');
       handleIframeResize();
     }
@@ -102,9 +96,9 @@ const ResponsiveExample = ({ storyId, title, theme }: ResponsiveExample) => {
 
   return (
     <>
-      <div className="c-responsive-example ds-u-border--1">
+      <div className="c-responsive-example ds-u-border--1" ref={rootRef}>
         <ol className="c-responsive-example__button-list ds-u-border-bottom--1 ds-l-row ds-u-margin--0 ds-u-padding-x--0">
-          {Object.keys(breakpointOpts).map((breakpointName) => (
+          {Object.keys(breakpoints).map((breakpointName: keyof typeof breakpoints) => (
             <li
               className="c-responsive-example__list-item ds-l-col ds-u-padding-x--0"
               key={`breakpoint-${breakpointName}`}
@@ -116,34 +110,29 @@ const ResponsiveExample = ({ storyId, title, theme }: ResponsiveExample) => {
                 onClick={() => setIframeBreakpoint(breakpointName)}
               >
                 <strong>{breakpointName}</strong>
-                <div className="ds-u-font-size--small">Width: {breakpointOpts[breakpointName]}</div>
+                <div className="ds-u-font-size--small">Width: {breakpoints[breakpointName]}</div>
               </button>
             </li>
           ))}
         </ol>
         <div
           className="c-responsive-example__example-wrapper "
-          style={{ height: getHeight() }}
+          style={{ height: exampleWrapperHeight }}
           ref={exampleWrapperRef}
         >
-          <div
-            className={`c-responsive-example__iframe-wrapper ${
-              iframeBreakpoint && `c-responsive-example__iframe-wrapper--width-${iframeBreakpoint}`
+          <iframe
+            referrerPolicy="no-referrer"
+            className={`c-responsive-example__iframe ${
+              iframeBreakpoint && `c-responsive-example__iframe--width-${iframeBreakpoint}`
             }`}
-            style={{ transform: `scale(${getScale()})` }}
-          >
-            <iframe
-              referrerPolicy="no-referrer"
-              className={`c-responsive-example__iframe ${
-                iframeBreakpoint && `c-responsive-example__iframe--width-${iframeBreakpoint}`
-              }`}
-              src={iframeUrl}
-              title={title}
-              ref={iframeRef}
-              onLoad={onIframeLoad}
-              height={iframeHeight}
-            />
-          </div>
+            src={iframeUrl}
+            title={title}
+            ref={iframeRef}
+            onLoad={onIFrameLoad}
+            height={iframeHeight}
+            width={iframeWidth}
+            style={{ transform: `scale(${iframeScale})` }}
+          />
         </div>
       </div>
       <StorybookExampleFooter storyId={storyId} theme={theme} />

--- a/packages/docs/src/styles/components/responsiveExample.scss
+++ b/packages/docs/src/styles/components/responsiveExample.scss
@@ -15,6 +15,15 @@
   transform-origin: 0px 0px;
 }
 
+.c-responsive-example__scale {
+  background-color: var(--color-info-lightest);
+  bottom: 0;
+  font-size: var(--font-size-sm);
+  padding: $spacer-half $spacer-1;
+  position: absolute;
+  right: 0;
+}
+
 .c-responsive-example__button-list {
   flex-direction: row;
   gap: 0;

--- a/packages/docs/src/styles/components/responsiveExample.scss
+++ b/packages/docs/src/styles/components/responsiveExample.scss
@@ -1,23 +1,8 @@
 .c-responsive-example__example-wrapper {
-  margin: $spacer-2;
+  background-color: var(--color-gray-lightest);
+  padding: $spacer-2;
   position: relative;
-
-  // adding a color to the background of examples for easier viewing
-  &:before {
-    background-color: var(--color-gray-lightest);
-    bottom: -$spacer-2;
-    content: '';
-    left: -$spacer-2;
-    position: absolute;
-    right: -$spacer-2;
-    top: -$spacer-2;
-    z-index: -100;
-  }
-}
-
-.c-responsive-example__iframe-wrapper {
-  overflow: hidden;
-  transform-origin: 0px 0px;
+  width: 100%;
 }
 
 .c-responsive-example {
@@ -26,26 +11,13 @@
 
 .c-responsive-example__iframe {
   border: 0;
-  width: 100%;
-}
-
-.c-responsive-example__iframe-wrapper--width-xs {
-  width: 360px;
-}
-.c-responsive-example__iframe-wrapper--width-sm {
-  width: $media-width-sm;
-}
-.c-responsive-example__iframe-wrapper--width-md {
-  width: $media-width-md;
-}
-.c-responsive-example__iframe-wrapper--width-lg {
-  width: $media-width-lg;
-}
-.c-responsive-example__iframe-wrapper--width-xl {
-  width: $media-width-xl;
+  position: absolute;
+  transform-origin: 0px 0px;
 }
 
 .c-responsive-example__button-list {
+  flex-direction: row;
+  gap: 0;
   list-style: none;
 }
 
@@ -68,6 +40,10 @@
 
   &:hover {
     color: var(--color-primary-darker);
+  }
+
+  :last-child > & {
+    border-right: none;
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixed `ul`/`ol` issue with reset styles
- Refactored the componenet calculations and CSS to fix overflow and scaling issues with the examples
- Added a scale overlay when the scale is less than 1. Thought it would be helpful information 🤷 

Before (with reset style regression fixed so we can see it):
![responsive-examples-old](https://github.com/CMSgov/design-system/assets/7595652/220c5720-955f-4618-a2d0-0d0dda2543b5)

After fix
![responsive-examples-fixed](https://github.com/CMSgov/design-system/assets/7595652/443c47fa-31a1-47da-a7ad-64dabaafe263)

I went back to v6, and the component was working fine. None of that code has directly changed, so I'm not sure why it broke. I tried reverting to `box-sizing: content-box` for most elements, but that hadn't totally fixed the calculations. I might not have needed to rewrite it had I figured out the true issue, but it seems to work well now.

## How to test

1. `yarn start`
2. Visit http://localhost:8000/foundation/typography/headings/
