### PR TITLE
[WNMGDS-2402] More informative storybook doc pages

### DIFF
--- a/.storybook/DocumentationTemplate.mdx
+++ b/.storybook/DocumentationTemplate.mdx
@@ -1,0 +1,31 @@
+import { Meta, Title, Subtitle, Description, Primary, ArgsTable, Stories } from '@storybook/blocks';
+
+<Meta isTemplate />
+
+<Title />
+<Subtitle />
+
+<Description />
+
+<Primary />
+
+## Props
+
+{/*
+  * Note that ArgsTable is technically deprecated in v7, but Storybook has yet
+  * to offer a solid alternative for stories with subcomponents. This args
+  * table will render multiple tabs when there is a `subcomponents` property
+  * present in the story meta. See the following discussions:
+  * 
+  *   - https://github.com/storybookjs/storybook/issues/21253
+  *   - https://github.com/storybookjs/storybook/issues/20782
+  * 
+  * If they remove this feature, the path forward may be to create our own
+  * custom "doc block" that uses the
+  * [useOf](https://storybook.js.org/docs/react/api/doc-block-useof) hook.
+  */}
+<ArgsTable />
+
+---
+
+<Stories />

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -80,7 +80,7 @@ const themeSettingDecorator = (Story, context) => {
   // specific to a brand and only make sense when viewed in that brand theme
   const theme = parameters.theme ?? globals.theme;
 
-  document.documentElement.setAttribute('data-theme', theme);
+  context.canvasElement.setAttribute('data-theme', theme);
 
   const themeCss = document.querySelector('link[title=themeCss]') as HTMLLinkElement;
   themeCss.href = `${theme}-theme.css`;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 import './storybookStyles.scss';
 import React from 'react';
+import DocumentationTemplate from './DocumentationTemplate.mdx';
 import {
   setAlertSendsAnalytics,
   setButtonSendsAnalytics,
@@ -169,6 +170,9 @@ const preview: Preview = {
     },
     viewport: {
       viewports: breakpointViewportSizes,
+    },
+    docs: {
+      page: DocumentationTemplate,
     },
   },
   decorators: [

--- a/packages/design-system/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.stories.tsx
@@ -7,6 +7,7 @@ import { useArgs } from '@storybook/preview-api';
 const meta: Meta<typeof Accordion> = {
   title: 'Components/Accordion',
   component: Accordion,
+  subcomponents: { AccordionItem },
   args: {
     bordered: true,
   },

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -7,6 +7,9 @@ export interface AccordionProps {
    * Applies a border to the accordion content.
    */
   bordered?: boolean;
+  /**
+   * Children should consist of AccordionItems
+   */
   children?: React.ReactNode;
   /**
    * Class to be applied to the outer `<div>` that contains all accordion items.
@@ -31,6 +34,10 @@ const handleKeyDown = (e) => {
   }
 };
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/accordion/).
+ */
 export const Accordion: FunctionComponent<AccordionProps> = ({
   bordered,
   children,

--- a/packages/design-system/src/components/Alert/Alert.tsx
+++ b/packages/design-system/src/components/Alert/Alert.tsx
@@ -61,6 +61,10 @@ export interface BaseAlertProps extends AnalyticsOverrideProps {
 export type AlertProps = BaseAlertProps &
   Omit<React.ComponentPropsWithRef<'div'>, keyof BaseAlertProps>;
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/alert/).
+ */
 export const Alert: React.FC<AlertProps> = (props: AlertProps) => {
   const { headingRef, bodyRef } = useAlertAnalytics(props);
   const focusRef = useAutofocus(props.autoFocus);

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -158,6 +158,10 @@ function isTextField(child: React.ReactElement): boolean {
   return child && (child.type === TextField || componentName === 'TextField');
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/autocomplete/).
+ */
 export const Autocomplete = (props: AutocompleteProps) => {
   const id = useRef(props.id ?? uniqueId('autocomplete__input--')).current;
   const labelId = useRef(props.labelId ?? uniqueId('autocomplete__label--')).current;

--- a/packages/design-system/src/components/Badge/Badge.tsx
+++ b/packages/design-system/src/components/Badge/Badge.tsx
@@ -25,6 +25,10 @@ export interface BadgeProps {
   variation?: BadgeVariation;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/badge/).
+ */
 export const Badge: React.FC<React.ComponentPropsWithRef<'span'> & BadgeProps> = (
   props: BadgeProps
 ) => {

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -72,6 +72,10 @@ type OtherProps = Omit<
 
 export type ButtonProps = CommonButtonProps & OtherProps;
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/button/).
+ */
 export const Button = (props: ButtonProps) => {
   const {
     analytics,

--- a/packages/design-system/src/components/ChoiceList/Choice.tsx
+++ b/packages/design-system/src/components/ChoiceList/Choice.tsx
@@ -105,6 +105,11 @@ type OmitProps =
 /** Used to emit events to all Choice components */
 const dsChoiceEmitter = new EvEmitter();
 
+/**
+ * For information about how and when to use this component, refer to the
+ * [checkbox](https://design.cms.gov/components/checkbox/) and
+ * [radio](https://design.cms.gov/components/radio/) documentation pages.
+ */
 export class Choice extends React.PureComponent<
   Omit<React.ComponentPropsWithRef<'input'>, OmitProps> & ChoiceProps,
   any

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
@@ -71,6 +71,11 @@ export interface BaseChoiceListProps extends Omit<FormFieldProps, 'id'> {
 export type ChoiceListProps = BaseChoiceListProps &
   Omit<React.ComponentPropsWithRef<'fieldset'>, keyof BaseChoiceListProps>;
 
+/**
+ * For information about how and when to use this component, refer to the
+ * [checkbox](https://design.cms.gov/components/checkbox/) and
+ * [radio](https://design.cms.gov/components/radio/) documentation pages.
+ */
 export const ChoiceList: React.FC<ChoiceListProps> = (props: ChoiceListProps) => {
   const { onBlur, onComponentBlur, choices, ...listProps } = props;
 

--- a/packages/design-system/src/components/DateField/MultiInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.tsx
@@ -131,6 +131,10 @@ export interface DateFieldProps extends Omit<FormFieldProps, 'label'> {
   yearValue?: DateFieldYearValue;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/date-field/multi-input-date-field/).
+ */
 export function MultiInputDateField(props: DateFieldProps): React.ReactElement {
   const { labelProps, fieldProps, wrapperProps, bottomError } = useFormLabel({
     label: t('dateField.label'),

--- a/packages/design-system/src/components/DateField/SingleInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.tsx
@@ -79,6 +79,11 @@ export interface SingleInputDateFieldProps extends FormFieldProps {
   toYear?: number;
 }
 
+/**
+ * For information about how and when to use this component, refer to the
+ * [Single Input Date Field](https://design.cms.gov/components/date-field/single-input-date-field/) and
+ * [Calendar Picker](https://design.cms.gov/components/date-field/date-picker/) documentation pages.
+ */
 const SingleInputDateField = (props: SingleInputDateFieldProps) => {
   const {
     className,

--- a/packages/design-system/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Dialog } from '@cmsgov/design-system';
+import { Dialog } from './Dialog';
 import { Button } from '@cmsgov/design-system';
 import { action } from '@storybook/addon-actions';
 

--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -93,6 +93,10 @@ export interface BaseDialogProps extends AnalyticsOverrideProps {
 export type DialogProps = BaseDialogProps &
   Omit<DialogHTMLAttributes<HTMLElement>, keyof BaseDialogProps>;
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/modal-dialog/).
+ */
 export const Dialog = (props: DialogProps) => {
   const {
     actions,

--- a/packages/design-system/src/components/Drawer/Drawer.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.tsx
@@ -50,6 +50,10 @@ export interface DrawerProps {
   onCloseClick: (event: React.MouseEvent | React.KeyboardEvent) => void;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/drawer/).
+ */
 export const Drawer = (props: DrawerProps) => {
   const headingRef = useRef(null);
   const id = useRef(props.headingId || uniqueId('drawer_'));

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -109,6 +109,10 @@ export type DropdownProps = BaseDropdownProps &
   OptionsOrChildren &
   Omit<React.ComponentPropsWithRef<'button'>, keyof BaseDropdownProps>;
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/dropdown/).
+ */
 export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
   validateProps(props);
 

--- a/packages/design-system/src/components/FilterChip/FilterChip.tsx
+++ b/packages/design-system/src/components/FilterChip/FilterChip.tsx
@@ -37,6 +37,10 @@ export interface FilterChipProps {
   size?: 'big';
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/filter-chip/).
+ */
 export class FilterChip extends React.Component<FilterChipProps> {
   filterChipId: string;
 

--- a/packages/design-system/src/components/FormLabel/FormLabel.tsx
+++ b/packages/design-system/src/components/FormLabel/FormLabel.tsx
@@ -54,6 +54,10 @@ export interface FormLabelProps {
   textClassName?: string;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/form-label/).
+ */
 export class FormLabel extends React.PureComponent<
   React.ComponentPropsWithRef<'label'> & React.ComponentPropsWithRef<'legend'> & FormLabelProps,
   any

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.tsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.tsx
@@ -6,6 +6,10 @@ import { AnalyticsOverrideProps } from '../analytics';
 
 export interface HelpDrawerProps extends DrawerProps, AnalyticsOverrideProps {}
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/drawer/).
+ */
 export const HelpDrawer = (props: HelpDrawerProps) => {
   const {
     analytics,

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
@@ -85,6 +85,10 @@ const defaultMessageFormatter = (timeTilTimeout: number): React.ReactNode => {
 // local storage variable name
 const lastActiveCookieName = 'CMS_DS_IT_LAST_ACTIVE';
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/idle-timeout/).
+ */
 export const IdleTimeout = ({
   closeButtonText = 'Close',
   continueSessionText = 'Continue session',

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
@@ -69,6 +69,10 @@ interface MonthPickerProps extends FormFieldProps {
   clearAllText?: string;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/month-picker/).
+ */
 export const MonthPicker = (props: MonthPickerProps) => {
   const locale = fallbackLocale(getLanguage(), 'US');
   const months = getMonthNames(locale);

--- a/packages/design-system/src/components/Pagination/Pagination.tsx
+++ b/packages/design-system/src/components/Pagination/Pagination.tsx
@@ -128,6 +128,10 @@ function paginationBuilder(page: number, pages: number): number[] {
   return paginationRange;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/pagination/).
+ */
 function Pagination({
   ariaLabel,
   className,

--- a/packages/design-system/src/components/Review/Review.tsx
+++ b/packages/design-system/src/components/Review/Review.tsx
@@ -43,6 +43,10 @@ const getHeading = (heading, headingLevel) => {
   }
 };
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/review/).
+ */
 export const Review = (props: ReviewProps) => {
   const handleClick = (event): void => {
     if (props.onEditClick) {

--- a/packages/design-system/src/components/SkipNav/SkipNav.tsx
+++ b/packages/design-system/src/components/SkipNav/SkipNav.tsx
@@ -18,6 +18,10 @@ export interface SkipNavProps {
   onClick?: (...args: any[]) => any;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/skip-nav/).
+ */
 export const SkipNav = ({ children, href, onClick }: SkipNavProps) => {
   return (
     <a className="ds-c-skip-nav" href={href} onClick={onClick}>

--- a/packages/design-system/src/components/Spinner/Spinner.tsx
+++ b/packages/design-system/src/components/Spinner/Spinner.tsx
@@ -32,6 +32,10 @@ export interface SpinnerProps {
   size?: SpinnerSize;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/spinner/).
+ */
 export const Spinner: React.FunctionComponent<SpinnerProps> = (props: SpinnerProps) => {
   const className = classNames(
     'ds-c-spinner',

--- a/packages/design-system/src/components/StepList/StepList.stories.tsx
+++ b/packages/design-system/src/components/StepList/StepList.stories.tsx
@@ -4,7 +4,7 @@ import { StepList as StepListComponent } from './StepList';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof StepListComponent> = {
-  title: 'Patterns/Step List',
+  title: 'Components/Step List',
   component: StepListComponent,
 };
 export default meta;

--- a/packages/design-system/src/components/StepList/StepList.tsx
+++ b/packages/design-system/src/components/StepList/StepList.tsx
@@ -39,6 +39,10 @@ export interface StepListProps {
   substepsLabelText?: string;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/step-list/).
+ */
 export const StepList = ({
   steps,
   component,

--- a/packages/design-system/src/components/Table/Table.stories.tsx
+++ b/packages/design-system/src/components/Table/Table.stories.tsx
@@ -10,6 +10,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta: Meta<typeof Table> = {
   title: 'Components/Table',
   component: Table as any,
+  subcomponents: {
+    TableCaption,
+    TableHead,
+    TableRow,
+    TableCell,
+    TableBody,
+  },
 };
 export default meta;
 

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -79,6 +79,10 @@ function isTableCaption(child: React.ReactElement): boolean {
   return child && (child.type === TableCaption || componentName === 'TableCaption');
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/table/).
+ */
 export class Table extends React.Component<
   Omit<React.ComponentPropsWithoutRef<'table'>, OmitProps> & TableProps,
   any

--- a/packages/design-system/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.stories.tsx
@@ -6,6 +6,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta: Meta<typeof TabsComponent> = {
   title: 'Components/Tabs',
   component: TabsComponent,
+  subcomponents: { TabPanel },
 };
 export default meta;
 

--- a/packages/design-system/src/components/Tabs/Tabs.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.tsx
@@ -72,6 +72,10 @@ const panelTabId = (panel): string => {
   return panel.props.tabId || `ds-c-tabs__item--${panel.props.id}`;
 };
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/tabs/).
+ */
 export const Tabs = (props: TabsProps) => {
   const initialSelectedId = props.defaultSelectedId || getDefaultSelectedId(props);
   const [selectedId, setSelectedId] = useState(initialSelectedId);

--- a/packages/design-system/src/components/TextField/TextField.tsx
+++ b/packages/design-system/src/components/TextField/TextField.tsx
@@ -95,6 +95,10 @@ export interface BaseTextFieldProps extends Omit<FormFieldProps, 'id'> {
 export type TextFieldProps = BaseTextFieldProps &
   Omit<React.ComponentPropsWithRef<'input'>, keyof BaseTextFieldProps>;
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/text-field/).
+ */
 export const TextField: React.FC<TextFieldProps> = (props: TextFieldProps) => {
   const { mask, labelMask, ...textFieldProps } = props;
 

--- a/packages/design-system/src/components/ThirdPartyExternalLink/ThirdPartyExternalLink.tsx
+++ b/packages/design-system/src/components/ThirdPartyExternalLink/ThirdPartyExternalLink.tsx
@@ -19,6 +19,10 @@ interface ThirdPartyExternalLinkProps {
   origin: string;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/third-party-external-link/).
+ */
 const ThirdPartyExternalLink = ({
   href,
   children,

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -96,6 +96,10 @@ export interface TooltipProps {
   zIndex?: number;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/tooltip/).
+ */
 export const Tooltip = (props: TooltipProps) => {
   const popper = useRef(null);
   const id = useRef(props.id ?? uniqueId('trigger_'));

--- a/packages/design-system/src/components/UsaBanner/UsaBanner.tsx
+++ b/packages/design-system/src/components/UsaBanner/UsaBanner.tsx
@@ -23,6 +23,10 @@ export interface UsaBannerProps {
   id?: string;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/usa-banner/).
+ */
 export const UsaBanner: React.FunctionComponent<UsaBannerProps> = (props: UsaBannerProps) => {
   const [isBannerOpen, setBannerOpen] = useState<boolean>(false);
   const [shouldRenderMobileView, setShouldRenderMobileView] = useState<boolean>(false);

--- a/packages/design-system/src/components/VerticalNav/VerticalNav.tsx
+++ b/packages/design-system/src/components/VerticalNav/VerticalNav.tsx
@@ -46,6 +46,10 @@ export interface VerticalNavProps {
   onLinkClick?: (evt: React.MouseEvent | React.KeyboardEvent, id: string, url: string) => any;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/vertical-navigation/).
+ */
 export const VerticalNav = (props: VerticalNavProps): React.ReactElement => {
   const classes = classNames(
     {

--- a/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
@@ -31,6 +31,10 @@ export interface FooterProps {
   footerTop?: React.ReactNode;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/footer/healthcare-footer/?theme=healthcare).
+ */
 export const Footer = (props: FooterProps) => {
   const classes = classnames('hc-c-footer', props.className);
 

--- a/packages/ds-healthcare-gov/src/components/Footer/Logo.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Logo.tsx
@@ -29,6 +29,10 @@ interface LogoProps {
  *
  */
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/logos/healthcare-logo/).
+ */
 const Logo = (props: LogoProps) => {
   const style: any = {};
 

--- a/packages/ds-healthcare-gov/src/components/Header/Header.tsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.tsx
@@ -133,9 +133,8 @@ export const VARIATION_NAMES = {
 };
 
 /**
- * The top-level component, responsible for maintaining the
- * header's state (like whether the mobile menu is expanded) and
- * determining which variation of the header to display
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/header/healthcare-header/?theme=healthcare).
  */
 export const Header = (props: HeaderProps) => {
   const [openMenu, setOpenMenu] = useState(false);

--- a/packages/ds-medicare-gov/src/components/MedicaregovLogo/MedicaregovLogo.tsx
+++ b/packages/ds-medicare-gov/src/components/MedicaregovLogo/MedicaregovLogo.tsx
@@ -9,6 +9,10 @@ export interface MedicaregovLogoProps {
   fill?: string;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/logos/medicare-logo/?theme=medicare).
+ */
 const MedicaregovLogo: FunctionComponent<MedicaregovLogoProps> = ({
   width = '273',
   height = '39',

--- a/packages/ds-medicare-gov/src/components/SimpleFooter/SimpleFooter.tsx
+++ b/packages/ds-medicare-gov/src/components/SimpleFooter/SimpleFooter.tsx
@@ -18,6 +18,10 @@ interface SimpleFooterProps {
   language?: string;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/footer/medicare-footer/?theme=medicare).
+ */
 const SimpleFooter: FunctionComponent<SimpleFooterProps> = ({
   aboutMedicareLabel = 'About Medicare',
   medicareGlossaryLabel = 'Medicare Glossary',

--- a/packages/ds-medicare-gov/src/components/Stars/Stars.tsx
+++ b/packages/ds-medicare-gov/src/components/Stars/Stars.tsx
@@ -17,6 +17,10 @@ export interface StarsProps {
   ariaHidden?: boolean;
 }
 
+/**
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/stars/?theme=medicare).
+ */
 const Stars: FunctionComponent<StarsProps> = ({
   number,
   total,


### PR DESCRIPTION
## Summary

WNMGDS-2402

- Shows additional props tables when a story has sub-components
- Adds some intro text to each component's storybook doc page that gives a link to the corresponding doc-site page
- Fixes a bug with v7 where storybook doc pages have unstyled headers when viewed in non-core themes

## How to test

1. Start Storybook
2. Look through all the component pages to see that...
    1. All the component and subcomponent props are documented
    2. The intro text includes a working link to the doc site

### If this is a change to documentation:

- [x] Checked for spelling and grammatical errors
