### PR TITLE
[WNMGDS-2418] Add `selectedId` prop to `Tabs` for controlled behavior

### DIFF
--- a/packages/design-system/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.stories.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Tabs as TabsComponent } from './Tabs';
 import TabPanel from './TabPanel';
 import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { useArgs } from '@storybook/preview-api';
 
 const meta: Meta<typeof TabsComponent> = {
   title: 'Components/Tabs',
@@ -11,59 +13,59 @@ export default meta;
 
 type Story = StoryObj<typeof TabsComponent>;
 
+const tabPanels = [
+  <TabPanel key="summary" id="summary" tab="Summary">
+    The Bill of Rights is the first ten amendments to the United States Constitution.
+  </TabPanel>,
+  <TabPanel key="preamble" id="preamble" tab="Preamble">
+    We the People of the United States, in Order to form a more perfect Union, establish Justice,
+    insure domestic Tranquility, provide for the common defence, promote the general Welfare, and
+    secure the Blessings of Liberty to ourselves and our Posterity, do ordain and establish this
+    Constitution for the United States of America.
+  </TabPanel>,
+  <TabPanel key="amendments" id="amendments" tab="Amendments">
+    <h2 className="ds-h4">Bill of Rights</h2>
+
+    <ol className="ds-c-list">
+      <li>Freedoms, Petitions, Assembly</li>
+      <li>Right to bear arms</li>
+      <li>Quartering of soldiers</li>
+      <li>Search and arrest</li>
+      <li>Rights in criminal cases</li>
+      <li>Right to a fair trial</li>
+      <li>Rights in civil cases</li>
+      <li>Bail, fines, punishment</li>
+      <li>Rights retained by the People</li>
+      <li>States’ rights</li>
+    </ol>
+
+    <h2 className="ds-h4">Later Amendments</h2>
+
+    <ol className="ds-c-list" start={11}>
+      <li>Lawsuits against states</li>
+      <li>Presidential elections</li>
+      <li>Abolition of slavery</li>
+      <li>Civil rights</li>
+      <li>Black suffrage</li>
+      <li>Income taxes</li>
+      <li>Senatorial elections</li>
+      <li>Prohibition of liquor</li>
+      <li>Women’s suffrage</li>
+      <li>Terms of office</li>
+      <li>Repeal of Prohibition</li>
+      <li>Term Limits for the Presidency</li>
+      <li>Washington, D.C., suffrage</li>
+      <li>Abolition of poll taxes</li>
+      <li>Presidential succession</li>
+      <li>18-year-old suffrage</li>
+      <li>Congressional pay raises</li>
+    </ol>
+  </TabPanel>,
+];
+
 export const Default: Story = {
   render: function Component(args) {
-    return (
-      <TabsComponent {...args}>
-        <TabPanel id="summary" tab="Summary">
-          The Bill of Rights is the first ten amendments to the United States Constitution.
-        </TabPanel>
-        <TabPanel id="preamble" tab="Preamble">
-          We the People of the United States, in Order to form a more perfect Union, establish
-          Justice, insure domestic Tranquility, provide for the common defence, promote the general
-          Welfare, and secure the Blessings of Liberty to ourselves and our Posterity, do ordain and
-          establish this Constitution for the United States of America.
-        </TabPanel>
-        <TabPanel id="amendments" tab="Amendments">
-          <h2 className="ds-h4">Bill of Rights</h2>
-
-          <ol className="ds-c-list">
-            <li>Freedoms, Petitions, Assembly</li>
-            <li>Right to bear arms</li>
-            <li>Quartering of soldiers</li>
-            <li>Search and arrest</li>
-            <li>Rights in criminal cases</li>
-            <li>Right to a fair trial</li>
-            <li>Rights in civil cases</li>
-            <li>Bail, fines, punishment</li>
-            <li>Rights retained by the People</li>
-            <li>States’ rights</li>
-          </ol>
-
-          <h2 className="ds-h4">Later Amendments</h2>
-
-          <ol className="ds-c-list" start={11}>
-            <li>Lawsuits against states</li>
-            <li>Presidential elections</li>
-            <li>Abolition of slavery</li>
-            <li>Civil rights</li>
-            <li>Black suffrage</li>
-            <li>Income taxes</li>
-            <li>Senatorial elections</li>
-            <li>Prohibition of liquor</li>
-            <li>Women’s suffrage</li>
-            <li>Terms of office</li>
-            <li>Repeal of Prohibition</li>
-            <li>Term Limits for the Presidency</li>
-            <li>Washington, D.C., suffrage</li>
-            <li>Abolition of poll taxes</li>
-            <li>Presidential succession</li>
-            <li>18-year-old suffrage</li>
-            <li>Congressional pay raises</li>
-          </ol>
-        </TabPanel>
-      </TabsComponent>
-    );
+    return <TabsComponent {...args}>{tabPanels}</TabsComponent>;
   },
 };
 
@@ -83,6 +85,21 @@ export const Disabled: Story = {
         <TabPanel id="disabled" tab="Disabled" disabled>
           You should not see this.
         </TabPanel>
+      </TabsComponent>
+    );
+  },
+};
+
+export const Controlled: Story = {
+  render: function Component(args) {
+    const [{ selectedId }, updateArgs] = useArgs();
+    const onChange = (selectedId, prevSelectedId) => {
+      action('onChange')(selectedId, prevSelectedId);
+      updateArgs({ selectedId });
+    };
+    return (
+      <TabsComponent {...args} selectedId={selectedId} onChange={onChange}>
+        {tabPanels}
       </TabsComponent>
     );
   },

--- a/packages/design-system/src/components/Tabs/Tabs.test.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.test.tsx
@@ -163,7 +163,7 @@ describe('Tabs', function () {
     const onChange = jest.fn();
     const children = createPanels(3);
     const baseProps = { onChange };
-    const { rerender } = renderTabs({ ...baseProps, selected: getPanelId(3) });
+    const { rerender } = renderTabs({ ...baseProps, selectedId: getPanelId(3) }, children);
     const tabEls = screen.getAllByRole('tab');
     const panelEls = screen.getAllByRole('tabpanel', { hidden: true });
 
@@ -174,14 +174,14 @@ describe('Tabs', function () {
     // Clicking the first tab shoudl call `onChange` but should do nothing else
     // because this is a controlled component
     tabEls[0].click();
-    expect(onChange).toHaveBeenCalledWith(getPanelId(1), getPanelId(2));
+    expect(onChange).toHaveBeenCalledWith(getPanelId(1), getPanelId(3));
     expect(panelEls[0].getAttribute('aria-hidden')).toBe('true');
     expect(panelEls[1].getAttribute('aria-hidden')).toBe('true');
     expect(panelEls[2].getAttribute('aria-hidden')).toBe('false');
 
     // But then if we re-render with a different panel selected, it should update
     rerender(
-      <Tabs {...baseProps} selected={getPanelId(2)}>
+      <Tabs {...baseProps} selectedId={getPanelId(2)}>
         {children}
       </Tabs>
     );

--- a/packages/design-system/src/components/Tabs/Tabs.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.tsx
@@ -10,10 +10,17 @@ export interface TabsProps {
    */
   children: React.ReactNode;
   /**
-   * Sets the initial selected `TabPanel` state. If this isn't set, the first
-   * `TabPanel` will be selected.
+   * Sets the initial selected state to the specified `TabPanel` id. Use this
+   * for an uncontrolled component; otherwise, use the `selectedId` property.
+   * If no selected id is specified, the first `TabPanel` will be selected.
    */
   defaultSelectedId?: string;
+  /**
+   * Sets the initial selected state to the specified `TabPanel` id. Use this
+   * in combination with `onChange` for a controlled component; otherwise, set
+   * `defaultSelectedId`.
+   */
+  selectedId?: string;
   /**
    * A callback function that's invoked when the selected tab is changed.
    * `(selectedId, prevSelectedId) => void`
@@ -74,7 +81,10 @@ const panelTabId = (panel): string => {
 
 export const Tabs = (props: TabsProps) => {
   const initialSelectedId = props.defaultSelectedId || getDefaultSelectedId(props);
-  const [selectedId, setSelectedId] = useState(initialSelectedId);
+  const [internalSelectedId, setSelectedId] = useState(initialSelectedId);
+  const isControlled = props.selectedId !== undefined;
+  const selectedId = isControlled ? props.selectedId : internalSelectedId;
+
   const listClasses = classnames('ds-c-tabs', props.tablistClassName);
   // using useRef hook to keep track of elements to focus
   const tabsRef = useRef({});

--- a/tests/browser/story-screenshots.test.ts
+++ b/tests/browser/story-screenshots.test.ts
@@ -10,6 +10,7 @@ const storySkipList = [
   'components-idle-timeout--default',
   'components-skip-nav--default-skip-nav',
   'components-skip-nav--skip-nav-example',
+  'components-tabs--controlled', // Redundant
   'foundations-layout-grid--equal-widths',
   'foundations-layout-grid--column-spanning',
   'foundations-layout-grid--fit-to-content',


### PR DESCRIPTION
## Summary

WNMGDS-2418

- Adds a `selectedId` prop to `Tabs` for using it as a controlled component\

Note that I'm marking it for the 7.0.1 release even though it's technically feature. My reasoning is that it fills in missing functionality for using it as a controlled component. In that sense, it's a fix, and it's fully backwards compatible.

## How to test

1. Try the new story
2. Look at the new unit test

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)
