### PR TITLE
[WNMGDS-2445] Make the `ds-cms-gov` package public and publishable

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "workspaces": [
     "packages/*"
   ],  "scripts": {
-    "build": "yarn build:tokens && yarn build:core && yarn build:healthcare && yarn build:medicare && yarn build:cdn-index",
+    "build": "yarn build:tokens && yarn build:core && yarn build:healthcare && yarn build:medicare && yarn build:cmsgov && yarn build:cdn-index",
     "build:core": "yarn gulp build",
     "build:healthcare": "yarn gulp build --package packages/ds-healthcare-gov",
     "build:medicare": "yarn gulp build --package packages/ds-medicare-gov",

--- a/packages/ds-cms-gov/package.json
+++ b/packages/ds-cms-gov/package.json
@@ -1,14 +1,20 @@
 {
   "name": "@cmsgov/ds-cms-gov",
   "version": "7.0.2",
-  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  },
+  "bin": {
+    "cmsds-migrate": "./scripts/cmsds-migrate/src/main.mjs"
+  },
   "description": "A design system for CMS.gov products",
-  "license": "CC0-1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/CMSgov/design-system",
     "directory": "packages/ds-cms-gov"
   },
+  "license": "SEE LICENSE IN LICENSE.md",
   "keywords": [
     "design-system",
     "cms.gov"


### PR DESCRIPTION
## Summary

WNMGDS-2445

- Fixes oversight where the `yarn build:cmsgov` subcommand wasn't part of `yarn build`. This was causing the publish job on Jenkins to not build that package
- Removes the `private` property that keeps `@cmsgov/ds-cms-gov` from being published to npm

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
