### PR TITLE
[NO-TICKET] Add a "patch" script for automatically cherry-picking commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ These scripts can all be run from the root level of the repo:
 - `yarn deploy-demo`
   - Builds the doc site locally and deploys it to a branch-specific path on GitHub Pages. The terminal will display the URL where the demo was deployed to after it is done running.
 - `yarn release`
-  - Bumps package versions and tags a release commit. Read our [release guide on Confluence](https://confluence.cms.gov/x/CAsuK) for more info.
+  - Interactive script that bumps package versions, tags a release commit, drafts notes, and more. Read our [release guide on Confluence](https://confluence.cms.gov/x/CAsuK) for more info.
 - `yarn release:notes`
-  - Generates draft release notes and associated ticket information from [GitHub Milestones](https://github.com/CMSgov/design-system/milestones) in the CMSDS public repository.
+  - Interactive script that generates draft release notes and associated ticket information from [GitHub Milestones](https://github.com/CMSgov/design-system/milestones) in the CMSDS public repository.
+- `yarn release:patch`
+  - Interactive script that collects the merge commits from pull requests associated with a given milestone and cherry-picks them onto the current branch (use with release branch)
 
 ### Visual regression testing
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "prettier": "yarn prettier --write 'packages/**/*.{js,jsx,tsx,scss,html,md,mdx,json}'",
     "release": "ts-node ./scripts/release.ts",
     "release:notes": "ts-node ./scripts/notes.ts",
+    "release:patch": "ts-node ./scripts/patch.ts",
     "serve:docs": "yarn --cwd ./packages/docs serve",
     "start": "yarn build:storybook:docs && yarn --cwd ./packages/docs develop",
     "storybook": "storybook dev -p 6006",

--- a/scripts/notes.ts
+++ b/scripts/notes.ts
@@ -1,9 +1,9 @@
 import * as themes from '../themes.json';
 import _ from 'lodash';
 import c from 'chalk';
-import { confirm, select } from '@inquirer/prompts';
+import { confirm } from '@inquirer/prompts';
 import { writeFileSync } from 'node:fs';
-import { sh, verifyGhInstalled, versionFromTag } from './utils';
+import { chooseMilestone, sh, verifyGhInstalled, versionFromTag } from './utils';
 
 interface PRDetails {
   author: string;
@@ -36,38 +36,6 @@ const icons = {
 
 type Icons = typeof icons | any;
 const icon: Icons = icons;
-
-/**
- * Current milestone reference
- */
-async function chooseMilestone() {
-  let milestone;
-  let milestoneQuery;
-  try {
-    const milestoneJSON = sh('gh api repos/CMSgov/design-system/milestones');
-    milestoneQuery = JSON.parse(milestoneJSON);
-  } catch (err) {
-    console.log(`${c.red('There was an error retrieving current milestones.')}`);
-    console.log(
-      `Please check to make sure you have the ${c.green(
-        'gh'
-      )} tool installed (https://cli.github.com)`
-    );
-    process.exit(1);
-  }
-
-  if (milestoneQuery.length < 1) {
-    throw Error('There are currently no milestones defined.');
-  } else if (milestoneQuery.length === 1) {
-    milestone = milestoneQuery[0];
-  } else {
-    milestone = await select({
-      message: 'Select an open milestone',
-      choices: milestoneQuery.map((ms: any) => ({ name: ms.title, value: ms })),
-    });
-  }
-  return milestone;
-}
 
 function fetchTags() {
   try {

--- a/scripts/patch.ts
+++ b/scripts/patch.ts
@@ -46,8 +46,10 @@ function formatPr({ title, mergeCommit }: PullRequest) {
     });
     if (ok) {
       console.log(
-        "Cool, good luck! Kicking off the cherry-picking process, but you'll have to take it from here. If you run into merge conflicts, just work through them and follow git's instructions to `git cherry-pick --continue` until you're done. May the Force be with you."
+        "Cool, good luck! Kicking off the cherry-picking process, but you'll have to take it from here. If you run into merge conflicts, just work through them and follow git's instructions to `git cherry-pick --continue` until you're done."
       );
+      console.log('');
+      console.log('May the Force be with you...');
       console.log('');
       console.log('------------------------------------------------------------');
       console.log('');

--- a/scripts/patch.ts
+++ b/scripts/patch.ts
@@ -45,6 +45,9 @@ function formatPr({ title, mergeCommit }: PullRequest) {
       message: 'Do you want to cherry-pick them onto your current branch now? (Y/n): ',
     });
     if (ok) {
+      console.log(
+        "Cool, good luck! Kicking off the cherry-picking process, but you'll have to take it from here. If you run into merge conflicts, just work through them and follow git's instructions to `git cherry-pick --continue` until you're done. May the Force be with you."
+      );
       shI('git', ['cherry-pick', ...commits]);
     } else {
       console.log(

--- a/scripts/patch.ts
+++ b/scripts/patch.ts
@@ -48,6 +48,9 @@ function formatPr({ title, mergeCommit }: PullRequest) {
       console.log(
         "Cool, good luck! Kicking off the cherry-picking process, but you'll have to take it from here. If you run into merge conflicts, just work through them and follow git's instructions to `git cherry-pick --continue` until you're done. May the Force be with you."
       );
+      console.log('');
+      console.log('------------------------------------------------------------');
+      console.log('');
       shI('git', ['cherry-pick', ...commits]);
     } else {
       console.log(

--- a/scripts/patch.ts
+++ b/scripts/patch.ts
@@ -1,0 +1,55 @@
+import _ from 'lodash';
+import c from 'chalk';
+import { chooseMilestone, sh, verifyGhInstalled } from './utils';
+import { confirm } from '@inquirer/prompts';
+
+type MergeCommit = { oid: string };
+type PullRequest = { title: string; mergeCommit?: MergeCommit; mergedAt?: string };
+
+function getPrMergeTime({ title, mergedAt }: PullRequest): number {
+  if (!mergedAt) {
+    throw new Error(`Unmerged commit found: '${title}'`);
+  }
+
+  return new Date(mergedAt).getTime();
+}
+
+function formatPr({ title, mergeCommit }: PullRequest) {
+  if (!mergeCommit) {
+    throw new Error(`Unmerged commit found: '${title}'`);
+  }
+  const hash = mergeCommit.oid.substring(0, 8);
+  return `${c.cyan(hash)} - ${title}`;
+}
+
+(async () => {
+  verifyGhInstalled();
+  try {
+    const milestone = await chooseMilestone();
+    const query = `milestone:"${milestone.title}"`;
+    const command = `gh pr list --search '${query}' --state merged -L 200 --json title,mergeCommit,mergedAt`;
+    const unsortedPrs = JSON.parse(sh(command).toString());
+    const prs: PullRequest[] = _.sortBy(unsortedPrs, [getPrMergeTime]);
+
+    console.log(
+      `The following pull requests were found for milestone ${c.green(milestone.title)}:`
+    );
+    console.log('');
+    console.log(prs.map(formatPr).join('\n'));
+    console.log('');
+    console.log(
+      'Their merge commits will be cherry-picked in the order they were originally merged.'
+    );
+    const ok = await confirm({
+      message: 'Do you want to cherry-pick them onto your current branch now? (Y/n): ',
+    });
+    if (ok) {
+      console.log('woohoo');
+    }
+
+    process.exit(0);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,5 +1,6 @@
 import c from 'chalk';
 import { execSync, spawnSync } from 'node:child_process';
+import { select } from '@inquirer/prompts';
 
 /**
  * Execute a shell command and wait for the response. Note that this does not
@@ -30,6 +31,27 @@ export function verifyGhInstalled() {
     );
     process.exit(1);
   }
+}
+
+/**
+ * Fetch open milestones and let one be selected. Returns a GH milestone object.
+ */
+export async function chooseMilestone() {
+  const milestoneJSON = sh('gh api repos/CMSgov/design-system/milestones');
+  const milestoneQuery = JSON.parse(milestoneJSON);
+
+  let milestone;
+  if (milestoneQuery.length < 1) {
+    throw Error('There are currently no milestones defined.');
+  } else if (milestoneQuery.length === 1) {
+    milestone = milestoneQuery[0];
+  } else {
+    milestone = await select({
+      message: 'Select an open milestone',
+      choices: milestoneQuery.map((ms: any) => ({ name: ms.title, value: ms })),
+    });
+  }
+  return milestone;
 }
 
 export function versionFromTag(tag: string): string {


### PR DESCRIPTION
## Summary

- Moves the milestone-picking function from the notes script into a shared utility module
- Creates a new `yarn release:patch` script that will guide you through applying commits from a milestone onto your current branch (the release branch)

## How to test

1. Check out the `test-release` branch, which I branched off of `release/8.0` and then merged the commits from this feature branch.
2. Run `yarn release:patch`. Note that there is only one open milestone right now, so it automatically chooses that. Also note that you don't have to actually go through with fixing all the merge conflicts; just run `git cherry-pick --abort` after you've seen that it kicks off the command successfully.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to documentation:

- [x] Checked for spelling and grammatical errors
