### PR TITLE
[WNMGDS-2514] Fix delayed receipt of items failing to open Autocomplete results list

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -24,16 +24,21 @@ type Story = StoryObj<typeof Autocomplete>;
 const Template = (args) => {
   const { items, textFieldLabel, textFieldHint, ...autocompleteArgs } = args;
   const [input, setInput] = useState('');
+  const [filteredItems, setFilteredItems] = useState(null);
   const onInputValueChange = (...args) => {
     action('onInputValueChange')(args);
     setInput(args[0]);
+
+    setTimeout(() => {
+      let filteredItems = null;
+      if (input.length > 0) {
+        filteredItems = items.filter(
+          (item) => !item.name || item.name.toLowerCase().includes(input.toLowerCase())
+        );
+      }
+      setFilteredItems(filteredItems);
+    }, 1000);
   };
-  let filteredItems = null;
-  if (input.length > 0) {
-    filteredItems = items.filter(
-      (item) => !item.name || item.name.toLowerCase().includes(input.toLowerCase())
-    );
-  }
   return (
     <Autocomplete
       {...autocompleteArgs}

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -24,21 +24,16 @@ type Story = StoryObj<typeof Autocomplete>;
 const Template = (args) => {
   const { items, textFieldLabel, textFieldHint, ...autocompleteArgs } = args;
   const [input, setInput] = useState('');
-  const [filteredItems, setFilteredItems] = useState(null);
   const onInputValueChange = (...args) => {
     action('onInputValueChange')(args);
     setInput(args[0]);
-
-    setTimeout(() => {
-      let filteredItems = null;
-      if (input.length > 0) {
-        filteredItems = items.filter(
-          (item) => !item.name || item.name.toLowerCase().includes(input.toLowerCase())
-        );
-      }
-      setFilteredItems(filteredItems);
-    }, 1000);
   };
+  let filteredItems = null;
+  if (input.length > 0) {
+    filteredItems = items.filter(
+      (item) => !item.name || item.name.toLowerCase().includes(input.toLowerCase())
+    );
+  }
   return (
     <Autocomplete
       {...autocompleteArgs}

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import Button from '../Button/Button';
 import DropdownMenu from '../Dropdown/DropdownMenu';
 import classNames from 'classnames';
@@ -14,7 +14,6 @@ import {
 import { t } from '../i18n';
 import { useComboBox } from '../react-aria'; // from react-aria
 import { useComboBoxState } from '../react-aria'; // from react-stately
-import usePrevious from '../utilities/usePrevious';
 
 export interface AutocompleteItem extends Omit<React.HTMLAttributes<'option'>, 'name'> {
   /**
@@ -288,16 +287,6 @@ export const Autocomplete = (props: AutocompleteProps) => {
       textField.props.onKeyDown?.(event);
     },
   };
-
-  const oldItems = usePrevious(items);
-  useEffect(() => {
-    // If the items come in significantly later than when the user started typing,
-    // react-stately will not realize that it should be showing those results. There
-    // might be items, but `isOpen` will be false 🤦‍♂️.
-    if (items && items !== oldItems && items.length !== oldItems?.length) {
-      state.open();
-    }
-  }, [items]);
 
   const rootClassName = classNames('ds-c-autocomplete', className);
 

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -294,7 +294,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
     // If the items come in significantly later than when the user started typing,
     // react-stately will not realize that it should be showing those results. There
     // might be items, but `isOpen` will be false 🤦‍♂️.
-    if (items && items !== oldItems && items.length !== oldItems?.length) {
+    if (state.isFocused && items && items !== oldItems && items.length !== oldItems?.length) {
       state.open();
     }
   }, [items]);

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import Button from '../Button/Button';
 import DropdownMenu from '../Dropdown/DropdownMenu';
 import classNames from 'classnames';
@@ -14,6 +14,7 @@ import {
 import { t } from '../i18n';
 import { useComboBox } from '../react-aria'; // from react-aria
 import { useComboBoxState } from '../react-aria'; // from react-stately
+import usePrevious from '../utilities/usePrevious';
 
 export interface AutocompleteItem extends Omit<React.HTMLAttributes<'option'>, 'name'> {
   /**
@@ -287,6 +288,16 @@ export const Autocomplete = (props: AutocompleteProps) => {
       textField.props.onKeyDown?.(event);
     },
   };
+
+  const oldItems = usePrevious(items);
+  useEffect(() => {
+    // If the items come in significantly later than when the user started typing,
+    // react-stately will not realize that it should be showing those results. There
+    // might be items, but `isOpen` will be false 🤦‍♂️.
+    if (items && items !== oldItems && items.length !== oldItems?.length) {
+      state.open();
+    }
+  }, [items]);
 
   const rootClassName = classNames('ds-c-autocomplete', className);
 

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -294,7 +294,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
     // If the items come in significantly later than when the user started typing,
     // react-stately will not realize that it should be showing those results. There
     // might be items, but `isOpen` will be false 🤦‍♂️.
-    if (state.isFocused && items && items !== oldItems && items.length !== oldItems?.length) {
+    if (state.isFocused && items && items !== oldItems) {
       state.open();
     }
   }, [items]);


### PR DESCRIPTION
## Summary

WNMGDS-2514

The most common way our applications use Autocomplete involves fetching asynchronous data to show in the results. After the results come back, they are passed to the Autocomplete component in an array. However, in the new implementation of Autocomplete, the internal heuristics (in `react-stately`) for determining when to open the menu determine that it shouldn't be open. This overcomes that problem by manually detecting when new items come in and that the results list should be open.

## How to test

1. Check out 8e13dca0d7a90d70db7f8c39219b058b07846041 to see the problem in the default Autocomplete story
2. Check out 3abfa13115a2071f9469767d6758c82bce41c227 to see it fixed
3. To see the new unit test work, comment out the new functionality in Autocomplete and watch it fail

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)
