### PR TITLE
[WNMGDS-2517] Remove "combobox" role from dropdown buttons

### DIFF
--- a/packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts
@@ -9,14 +9,14 @@ Object.keys(themes).forEach((theme) => {
 
   test(`Dropdown open: ${theme}`, async ({ page }) => {
     await page.goto(storyUrl(theme, 'components-dropdown--default'));
-    await page.getByRole('combobox').click();
+    await page.getByRole('button').click();
     await page.keyboard.press('ArrowDown');
     await expect(page).toHaveScreenshot(`dropdown--open--${theme}.png`, { fullPage: true });
   });
 
   test(`Dropdown open with option groups: ${theme}`, async ({ page }) => {
     await page.goto(storyUrl(theme, 'components-dropdown--option-groups'));
-    await page.getByRole('combobox').click();
+    await page.getByRole('button').click();
     await page.keyboard.press('ArrowDown');
     await expect(page).toHaveScreenshot(`dropdown-optgroups--open--${theme}.png`, {
       fullPage: true,

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -34,7 +34,7 @@ function makeDropdown(customProps = {}, optionsCount = 1) {
 }
 
 function getButton() {
-  return screen.getByRole('combobox');
+  return screen.getByRole('button', { name: RegExp(defaultProps.label) });
 }
 
 describe('Dropdown', () => {
@@ -82,7 +82,7 @@ describe('Dropdown', () => {
 
   it('has error', () => {
     makeDropdown({ errorMessage: 'Really bad error' });
-    const button = screen.getByRole('combobox', { name: /Really bad error/ });
+    const button = screen.getByRole('button', { name: /Really bad error/ });
     expect(button).toHaveAttribute('aria-invalid', 'true');
   });
 

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -256,11 +256,16 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
       fieldClassName
     ),
     ref: mergeRefs([triggerRef, inputRef, useAutofocus<HTMLButtonElement>(props.autoFocus)]),
-    // Screen reader users are more familiar with this pattern. The react-aria library makes
-    // this a role="button" for useSelect.
-    // role: 'combobox',
     'aria-controls': menuId,
     'aria-labelledby': `${buttonContentId} ${labelId}`,
+    // TODO: Someday we may want to add this `combobox` role back to the button, but right
+    // now desktop VoiceOver has an issue. It seems to interpret the selected value in the
+    // button as user input that needs to be checked for spelling (default setting). It
+    // therefore announces anything it deems misspelled as such. The `react-aria` authors
+    // likely ran into the same issue, since they leave it off for `useSelect` buttons.
+    // Adding the combobox role in the future can help because screen reader users are more
+    // familiar with the combobox pattern.
+    // role: 'combobox',
   };
 
   const labelProps = {

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -258,7 +258,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     ref: mergeRefs([triggerRef, inputRef, useAutofocus<HTMLButtonElement>(props.autoFocus)]),
     // Screen reader users are more familiar with this pattern. The react-aria library makes
     // this a role="button" for useSelect.
-    role: 'combobox',
+    // role: 'combobox',
     'aria-controls': menuId,
     'aria-labelledby': `${buttonContentId} ${labelId}`,
   };

--- a/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -186,7 +186,6 @@ exports[`Dropdown dropdown matches snapshot 1`] = `
     class="ds-c-dropdown__button ds-c-field"
     id="static-id"
     name="dropdown"
-    role="combobox"
     type="button"
   >
     <span
@@ -265,7 +264,6 @@ exports[`Dropdown supports bottom placed error 1`] = `
       class="ds-c-dropdown__button ds-c-field ds-c-field--error"
       id="static-id"
       name="dropdown"
-      role="combobox"
       type="button"
     >
       <span


### PR DESCRIPTION
## Summary

After much discussion, we've decided to follow Adobe Spectrum's lead in keeping the `role="combobox"` off of the dropdown buttons. The problem we were having was isolated to desktop users of VoiceOver, and it was that the selected value inside a dropdown button was read out differently than the options in the list when containing something that it deemed was a spelling error.

What we believe was happening was that when the role is `combobox`, VoiceOver thinks that it’s a text field (because that's the common combobox pattern), and it wants to warn the user that they typed something in wrong. That resulted in "Nisqually Indian Tribe (formerly the Nisqually Indian Tribe of the Nisqually Reservation" being read out as “Mispelled Nisqually Indian Tribe (formerly the Mispelled Nisqually Indian Tribe of the Mispelled Nisqually Mispelled Reservatio”.

- Removes the `combobox` role from the dropdown button until such a date when the desktop version of VoiceOver supports the [select-only combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/) correctly

## How to test

[Demo](https://cmsgov.github.io/design-system/branch/pwolfert/dropdown-button-readout/storybook/?path=/docs/components-dropdown--docs)

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)
