### PR TITLE
[LHDM-1932] Add ReactNode to tab type definition for TabPanel

### DIFF
--- a/packages/design-system/src/components/Tabs/TabPanel.tsx
+++ b/packages/design-system/src/components/Tabs/TabPanel.tsx
@@ -17,7 +17,7 @@ export interface TabPanelProps {
    * The associated tab's label. Only applicable when the panel is a
    * child of `Tabs`.
    */
-  tab?: string | React.ReactNode;
+  tab?: React.ReactNode;
   /**
    * Additional classes for the associated tab. Only applicable when the panel
    * is a child of `Tabs`.

--- a/packages/design-system/src/components/Tabs/TabPanel.tsx
+++ b/packages/design-system/src/components/Tabs/TabPanel.tsx
@@ -17,7 +17,7 @@ export interface TabPanelProps {
    * The associated tab's label. Only applicable when the panel is a
    * child of `Tabs`.
    */
-  tab?: string;
+  tab?: string | React.ReactNode;
   /**
    * Additional classes for the associated tab. Only applicable when the panel
    * is a child of `Tabs`.


### PR DESCRIPTION
## Summary

- Adding `ReactNode` to `tab` prop on `TabPanel` component to allow providing markup as a tab title
- https://jira.cms.gov/browse/LHDM-1932 

## How to test

1. `yarn storybook`
2. Provide jsx markup on the `tab` prop in [the Tabs stories](https://github.com/CMSgov/design-system/blob/679393310324b8f4fd46b843e350888efb8cfaef/packages/design-system/src/components/Tabs/Tabs.stories.tsx#L18)

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [ ] Created or updated unit tests to cover any new or modified code
- [ ] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)

### If this is a change to documentation:

- [x] Checked for spelling and grammatical errors
