### PR TITLE
[WNMGDS-2529] Give the calendar button more context for screen readers

### DIFF
--- a/packages/design-system/src/components/DateField/SingleInputDateField.test.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.test.tsx
@@ -85,10 +85,13 @@ describe('SingleInputDateField', function () {
     it('renders with picker', () => {
       const { container } = renderPicker();
 
+      const label = container.querySelector('.ds-c-label');
+      const hint = container.querySelector('.ds-c-hint');
+
       expect(
         container.querySelector('.ds-c-single-input-date-field--with-picker')
       ).toBeInTheDocument();
-      expect(container.querySelector('.ds-c-label')).toBeInTheDocument();
+      expect(label).toBeInTheDocument();
       expect(container.querySelector('.ds-c-label-mask')).toBeInTheDocument();
       expect(
         container.querySelector('.ds-c-single-input-date-field__field-wrapper')
@@ -98,6 +101,7 @@ describe('SingleInputDateField', function () {
       const button = screen.getByRole('button');
       expect(button).toBeInTheDocument();
       expect(button).toHaveClass('ds-c-single-input-date-field__button');
+      expect(button).toHaveAttribute('aria-describedby', `${label.id} ${hint.id}`);
       expect(button.firstElementChild.tagName).toBe('svg');
       expect(button.firstElementChild.classList).toContain('ds-c-icon--calendar');
 

--- a/packages/design-system/src/components/DateField/SingleInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.tsx
@@ -166,6 +166,9 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
             onClick={() => setPickerVisible(!pickerVisible)}
             type="button"
             ref={calendarButtonRef}
+            // The `?? ''` after `hintId` is only to support v8.0, which doesn't have a `hintId`.
+            // It can be removed after we're done supporting v8.0.
+            aria-describedby={`${labelProps.id} ${labelProps.hintId ?? ''}`}
           >
             <CalendarIcon
               ariaHidden={false}


### PR DESCRIPTION
## Summary

WNMGDS-2529

Sometimes there are multiple date pickers on the same page. Screen reader users need to be able to distinguish between the different calendar buttons.

- Give the calendar button more context for screen readers by describing by the label and hint

## How to test

[Branch demo](https://cmsgov.github.io/design-system/branch/pwolfert/give-calendar-button-sr-context/storybook)

1. Open the [with picker](https://cmsgov.github.io/design-system/branch/pwolfert/give-calendar-button-sr-context/storybook/?path=/story/components-singleinputdatefield--with-picker) story in Storybook
2. Using a screen reader, focus on the calendar button. It should read out the label and hint after a short pause to give some extra context

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)