### PR TITLE
[WNMGDS-2420] Left align wrapping text in Accordion; side effect of reset CSS

### DIFF
--- a/packages/design-system/src/styles/components/_Accordion.scss
+++ b/packages/design-system/src/styles/components/_Accordion.scss
@@ -22,6 +22,7 @@
   font-weight: var(--font-weight-bold);
   justify-content: space-between;
   padding: $spacer-2 $spacer-3 $spacer-2 $spacer-3;
+  text-align: start;
   width: 100%;
 
   &:hover {


### PR DESCRIPTION
No ticket for this work.

If teams have extra extra extra long text in the Accordion headers, the text center-aligns. Text should always be left-aligned.

This behavior came about because of the button CSS reset. Button text is center aligned. Accordions use buttons. Therefore, Accordion text ends up center aligned unless that style is overwritten.