### PR TITLE
[WNMGDS-2146] Deprecate font size classes

### DIFF
--- a/packages/design-system/src/styles/_base.scss
+++ b/packages/design-system/src/styles/_base.scss
@@ -261,55 +261,56 @@ $breakpoints: (
   color: var(--color-muted-inverse);
 }
 
-// @TODO: Remove the semantic classes h1, h2, h3, display, title, etc... after deprecating
+// WNMGDS-2146: Deprecate semantic font-size classes
+// Refer to `_set-for-deprecation.scss` for complete list
+// Classes marked with 💀 are deprecated and will be removed in the next major release
 
-.ds-display,
+.ds-display, // 💀
 .ds-text-heading--5xl {
   @include heading--5xl;
 }
 
-.ds-title,
+.ds-title, // 💀
 .ds-text-heading--4xl {
   @include heading--4xl;
 }
 
-.ds-h1,
+.ds-h1, // 💀
 .ds-text-heading--3xl {
   @include heading--3xl;
 }
 
-.ds-h2,
+.ds-h2, // 💀
 .ds-text-heading--2xl {
   @include heading--2xl;
 }
 
-.ds-h3,
+.ds-h3, // 💀
 .ds-text-heading--xl {
   @include heading--xl;
 }
 
-.ds-h4,
+.ds-h4, // 💀
 .ds-text-heading--lg {
   @include heading--lg;
 }
 
-.ds-h5,
+.ds-h5, // 💀
 .ds-text-heading--md {
   @include heading--md;
 }
 
-.ds-h6,
+.ds-h6, // 💀
 .ds-text-heading--sm {
   @include heading--sm;
+
+  .ds-base--inverse & {
+    color: var(--color-muted-inverse);
+  }
 }
 
-.ds-base--inverse .ds-h6,
-.ds-base--inverse .ds-text-heading--sm {
-  color: var(--color-muted-inverse);
-}
-
-.ds-text,
-.ds-text--lead,
+.ds-text, // 💀
+.ds-text--lead, // 💀
 .ds-text-body--lg,
 .ds-text-body--md,
 .ds-text-body--sm {
@@ -326,12 +327,12 @@ $breakpoints: (
   }
 }
 
-.ds-text--lead,
+.ds-text--lead, // 💀
 .ds-text-body--lg {
   font-size: var(--typography-heading-lg__font-size);
 }
 
-.ds-text,
+.ds-text, // 💀
 .ds-text-body--md {
   font-size: var(--typography-heading-base__font-size);
 }

--- a/packages/design-system/src/styles/_set-for-deprecation.scss
+++ b/packages/design-system/src/styles/_set-for-deprecation.scss
@@ -56,19 +56,17 @@ $breakpoints: (
   }
 
   @each $breakpoint in map-keys($breakpoints) {
-    @media (min-width: $value) {
-      .ds-u-#{$breakpoint}-font-size--small,
-      .ds-u-#{$breakpoint}-font-size--lead,
-      .ds-u-#{$breakpoint}-font-size--display,
-      .ds-u-#{$breakpoint}-font-size--title,
-      .ds-u-#{$breakpoint}-font-size--h1,
-      .ds-u-#{$breakpoint}-font-size--h2,
-      .ds-u-#{$breakpoint}-font-size--h3,
-      .ds-u-#{$breakpoint}-font-size--h4,
-      .ds-u-#{$breakpoint}-font-size--h5,
-      .ds-u-#{$breakpoint}-font-size--h6 {
-        @include debug;
-      }
+    .ds-u-#{$breakpoint}-font-size--small,
+    .ds-u-#{$breakpoint}-font-size--lead,
+    .ds-u-#{$breakpoint}-font-size--display,
+    .ds-u-#{$breakpoint}-font-size--title,
+    .ds-u-#{$breakpoint}-font-size--h1,
+    .ds-u-#{$breakpoint}-font-size--h2,
+    .ds-u-#{$breakpoint}-font-size--h3,
+    .ds-u-#{$breakpoint}-font-size--h4,
+    .ds-u-#{$breakpoint}-font-size--h5,
+    .ds-u-#{$breakpoint}-font-size--h6 {
+      @include debug;
     }
   }
 }

--- a/packages/design-system/src/styles/_set-for-deprecation.scss
+++ b/packages/design-system/src/styles/_set-for-deprecation.scss
@@ -2,18 +2,12 @@
 
 // Imported to access $breakpoints to generate utility classes.
 // Remove with semantic font-size classes
-@use './layout' as *; // 💀
-$breakpoints: (
-  sm: $media-width-sm,
-  md: $media-width-md,
-  lg: $media-width-lg,
-  xl: $media-width-xl,
-) !default; // 💀
+$breakpoints: sm, md, lg, xl; // 💀
 
 // This adds a border to all soon-to-be deprecated classes.
 // When the class is deprecated, remove it from the list below.
 
-@mixin debug {
+@mixin deprecate {
   border: 2px solid lawngreen;
   padding-block-end: 0.5rem;
   position: relative;
@@ -52,10 +46,10 @@ $breakpoints: (
   .ds-u-font-size--lead,
   .ds-u-font-size--title,
   .ds-u-font-size--display {
-    @include debug;
+    @include deprecate;
   }
 
-  @each $breakpoint in map-keys($breakpoints) {
+  @each $breakpoint in $breakpoints {
     .ds-u-#{$breakpoint}-font-size--small,
     .ds-u-#{$breakpoint}-font-size--lead,
     .ds-u-#{$breakpoint}-font-size--display,
@@ -66,7 +60,7 @@ $breakpoints: (
     .ds-u-#{$breakpoint}-font-size--h4,
     .ds-u-#{$breakpoint}-font-size--h5,
     .ds-u-#{$breakpoint}-font-size--h6 {
-      @include debug;
+      @include deprecate;
     }
   }
 }

--- a/packages/design-system/src/styles/_set-for-deprecation.scss
+++ b/packages/design-system/src/styles/_set-for-deprecation.scss
@@ -1,13 +1,74 @@
 // Classes included in this file are set for deprecation and will be removed in the next major release.
 
-// Include the soon-to-be deprecated classes here (remove them from their original files).
-// This makes it easier to find all the soon-to-be deprecated classes in one place and delete them.
-// For each class, include a comment above with the date the class was added to this file. This will help maintainers know how long a class has been listed as deprecated and when it should be removed from the project.
+// Imported to access $breakpoints to generate utility classes.
+// Remove with semantic font-size classes
+@use './layout' as *; // 💀
+$breakpoints: (
+  sm: $media-width-sm,
+  md: $media-width-md,
+  lg: $media-width-lg,
+  xl: $media-width-xl,
+) !default; // 💀
 
 // This adds a border to all soon-to-be deprecated classes.
 // When the class is deprecated, remove it from the list below.
+
+@mixin debug {
+  border: 2px solid lawngreen;
+  padding-block-end: 0.5rem;
+  position: relative;
+
+  &::after {
+    background-color: honeydew;
+    border: 1px solid lawngreen;
+    border-radius: 0.5em;
+    content: '💀 DEPRECATED';
+    font-size: 10px;
+    font-weight: 400;
+    inset: auto 0.5rem -0.5rem auto;
+    padding: 0.25em 0.5em;
+    position: absolute;
+    z-index: 1;
+  }
+}
 @container style(--debugger: true) {
-  // .soon-to-be-deprecated-class {
-  //   border: 2px solid magenta;
-  // }
+  .ds-display,
+  .ds-title,
+  .ds-h1,
+  .ds-h2,
+  .ds-h3,
+  .ds-h4,
+  .ds-h5,
+  .ds-h6,
+  .ds-text,
+  .ds-text--lead,
+  .ds-u-font-size--small,
+  .ds-u-font-size--h6,
+  .ds-u-font-size--h5,
+  .ds-u-font-size--h4,
+  .ds-u-font-size--h3,
+  .ds-u-font-size--h2,
+  .ds-u-font-size--h1,
+  .ds-u-font-size--lead,
+  .ds-u-font-size--title,
+  .ds-u-font-size--display {
+    @include debug;
+  }
+
+  @each $breakpoint in map-keys($breakpoints) {
+    @media (min-width: $value) {
+      .ds-u-#{$breakpoint}-font-size--small,
+      .ds-u-#{$breakpoint}-font-size--lead,
+      .ds-u-#{$breakpoint}-font-size--display,
+      .ds-u-#{$breakpoint}-font-size--title,
+      .ds-u-#{$breakpoint}-font-size--h1,
+      .ds-u-#{$breakpoint}-font-size--h2,
+      .ds-u-#{$breakpoint}-font-size--h3,
+      .ds-u-#{$breakpoint}-font-size--h4,
+      .ds-u-#{$breakpoint}-font-size--h5,
+      .ds-u-#{$breakpoint}-font-size--h6 {
+        @include debug;
+      }
+    }
+  }
 }

--- a/packages/design-system/src/styles/typography-headings.stories.tsx
+++ b/packages/design-system/src/styles/typography-headings.stories.tsx
@@ -21,13 +21,13 @@ export const AllHeadings: Story = {
   render: function Component() {
     return (
       <>
-        <h1 className="ds-text-heading--5xl ds-u-font-size--display">{heading} (5xl)</h1>
-        <h1 className="ds-text-heading--4xl ds-u-font-size--h3">{heading} (4xl)</h1>
-        <h1 className="ds-text-heading--3xl ds-u-md-font-size--h3">{heading} (3xl)</h1>
-        <h1 className="ds-text-heading--2xl ds-h3">{heading} (2xl)</h1>
-        <h1 className="ds-text-heading--xl ds-text">{heading} (xl)</h1>
-        <h1 className="ds-text-heading--lg ds-display">{heading} (lg)</h1>
-        <h1 className="ds-text-heading--md ds-u-sm-font-size--small">{heading} (md)</h1>
+        <h1 className="ds-text-heading--5xl">{heading} (5xl)</h1>
+        <h1 className="ds-text-heading--4xl">{heading} (4xl)</h1>
+        <h1 className="ds-text-heading--3xl">{heading} (3xl)</h1>
+        <h1 className="ds-text-heading--2xl">{heading} (2xl)</h1>
+        <h1 className="ds-text-heading--xl">{heading} (xl)</h1>
+        <h1 className="ds-text-heading--lg">{heading} (lg)</h1>
+        <h1 className="ds-text-heading--md">{heading} (md)</h1>
         <h1 className="ds-text-heading--sm">{heading} (sm)</h1>
       </>
     );

--- a/packages/design-system/src/styles/typography-headings.stories.tsx
+++ b/packages/design-system/src/styles/typography-headings.stories.tsx
@@ -21,13 +21,13 @@ export const AllHeadings: Story = {
   render: function Component() {
     return (
       <>
-        <h1 className="ds-text-heading--5xl">{heading} (5xl)</h1>
-        <h1 className="ds-text-heading--4xl">{heading} (4xl)</h1>
-        <h1 className="ds-text-heading--3xl">{heading} (3xl)</h1>
-        <h1 className="ds-text-heading--2xl">{heading} (2xl)</h1>
-        <h1 className="ds-text-heading--xl">{heading} (xl)</h1>
-        <h1 className="ds-text-heading--lg">{heading} (lg)</h1>
-        <h1 className="ds-text-heading--md">{heading} (md)</h1>
+        <h1 className="ds-text-heading--5xl ds-u-font-size--display">{heading} (5xl)</h1>
+        <h1 className="ds-text-heading--4xl ds-u-font-size--h3">{heading} (4xl)</h1>
+        <h1 className="ds-text-heading--3xl ds-u-md-font-size--h3">{heading} (3xl)</h1>
+        <h1 className="ds-text-heading--2xl ds-h3">{heading} (2xl)</h1>
+        <h1 className="ds-text-heading--xl ds-text">{heading} (xl)</h1>
+        <h1 className="ds-text-heading--lg ds-display">{heading} (lg)</h1>
+        <h1 className="ds-text-heading--md ds-u-sm-font-size--small">{heading} (md)</h1>
         <h1 className="ds-text-heading--sm">{heading} (sm)</h1>
       </>
     );

--- a/packages/design-system/src/styles/utilities/_font-size.scss
+++ b/packages/design-system/src/styles/utilities/_font-size.scss
@@ -1,46 +1,48 @@
 @use '../base' as *;
 
-// To Do: Remove the semantic classes h1, h2, h3, display, title, etc... after deprecating
+// WNMGDS-2146: Deprecate semantic font-size classes
+// Refer to `_set-for-deprecation.scss` for complete list
+// Classes marked with 💀 are deprecated and will be removed in the next major release
 
-.ds-u-font-size--h5,
-.ds-u-font-size--sm,
-.ds-u-font-size--small {
+.ds-u-font-size--h5, // 💀 - also this appears to be a typo but it's too late to fix now!
+.ds-u-font-size--small, // 💀
+.ds-u-font-size--sm {
   font-size: var(--font-size-sm) !important;
 }
 
-.ds-u-font-size--h5,
+.ds-u-font-size--h5, // 💀
 .ds-u-font-size--base,
 .ds-u-font-size--md {
   font-size: var(--font-size-base) !important;
 }
 
-.ds-u-font-size--h4,
-.ds-u-font-size--lg,
-.ds-u-font-size--lead {
+.ds-u-font-size--h4, // 💀
+.ds-u-font-size--lead, // 💀 
+.ds-u-font-size--lg {
   font-size: var(--font-size-lg) !important;
 }
 
-.ds-u-font-size--h3,
+.ds-u-font-size--h3, // 💀
 .ds-u-font-size--xl {
   font-size: var(--font-size-xl) !important;
 }
 
-.ds-u-font-size--h2,
+.ds-u-font-size--h2, // 💀
 .ds-u-font-size--2xl {
   font-size: var(--font-size-2xl) !important;
 }
 
-.ds-u-font-size--h1,
+.ds-u-font-size--h1, // 💀
 .ds-u-font-size--3xl {
   font-size: var(--font-size-3xl) !important;
 }
 
-.ds-u-font-size--title,
+.ds-u-font-size--title, // 💀
 .ds-u-font-size--4xl {
   font-size: var(--font-size-4xl) !important;
 }
 
-.ds-u-font-size--display,
+.ds-u-font-size--display, // 💀
 .ds-u-font-size--5xl {
   font-size: var(--font-size-5xl) !important;
 }
@@ -49,7 +51,7 @@
   $value: map-get($breakpoints, $breakpoint);
 
   @media (min-width: $value) {
-    .ds-u-#{$breakpoint}-font-size--small,
+    .ds-u-#{$breakpoint}-font-size--small, // 💀
     .ds-u-#{$breakpoint}-font-size--sm {
       font-size: var(--font-size-sm) !important;
     }
@@ -58,39 +60,35 @@
       font-size: var(--font-size-base) !important;
     }
 
-    .ds-u-#{$breakpoint}-font-size--lg,
-    .ds-u-#{$breakpoint}-font-size--lead {
+    .ds-u-#{$breakpoint}-font-size--h4, // 💀
+    .ds-u-#{$breakpoint}-font-size--lead, // 💀 
+    .ds-u-#{$breakpoint}-font-size--lg {
       font-size: var(--font-size-lg) !important;
     }
 
-    .ds-u-#{$breakpoint}-font-size--display,
+    .ds-u-#{$breakpoint}-font-size--display, // 💀
     .ds-u-#{$breakpoint}-font-size--5xl {
       font-size: var(--font-size-5xl) !important;
     }
 
-    .ds-u-#{$breakpoint}-font-size--title,
+    .ds-u-#{$breakpoint}-font-size--title, // 💀
     .ds-u-#{$breakpoint}-font-size--4xl {
       font-size: var(--font-size-4xl) !important;
     }
 
-    .ds-u-#{$breakpoint}-font-size--h1,
+    .ds-u-#{$breakpoint}-font-size--h1, // 💀
     .ds-u-#{$breakpoint}-font-size--3xl {
       font-size: var(--font-size-3xl) !important;
     }
 
-    .ds-u-#{$breakpoint}-font-size--h2,
+    .ds-u-#{$breakpoint}-font-size--h2, // 💀
     .ds-u-#{$breakpoint}-font-size--2xl {
       font-size: var(--font-size-2xl) !important;
     }
 
-    .ds-u-#{$breakpoint}-font-size--h3,
+    .ds-u-#{$breakpoint}-font-size--h3, // 💀
     .ds-u-#{$breakpoint}-font-size--xl {
       font-size: var(--font-size-xl) !important;
-    }
-
-    .ds-u-#{$breakpoint}-font-size--h4,
-    .ds-u-#{$breakpoint}-font-size--lg {
-      font-size: var(--font-size-lg) !important;
     }
   }
 }


### PR DESCRIPTION
WNMGDS-2146

- Deprecate semantic font-size class names (`ds-h1`, `ds-display`, etc.)
- Made the call to also deprecate `ds-u-font-size--small` as it's redundant and doesn't match naming convention
- Added styles to make it more obvious the lawngreen color is intention, included label as well

I deviated from the initial deprecation strategy; no longer copying over classes to be deprecated into deprecation SCSS file for two reasons:

1. Changing the location of the CSS could impact how it's rendered in the cascade, introducing more bugs somehow
2. It created a lot of unnecessary work in duplicating `@mixin` logic and other SCSS stuff

Instead, I each each class with a deprecation comment.

To test this work

1. Pull the commit ~9e5bc7c74dc2d092737f6de28ae1fa9c4ba12639~ 49fead9028620a9a72f847db4f6f0beeb9298d93
2. Start Storybook 
3. Visit USA banner to turn `--debugger` on (or manually toggle this in dev tools)
4. Visit Typography/All headings story