### PR TITLE
[WNMGDS-2552] Add reference links to design artboards in Sketch cloud

### DIFF
--- a/packages/docs/content/components/autocomplete.mdx
+++ b/packages/docs/content/components/autocomplete.mdx
@@ -7,6 +7,8 @@ core:
   storybookLink: components-autocomplete--docs
 healthcare:
   sketchLink: ZOZk4rx
+medicare:
+  sketchLink: j4o8n5z
 ---
 
 ## Examples

--- a/packages/docs/content/components/checkbox.mdx
+++ b/packages/docs/content/components/checkbox.mdx
@@ -7,6 +7,8 @@ core:
   storybookLink: components-choicelist--docs
 healthcare:
   sketchLink: 4a7lxP3
+medicare:
+  sketchLink: zyqD9mo
 ---
 
 ## Examples

--- a/packages/docs/content/components/drawer.mdx
+++ b/packages/docs/content/components/drawer.mdx
@@ -9,6 +9,7 @@ healthcare:
   sketchLink: GmlMnkL
 medicare:
   storybookLink: medicare-helpdrawer--help-drawer-toggle-with-drawer
+  sketchLink: 8yGr0OR
 ---
 
 On large screens it's fixed to the side of the screen, and on smaller screens it overlays the entire screen.

--- a/packages/docs/content/components/dropdown.mdx
+++ b/packages/docs/content/components/dropdown.mdx
@@ -7,6 +7,8 @@ core:
   storybookLink: components-dropdown--docs
 healthcare:
   sketchLink: eK07830
+medicare:
+  sketchLink: Wdna93w
 ---
 
 ## Examples

--- a/packages/docs/content/components/icon.mdx
+++ b/packages/docs/content/components/icon.mdx
@@ -5,6 +5,8 @@ core:
   githubLink: design-system/src/components/Icons
   sketchLink: ZOm83Y3
   storybookLink: components-icons--docs
+healthcare:
+  sketchLink: OmKvWww
 medicare:
   githubLink: ds-medicare-gov/src/components/Icons
 ---

--- a/packages/docs/content/components/spinner.mdx
+++ b/packages/docs/content/components/spinner.mdx
@@ -7,6 +7,8 @@ core:
   storybookLink: components-spinner--docs
 healthcare:
   sketchLink: YGzlveZ
+medicare:
+  sketchLink: eKAkJWm
 ---
 
 import { Spinner, Button } from '@cmsgov/design-system';

--- a/packages/docs/content/components/usa-banner.mdx
+++ b/packages/docs/content/components/usa-banner.mdx
@@ -7,6 +7,8 @@ core:
   storybookLink: components-usabanner--docs
 healthcare:
   sketchLink: 25qAbzl
+medicare:
+  sketchLink: vRQWprd
 ---
 
 import { Alert } from '@cmsgov/design-system';

--- a/packages/docs/content/foundation/layout-grid/layout-grid.mdx
+++ b/packages/docs/content/foundation/layout-grid/layout-grid.mdx
@@ -1,6 +1,12 @@
 ---
 title: Layout Grid
 order: 41
+core:
+    sketchLink: qeZlYmk
+healthcare:
+    sketchLink: l1jypEO
+medicare:
+    sketchLink: PG58vbQ
 ---
 
 

--- a/packages/docs/content/foundation/spacing.mdx
+++ b/packages/docs/content/foundation/spacing.mdx
@@ -1,6 +1,12 @@
 ---
 title: Spacing
 order: 30
+core:
+    sketchLink: L03RwGd
+healthcare:
+    sketchLink: rb7Zo3a
+medicare:
+    sketchLink: oYdAAa5
 ---
 
 The design system uses multiples of `8px` for all spacing values: dimensions, padding, and margins. The goal behind this is to achieve a consistent vertical rhythm and to reduce the cognitive load of fiddling with different spacing options.

--- a/packages/docs/content/layouts/Healthcare/one-col-page-layout.mdx
+++ b/packages/docs/content/layouts/Healthcare/one-col-page-layout.mdx
@@ -1,5 +1,7 @@
 ---
 title: One Column Page Layout
+healthcare:
+  sketchLink: EL1l44v
 ---
 
 A one column page, as basic as it comes.

--- a/packages/docs/content/layouts/documentation-page.mdx
+++ b/packages/docs/content/layouts/documentation-page.mdx
@@ -1,5 +1,9 @@
 ---
 title: Documentation Page
+core:
+  sketchLink: Vr4yML8
+healthcare:
+  sketchLink: MyVZW9a
 ---
 
 A documentation page presents information on a certain theme, topic, or idea. People often arrive here after visiting the landing page or after searching for a specific piece of information, so documentation pages don’t need to provide as much contextualizing information as more introductory pages would.


### PR DESCRIPTION
## Summary

- Added missing Sketch UI kit references for Core, HealthCare, and Medicare

## How to test

1. Running doc site locally, may check sketch references point to their proper cloud counterpart

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [?] Selected appropriate `Type: non-breaking`
- [?] Selected appropriate `Impacts: documentation site`


<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:
### If this is a change to documentation:

- [x] Checked URL cloud references
