### PR TITLE
[WNMGDS-1922] Document pass-through props in Storybook dev docs

### DIFF
--- a/.storybook/docs/DocumentationTemplate.mdx
+++ b/.storybook/docs/DocumentationTemplate.mdx
@@ -1,4 +1,5 @@
 import { Meta, Title, Subtitle, Description, Primary, ArgsTable, Stories } from '@storybook/blocks';
+import { HtmlElementArgs } from './HtmlElementArgs';
 
 <Meta isTemplate />
 
@@ -25,6 +26,7 @@ import { Meta, Title, Subtitle, Description, Primary, ArgsTable, Stories } from 
   * [useOf](https://storybook.js.org/docs/react/api/doc-block-useof) hook.
   */}
 <ArgsTable />
+<HtmlElementArgs />
 
 ---
 

--- a/.storybook/docs/HtmlElementArgs.tsx
+++ b/.storybook/docs/HtmlElementArgs.tsx
@@ -25,7 +25,7 @@ export const HtmlElementArgs = ({ of }) => {
   const elementNames = elements.map((name) => <code key={name}>{`<${name}>`}</code>);
   const elementLinks = elements.map((name) => (
     <a href={`https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${name}`} key={name}>
-      {name}
+      {`<${name}>`}
     </a>
   ));
   const formattedElementNames = humanizeList(elementNames, { conjunction: 'or' });

--- a/.storybook/docs/HtmlElementArgs.tsx
+++ b/.storybook/docs/HtmlElementArgs.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import humanizeList from 'humanize-react';
 import { useOf } from '@storybook/blocks';
 
+interface HtmlElementArgsProps {
+  attributes?: boolean;
+  of?: any;
+}
+
 /**
  * If the component we're documenting passes extra props through to an HTML element,
  * we want to include documentation about that. Rather than listing out all the
@@ -11,7 +16,7 @@ import { useOf } from '@storybook/blocks';
  * determine if it should show this addtional text and what elements' documentation
  * it should link to.
  */
-export const HtmlElementArgs = ({ of }) => {
+export const HtmlElementArgs = ({ attributes, of }) => {
   const resolvedOf = useOf(of || 'story', ['story', 'meta']);
   if (resolvedOf.type !== 'story') {
     return null;
@@ -33,7 +38,7 @@ export const HtmlElementArgs = ({ of }) => {
 
   return (
     <>
-      <h3 id="additional-props">Additional props</h3>
+      <h3 id="additional-props">Additional {attributes ? 'attributes' : 'props'}</h3>
       <p>
         This component passes any additional props to its underlying {formattedElementNames} element
         as attributes. See the corresponding MDN documentation for {formattedElementLinks} for a

--- a/.storybook/docs/HtmlElementArgs.tsx
+++ b/.storybook/docs/HtmlElementArgs.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import humanizeList from 'humanize-react';
+import { useOf } from '@storybook/blocks';
+
+/**
+ * If the component we're documenting passes extra props through to an HTML element,
+ * we want to include documentation about that. Rather than listing out all the
+ * additional attributes for those HTML elements in our props table, we will add
+ * some explanatory text with MDN documentation links to the bottom of our props
+ * table. Looks for a `underlyingHtmlElements` array in `story.parameters.docs` to
+ * determine if it should show this addtional text and what elements' documentation
+ * it should link to.
+ */
+export const HtmlElementArgs = ({ of }) => {
+  const resolvedOf = useOf(of || 'story', ['story', 'meta']);
+  if (resolvedOf.type !== 'story') {
+    return null;
+  }
+
+  const elements = resolvedOf.story.parameters?.docs?.underlyingHtmlElements;
+  if (!elements) {
+    return null;
+  }
+
+  const elementNames = elements.map((name) => <code key={name}>{`<${name}>`}</code>);
+  const elementLinks = elements.map((name) => (
+    <a href={`https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${name}`} key={name}>
+      {name}
+    </a>
+  ));
+  const formattedElementNames = humanizeList(elementNames, { conjunction: 'or' });
+  const formattedElementLinks = humanizeList(elementLinks, { conjunction: 'and' });
+
+  return (
+    <>
+      <h3 id="additional-props">Additional props</h3>
+      <p>
+        This component passes any additional props to its underlying {formattedElementNames} element
+        as attributes. See the corresponding MDN documentation for {formattedElementLinks} for a
+        list of valid attributes.
+      </p>
+      <br />
+    </>
+  );
+};

--- a/.storybook/docs/WebComponentDocTemplate.mdx
+++ b/.storybook/docs/WebComponentDocTemplate.mdx
@@ -1,6 +1,6 @@
 import { Meta, Title, Subtitle, Description, Primary, ArgsTable, Stories } from '@storybook/blocks';
-import {WebComponentArgsTable} from './WebComponentArgsTable';
-import {WebComponentEventsTable} from './WebComponentEventsTable';
+import { WebComponentArgsTable } from './WebComponentArgsTable';
+import { WebComponentEventsTable } from './WebComponentEventsTable';
 
 <Meta isTemplate />
 

--- a/.storybook/docs/WebComponentDocTemplate.mdx
+++ b/.storybook/docs/WebComponentDocTemplate.mdx
@@ -1,4 +1,5 @@
-import { Meta, Title, Subtitle, Description, Primary, ArgsTable, Stories } from '@storybook/blocks';
+import { Meta, Title, Subtitle, Description, Primary, Stories } from '@storybook/blocks';
+import { HtmlElementArgs } from './HtmlElementArgs';
 import { WebComponentArgsTable } from './WebComponentArgsTable';
 import { WebComponentEventsTable } from './WebComponentEventsTable';
 
@@ -14,6 +15,7 @@ import { WebComponentEventsTable } from './WebComponentEventsTable';
 ## Attributes
 
 <WebComponentArgsTable />
+<HtmlElementArgs attributes />
 
 <WebComponentEventsTable />
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "gulp-svgmin": "^4.1.0",
     "gulp-typescript": "^6.0.0-alpha.1",
     "http-server": "^14.1.1",
+    "humanize-react": "^1.0.0",
     "husky": "^7.0.0",
     "jest": "^27.5.1",
     "lerna": "^5.6.2",

--- a/packages/design-system/src/components/Badge/Badge.stories.tsx
+++ b/packages/design-system/src/components/Badge/Badge.stories.tsx
@@ -15,6 +15,11 @@ const meta: Meta = {
     },
     children: { control: 'text' },
   },
+  parameters: {
+    docs: {
+      underlyingHtmlElements: ['span'],
+    },
+  },
 };
 
 export default meta;

--- a/packages/design-system/src/components/Button/Button.stories.tsx
+++ b/packages/design-system/src/components/Button/Button.stories.tsx
@@ -11,6 +11,11 @@ const meta: Meta<typeof Button> = {
     children: 'Your button text here',
     onDark: false,
   },
+  parameters: {
+    docs: {
+      underlyingHtmlElements: ['a', 'button'],
+    },
+  },
 };
 export default meta;
 

--- a/packages/design-system/src/components/ChoiceList/Choice.stories.tsx
+++ b/packages/design-system/src/components/ChoiceList/Choice.stories.tsx
@@ -15,6 +15,11 @@ const meta: Meta<typeof Choice> = {
     errorMessage: 'You must agree to the terms and conditions before continuing',
     defaultChecked: false,
   },
+  parameters: {
+    docs: {
+      underlyingHtmlElements: ['input'],
+    },
+  },
 };
 export default meta;
 

--- a/packages/design-system/src/components/DateField/SingleInputDateField.stories.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.stories.tsx
@@ -11,6 +11,11 @@ const meta: Meta<typeof SingleInputDateField> = {
     label: 'Birthday',
     name: 'single-input-date-field',
   },
+  parameters: {
+    docs: {
+      underlyingHtmlElements: ['input'],
+    },
+  },
 };
 export default meta;
 

--- a/packages/design-system/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.stories.tsx
@@ -23,6 +23,7 @@ const meta: Meta<typeof Dialog> = {
       source: {
         type: 'code',
       },
+      underlyingHtmlElements: ['dialog'],
     },
   },
 };

--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
@@ -11,6 +11,11 @@ const meta: Meta<typeof Dropdown> = {
   args: {
     name: 'dropdown-field',
   },
+  parameters: {
+    docs: {
+      underlyingHtmlElements: ['button'],
+    },
+  },
 };
 export default meta;
 

--- a/packages/design-system/src/components/Icons/icons.stories.tsx
+++ b/packages/design-system/src/components/Icons/icons.stories.tsx
@@ -34,6 +34,11 @@ import {
 export default {
   title: 'Components/Icons',
   component: SvgIcon,
+  parameters: {
+    docs: {
+      underlyingHtmlElements: ['svg'],
+    },
+  },
 };
 
 const iconData = [

--- a/packages/design-system/src/components/Label/Label.stories.tsx
+++ b/packages/design-system/src/components/Label/Label.stories.tsx
@@ -8,6 +8,11 @@ const meta: Meta<typeof Label> = {
   args: {
     children: 'Sample Label',
   },
+  parameters: {
+    docs: {
+      underlyingHtmlElements: ['label', 'legend'],
+    },
+  },
 };
 export default meta;
 

--- a/packages/design-system/src/components/Table/Table.stories.tsx
+++ b/packages/design-system/src/components/Table/Table.stories.tsx
@@ -17,6 +17,11 @@ const meta: Meta<typeof Table> = {
     TableCell,
     TableBody,
   },
+  parameters: {
+    docs: {
+      underlyingHtmlElements: ['table'],
+    },
+  },
 };
 export default meta;
 

--- a/packages/design-system/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system/src/components/TextField/TextField.stories.tsx
@@ -15,6 +15,11 @@ const meta: Meta<typeof TextField> = {
     onBlur: action('onBlur'),
     name: 'text-field-story',
   },
+  parameters: {
+    docs: {
+      underlyingHtmlElements: ['input'],
+    },
+  },
 };
 export default meta;
 

--- a/packages/design-system/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.stories.tsx
@@ -37,6 +37,11 @@ const meta: Meta<typeof Tooltip> = {
       control: 'radio',
     },
   },
+  parameters: {
+    docs: {
+      underlyingHtmlElements: ['a', 'button'],
+    },
+  },
 };
 export default meta;
 

--- a/packages/design-system/src/components/web-components/ds-badge.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-badge.stories.tsx
@@ -31,6 +31,7 @@ export default {
       description: {
         component: `For information about how and when to use this component, [refer to its full documentation page](https://design.cms.gov/components/badge/).`,
       },
+      underlyingHtmlElements: ['span'],
     },
   },
 };

--- a/packages/design-system/src/components/web-components/ds-button.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-button.stories.tsx
@@ -37,6 +37,7 @@ export default {
       description: {
         component: `For information about how and when to use this component, [refer to its full documentation page](https://design.cms.gov/components/button/).`,
       },
+      underlyingHtmlElements: ['a', 'button'],
     },
   },
 };

--- a/packages/design-system/src/components/web-components/ds-dropdown.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-dropdown.stories.tsx
@@ -105,6 +105,7 @@ export default {
           description: 'Dispatched whenever the dropdown loses focus.',
         },
       },
+      underlyingHtmlElements: ['button'],
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -13511,7 +13511,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-humanize-react@1.0.0:
+humanize-react@1.0.0, humanize-react@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/humanize-react/-/humanize-react-1.0.0.tgz#542c78db7c919b9b8e8c095487469c8868b8c26f"
   integrity sha512-d68v6HGH4EnYgH/YgbRKj1+4KYi3TLkMXlZgk4On1ee18XbCQO1Eb/ur0BOZvmEgu8TES5G9Cqu7a4lQng4Sig==


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/CMSgov/design-system/pull/2798. Adds the actual documentation in Storybook for each of the components that have pass-through props.

## How to test

Check out the component documentation in storybook

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to documentation:

- [x] Checked for spelling and grammatical errors
