### PR TITLE
[NO-TICKET] Allow the setting of an error message on the inverse ChoiceList story

### DIFF
--- a/packages/design-system/src/components/ChoiceList/ChoiceList.stories.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.stories.tsx
@@ -19,6 +19,9 @@ const meta: Meta<typeof ChoiceList> = {
       { label: 'Choice 2', requirementLabel: 'Choice hint text', value: 'B' },
     ],
   },
+  argTypes: {
+    errorMessage: { control: 'text' },
+  },
 };
 export default meta;
 


### PR DESCRIPTION
## Summary

- Fix the `errorMessage` control in the inverse ChoiceList story so that it can be set. Previously it was an object type
