### PR TITLE
[WNMGDS-2421] Style autocomplete message options

### DIFF
--- a/packages/design-system/src/styles/components/_Autocomplete.scss
+++ b/packages/design-system/src/styles/components/_Autocomplete.scss
@@ -27,6 +27,11 @@
   padding: var(--text-input__padding);
 }
 
+.ds-c-autocomplete__menu-item-message {
+  color: var(--autocomplete-item-message__font-color);
+  padding: var(--text-input__padding);
+}
+
 .ds-c-autocomplete__menu-item--highlighted {
   @extend .ds-c-dropdown__menu-item--highlighted;
   @media (-ms-high-contrast: active), (forced-colors: active) {
@@ -35,11 +40,6 @@
     forced-color-adjust: none;
     -ms-high-contrast-adjust: none;
   }
-}
-
-.ds-c-autocomplete__list-item-message {
-  color: var(--autocomplete-item-message__font-color);
-  padding: $spacer-1;
 }
 
 // Need a custom class so the bottom error message does not conflict with the clear search button


### PR DESCRIPTION
## Summary

WNMGDS-2421

- Remove unused CSS class
- Add spacing to the autocomplete message options ("Loading...", "No results")
- Apply correct color token to autocomplete message options (as original Autocomplete had)