### PR TITLE
[NO-TICKET] Fix the USA banner content width on doc site

### DIFF
--- a/packages/docs/src/styles/pages/layout.scss
+++ b/packages/docs/src/styles/pages/layout.scss
@@ -2,6 +2,10 @@ body {
   margin: 0;
 }
 
+:root {
+  --usa-banner__max-width: unset;
+}
+
 .full-height {
   // viewport height minus the USA banner at the top
   height: calc(100vh - 22px);


### PR DESCRIPTION

## Summary

Use the new design token to fix the width of the USA banner on the doc site. Its content was getting constrained to the "site max width", but our doc site is full screen.

## How to test

`yarn start`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.