### PR TITLE
[WNMGDS-2416] Add background color to calendar dialog

### DIFF
--- a/packages/design-system/src/styles/components/_SingleInputDateField.scss
+++ b/packages/design-system/src/styles/components/_SingleInputDateField.scss
@@ -460,6 +460,7 @@
   position: relative;
 
   .rdp {
+    background-color: var(--color-background-dialog);
     border: 1px solid var(--color-gray-dark);
     border-radius: 8px;
     box-shadow: 0 0 17px 0 var(--color-gray-light);


### PR DESCRIPTION
## Summary

WNMGDS-2416

The calendar dialog was missing a background color, causing the background elements to appear whenever the dialog was open (overlapping text elements). I added a background color using our `--color-background-dialog` token since this is a dialog.

### Testing

To test, build storybook locally and modify the SingleInputDateField story file; add several `<TextField>` components to the Default story to see the fix.

Before:

https://github.com/CMSgov/design-system/assets/5159392/4b48ff2f-9d2a-4bf8-8d8d-29787c13d2d3

After:


https://github.com/CMSgov/design-system/assets/5159392/a37899d9-2c3d-48ed-9654-7f9ad292006e

