### PR TITLE
[NO-TICKET] Fix missing role="option" on dropdown items

### DIFF
--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -272,7 +272,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
           item,
           index,
           disabled: isOptGroup,
-          role: isOptGroup ? 'group' : undefined,
+          role: isOptGroup ? 'group' : 'option',
         })}
       >
         {selectedItem === item && (


### PR DESCRIPTION
## Summary

- Fixes dropdown item roles being clobbered by a wrong assumption. I assumed that if we passed `undefined` for the value of that role property to the `getItemProps`, the default value would come through, but it wasn't.

## How to test

1. Open up a dropdown story
2. Open your dev tools, and make sure you have the Axe DevTools installed
3. Click to open the dialog, and then right-click on some item to confuse the browser (tested on Chrome) into allowing you to click in the dev tools without closing the dropdown
4. Click on the button in Axe DevTools to scan the page
5. On `main`, you'll get a list of errors about the list items. On this branch the will be gone. (Note that Storybook itself has a couple errors, but these can be ignored.)

## Checklist

- [ ] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [ ] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [ ] Selected appropriate `Impacts`, multiple can be selected.
- [ ] Selected appropriate release milestone

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [ ] Created or updated unit tests to cover any new or modified code
- [ ] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)

### If this is a change to documentation:

- [ ] Checked for spelling and grammatical errors
