### PR TITLE
[WNMGDS-2512] Fix event handlers for Autocomplete child TextField

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
@@ -194,7 +194,7 @@ describe('Autocomplete', () => {
     });
   });
 
-  it('Should set the input value correctly when a listbox selection is clicked', () => {
+  it('should set the input value correctly when a listbox selection is clicked', () => {
     const onChange = jest.fn();
     makeAutocomplete({ onChange });
     const autocompleteField = screen.getByRole('combobox') as HTMLInputElement;
@@ -208,7 +208,7 @@ describe('Autocomplete', () => {
     expect(onChange).toHaveBeenCalledWith(defaultItems[0]);
   });
 
-  it('Should set the input value to empty when "Clear search" is clicked', () => {
+  it('should set the input value to empty when "Clear search" is clicked', () => {
     makeAutocomplete();
     const autocompleteField = screen.getByRole('combobox') as HTMLInputElement;
     userEvent.click(autocompleteField);
@@ -223,7 +223,7 @@ describe('Autocomplete', () => {
     expect(autocompleteField.value).toBe('');
   });
 
-  it('Should call onChange with null item when "Clear search" is clicked', () => {
+  it('should call onChange with null item when "Clear search" is clicked', () => {
     const onChange = jest.fn();
     makeAutocomplete({ onChange });
     const autocompleteField = screen.getByRole('combobox') as HTMLInputElement;
@@ -240,7 +240,7 @@ describe('Autocomplete', () => {
     expect(onChange).toHaveBeenLastCalledWith(null);
   });
 
-  it('Should select list items by keyboard', () => {
+  it('should select list items by keyboard', () => {
     const onChange = jest.fn();
     makeAutocomplete({ onChange });
     const autocompleteField = screen.getByRole('combobox') as HTMLInputElement;
@@ -253,7 +253,7 @@ describe('Autocomplete', () => {
     expect(onChange).toHaveBeenCalledWith(defaultItems[0]);
   });
 
-  it('Should not call onChange when an item was not selected', () => {
+  it('should not call onChange when an item was not selected', () => {
     const onChange = jest.fn();
     makeAutocomplete({ onChange });
     const autocompleteField = screen.getByRole('combobox') as HTMLInputElement;
@@ -264,7 +264,7 @@ describe('Autocomplete', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('Should clear the input value by keyboard', () => {
+  it('should clear the input value by keyboard', () => {
     makeAutocomplete();
     const autocompleteField = screen.getByRole('combobox') as HTMLInputElement;
     autocompleteField.focus();
@@ -283,7 +283,7 @@ describe('Autocomplete', () => {
     expect(autocompleteField.value).toBe('');
   });
 
-  it('Closes the listbox when ESC is pressed', () => {
+  it('closes the listbox when ESC is pressed', () => {
     makeAutocomplete();
     const autocompleteField = screen.getByRole('combobox') as HTMLInputElement;
     userEvent.click(autocompleteField);
@@ -296,5 +296,26 @@ describe('Autocomplete', () => {
     userEvent.type(autocompleteField, '{esc}');
 
     expectMenuToBeClosed();
+  });
+
+  it("calls child TextField's event handlers", () => {
+    const props = {
+      label: 'autocomplete',
+      name: 'autocomplete_field',
+      onFocus: jest.fn(),
+      onChange: jest.fn(),
+      onKeyDown: jest.fn(),
+      // onTouchEnd : jest.fn(), Doesn't look like we can actually test onTouchEnd
+      onBlur: jest.fn(),
+    };
+    makeAutocomplete({ children: <TextField {...props} /> });
+    const field = screen.getByRole('combobox');
+    userEvent.click(field);
+    expect(props.onFocus).toHaveBeenCalledTimes(1);
+    userEvent.type(field, 'c');
+    expect(props.onKeyDown).toHaveBeenCalledTimes(1);
+    expect(props.onChange).toHaveBeenCalledTimes(1);
+    userEvent.tab();
+    expect(props.onBlur).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -265,7 +265,26 @@ export const Autocomplete = (props: AutocompleteProps) => {
     // list again without having to press anything on the keyboard.
     onFocus: (event) => {
       useComboboxProps.inputProps.onFocus?.(event);
+      textField.props.onFocus?.(event);
       state.open();
+    },
+    // Allow the user to continue to attach their own event handlers to the TextField.
+    // The following event handlers would normally be overwritten by useCombobox.
+    onChange: (event) => {
+      useComboboxProps.inputProps.onChange?.(event);
+      textField.props.onChange?.(event);
+    },
+    onBlur: (event) => {
+      useComboboxProps.inputProps.onBlur?.(event);
+      textField.props.onBlur?.(event);
+    },
+    onTouchEnd: (event) => {
+      useComboboxProps.inputProps.onTouchEnd?.(event);
+      textField.props.onTouchEnd?.(event);
+    },
+    onKeyDown: (event) => {
+      useComboboxProps.inputProps.onKeyDown?.(event);
+      textField.props.onKeyDown?.(event);
     },
   };
 


### PR DESCRIPTION
## Summary

Several of the event handlers for TextField no longer worked because the props from `useComboBox` were overriding them. While they shouldn't really be needed, this was an unexpected change for some teams, and it broke their code.

## How to test

Add props to the `TextField` in one of the `Autocomplete` stories like `onKeyDown={action('onKeyDown')}` and then check the _Actions_ tab in Storybook for a log.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)