### PR TITLE
[WNMGDS-2542] Fix radio example showing on checkbox doc page

### DIFF
--- a/packages/docs/content/components/checkbox.mdx
+++ b/packages/docs/content/components/checkbox.mdx
@@ -28,7 +28,7 @@ Checkboxes can have optional checked or unchecked children that are conditionall
 <StorybookExample
   componentName="choice"
   sourceFilePath="components/ChoiceList/Choice.tsx"
-  storyId="components-choicelist--choice-children"
+  storyId="components-choicelist--choice-children&args=type:checkbox"
 />
 
 ## Code


### PR DESCRIPTION
## Summary

The [Checkbox](https://design.cms.gov/components/checkbox/) page on the doc site was showing radio buttons for one of its examples. This fixes it so that the example is of checkboxes.

## How to test

1. `yarn start`
2. Go to http://localhost:8000/components/checkbox/
3. Take a look at the "checkbox children"

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
