### PR TITLE
[WNMGDS-2535] Make storybook use Preact by default

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-const usePreact = Boolean(process.env.PREACT && JSON.parse(process.env.PREACT));
+const usePreact = Boolean(JSON.parse(process.env.PREACT ?? 'true'));
 const preactAliases = usePreact
   ? {
       react: 'preact/compat',

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "serve:docs": "yarn --cwd ./packages/docs serve",
     "start": "yarn build:storybook:docs && yarn --cwd ./packages/docs develop",
     "storybook": "storybook dev -p 6006",
-    "storybook:preact": "PREACT=true storybook dev -p 6006",
+    "storybook:react": "PREACT=false storybook dev -p 6006",
     "test": "yarn test:unit && yarn test:a11y",
     "posttest": "yarn lint",
     "test:unit:coverage": "yarn test:unit --collectCoverage",


### PR DESCRIPTION
## Summary

WNMGDS-2535

Follows up https://github.com/CMSgov/design-system/pull/2768

- Change how we evaluate the `PREACT` environment variable in Storybook so that we assume we're using Preact unless that environment variable is explicitly set to something falsey. That means `yarn storybook` will use Preact by default, and the statically built versions will too as well.
- Replaced `yarn storybook:preact` with `yarn storybook:react` that runs it in React mode instead of Preact

## How to test

1. `yarn storybook` and make sure the web component stories work
2. `yarn storybook:react` and see that they don't
3. `yarn build:storybook` and serve the `storybook-static` directory from a web server like `http-server ./storybook-static` and make sure the web component stories work

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
