### PR TITLE
[WNMGDS-2405] Remove `aria-hidden` from HHS logo

### DIFF
--- a/packages/design-system/src/components/Icons/HhsLogo.tsx
+++ b/packages/design-system/src/components/Icons/HhsLogo.tsx
@@ -5,6 +5,7 @@ import { SvgIcon, IconCommonProps } from './SvgIcon';
 const defaultProps = {
   className: '',
   viewBox: '0 0 252 252',
+  ariaHidden: false,
 };
 
 export function HHSLogo(props: IconCommonProps): React.ReactElement {


### PR DESCRIPTION
## Summary

WNMGDS-2405

Setting `ariaHidden` to false on HHS logo component. Basically, our SVG icon component hides `<description>` and `<title>` SVG tags when set to `aria-hidden="true"`. Setting it to `false` makes these elements visible, therefore showing the title text on hover.

I figure it's a safe change to make on the core HHS logo since gov't logos should be accessible.