### PR TITLE
[WNMGDS-2518] Fix additional Autocomplete open/close issues

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -24,16 +24,21 @@ type Story = StoryObj<typeof Autocomplete>;
 const Template = (args) => {
   const { items, textFieldLabel, textFieldHint, ...autocompleteArgs } = args;
   const [input, setInput] = useState('');
+  const [filteredItems, setFilteredItems] = useState(null);
   const onInputValueChange = (...args) => {
     action('onInputValueChange')(args);
     setInput(args[0]);
+
+    setTimeout(() => {
+      let filteredItems = null;
+      if (input.length > 0) {
+        filteredItems = items.filter(
+          (item) => !item.name || item.name.toLowerCase().includes(input.toLowerCase())
+        );
+      }
+      setFilteredItems(filteredItems);
+    }, 1000);
   };
-  let filteredItems = null;
-  if (input.length > 0) {
-    filteredItems = items.filter(
-      (item) => !item.name || item.name.toLowerCase().includes(input.toLowerCase())
-    );
-  }
   return (
     <Autocomplete
       {...autocompleteArgs}

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -24,21 +24,16 @@ type Story = StoryObj<typeof Autocomplete>;
 const Template = (args) => {
   const { items, textFieldLabel, textFieldHint, ...autocompleteArgs } = args;
   const [input, setInput] = useState('');
-  const [filteredItems, setFilteredItems] = useState(null);
   const onInputValueChange = (...args) => {
     action('onInputValueChange')(args);
     setInput(args[0]);
-
-    setTimeout(() => {
-      let filteredItems = null;
-      if (input.length > 0) {
-        filteredItems = items.filter(
-          (item) => !item.name || item.name.toLowerCase().includes(input.toLowerCase())
-        );
-      }
-      setFilteredItems(filteredItems);
-    }, 1000);
   };
+  let filteredItems = null;
+  if (input.length > 0) {
+    filteredItems = items.filter(
+      (item) => !item.name || item.name.toLowerCase().includes(input.toLowerCase())
+    );
+  }
   return (
     <Autocomplete
       {...autocompleteArgs}

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
@@ -224,6 +224,7 @@ describe('Autocomplete', () => {
 
     expect(autocompleteField.value).toBe('Cook County, IL');
     expect(onChange).toHaveBeenCalledWith(defaultItems[0]);
+    expectMenuToBeClosed();
   });
 
   it('should set the input value to empty when "Clear search" is clicked', () => {
@@ -269,6 +270,7 @@ describe('Autocomplete', () => {
 
     expect(autocompleteField.value).toBe('Cook County, IL');
     expect(onChange).toHaveBeenCalledWith(defaultItems[0]);
+    expectMenuToBeClosed();
   });
 
   it('should not call onChange when an item was not selected', () => {

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -295,7 +295,14 @@ export const Autocomplete = (props: AutocompleteProps) => {
     // react-stately will not realize that it should be showing those results. There
     // might be items, but `isOpen` will be false 🤦‍♂️.
     if (state.isFocused && items && items !== oldItems) {
-      state.open();
+      const itemsJson = JSON.stringify(items);
+      const oldItemsJson = JSON.stringify(oldItems);
+      // Only open it if the actual data changed. This whole useEffect is a hack, and
+      // we need to get really specific here if we don't want there to be problems.
+      if (itemsJson !== oldItemsJson) {
+        console.log(itemsJson, oldItemsJson);
+        state.open();
+      }
     }
   }, [items]);
 

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -199,6 +199,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
   const state = useComboBoxState({
     ...autocompleteProps,
     allowsCustomValue: true,
+    allowsEmptyCollection: true,
     children: reactStatelyItems,
     inputValue: textField.props.value,
     onInputChange: onInputValueChange
@@ -289,22 +290,22 @@ export const Autocomplete = (props: AutocompleteProps) => {
     },
   };
 
-  const oldItems = usePrevious(items);
-  useEffect(() => {
-    // If the items come in significantly later than when the user started typing,
-    // react-stately will not realize that it should be showing those results. There
-    // might be items, but `isOpen` will be false 🤦‍♂️.
-    if (state.isFocused && items && items !== oldItems) {
-      const itemsJson = JSON.stringify(items);
-      const oldItemsJson = JSON.stringify(oldItems);
-      // Only open it if the actual data changed. This whole useEffect is a hack, and
-      // we need to get really specific here if we don't want there to be problems.
-      if (itemsJson !== oldItemsJson) {
-        console.log(itemsJson, oldItemsJson);
-        state.open();
-      }
-    }
-  }, [items]);
+  // const oldItems = usePrevious(items);
+  // useEffect(() => {
+  //   // If the items come in significantly later than when the user started typing,
+  //   // react-stately will not realize that it should be showing those results. There
+  //   // might be items, but `isOpen` will be false 🤦‍♂️.
+  //   if (state.isFocused && items && items !== oldItems) {
+  //     const itemsJson = JSON.stringify(items);
+  //     const oldItemsJson = JSON.stringify(oldItems);
+  //     // Only open it if the actual data changed. This whole useEffect is a hack, and
+  //     // we need to get really specific here if we don't want there to be problems.
+  //     if (itemsJson !== oldItemsJson) {
+  //       console.log(itemsJson, oldItemsJson);
+  //       state.open();
+  //     }
+  //   }
+  // }, [items]);
 
   const rootClassName = classNames('ds-c-autocomplete', className);
 
@@ -312,7 +313,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
     <div className={rootClassName} ref={wrapperRef}>
       {React.cloneElement(textField, textFieldProps)}
 
-      {(state.isOpen || (state.isFocused && statusMessage)) && (
+      {((state.isOpen && reactStatelyItems.length > 0) || (state.isFocused && statusMessage)) && (
         <DropdownMenu
           {...useComboboxProps.listBoxProps}
           componentClass="ds-c-autocomplete"

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -290,23 +290,6 @@ export const Autocomplete = (props: AutocompleteProps) => {
     },
   };
 
-  // const oldItems = usePrevious(items);
-  // useEffect(() => {
-  //   // If the items come in significantly later than when the user started typing,
-  //   // react-stately will not realize that it should be showing those results. There
-  //   // might be items, but `isOpen` will be false 🤦‍♂️.
-  //   if (state.isFocused && items && items !== oldItems) {
-  //     const itemsJson = JSON.stringify(items);
-  //     const oldItemsJson = JSON.stringify(oldItems);
-  //     // Only open it if the actual data changed. This whole useEffect is a hack, and
-  //     // we need to get really specific here if we don't want there to be problems.
-  //     if (itemsJson !== oldItemsJson) {
-  //       console.log(itemsJson, oldItemsJson);
-  //       state.open();
-  //     }
-  //   }
-  // }, [items]);
-
   const rootClassName = classNames('ds-c-autocomplete', className);
 
   return (

--- a/packages/design-system/src/components/react-aria/index.js
+++ b/packages/design-system/src/components/react-aria/index.js
@@ -4976,7 +4976,7 @@ function $628037886ba31236$export$f9d5c8beee7d008d(props, state, ref) {
 let $5e3802645cc19319$var$refCountMap = new WeakMap();
 let $5e3802645cc19319$var$observerStack = [];
 function $5e3802645cc19319$export$1c3ebcada18427bf(targets, root = document.body) {
-  let visibleNodes = new Set(targets);
+  let visibleNodes = new Set(targets.filter((target) => target));
   let hiddenNodes = new Set();
   let walk = (root) => {
     // Keep live announcer and top layer elements (e.g. toasts) visible.


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/CMSgov/design-system/pull/2694.

The first iteration of a fix to that reported issue involved utilizing a flag for `useComboBoxState` called `allowsEmptyCollection`. Looking in the source code for `react-stately` to figure out what conditions will open the results menu, we saw that that `allowsEmptyCollection` flag would [let us pass through this logic gate](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-stately/combobox/src/useComboBoxState.ts#L116-L119). The triggering event for opening the dialog is typing stuff into the text field, but if the results aren't ready at the time the triggering event is handled (because they're being fetched asynchronously and we're waiting), `react-stately` will fail to open the results...unless we have that flag set to true. Setting the flag worked for one of the two applications that reported the issue; however, it had side-effects of showing an empty list sometimes. Unfortunatly when testing in the other application, we falsely assumed the fix was not working because of a caching issue. That led us to create another fix.

The second iteration of the fix, [which resulted in this pull request](https://github.com/CMSgov/design-system/pull/2694), involved detecting when a new set of result items came in through the component props and manually triggering an `open` event through `useComboBoxState`'s (`react-stately`'s) imperative `state.open()` interface. Unfortunately this path was fraught with danger. While it appeared that this fix worked in the narrow situation that we tested for, it was flawed logic. The assumption was that if items are changing, they're changing due to interaction by the user. For example, if the user has typed `a` to start searching for drugs (see our default Autocomplete Storybook story), the backend does a search for drugs, finds a bunch of matches, and supplies them in an array to the Autocomplete through its `items` prop. We'd therefore want to show them those results, so we call open—simple. The problem is that there's another valid time to change the items array when we don't want it to show. When we then select `Acetaminophen` from the list, the implementing application will naturally filter the results list down to one (the item just selected), but since they've just made a selection, we want to hide the results. The logic in the second iteration of the fix does not make that distinction. It therefore shows the list when it shouldn't.

I've gone back to the original style of fix but made improvements. Rather than try to force it to open at certain times with an unreliable imperative call to the `state.open` function, I'm embracing the library's own logic for determining the `isOpen` state.

The first problem with showing empty collections before was that we sometimes didn't have anything to show. That's why I've added another qualifier in [the expression that determines whether we should render the dropdown menu](https://github.com/CMSgov/design-system/commit/50678b22af7276df666af2a700b5529a98f87797#diff-d2902bdfecf5438a3e627f3b010ca640e6a471dd917ed3463f285d201ade4d61R316) to only rely on the value of `isOpen` if we have actual result items to show.

The second problem was an error I found when testing it out in one of the applications. The error was due to the `popoverRef.current` being undefined, probably due to either fact that I don't use _their_ popover and or to [the chicken/egg problem described in this react-spectrum issue](https://github.com/adobe/react-spectrum/issues/4016#issuecomment-1417369731). I fixed it by filtering out `undefined` values in one of the Adobe Spectrum functions that assumed that ref had a `.current` value. I'm not too concerned about this. This code isn't going to live forever.

## How to test

There's a test commit that recreates the original issue in one of our storybook stories, but we found in the last PR that it's not really the best test. It's better to test this fix in the two applications and also lean on the unit test that I wrote in the last PR.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
