### PR TITLE
[NO-TICKET] Put the USA banner in healthcare Header behind a feature flag

### DIFF
--- a/packages/ds-healthcare-gov/src/components/Header/Header.tsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.tsx
@@ -125,6 +125,11 @@ export interface HeaderProps {
    * Additional classes to be added to the Logo component
    */
   logoClassName?: string;
+  /**
+   * Temporary feature flag for showing or not showing the USA Banner above the
+   * header. Defaults to true
+   */
+  showUsaBanner?: boolean;
 }
 
 export const VARIATION_NAMES = {
@@ -205,7 +210,7 @@ export const Header = (props: HeaderProps) => {
 
   return (
     <>
-      <UsaBanner />
+      {props.showUsaBanner && <UsaBanner />}
       <header className={classes} role="banner" aria-label="global">
         <SkipNav href={props.skipNavHref} onClick={props.onSkipNavClick}>
           {t('header.skipNav')}
@@ -252,6 +257,7 @@ export const Header = (props: HeaderProps) => {
 };
 
 Header.defaultProps = {
+  showUsaBanner: true,
   skipNavHref: '#main',
 };
 


### PR DESCRIPTION
## Summary

Put the USA banner in healthcare Header behind a feature flag to aid in the coordinated rollout

## How to test

Toggle it on and off in Storybook

## Checklist

- [ ] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
