### PR TITLE
[WNMGDS-2556] Fix the Dropdown not scrolling to the selected item when using pointer

### DIFF
--- a/packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts
@@ -29,3 +29,26 @@ Object.keys(themes).forEach((theme) => {
     });
   });
 });
+
+// Don't need to test these in all themes
+test.only('Dropdown scrolls to selected item', async ({ page }) => {
+  await page.goto(storyUrl('core', 'components-dropdown--default'));
+  await page.getByRole('button').click();
+  // Cannot figure out an alternative to this wait time
+  await page.waitForTimeout(200);
+  await page.getByRole('listbox').waitFor();
+
+  // Select the last item and wait for it to close
+  let lastOption = await page.getByRole('option').last();
+  // Make sure our test is even valid by verifying that the last item isn't normally visible
+  await expect(lastOption).not.toBeInViewport();
+  lastOption.click();
+  await page.getByRole('listbox').waitFor({ state: 'hidden' });
+
+  // Open it back up and see if the selected item is visible
+  await page.getByRole('button').click();
+  await page.waitForTimeout(200);
+  await page.getByRole('listbox').waitFor();
+  lastOption = await page.getByRole('option').last();
+  await expect(lastOption).toBeInViewport();
+});

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts
@@ -31,7 +31,7 @@ Object.keys(themes).forEach((theme) => {
 });
 
 // Don't need to test these in all themes
-test.only('Dropdown scrolls to selected item', async ({ page }) => {
+test('Dropdown scrolls to selected item', async ({ page }) => {
   await page.goto(storyUrl('core', 'components-dropdown--default'));
   await page.getByRole('button').click();
   // Cannot figure out an alternative to this wait time

--- a/packages/design-system/src/components/Dropdown/DropdownMenuOption.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenuOption.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { ListState, Node } from '../react-aria'; // from react-stately
 import { SvgIcon } from '../Icons';
 import { useOption } from '../react-aria'; // from react-aria
@@ -37,6 +37,15 @@ export function DropdownMenuOption<T>({
   );
 
   const { textValue, ...extraAttrs } = item.props;
+
+  // Work around [this issue](https://github.com/adobe/react-spectrum/issues/4974) by manually
+  // scrolling the selected option into view. At the time of writing this, we are using
+  // `@react-aria/selection` version 3.16.1
+  useEffect(() => {
+    if (state.isOpen && isSelected) {
+      ref.current?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [isSelected, state.isOpen]);
 
   return (
     <li

--- a/packages/design-system/src/components/Dropdown/DropdownMenuOption.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenuOption.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { ListState, Node } from '../react-aria'; // from react-stately
+import { ListState, Node, OverlayTriggerState } from '../react-aria'; // from react-stately
 import { SvgIcon } from '../Icons';
 import { useOption } from '../react-aria'; // from react-aria
 import classNames from 'classnames';
@@ -11,7 +11,7 @@ export function getOptionId(rootId: string, index: number): string {
 export interface DropdownMenuOptionProps<T> {
   componentClass: string;
   item: Node<T>;
-  state: ListState<T>;
+  state: ListState<T> & OverlayTriggerState;
   rootId?: string;
 }
 

--- a/packages/design-system/src/components/Dropdown/DropdownMenuSection.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenuSection.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { DropdownMenuOption } from './DropdownMenuOption';
-import { ListState, Node } from '../react-aria'; // from react-stately
+import { ListState, Node, OverlayTriggerState } from '../react-aria'; // from react-stately
 import { useListBoxSection } from '../react-aria'; // from react-aria
 
 export interface DropdownMenuOptionProps<T> {
   componentClass: string;
   section: Node<T>;
-  state: ListState<T>;
+  state: ListState<T> & OverlayTriggerState;
   rootId?: string;
 }
 

--- a/tests/unit/setupTests.js
+++ b/tests/unit/setupTests.js
@@ -19,6 +19,8 @@ window.matchMedia = (query) => ({
 window.scroll = () => {};
 window.scrollTo = () => {};
 
+Element.prototype.scrollIntoView = () => {};
+
 const localStorageMock = (function () {
   return {
     getItem: jest.fn((itemName) => (itemName === 'CMS_DS_IT_LAST_ACTIVE' ? 1643811720 : null)),


### PR DESCRIPTION
## Summary

WNMGDS-2556

If you’ve selected an option you had to scroll to reach and then use a pointer device to click the dropdown button, the menu that opens won’t be scrolled to the selected item. It's a bug in Adobe Spectrum that has already been reported (see link in code comment). This works around that issue by manually scrolling it into view.

## How to test

### Automated testing

1. Before you build anything, try out the new test to make sure it fails when the fix is not in place:
    1. Check out c8bc0d4b44c990f56227cf7fadeda27c5842a479
    2. Run `yarn playwright test --config tests/browser/interaction.config.ts --headed --debug --ignore-snapshots packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts` to see it in the browser and step through it if you want
2. Build storybook with the fix to make sure the test passes:
    1. Run `yarn build && yarn build:storybook`
    2. Run `yarn playwright test --config tests/browser/interaction.config.ts --headed --debug --ignore-snapshots packages/design-system/src/components/Dropdown/Dropdown.test.interaction.ts` to see it in the browser
    3. Also run `yarn test:browser:interaction` to run it in Docker with all the other interaction tests

### Manual testing

- Manually test the Dropdown and variety of modalities and in varying circumstances
- Verify that the Autocomplete is unaffected

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)