### PR TITLE
[NO-TICKET] Check the "forced colors mode" item of Autocomplete's maturity checklist

### DIFF
--- a/packages/docs/content/components/autocomplete.mdx
+++ b/packages/docs/content/components/autocomplete.mdx
@@ -86,7 +86,7 @@ The `<Autocomplete>` component also makes use of a text field, which can be cust
 <MaturityChecklist
   a11yStandards={true}
   color={true}
-  forcedColors={false}
+  forcedColors={true}
   screenReaders={true}
   keyboardNavigable={true}
   storybook={true}


### PR DESCRIPTION
## Summary

Sarah noted that we still have the forced-colors item unchecked in Autocomplete's maturity checklist on the doc site, but we're actually good there now.
