### PR TITLE
[NO-TICKET] Fix possibility of null reference in Dropdown

### DIFF
--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -257,7 +257,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
 
   const renderItem = (item: DropdownOption, index: number) => {
     const { value, label, className, ...extraAttrs } = item;
-    const isSelected = selectedItem.value === item.value;
+    const isSelected = selectedItem?.value === item.value;
     return (
       <li
         key={value}


### PR DESCRIPTION
## Summary

- Fix reference to `selectedItem` that assumes it's not nullable. See commit message for details

## How to test

I actually have no idea how to reproduce this, [but it's failing on Jenkins](https://ci.backends.cms.gov/wds/job/design-system/job/publish-docs/116/console). I thought having an empty list of options would do the trick, but our code that finds the selected option correctly logs a warning to the console.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
