### PR TITLE
[WNMGDS-2517] Fix Autocomplete stripping props from TextField unintentionally

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
@@ -336,4 +336,28 @@ describe('Autocomplete', () => {
     userEvent.tab();
     expect(props.onBlur).toHaveBeenCalledTimes(1);
   });
+
+  it('allows arbitrary props to remain on the TextField', () => {
+    const props = {
+      label: 'autocomplete',
+      name: 'autocomplete_field',
+      placeholder: 'Hello world!',
+      fieldClassName: 'a-custom-class',
+    };
+    renderAutocomplete({ children: <TextField {...props} /> });
+    const field = screen.getByRole('combobox');
+    expect(field).toHaveAttribute('placeholder', props.placeholder);
+    expect(field).toHaveClass(props.fieldClassName);
+  });
+
+  it('inherits size prop from the TextField', () => {
+    const { container } = renderAutocomplete({
+      children: <TextField label="autocomplete" name="field" size="medium" />,
+    });
+    const field = screen.getByRole('combobox');
+    expect(field).toHaveClass('ds-c-field--medium');
+    open();
+    const menuContainer = container.querySelector('.ds-c-autocomplete__menu-container');
+    expect(menuContainer).toHaveClass('ds-c-field--medium');
+  });
 });

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -10,6 +10,7 @@ import {
   renderStatusMessage,
   getTextFieldChild,
   getActiveDescendant,
+  removeUndefined,
 } from './utils';
 import { t } from '../i18n';
 import { useComboBox } from '../react-aria'; // from react-aria
@@ -248,7 +249,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
     bottomError && clearSearchButton && 'ds-c-autocomplete__error-message-clear-btn'
   );
 
-  const textFieldProps = {
+  const textFieldProps = removeUndefined({
     ...useComboboxProps.inputProps,
     autoComplete: autoCompleteLabel,
     autoFocus: autoFocus || focusTrigger,
@@ -287,7 +288,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
       useComboboxProps.inputProps.onKeyDown?.(event);
       textField.props.onKeyDown?.(event);
     },
-  };
+  });
 
   const oldItems = usePrevious(items);
   useEffect(() => {

--- a/packages/design-system/src/components/Autocomplete/utils.tsx
+++ b/packages/design-system/src/components/Autocomplete/utils.tsx
@@ -61,3 +61,12 @@ export function getActiveDescendant(
   const index = (items ?? []).findIndex((item) => state.selectionManager.focusedKey === item.id);
   return getOptionId(rootId, index);
 }
+
+/**
+ * Mutates the original object, deleting properties whose values are undefined.
+ * Returns the object.
+ */
+export function removeUndefined<T>(obj: T): T {
+  Object.keys(obj).forEach((key) => obj[key] === undefined && delete obj[key]);
+  return obj;
+}


### PR DESCRIPTION
## Summary

- Don't clobber user-set props on textfield by undefined properties in Autocomplete
    - Note that while it's possible to pass the text field's props to the `useComboBox` function, there's no guarantee that it will honor those props or pass them on or use them the way we intend.

## How to test

Add a `placeholder` prop to the `TextField` in one of the Autocomplete stories and make sure it doesn't get stripped.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)
