### PR TITLE
[NO-TICKET] Update CDN examples to use latest DS version

### DIFF
--- a/examples/cdn-html-css/index.html
+++ b/examples/cdn-html-css/index.html
@@ -5,12 +5,12 @@
     <title>Design System</title>
     <!-- In a real project this will contain a href link to your local CSS file, 
       while in this case we are using a CDN as an example -->
-    <link rel="stylesheet" href="https://design.cms.gov/cdn/design-system/6.0.0/css/index.css" />
+    <link rel="stylesheet" href="https://design.cms.gov/cdn/design-system/8.0.2/css/index.css" />
     <!-- In this case we're loading the core-theme styles which include all the CSS
       variables for the core CMSDS theme, a theme must be loaded for the styles to work -->
     <link
       rel="stylesheet"
-      href="https://design.cms.gov/cdn/design-system/6.0.0/css/core-theme.css"
+      href="https://design.cms.gov/cdn/design-system/8.0.2/css/core-theme.css"
     />
     <link rel="stylesheet" href="style.css" />
   </head>

--- a/examples/cdn-preact/README.md
+++ b/examples/cdn-preact/README.md
@@ -9,5 +9,4 @@ This shows the usage of CMS design system preact components from the CDN:
 
 ## Getting started
 
-1. Run `./copy.sh` (Temporary step until we've deployed to the CDN)
 1. Open `index.html` in a browser.

--- a/examples/cdn-preact/copy.sh
+++ b/examples/cdn-preact/copy.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# Remove once we have a version available on the CDN
-
-mkdir -p dist/js
-cp -R ../../packages/design-system/dist/preact-components/bundle/. dist/js/

--- a/examples/cdn-preact/index.html
+++ b/examples/cdn-preact/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <title>CDN Example</title>
-    <link rel="stylesheet" href="https://design.cms.gov/cdn/design-system/6.0.0/css/index.css" />
+    <link rel="stylesheet" href="https://design.cms.gov/cdn/design-system/8.0.2/css/index.css" />
     <link
       rel="stylesheet"
-      href="https://design.cms.gov/cdn/design-system/6.0.0/css/core-theme.css"
+      href="https://design.cms.gov/cdn/design-system/8.0.2/css/core-theme.css"
     />
     <link rel="stylesheet" href="style.css" />
-    <script src="dist/js/preact.min.umd.js"></script>
-    <script src="dist/js/preact-components.js"></script>
+    <script src="https://design.cms.gov/cdn/design-system/8.0.2/preact-components/bundle/preact.min.umd.js"></script>
+    <script src="https://design.cms.gov/cdn/design-system/8.0.2/preact-components/bundle/preact-components.js"></script>
   </head>
   <body class="ds-base">
     <div id="usa-banner"></div>

--- a/examples/cdn-react/index.html
+++ b/examples/cdn-react/index.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <title>CDN Example</title>
-    <link rel="stylesheet" href="https://design.cms.gov/cdn/design-system/6.0.0/css/index.css" />
+    <link rel="stylesheet" href="https://design.cms.gov/cdn/design-system/8.0.2/css/index.css" />
     <link
       rel="stylesheet"
-      href="https://design.cms.gov/cdn/design-system/6.0.0/css/core-theme.css"
+      href="https://design.cms.gov/cdn/design-system/8.0.2/css/core-theme.css"
     />
     <link rel="stylesheet" href="style.css" />
-    <script src="https://design.cms.gov/cdn/design-system/6.0.0/js/react.production.min.js"></script>
-    <script src="https://design.cms.gov/cdn/design-system/6.0.0/js/react-dom.production.min.js"></script>
-    <script src="https://design.cms.gov/cdn/design-system/6.0.0/js/bundle.js"></script>
+    <script src="https://design.cms.gov/cdn/design-system/8.0.2/react-components/bundle/react.production.min.js"></script>
+    <script src="https://design.cms.gov/cdn/design-system/8.0.2/react-components/bundle/react-dom.production.min.js"></script>
+    <script src="https://design.cms.gov/cdn/design-system/8.0.2/react-components/bundle/react-components.js"></script>
   </head>
   <body class="ds-base">
     <div id="usa-banner"></div>

--- a/examples/cdn-web-components/README.md
+++ b/examples/cdn-web-components/README.md
@@ -9,5 +9,4 @@ This shows the usage of CMS design system web components from the CDN:
 
 ## Getting started
 
-1. Run `./copy.sh` (Temporary step until we've deployed to the CDN)
 1. Open `index.html` in a browser.

--- a/examples/cdn-web-components/copy.sh
+++ b/examples/cdn-web-components/copy.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# Remove once we have a version available on the CDN
-
-mkdir -p dist/js
-cp -R ../../packages/design-system/dist/web-components/bundle/. dist/js/

--- a/examples/cdn-web-components/index.html
+++ b/examples/cdn-web-components/index.html
@@ -62,7 +62,7 @@
       Must load the JavaScript after your page HTML or else it won't evaluate
       the custom design-system elements that already exist on the page
     -->
-    <script src="dist/js/web-components.js"></script>
+    <script src="https://design.cms.gov/cdn/design-system/8.0.2/web-components/bundle/web-components.js"></script>
     <script>
       document.getElementById('the-button').addEventListener('click', function () {
         const oldAlert = document.getElementById('alert');

--- a/examples/cdn-web-components/index.html
+++ b/examples/cdn-web-components/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <title>CDN Example</title>
-    <link rel="stylesheet" href="https://design.cms.gov/cdn/design-system/6.0.0/css/index.css" />
+    <link rel="stylesheet" href="https://design.cms.gov/cdn/design-system/8.0.2/css/index.css" />
     <link
       rel="stylesheet"
-      href="https://design.cms.gov/cdn/design-system/6.0.0/css/core-theme.css"
+      href="https://design.cms.gov/cdn/design-system/8.0.2/css/core-theme.css"
     />
     <link rel="stylesheet" href="style.css" />
   </head>


### PR DESCRIPTION
## Summary

Update all the CDN examples to use the latest version of the assets

## How to test

Open up all the `index.html` files (see readmes)