### PR TITLE
[WNMGDS-2535] Fix interaction tests run with Preact

### DIFF
--- a/packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts
@@ -10,6 +10,7 @@ Object.keys(themes).forEach((theme) => {
   test(`Dropdown open: ${theme}`, async ({ page }) => {
     await page.goto(storyUrl(theme, 'components-dropdown--default'));
     await page.getByRole('button').click();
+    await page.getByRole('listbox').waitFor();
     await page.keyboard.press('ArrowDown');
     await expect(page).toHaveScreenshot(`dropdown--open--${theme}.png`, { fullPage: true });
   });
@@ -17,6 +18,7 @@ Object.keys(themes).forEach((theme) => {
   test(`Dropdown open with option groups: ${theme}`, async ({ page }) => {
     await page.goto(storyUrl(theme, 'components-dropdown--option-groups'));
     await page.getByRole('button').click();
+    await page.getByRole('listbox').waitFor();
     await page.keyboard.press('ArrowDown');
     await expect(page).toHaveScreenshot(`dropdown-optgroups--open--${theme}.png`, {
       fullPage: true,

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts
@@ -10,6 +10,8 @@ Object.keys(themes).forEach((theme) => {
   test(`Dropdown open: ${theme}`, async ({ page }) => {
     await page.goto(storyUrl(theme, 'components-dropdown--default'));
     await page.getByRole('button').click();
+    // Cannot figure out an alternative to this wait time
+    await page.waitForTimeout(200);
     await page.getByRole('listbox').waitFor();
     await page.keyboard.press('ArrowDown');
     await expect(page).toHaveScreenshot(`dropdown--open--${theme}.png`, { fullPage: true });
@@ -18,6 +20,8 @@ Object.keys(themes).forEach((theme) => {
   test(`Dropdown open with option groups: ${theme}`, async ({ page }) => {
     await page.goto(storyUrl(theme, 'components-dropdown--option-groups'));
     await page.getByRole('button').click();
+    // Cannot figure out an alternative to this wait time
+    await page.waitForTimeout(200);
     await page.getByRole('listbox').waitFor();
     await page.keyboard.press('ArrowDown');
     await expect(page).toHaveScreenshot(`dropdown-optgroups--open--${theme}.png`, {

--- a/packages/design-system/src/components/TextField/Mask.test.interaction.ts
+++ b/packages/design-system/src/components/TextField/Mask.test.interaction.ts
@@ -10,7 +10,7 @@ Object.keys(themes).forEach((theme) => {
   test(`Mask partial text entry: ${theme}`, async ({ page }) => {
     await page.goto(`${storyUrl}&globals=theme:${theme}`);
     const elem = page.locator('input.ds-c-field');
-    await elem.type('22');
+    await elem.type('22', { delay: 220 });
     await expect(page).toHaveScreenshot(`mask--text-entry--${theme}.png`, { fullPage: true });
   });
 

--- a/packages/design-system/src/components/Tooltip/Tooltip.test.interaction.ts
+++ b/packages/design-system/src/components/Tooltip/Tooltip.test.interaction.ts
@@ -10,8 +10,7 @@ Object.keys(themes).forEach((theme) => {
   test(`Tooltip interaction: ${theme}`, async ({ page }) => {
     await page.goto(`${storyUrl}&globals=theme:${theme}`);
     await page.getByRole('button').click();
-    await expect(page).toHaveScreenshot(`tooltip--open-interactive--${theme}.png`, {
-      fullPage: true,
-    });
+    await page.getByRole('dialog').waitFor();
+    await expect(page).toHaveScreenshot(`tooltip--open-interactive--${theme}.png`);
   });
 });


### PR DESCRIPTION
## Summary

WNMGDS-2535

- Fixes interaction test failures when running against a Preact-built storybook, including
    - `Dropdown` interaction tests
    - `Tooltip` interaction tests
    - `Mask` interaction tests (intermittent failures)

## How to test

1. `PREACT=true yarn build:storybook`
2. `yarn test:browser:interaction`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

