### PR TITLE
[LHDM-2080] Add text property in HelpDrawer onAnalyticsEvent call

### DIFF
--- a/packages/design-system/src/components/HelpDrawer/useHelpDrawerAnalytics.ts
+++ b/packages/design-system/src/components/HelpDrawer/useHelpDrawerAnalytics.ts
@@ -34,6 +34,7 @@ export default function useHelpDrawerAnalytics({
       event_label: eventHeadingText,
       event_extension: eventExtensionText,
       heading: eventHeadingText,
+      text: eventHeadingText,
       ...eventAttributes,
     });
   }


### PR DESCRIPTION
## Summary

- We got feedback from Blast to add `text` in HelpDrawer analytics calls. Since we're leveraging the built-in `useHelpDrawerAnalytics` in HelpDrawer, I've made a change to include that here.
- https://jira.cms.gov/browse/BLSTANALYT-7011 

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [ ] Selected appropriate release milestone

### If this is a change to code:

- [ ] Created or updated unit tests to cover any new or modified code
- [ ] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)