### PR TITLE
[NO-TICKET] Fix inverse stories being too tall

### DIFF
--- a/.storybook/storybookStyles.scss
+++ b/.storybook/storybookStyles.scss
@@ -14,11 +14,14 @@
 // Storybook's styles change, we'll need to update these rules. It is used for
 // the decorator of on-dark stories.
 .on-dark-story {
-  height: 100vh;
   padding: 1rem;
 
   #storybook-docs & {
     padding: 30px 20px;
+  }
+
+  #storybook-root & {
+    height: 100vh;
   }
 }
 


### PR DESCRIPTION
## Summary

A follow-up to https://github.com/CMSgov/design-system/pull/2502, this fixes a problem where the inverse stories were really tall when viewed in the component docs pages in storybook, where they aren't in iframes.

This is what it looked like before:

<img width="1239" alt="Inverse stories taking up way more vertical space than they should on a docs page in storybook" src="https://github.com/CMSgov/design-system/assets/7595652/f19cc60d-ea5a-40c8-aa57-05c21ab7a250">

## How to test

Go to the button docs page in storybook and scroll down to the inverse story. Also try the inverse story itself and try it out on the doc site as well.