### PR TITLE
[WNMGDS-2557] Restore ability to disable autocompletes

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -40,7 +40,13 @@ const Template = (args) => {
       onInputValueChange={onInputValueChange}
       items={filteredItems}
     >
-      <TextField label={textFieldLabel} hint={textFieldHint} name="autocomplete" value={input} />
+      <TextField
+        label={textFieldLabel}
+        hint={textFieldHint}
+        name="autocomplete"
+        value={input}
+        disabled
+      />
     </Autocomplete>
   );
 };

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -40,13 +40,7 @@ const Template = (args) => {
       onInputValueChange={onInputValueChange}
       items={filteredItems}
     >
-      <TextField
-        label={textFieldLabel}
-        hint={textFieldHint}
-        name="autocomplete"
-        value={input}
-        disabled
-      />
+      <TextField label={textFieldLabel} hint={textFieldHint} name="autocomplete" value={input} />
     </Autocomplete>
   );
 };

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
@@ -362,4 +362,14 @@ describe('Autocomplete', () => {
     const menuContainer = container.querySelector('.ds-c-autocomplete__menu-container');
     expect(menuContainer).toHaveClass('ds-c-field--medium');
   });
+
+  it('can have a disabled TextField', () => {
+    renderAutocomplete({
+      children: <TextField label="autocomplete" name="field" disabled />,
+    });
+    const field = screen.getByRole('combobox');
+    expect(field).toHaveAttribute('disabled');
+    const clearButton = screen.getByText('Clear search');
+    expect(clearButton).toHaveAttribute('disabled');
+  });
 });

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -231,6 +231,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
       ...autocompleteProps,
       name: textField.props.name,
       label: textField.props.label,
+      isDisabled: textField.props.disabled,
       inputRef,
       listBoxRef,
       popoverRef: listBoxRef,
@@ -327,6 +328,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
           }}
           size="small"
           variation="ghost"
+          disabled={textField.props.disabled}
         >
           {clearInputText ?? t('autocomplete.clearInputText')}
         </Button>


### PR DESCRIPTION
## Summary

WNMGDS-2557

- Restores the ability for an `Autocomplete`'s `TextField` to be disabled, which was lost in the conversion to `react-aria`
- Making the `TextField` disabled also disables the _clear search_ button so that we can't modify what's in the search field and so it does not appear in the accessibility tree as a random button without a search field

## How to test

Modify the Autocomplete story render function by adding a `disabled` attribute to the `TextField`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)
