### PR TITLE
[NO-TICKET] Move `aria-describedby` back to fieldsets

### DIFF
--- a/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
@@ -21,6 +21,8 @@ function renderChoiceList(customProps = {}, choicesCount = 2) {
   const props = {
     choices: generateChoices(choicesCount),
     label: 'Foo',
+    hint: 'Psst! I know the answer',
+    errorMessage: 'Hey, you have to pick an answer',
     name: 'spec-field',
     type: 'radio' as ChoiceListType,
     onChange: () => {},

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
@@ -112,7 +112,7 @@ export const ChoiceList: React.FC<ChoiceListProps> = (props: ChoiceListProps) =>
     }, 20);
   };
 
-  const { labelProps, fieldProps, wrapperProps, bottomError } = useFormLabel({
+  const { labelProps, wrapperProps, bottomError } = useFormLabel({
     ...listProps,
     labelComponent: 'legend',
     wrapperIsFieldset: true,
@@ -138,11 +138,6 @@ export const ChoiceList: React.FC<ChoiceListProps> = (props: ChoiceListProps) =>
           choiceProps.inputRef(ref);
         }
       },
-      // @ts-ignore: If I update the Choice props to inherit from the HTML element,
-      // I get a bunch of other TS errors that are out of scope to fix. We can
-      // probably clean it up by turning Choice into a functional component, and we
-      // may want to rethink our array of `choiceRefs` too.
-      'aria-describedby': fieldProps['aria-describedby'],
     };
 
     return <Choice key={choiceProps.value} {...completeChoiceProps} />;

--- a/packages/design-system/src/components/ChoiceList/__snapshots__/ChoiceList.test.tsx.snap
+++ b/packages/design-system/src/components/ChoiceList/__snapshots__/ChoiceList.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`ChoiceList Radio buttons and Checkboxes is a radio button group 1`] = `
 <DocumentFragment>
   <fieldset
-    aria-invalid="false"
+    aria-describedby="field_1-error field_1-hint"
+    aria-invalid="true"
     class="ds-c-fieldset"
   >
     <legend
@@ -12,20 +13,51 @@ exports[`ChoiceList Radio buttons and Checkboxes is a radio button group 1`] = `
     >
       Foo
     </legend>
+    <div
+      class="ds-c-field__hint"
+      id="field_1-hint"
+    >
+      Psst! I know the answer
+    </div>
+    <span
+      aria-atomic="true"
+      aria-live="assertive"
+      class="ds-c-inline-error ds-c-field__error-message"
+      id="field_1-error"
+    >
+      <svg
+        aria-hidden="true"
+        class="ds-c-icon ds-c-icon--alert-circle "
+        focusable="false"
+        id="icon-2"
+        viewBox="36 -12 186 186"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M162.18 41.592c-5.595-9.586-13.185-17.176-22.771-22.771-9.588-5.595-20.055-8.392-31.408-8.392-11.352 0-21.821 2.797-31.408 8.392-9.587 5.594-17.177 13.184-22.772 22.771-5.596 9.587-8.393 20.057-8.393 31.408 0 11.351 2.798 21.82 8.392 31.408 5.595 9.584 13.185 17.176 22.772 22.771 9.587 5.595 20.056 8.392 31.408 8.392s21.822-2.797 31.408-8.392c9.586-5.594 17.176-13.185 22.771-22.771C167.773 94.82 170.57 84.35 170.57 73c0-11.351-2.797-21.822-8.39-31.408zm-43.75 70.433c0 .761-.246 1.398-.734 1.914s-1.086.773-1.793.773H100.26c-.706 0-1.331-.271-1.874-.814-.543-.543-.814-1.168-.814-1.873V96.546c0-.706.271-1.331.814-1.874.543-.543 1.168-.814 1.874-.814h15.643c.707 0 1.306.258 1.793.773.488.518.734 1.154.734 1.915v15.479zm-.164-28.026c-.055.543-.339 1.019-.854 1.426-.517.407-1.154.61-1.914.61h-15.073c-.761 0-1.413-.203-1.956-.61-.543-.407-.815-.883-.815-1.426l-1.385-50.595c0-.653.271-1.141.814-1.467.544-.434 1.196-.652 1.956-.652h17.926c.761 0 1.412.217 1.955.652.543.326.813.815.813 1.467l-1.467 50.595z"
+        />
+      </svg>
+      <span
+        class="ds-u-visibility--screen-reader"
+      >
+        Error: 
+      </span>
+      Hey, you have to pick an answer
+    </span>
     <div>
       <div
         class="ds-c-choice-wrapper"
       >
         <input
-          class="ds-c-choice"
-          id="radio_spec-field_2"
+          class="ds-c-choice--error ds-c-choice"
+          id="radio_spec-field_3"
           name="spec-field"
           type="radio"
           value="1"
         />
         <label
           class="ds-c-label"
-          for="radio_spec-field_2"
+          for="radio_spec-field_3"
         >
           Choice 1
         </label>
@@ -36,15 +68,15 @@ exports[`ChoiceList Radio buttons and Checkboxes is a radio button group 1`] = `
         class="ds-c-choice-wrapper"
       >
         <input
-          class="ds-c-choice"
-          id="radio_spec-field_3"
+          class="ds-c-choice--error ds-c-choice"
+          id="radio_spec-field_4"
           name="spec-field"
           type="radio"
           value="2"
         />
         <label
           class="ds-c-label"
-          for="radio_spec-field_3"
+          for="radio_spec-field_4"
         >
           Choice 2
         </label>

--- a/packages/design-system/src/components/DateField/DateInput.tsx
+++ b/packages/design-system/src/components/DateField/DateInput.tsx
@@ -213,7 +213,6 @@ export class DateInput extends React.PureComponent<DateInputProps> {
           }
         }}
         autoComplete={this.props.autoComplete && `bday-${type}`}
-        aria-describedby={this.props['aria-describedby']}
         aria-invalid={this.props[`${type}Invalid`]}
       />
     );

--- a/packages/design-system/src/components/DateField/__snapshots__/MultiInputDateField.test.tsx.snap
+++ b/packages/design-system/src/components/DateField/__snapshots__/MultiInputDateField.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`MultiInputDateField renders 1`] = `
 <DocumentFragment>
   <fieldset
+    aria-describedby="field_snapshot-hint"
     aria-invalid="false"
     class="ds-c-fieldset"
   >
@@ -32,7 +33,6 @@ exports[`MultiInputDateField renders 1`] = `
           Month
         </label>
         <input
-          aria-describedby="field_snapshot-hint"
           aria-invalid="false"
           class="ds-c-field ds-c-field--month"
           id="field_snapshot"
@@ -60,7 +60,6 @@ exports[`MultiInputDateField renders 1`] = `
           Day
         </label>
         <input
-          aria-describedby="field_snapshot-hint"
           aria-invalid="false"
           class="ds-c-field ds-c-field--day"
           id="field_snapshot"
@@ -88,7 +87,6 @@ exports[`MultiInputDateField renders 1`] = `
           Year
         </label>
         <input
-          aria-describedby="field_snapshot-hint"
           aria-invalid="false"
           class="ds-c-field ds-c-field--year"
           id="field_snapshot"

--- a/packages/design-system/src/components/FormLabel/useFormLabel.tsx
+++ b/packages/design-system/src/components/FormLabel/useFormLabel.tsx
@@ -144,6 +144,13 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
   const bottomError = errorPlacement === 'bottom' ? errorElement : undefined;
   const ariaInvalid = props['aria-invalid'] ?? !!errorMessage;
 
+  const ariaDescribedBy =
+    mergeIds(
+      props['aria-describedby'],
+      errorElement && errorId,
+      (hint || requirementLabel) && hintId
+    ) || undefined;
+
   const labelProps = {
     children: label,
     className: labelClassName,
@@ -165,18 +172,14 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
     id,
     errorMessage,
     inversed,
-    'aria-describedby':
-      mergeIds(
-        props['aria-describedby'],
-        errorElement && errorId,
-        (hint || requirementLabel) && hintId
-      ) || undefined,
+    'aria-describedby': !wrapperIsFieldset ? ariaDescribedBy : undefined,
     'aria-invalid': !wrapperIsFieldset ? ariaInvalid : undefined,
   };
 
   const wrapperClassNames = classNames({ 'ds-c-fieldset': wrapperIsFieldset }, className);
   const wrapperProps = {
     className: wrapperClassNames,
+    'aria-describedby': wrapperIsFieldset ? ariaDescribedBy : undefined,
     'aria-invalid': wrapperIsFieldset ? ariaInvalid : undefined,
   };
 

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.test.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.test.tsx
@@ -7,6 +7,9 @@ import { setLanguage } from '@cmsgov/design-system';
 const defaultProps = {
   name: 'months',
   label: 'Months',
+  hint: 'Guess and test',
+  errorMessage:
+    'Only odd-numbered months accepted until July, except on leap years, then only prime-numbered months that have an "A" in them',
   selectAllText: 'Select all',
   clearAllText: 'Clear all',
 };

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
@@ -122,7 +122,7 @@ export const MonthPicker = (props: MonthPickerProps) => {
   const selectAllPressed = selectedMonths.length === NUM_MONTHS - disabledMonths.length;
   const clearAllPressed = selectedMonths.length === 0;
 
-  const { labelProps, fieldProps, wrapperProps, bottomError } = useFormLabel({
+  const { labelProps, wrapperProps, bottomError } = useFormLabel({
     ...props,
     className: classNames('ds-c-month-picker', props.className),
     labelComponent: 'legend',
@@ -140,7 +140,6 @@ export const MonthPicker = (props: MonthPickerProps) => {
           onClick={handleSelectAll}
           onDark={props.inversed}
           variation={props.buttonVariation}
-          aria-describedby={fieldProps['aria-describedby']}
         >
           {props.selectAllText ?? t('monthPicker.selectAllText')}
         </Button>
@@ -151,7 +150,6 @@ export const MonthPicker = (props: MonthPickerProps) => {
           onClick={handleClearAll}
           onDark={props.inversed}
           variation={props.buttonVariation}
-          aria-describedby={fieldProps['aria-describedby']}
         >
           {props.clearAllText ?? t('monthPicker.clearAllText')}
         </Button>
@@ -171,7 +169,6 @@ export const MonthPicker = (props: MonthPickerProps) => {
                 type="checkbox"
                 value={i + 1}
                 label={month}
-                aria-describedby={fieldProps['aria-describedby']}
               />
             </li>
           ))}

--- a/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.tsx.snap
+++ b/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`MonthPicker renders a snapshot 1`] = `
 <DocumentFragment>
   <fieldset
-    aria-invalid="false"
+    aria-describedby="field_1-error field_1-hint"
+    aria-invalid="true"
     class="ds-c-fieldset ds-c-month-picker"
   >
     <legend
@@ -12,6 +13,37 @@ exports[`MonthPicker renders a snapshot 1`] = `
     >
       Months
     </legend>
+    <div
+      class="ds-c-field__hint"
+      id="field_1-hint"
+    >
+      Guess and test
+    </div>
+    <span
+      aria-atomic="true"
+      aria-live="assertive"
+      class="ds-c-inline-error ds-c-field__error-message"
+      id="field_1-error"
+    >
+      <svg
+        aria-hidden="true"
+        class="ds-c-icon ds-c-icon--alert-circle "
+        focusable="false"
+        id="icon-2"
+        viewBox="36 -12 186 186"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M162.18 41.592c-5.595-9.586-13.185-17.176-22.771-22.771-9.588-5.595-20.055-8.392-31.408-8.392-11.352 0-21.821 2.797-31.408 8.392-9.587 5.594-17.177 13.184-22.772 22.771-5.596 9.587-8.393 20.057-8.393 31.408 0 11.351 2.798 21.82 8.392 31.408 5.595 9.584 13.185 17.176 22.772 22.771 9.587 5.595 20.056 8.392 31.408 8.392s21.822-2.797 31.408-8.392c9.586-5.594 17.176-13.185 22.771-22.771C167.773 94.82 170.57 84.35 170.57 73c0-11.351-2.797-21.822-8.39-31.408zm-43.75 70.433c0 .761-.246 1.398-.734 1.914s-1.086.773-1.793.773H100.26c-.706 0-1.331-.271-1.874-.814-.543-.543-.814-1.168-.814-1.873V96.546c0-.706.271-1.331.814-1.874.543-.543 1.168-.814 1.874-.814h15.643c.707 0 1.306.258 1.793.773.488.518.734 1.154.734 1.915v15.479zm-.164-28.026c-.055.543-.339 1.019-.854 1.426-.517.407-1.154.61-1.914.61h-15.073c-.761 0-1.413-.203-1.956-.61-.543-.407-.815-.883-.815-1.426l-1.385-50.595c0-.653.271-1.141.814-1.467.544-.434 1.196-.652 1.956-.652h17.926c.761 0 1.412.217 1.955.652.543.326.813.815.813 1.467l-1.467 50.595z"
+        />
+      </svg>
+      <span
+        class="ds-u-visibility--screen-reader"
+      >
+        Error: 
+      </span>
+      Only odd-numbered months accepted until July, except on leap years, then only prime-numbered months that have an "A" in them
+    </span>
     <div
       class="ds-c-month-picker__buttons ds-u-clearfix"
     >
@@ -47,14 +79,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="January"
                 class="ds-c-choice"
-                id="checkbox_months_2"
+                id="checkbox_months_3"
                 name="months"
                 type="checkbox"
                 value="1"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_2"
+                for="checkbox_months_3"
               >
                 Jan
               </label>
@@ -71,14 +103,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="February"
                 class="ds-c-choice"
-                id="checkbox_months_3"
+                id="checkbox_months_4"
                 name="months"
                 type="checkbox"
                 value="2"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_3"
+                for="checkbox_months_4"
               >
                 Feb
               </label>
@@ -95,14 +127,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="March"
                 class="ds-c-choice"
-                id="checkbox_months_4"
+                id="checkbox_months_5"
                 name="months"
                 type="checkbox"
                 value="3"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_4"
+                for="checkbox_months_5"
               >
                 Mar
               </label>
@@ -119,14 +151,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="April"
                 class="ds-c-choice"
-                id="checkbox_months_5"
+                id="checkbox_months_6"
                 name="months"
                 type="checkbox"
                 value="4"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_5"
+                for="checkbox_months_6"
               >
                 Apr
               </label>
@@ -143,14 +175,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="May"
                 class="ds-c-choice"
-                id="checkbox_months_6"
+                id="checkbox_months_7"
                 name="months"
                 type="checkbox"
                 value="5"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_6"
+                for="checkbox_months_7"
               >
                 May
               </label>
@@ -167,14 +199,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="June"
                 class="ds-c-choice"
-                id="checkbox_months_7"
+                id="checkbox_months_8"
                 name="months"
                 type="checkbox"
                 value="6"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_7"
+                for="checkbox_months_8"
               >
                 Jun
               </label>
@@ -191,14 +223,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="July"
                 class="ds-c-choice"
-                id="checkbox_months_8"
+                id="checkbox_months_9"
                 name="months"
                 type="checkbox"
                 value="7"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_8"
+                for="checkbox_months_9"
               >
                 Jul
               </label>
@@ -215,14 +247,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="August"
                 class="ds-c-choice"
-                id="checkbox_months_9"
+                id="checkbox_months_10"
                 name="months"
                 type="checkbox"
                 value="8"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_9"
+                for="checkbox_months_10"
               >
                 Aug
               </label>
@@ -239,14 +271,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="September"
                 class="ds-c-choice"
-                id="checkbox_months_10"
+                id="checkbox_months_11"
                 name="months"
                 type="checkbox"
                 value="9"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_10"
+                for="checkbox_months_11"
               >
                 Sep
               </label>
@@ -263,14 +295,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="October"
                 class="ds-c-choice"
-                id="checkbox_months_11"
+                id="checkbox_months_12"
                 name="months"
                 type="checkbox"
                 value="10"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_11"
+                for="checkbox_months_12"
               >
                 Oct
               </label>
@@ -287,14 +319,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="November"
                 class="ds-c-choice"
-                id="checkbox_months_12"
+                id="checkbox_months_13"
                 name="months"
                 type="checkbox"
                 value="11"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_12"
+                for="checkbox_months_13"
               >
                 Nov
               </label>
@@ -311,14 +343,14 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="December"
                 class="ds-c-choice"
-                id="checkbox_months_13"
+                id="checkbox_months_14"
                 name="months"
                 type="checkbox"
                 value="12"
               />
               <label
                 class="ds-c-label"
-                for="checkbox_months_13"
+                for="checkbox_months_14"
               >
                 Dec
               </label>


### PR DESCRIPTION
## Summary

We've gone back and forth on this a bit, but the latest advice we've gotten from an assistive tech user and accessibility expert is to place them on the fieldsets despite the issues with JAWS. Notes:
- Remove the  `aria-describedby` (for error and hint text) of each input. The `aria-describedby` on each input was way too verbose
- It won’t read out for all JAWS users but still will have a benefit for a lot of users. Just allow the aria-live on error messaging to do it’s job (when user submits) with the error. And the backup is that we’ll have the  `aria-describedby` on fieldset

## How to test

This version of the change has been tested a couple times, but specifically the components we're testing are `ChoiceList`, `MonthPicker`, and `MultiInputDateField`.

[demo branch](https://cmsgov.github.io/design-system/branch/pwolfert/aria-describedby-on-fieldsets)