### PR TITLE
[NO-TICKET] Fix release script trying to use the tags before we make them

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -54,8 +54,6 @@ async function undoLastCommit() {
 }
 
 async function bumpVersions() {
-  const { tags } = readLastPublishCommit();
-
   console.log(c.green('Bumping package versions for release...'));
   const preBumpHash = getCurrentCommit();
   shI('./node_modules/.bin/lerna', ['version', '--no-push', '--exact']);
@@ -76,7 +74,7 @@ async function bumpVersions() {
   console.log(c.green('Pushing to origin...'));
   sh(`git push --set-upstream origin ${getCurrentBranch()}`);
   console.log(c.green('Pushed bump commit to origin.'));
-  sh(`git push origin ${tags.join(' ')}`);
+  sh(`git push origin ${readLastPublishCommit().tags.join(' ')}`);
   console.log(c.green('Pushed tags to origin.'));
 }
 


### PR DESCRIPTION
## Summary

Undoes [this mistake](https://github.com/CMSgov/design-system/pull/2688/files#diff-21f9896491d70e481e031a1c66e9ffed07592f08455bdcd4a3cecc9c63814768R57) that was leftover from a version of that change where I had to pass the tags to one of the functions. The release script crashed on our release branch after cherry-picking new commits onto it because it couldn't find the publish commit. When I committed the change, I think I had been testing on a test branch that already had a publish commit on it, which gave us a false positive.

## How to test

1. Create a release
2. Undo the release