### PR TITLE
[WNMGDS-2523] Break some `useFormLabel` functionality into a `useInlineError` hook

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import Button from '../Button/Button';
 import DropdownMenu from '../Dropdown/DropdownMenu';
 import classNames from 'classnames';
@@ -15,7 +15,6 @@ import {
 import { t } from '../i18n';
 import { useComboBox } from '../react-aria'; // from react-aria
 import { useComboBoxState } from '../react-aria'; // from react-stately
-import usePrevious from '../utilities/usePrevious';
 import { ErrorPlacement } from '../InlineError/useInlineError';
 
 export interface AutocompleteItem extends Omit<React.HTMLAttributes<'option'>, 'name'> {

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -16,6 +16,7 @@ import { t } from '../i18n';
 import { useComboBox } from '../react-aria'; // from react-aria
 import { useComboBoxState } from '../react-aria'; // from react-stately
 import usePrevious from '../utilities/usePrevious';
+import { ErrorPlacement } from '../InlineError/useInlineError';
 
 export interface AutocompleteItem extends Omit<React.HTMLAttributes<'option'>, 'name'> {
   /**
@@ -242,7 +243,8 @@ export const Autocomplete = (props: AutocompleteProps) => {
   // The display of bottom placed errorMessages in TextField breaks the Autocomplete's UI design.
   // Add errorMessageClassName to fix the styles for bottom placed errors
   const bottomError =
-    (textField.props.errorPlacement === 'bottom' || errorPlacementDefault() === 'bottom') &&
+    (textField.props.errorPlacement === ErrorPlacement.Bottom ||
+      errorPlacementDefault() === ErrorPlacement.Bottom) &&
     textField.props.errorMessage != null;
 
   const errorMessageClassName = classNames(

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
@@ -4,6 +4,8 @@ import { Label } from '../Label';
 import React from 'react';
 import classNames from 'classnames';
 import useId from '../utilities/useId';
+import { useInlineError, UseInlineErrorProps } from '../InlineError/useInlineError';
+import describeField from '../utilities/describeField';
 
 export type ChoiceListSize = 'small';
 export type ChoiceListType = 'checkbox' | 'radio';
@@ -115,7 +117,8 @@ export const ChoiceList: React.FC<ChoiceListProps> = (props: ChoiceListProps) =>
     }, 20);
   };
 
-  const { labelProps, wrapperProps, bottomError } = useFormLabel({
+  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
+  const { labelProps, wrapperProps, hintId } = useFormLabel({
     ...listProps,
     labelComponent: 'legend',
     wrapperIsFieldset: true,
@@ -150,8 +153,13 @@ export const ChoiceList: React.FC<ChoiceListProps> = (props: ChoiceListProps) =>
   });
 
   return (
-    <fieldset {...wrapperProps}>
+    <fieldset
+      {...wrapperProps}
+      aria-invalid={invalid}
+      aria-describedby={describeField({ ...props, hintId, errorId })}
+    >
       <Label {...labelProps} />
+      {topError}
       {choiceItems}
       {bottomError}
     </fieldset>

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
@@ -117,7 +117,7 @@ export const ChoiceList: React.FC<ChoiceListProps> = (props: ChoiceListProps) =>
     }, 20);
   };
 
-  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
+  const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
   const { labelProps, wrapperProps, hintId } = useFormLabel({
     ...listProps,
     labelComponent: 'legend',

--- a/packages/design-system/src/components/DateField/MultiInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.tsx
@@ -5,6 +5,8 @@ import { FormFieldProps, useFormLabel } from '../FormLabel';
 import { Label } from '../Label';
 import { t } from '../i18n';
 import useId from '../utilities/useId';
+import { useInlineError } from '../InlineError/useInlineError';
+import describeField from '../utilities/describeField';
 
 export type DateFieldDayDefaultValue = string | number;
 export type DateFieldDayValue = string | number;
@@ -139,7 +141,8 @@ export interface DateFieldProps extends Omit<FormFieldProps, 'label'> {
  */
 export function MultiInputDateField(props: DateFieldProps): React.ReactElement {
   const id = useId('date-field--', props.id);
-  const { labelProps, fieldProps, wrapperProps, bottomError } = useFormLabel({
+  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
+  const { labelProps, fieldProps, wrapperProps, hintId } = useFormLabel({
     label: t('dateField.label'),
     hint: t('dateField.hint'),
     dayName: 'day',
@@ -152,11 +155,14 @@ export function MultiInputDateField(props: DateFieldProps): React.ReactElement {
     id,
   });
 
-  delete fieldProps.errorId;
-
   return (
-    <fieldset {...wrapperProps}>
+    <fieldset
+      {...wrapperProps}
+      aria-invalid={invalid}
+      aria-describedby={describeField({ ...props, hintId, errorId })}
+    >
       <Label {...labelProps} />
+      {topError}
       <DateInput {...fieldProps} />
       {bottomError}
     </fieldset>

--- a/packages/design-system/src/components/DateField/MultiInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.tsx
@@ -141,7 +141,7 @@ export interface DateFieldProps extends Omit<FormFieldProps, 'label'> {
  */
 export function MultiInputDateField(props: DateFieldProps): React.ReactElement {
   const id = useId('date-field--', props.id);
-  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
+  const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
   const { labelProps, fieldProps, wrapperProps, hintId } = useFormLabel({
     label: t('dateField.label'),
     hint: t('dateField.hint'),

--- a/packages/design-system/src/components/DateField/SingleInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.tsx
@@ -14,6 +14,9 @@ import { TextInput } from '../TextField';
 import { TextInputProps } from '../TextField/TextInput';
 import { t } from '../i18n';
 import useId from '../utilities/useId';
+import { useInlineError } from '../InlineError/useInlineError';
+import describeField from '../utilities/describeField';
+import mergeIds from '../utilities/mergeIds';
 
 interface BaseSingleInputDateFieldProps extends FormFieldProps {
   /**
@@ -122,7 +125,8 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
   }
 
   // Collect all the props and elements for the input and its labels
-  const { labelProps, fieldProps, wrapperProps, bottomError } = useFormLabel({
+  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
+  const { labelProps, fieldProps, wrapperProps, hintId } = useFormLabel({
     ...remainingProps,
     className: classNames(
       'ds-c-single-input-date-field',
@@ -161,18 +165,21 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
   return (
     <div {...wrapperProps}>
       <Label {...labelProps} />
+      {topError}
       {labelMask}
       <div className="ds-c-single-input-date-field__field-wrapper">
-        <TextInput {...inputProps} />
+        <TextInput
+          {...inputProps}
+          aria-invalid={invalid}
+          aria-describedby={describeField({ ...props, hintId, errorId })}
+        />
         {withPicker && (
           <button
             className="ds-c-single-input-date-field__button"
             onClick={() => setPickerVisible(!pickerVisible)}
             type="button"
             ref={calendarButtonRef}
-            // The `?? ''` after `hintId` is only to support v8.0, which doesn't have a `hintId`.
-            // It can be removed after we're done supporting v8.0.
-            aria-describedby={`${labelProps.id} ${labelProps.hintId ?? ''}`}
+            aria-describedby={mergeIds(labelProps.id, hintId)}
           >
             <CalendarIcon
               ariaHidden={false}

--- a/packages/design-system/src/components/DateField/SingleInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.tsx
@@ -125,7 +125,7 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
   }
 
   // Collect all the props and elements for the input and its labels
-  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
+  const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
   const { labelProps, fieldProps, wrapperProps, hintId } = useFormLabel({
     ...remainingProps,
     className: classNames(

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -208,7 +208,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     onSelectionChange,
   });
 
-  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
+  const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
   const useFormLabelProps = useFormLabel({
     ...extraProps,
     id,

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -12,6 +12,8 @@ import DropdownMenu from './DropdownMenu';
 import useClickOutsideHandler from '../utilities/useClickOutsideHandler';
 import useId from '../utilities/useId';
 import debounce from '../utilities/debounce';
+import { useInlineError } from '../InlineError/useInlineError';
+import describeField from '../utilities/describeField';
 
 const caretIcon = (
   <SvgIcon title="" viewBox="0 0 448 512" className="ds-u-font-size--sm">
@@ -206,6 +208,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     onSelectionChange,
   });
 
+  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
   const useFormLabelProps = useFormLabel({
     ...extraProps,
     id,
@@ -216,8 +219,6 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
   });
 
   // We don't want to pass these down to the button
-  delete useFormLabelProps.fieldProps.errorMessage;
-  delete useFormLabelProps.fieldProps.errorId;
   delete useFormLabelProps.fieldProps.inversed;
 
   const onBlur = useCallback(
@@ -260,6 +261,8 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     ref: mergeRefs([triggerRef, inputRef, useAutofocus<HTMLButtonElement>(props.autoFocus)]),
     'aria-controls': menuId,
     'aria-labelledby': `${buttonContentId} ${labelId}`,
+    'aria-invalid': invalid,
+    'aria-describedby': describeField({ ...props, hintId: useFormLabelProps.hintId, errorId }),
     // TODO: Someday we may want to add this `combobox` role back to the button, but right
     // now desktop VoiceOver has an issue. It seems to interpret the selected value in the
     // button as user input that needs to be checked for spelling (default setting). It
@@ -282,6 +285,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
   return (
     <div {...useFormLabelProps.wrapperProps} ref={wrapperRef}>
       <Label {...labelProps} />
+      {topError}
       <HiddenSelect
         isDisabled={props.disabled}
         state={state}
@@ -307,7 +311,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
           triggerRef={triggerRef}
         />
       )}
-      {useFormLabelProps.bottomError}
+      {bottomError}
     </div>
   );
 };

--- a/packages/design-system/src/components/FormLabel/useFormLabel.tsx
+++ b/packages/design-system/src/components/FormLabel/useFormLabel.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import InlineError from '../InlineError/InlineError';
 import classNames from 'classnames';
-import mergeIds from '../utilities/mergeIds';
 import useId from '../utilities/useId';
 import { LabelProps } from '../Label';
+import { UseInlineErrorProps } from '../InlineError/useInlineError';
 
 // TODO: Reimplement focusTrigger in another place, like another hook
 
@@ -12,7 +11,8 @@ import { LabelProps } from '../Label';
 type PassedOnFormLabelProps = Omit<
   LabelProps,
   'children' | 'className' | 'component' | 'fieldId' | 'id' | 'errorMessage'
->;
+> &
+  Omit<UseInlineErrorProps, 'id'>;
 
 /**
  * This is the set of public-facing props that each component that uses `useFormLabel`
@@ -96,12 +96,22 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
     label,
     labelClassName,
     labelComponent,
-    // Throw away this value and don't pass it to `fieldProps`
-    labelId: _labelId,
     hint,
     requirementLabel,
     inversed,
     wrapperIsFieldset,
+
+    // Remove these from the pass-through props
+    errorId,
+    errorMessage,
+    errorMessageClassName,
+    errorPlacement,
+    labelId: _labelId,
+    // TODO: Figure out a nice way to calculate the remaining pass-through props that still
+    // allows us to break up this hook into multiple smaller hooks. There are certain props
+    // that we just know we don't want to pass down to the field, and it seems a shame to
+    // duplicate that logic everywhere.
+
     ...remainingProps
   } = props;
 

--- a/packages/design-system/src/components/FormLabel/useFormLabel.tsx
+++ b/packages/design-system/src/components/FormLabel/useFormLabel.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import mergeIds from '../utilities/mergeIds';
 import useId from '../utilities/useId';
 import { LabelProps } from '../Label';
-import { errorPlacementDefault } from '../flags';
 
 // TODO: Reimplement focusTrigger in another place, like another hook
 
@@ -24,22 +23,6 @@ export interface FormFieldProps extends PassedOnFormLabelProps {
    * Additional classes to be added to the root element.
    */
   className?: string;
-  /**
-   * The ID of the error message applied to this field.
-   */
-  errorId?: string;
-  /**
-   * Location of the error message relative to the field input
-   */
-  errorPlacement?: 'top' | 'bottom';
-  /**
-   * Enable the error state by providing an error message.
-   */
-  errorMessage?: React.ReactNode;
-  /**
-   * Additional classes to be added to the error message
-   */
-  errorMessageClassName?: string;
   /**
    * A unique `id` for the field element. Useful for referencing the field from
    * other components with `aria-describedby`.
@@ -106,7 +89,6 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
   // TODO: Once we're on React 18, we can use the `useId` hook
   const id = useId('field--', props.id);
   const labelId = props.labelId ?? `${id}__label`;
-  const errorId = props.errorId ?? `${id}__error`;
   const hintId = props.hintId ?? `${id}__hint`;
 
   const {
@@ -116,9 +98,6 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
     labelComponent,
     // Throw away this value and don't pass it to `fieldProps`
     labelId: _labelId,
-    errorMessage,
-    errorMessageClassName,
-    errorPlacement = errorPlacementDefault(),
     hint,
     requirementLabel,
     inversed,
@@ -126,35 +105,10 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
     ...remainingProps
   } = props;
 
-  const errorElement = errorMessage ? (
-    <InlineError
-      id={errorId}
-      inversed={inversed}
-      className={classNames(
-        errorMessageClassName,
-        errorPlacement === 'bottom' && 'ds-c-inline-error--bottom'
-      )}
-    >
-      {errorMessage}
-    </InlineError>
-  ) : undefined;
-  const topError = errorPlacement === 'top' ? errorElement : undefined;
-  const bottomError = errorPlacement === 'bottom' ? errorElement : undefined;
-  const ariaInvalid = props['aria-invalid'] ?? !!errorMessage;
-
-  const ariaDescribedBy =
-    mergeIds(
-      props['aria-describedby'],
-      errorElement && errorId,
-      (hint || requirementLabel) && hintId
-    ) || undefined;
-
   const labelProps = {
     children: label,
     className: labelClassName,
     component: labelComponent,
-    errorMessage: topError,
-    errorId,
     // Avoid using `for` attribute for components with multiple inputs
     // i.e. ChoiceList, DateField, and other components that use `fieldset`
     fieldId: wrapperIsFieldset ? undefined : id,
@@ -168,20 +122,20 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
   const fieldProps = {
     ...remainingProps,
     id,
-    errorMessage,
     inversed,
-    'aria-describedby': !wrapperIsFieldset ? ariaDescribedBy : undefined,
-    'aria-invalid': !wrapperIsFieldset ? ariaInvalid : undefined,
   };
 
   const wrapperClassNames = classNames({ 'ds-c-fieldset': wrapperIsFieldset }, className);
   const wrapperProps = {
     className: wrapperClassNames,
-    'aria-describedby': wrapperIsFieldset ? ariaDescribedBy : undefined,
-    'aria-invalid': wrapperIsFieldset ? ariaInvalid : undefined,
   };
 
-  return { labelProps, fieldProps, wrapperProps, bottomError, errorId };
+  return {
+    labelProps,
+    fieldProps,
+    wrapperProps,
+    hintId: hint || requirementLabel ? hintId : undefined,
+  };
 }
 
 export default useFormLabel;

--- a/packages/design-system/src/components/InlineError/index.ts
+++ b/packages/design-system/src/components/InlineError/index.ts
@@ -1,2 +1,1 @@
 export * from './InlineError';
-export * from './useInlineError';

--- a/packages/design-system/src/components/InlineError/index.ts
+++ b/packages/design-system/src/components/InlineError/index.ts
@@ -1,1 +1,2 @@
-export { default as InlineError } from './InlineError';
+export * from './InlineError';
+export * from './useInlineError';

--- a/packages/design-system/src/components/InlineError/useInlineError.tsx
+++ b/packages/design-system/src/components/InlineError/useInlineError.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import InlineError from './InlineError';
 import classNames from 'classnames';
-import { errorPlacementDefault } from '../flags';
+import { ErrorPlacement, errorPlacementDefault } from '../flags';
 
-export enum ErrorPlacement {
-  Top = 'top',
-  Bottom = 'bottom',
-}
+export { ErrorPlacement };
 
 // TODO: We should conditionally return an errorId, because we want to be able
 // to include it in the aria-describedby without conditional logic in the component
@@ -74,7 +71,7 @@ export function useInlineError<T extends UseInlineErrorProps>(props: T) {
   const invalid = props['aria-invalid'] ?? !!errorMessage;
 
   return {
-    errorId,
+    errorId: errorMessage ? errorId : undefined,
     invalid,
     topError,
     bottomError,

--- a/packages/design-system/src/components/InlineError/useInlineError.tsx
+++ b/packages/design-system/src/components/InlineError/useInlineError.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import InlineError from './InlineError';
+import classNames from 'classnames';
+import { errorPlacementDefault } from '../flags';
+
+export enum ErrorPlacement {
+  Top = 'top',
+  Bottom = 'bottom',
+}
+
+// TODO: We should conditionally return an errorId, because we want to be able
+// to include it in the aria-describedby without conditional logic in the component
+
+export interface UseInlineErrorProps {
+  /**
+   * The ID of the error message applied to this field. If none is provided, the id
+   * will be derived from the `id` prop for the field.
+   */
+  errorId?: string;
+  /**
+   * Location of the error message relative to the field input
+   */
+  errorPlacement?: ErrorPlacement;
+  /**
+   * Enable the error state by providing an error message.
+   */
+  errorMessage?: React.ReactNode;
+  /**
+   * Additional classes to be added to the error message
+   */
+  errorMessageClassName?: string;
+  /**
+   * A unique `id` for the field element
+   */
+  id: string;
+  /**
+   * Set to `true` to apply the "inverse" color scheme
+   */
+  inversed?: boolean;
+}
+
+export function useInlineError<T extends UseInlineErrorProps>(props: T) {
+  const errorId = props.errorId ?? `${props.id}__error`;
+  const {
+    errorMessage,
+    errorMessageClassName,
+    errorPlacement = errorPlacementDefault(),
+    inversed,
+  } = props;
+
+  const errorElement = errorMessage ? (
+    <InlineError
+      id={errorId}
+      inversed={inversed}
+      className={classNames(
+        errorMessageClassName,
+        errorPlacement === ErrorPlacement.Bottom && 'ds-c-inline-error--bottom'
+      )}
+    >
+      {errorMessage}
+    </InlineError>
+  ) : undefined;
+
+  let topError;
+  let bottomError;
+  if (errorPlacement === ErrorPlacement.Top) {
+    topError = errorElement;
+  } else {
+    bottomError = errorElement;
+  }
+
+  // If the user has provided an `aria-invalid` attribute, use that as the source
+  // of truth; otherwise, it's invalid if there's an error message.
+  const invalid = props['aria-invalid'] ?? !!errorMessage;
+
+  return {
+    errorId,
+    invalid,
+    topError,
+    bottomError,
+  };
+}

--- a/packages/design-system/src/components/InlineError/useInlineError.tsx
+++ b/packages/design-system/src/components/InlineError/useInlineError.tsx
@@ -36,6 +36,12 @@ export interface UseInlineErrorProps {
   inversed?: boolean;
 }
 
+/**
+ * Hook that takes the props for a form field component, extracts the props relevant
+ * to the error message, and conditionally renders an `InlineError` in the `topError`
+ * or `bottomError` property based on the `errorPlacement` and the presence of an
+ * `errorMessage`.
+ */
 export function useInlineError<T extends UseInlineErrorProps>(props: T) {
   const errorId = props.errorId ?? `${props.id}__error`;
   const {

--- a/packages/design-system/src/components/Label/Label.stories.tsx
+++ b/packages/design-system/src/components/Label/Label.stories.tsx
@@ -5,6 +5,11 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta: Meta<typeof Label> = {
   title: 'Components/Label',
   component: Label as any,
+  argTypes: {
+    errorMessage: { control: 'text' },
+    hint: { control: 'text' },
+    requirementLabel: { control: 'text' },
+  },
   args: {
     children: 'Sample Label',
   },

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
@@ -3,13 +3,15 @@ import React from 'react';
 import 'core-js/stable/array/includes';
 import Button, { ButtonVariation } from '../Button/Button';
 import Choice from '../ChoiceList/Choice';
-import { ChangeEvent, useState } from 'react';
 import classNames from 'classnames';
+import describeField from '../utilities/describeField';
+import useId from '../utilities/useId';
+import { ChangeEvent, useState } from 'react';
 import { NUM_MONTHS, getMonthNames } from './getMonthNames';
 import { fallbackLocale, getLanguage, t } from '../i18n';
 import { FormFieldProps, useFormLabel } from '../FormLabel';
 import { Label } from '../Label';
-import useId from '../utilities/useId';
+import { useInlineError } from '../InlineError/useInlineError';
 
 const monthNumbers = (() => {
   const months = [];
@@ -123,7 +125,8 @@ export const MonthPicker = (props: MonthPickerProps) => {
   const selectAllPressed = selectedMonths.length === NUM_MONTHS - disabledMonths.length;
   const clearAllPressed = selectedMonths.length === 0;
 
-  const { labelProps, wrapperProps, bottomError } = useFormLabel({
+  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
+  const { labelProps, wrapperProps, hintId } = useFormLabel({
     ...props,
     className: classNames('ds-c-month-picker', props.className),
     labelComponent: 'legend',
@@ -132,8 +135,13 @@ export const MonthPicker = (props: MonthPickerProps) => {
   });
 
   return (
-    <fieldset {...wrapperProps}>
+    <fieldset
+      {...wrapperProps}
+      aria-invalid={invalid}
+      aria-describedby={describeField({ ...props, hintId, errorId })}
+    >
       <Label {...labelProps} />
+      {topError}
       <div className="ds-c-month-picker__buttons ds-u-clearfix">
         <Button
           aria-pressed={selectAllPressed}

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
@@ -125,7 +125,7 @@ export const MonthPicker = (props: MonthPickerProps) => {
   const selectAllPressed = selectedMonths.length === NUM_MONTHS - disabledMonths.length;
   const clearAllPressed = selectedMonths.length === 0;
 
-  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
+  const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
   const { labelProps, wrapperProps, hintId } = useFormLabel({
     ...props,
     className: classNames('ds-c-month-picker', props.className),

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
@@ -19,8 +19,6 @@ const monthNumbers = (() => {
   return months;
 })();
 
-export type MonthPickerErrorPlacement = 'top' | 'bottom';
-
 interface MonthPickerProps extends FormFieldProps {
   /**
    * The `input` field's `name` attribute

--- a/packages/design-system/src/components/TextField/Mask.test.tsx
+++ b/packages/design-system/src/components/TextField/Mask.test.tsx
@@ -47,7 +47,6 @@ describe('Mask', function () {
     expect(container.querySelector('.ds-c-field-mask--ssn')).toBeInTheDocument();
 
     const input = screen.getByRole('textbox');
-    expect(input).toHaveAttribute('aria-invalid', 'false');
     expect(input.classList).toContain('ds-c-field--ssn');
     expect(input).toHaveAttribute('type', 'text');
     expect(input).toHaveAttribute('pattern', '[0-9-*]*');
@@ -63,7 +62,6 @@ describe('Mask', function () {
     expect(inputPrefix.textContent).toBe('$');
 
     const input = screen.getByRole('textbox');
-    expect(input).toHaveAttribute('aria-invalid', 'false');
     expect(input.classList).toContain('ds-c-field--currency');
     expect(input).toHaveAttribute('type', 'text');
     expect(input).toHaveAttribute('pattern', '[0-9.,-]*');

--- a/packages/design-system/src/components/TextField/TextField.tsx
+++ b/packages/design-system/src/components/TextField/TextField.tsx
@@ -115,7 +115,7 @@ export const TextField: React.FC<TextFieldProps> = (props: TextFieldProps) => {
     }
   }
 
-  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
+  const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
   const { labelProps, fieldProps, wrapperProps, hintId } = useFormLabel({
     ...textFieldProps,
     labelComponent: 'label',

--- a/packages/design-system/src/components/TextField/TextField.tsx
+++ b/packages/design-system/src/components/TextField/TextField.tsx
@@ -6,6 +6,8 @@ import classNames from 'classnames';
 import { FormFieldProps, useFormLabel } from '../FormLabel';
 import { Label } from '../Label';
 import useId from '../utilities/useId';
+import { useInlineError } from '../InlineError/useInlineError';
+import describeField from '../utilities/describeField';
 
 export type TextFieldDefaultValue = string | number;
 export type TextFieldMask = 'currency' | 'phone' | 'ssn' | 'zip';
@@ -103,6 +105,7 @@ export type TextFieldProps = BaseTextFieldProps &
  */
 export const TextField: React.FC<TextFieldProps> = (props: TextFieldProps) => {
   const { mask, labelMask, ...textFieldProps } = props;
+  const id = useId('text-field--', textFieldProps.id);
 
   if (process.env.NODE_ENV !== 'production') {
     if (props.type === 'number') {
@@ -112,11 +115,12 @@ export const TextField: React.FC<TextFieldProps> = (props: TextFieldProps) => {
     }
   }
 
-  const { labelProps, fieldProps, wrapperProps, bottomError } = useFormLabel({
+  const { errorId, topError, bottomError, invalid } = useInlineError({ id, ...props });
+  const { labelProps, fieldProps, wrapperProps, hintId } = useFormLabel({
     ...textFieldProps,
     labelComponent: 'label',
     wrapperIsFieldset: false,
-    id: useId('text-field--', textFieldProps.id),
+    id,
   });
 
   wrapperProps.className = classNames(
@@ -129,12 +133,15 @@ export const TextField: React.FC<TextFieldProps> = (props: TextFieldProps) => {
       type={TextField.defaultProps.type} // Appeases TypeScript
       inversed={props.inversed}
       {...fieldProps}
+      aria-invalid={invalid}
+      aria-describedby={describeField({ ...props, errorId, hintId })}
     />
   );
 
   return (
     <div {...wrapperProps}>
       <Label {...labelProps} />
+      {topError}
       {mask && <Mask mask={mask}>{input}</Mask>}
       {labelMask && <LabelMask labelMask={labelMask}>{input}</LabelMask>}
       {!mask && !labelMask && input}

--- a/packages/design-system/src/components/TextField/TextInput.test.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.test.tsx
@@ -10,7 +10,6 @@ const defaultProps: Omit<React.ComponentPropsWithRef<'textarea'>, OmitProps> &
   inputRef: jest.fn(),
   id: 'static-id',
   type: 'text',
-  errorPlacement: 'top',
 };
 
 function renderInput(props = {}) {
@@ -53,7 +52,6 @@ describe('TextInput', function () {
 
   it('has error', () => {
     renderInput({ errorMessage: 'Error' });
-    expect(getInput().getAttribute('aria-invalid')).toBe('true');
     expect(getInput().classList.contains('ds-c-field--error')).toBe(true);
   });
 
@@ -61,12 +59,8 @@ describe('TextInput', function () {
     renderInput({
       errorMessage: 'Error',
       errorPlacement: 'bottom',
-      errorId: '1_error',
-      'aria-describedby': '1_label',
     });
 
-    expect(getInput().getAttribute('aria-invalid')).toBe('true');
-    expect(getInput().getAttribute('aria-describedby')).toBe('1_label 1_error');
     expect(getInput().classList.contains('ds-c-field--error')).toBe(true);
     expect(getInput()).toMatchSnapshot();
   });

--- a/packages/design-system/src/components/TextField/TextInput.test.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.test.tsx
@@ -51,18 +51,8 @@ describe('TextInput', function () {
   });
 
   it('has error', () => {
-    renderInput({ errorMessage: 'Error' });
+    renderInput({ 'aria-invalid': true });
     expect(getInput().classList.contains('ds-c-field--error')).toBe(true);
-  });
-
-  it('handles bottom placed error', () => {
-    renderInput({
-      errorMessage: 'Error',
-      errorPlacement: 'bottom',
-    });
-
-    expect(getInput().classList.contains('ds-c-field--error')).toBe(true);
-    expect(getInput()).toMatchSnapshot();
   });
 
   it('has inversed theme', () => {

--- a/packages/design-system/src/components/TextField/TextInput.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { FunctionComponent } from 'react';
 import classNames from 'classnames';
 import mergeIds from '../utilities/mergeIds';
+import { ErrorPlacement } from '../InlineError/useInlineError';
 
 export type TextInputDefaultValue = string | number;
 export type TextInputRows = number | string;
 export type TextInputSize = 'small' | 'medium';
 export type TextInputValue = string | number;
-export type TextInputErrorPlacement = 'top' | 'bottom';
 
 export type OmitProps = 'size' | 'ref';
 
@@ -31,7 +31,7 @@ export type TextInputProps = Omit<React.ComponentPropsWithoutRef<'input'>, OmitP
   /**
    * Location of the error message relative to the field input
    */
-  errorPlacement?: TextInputErrorPlacement;
+  errorPlacement?: ErrorPlacement;
   /**
    * Additional classes to be added to the field element
    */
@@ -149,7 +149,7 @@ const TextInput: FunctionComponent<TextInputProps> = (props: TextInputProps) => 
       aria-describedby={
         mergeIds(
           props['aria-describedby'],
-          errorPlacement === 'bottom' && errorMessage && errorId
+          errorPlacement === ErrorPlacement.Bottom && errorMessage && errorId
         ) || undefined
       }
     />

--- a/packages/design-system/src/components/TextField/TextInput.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { FunctionComponent } from 'react';
 import classNames from 'classnames';
-import mergeIds from '../utilities/mergeIds';
-import { ErrorPlacement } from '../InlineError/useInlineError';
 
 export type TextInputDefaultValue = string | number;
 export type TextInputRows = number | string;

--- a/packages/design-system/src/components/TextField/TextInput.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.tsx
@@ -23,10 +23,6 @@ export type TextInputProps = Omit<React.ComponentPropsWithoutRef<'input'>, OmitP
    */
   defaultValue?: TextInputDefaultValue;
   disabled?: boolean;
-  /**
-   * The ID of the error message applied to the Select field.
-   */
-  errorId?: string;
   errorMessage?: React.ReactNode;
   /**
    * Location of the error message relative to the field input
@@ -93,7 +89,6 @@ export type SingleLineTextInputProps = TextInputProps;
 const TextInput: FunctionComponent<TextInputProps> = (props: TextInputProps) => {
   const {
     ariaLabel,
-    errorId,
     errorMessage,
     errorPlacement,
     fieldClassName,
@@ -140,18 +135,8 @@ const TextInput: FunctionComponent<TextInputProps> = (props: TextInputProps) => 
       // @ts-ignore: The ClipboardEventHandler for textareas and inputs are incompatible, and TS
       // is failing to infer which one is being used here based on ComponentType.
       onCopyCapture={onCopyCapture}
-      // This can be purposefully overwritten by an 'aria-invalid' defined in inputProps
-      aria-invalid={!!errorMessage}
       {...inputProps}
       aria-label={ariaLabel || props['aria-label']}
-      // Link input to bottom placed error message
-      // Use of the classNames function for this is confusing
-      aria-describedby={
-        mergeIds(
-          props['aria-describedby'],
-          errorPlacement === ErrorPlacement.Bottom && errorMessage && errorId
-        ) || undefined
-      }
     />
   );
 };

--- a/packages/design-system/src/components/TextField/TextInput.tsx
+++ b/packages/design-system/src/components/TextField/TextInput.tsx
@@ -23,11 +23,6 @@ export type TextInputProps = Omit<React.ComponentPropsWithoutRef<'input'>, OmitP
    */
   defaultValue?: TextInputDefaultValue;
   disabled?: boolean;
-  errorMessage?: React.ReactNode;
-  /**
-   * Location of the error message relative to the field input
-   */
-  errorPlacement?: ErrorPlacement;
   /**
    * Additional classes to be added to the field element
    */
@@ -89,8 +84,6 @@ export type SingleLineTextInputProps = TextInputProps;
 const TextInput: FunctionComponent<TextInputProps> = (props: TextInputProps) => {
   const {
     ariaLabel,
-    errorMessage,
-    errorPlacement,
     fieldClassName,
     inversed,
     multiline,
@@ -107,7 +100,7 @@ const TextInput: FunctionComponent<TextInputProps> = (props: TextInputProps) => 
   const classes = classNames(
     'ds-c-field',
     {
-      'ds-c-field--error': errorMessage,
+      'ds-c-field--error': props['aria-invalid'],
       'ds-c-field--inverse': inversed,
     },
     size && `ds-c-field--${size}`,

--- a/packages/design-system/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/design-system/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`TextField renders 1`] = `
       Foo
     </label>
     <input
+      aria-describedby=""
       aria-invalid="false"
       class="ds-c-field"
       id="static-id"

--- a/packages/design-system/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/design-system/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`TextField renders 1`] = `
       Foo
     </label>
     <input
-      aria-describedby=""
       aria-invalid="false"
       class="ds-c-field"
       id="static-id"

--- a/packages/design-system/src/components/TextField/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/design-system/src/components/TextField/__snapshots__/TextInput.test.tsx.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TextInput handles bottom placed error 1`] = `
-<input
-  class="ds-c-field ds-c-field--error"
-  id="static-id"
-  name="spec-field"
-  type="text"
-/>
-`;
-
 exports[`TextInput is a textarea 1`] = `
 <textarea
   class="ds-c-field"

--- a/packages/design-system/src/components/TextField/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/design-system/src/components/TextField/__snapshots__/TextInput.test.tsx.snap
@@ -2,8 +2,6 @@
 
 exports[`TextInput handles bottom placed error 1`] = `
 <input
-  aria-describedby="1_label 1_error"
-  aria-invalid="true"
   class="ds-c-field ds-c-field--error"
   id="static-id"
   name="spec-field"
@@ -13,7 +11,6 @@ exports[`TextInput handles bottom placed error 1`] = `
 
 exports[`TextInput is a textarea 1`] = `
 <textarea
-  aria-invalid="false"
   class="ds-c-field"
   id="static-id"
   name="spec-field"
@@ -22,7 +19,6 @@ exports[`TextInput is a textarea 1`] = `
 
 exports[`TextInput is an input field 1`] = `
 <input
-  aria-invalid="false"
   class="ds-c-field"
   id="static-id"
   name="spec-field"

--- a/packages/design-system/src/components/flags.ts
+++ b/packages/design-system/src/components/flags.ts
@@ -1,3 +1,5 @@
+import { ErrorPlacement } from './InlineError/useInlineError';
+
 type errorPlacementValue = 'top' | 'bottom';
 
 interface flagsType {
@@ -10,7 +12,7 @@ interface flagsType {
 
 // featureFlags.js
 const flags: flagsType = {
-  ERROR_PLACEMENT_DEFAULT: 'top',
+  ERROR_PLACEMENT_DEFAULT: ErrorPlacement.Top,
   ALERT_SENDS_ANALYTICS: false,
   BUTTON_SENDS_ANALYTICS: false,
   DIALOG_SENDS_ANALYTICS: false,

--- a/packages/design-system/src/components/flags.ts
+++ b/packages/design-system/src/components/flags.ts
@@ -1,9 +1,10 @@
-import { ErrorPlacement } from './InlineError/useInlineError';
-
-type errorPlacementValue = 'top' | 'bottom';
+export enum ErrorPlacement {
+  Top = 'top',
+  Bottom = 'bottom',
+}
 
 interface flagsType {
-  ERROR_PLACEMENT_DEFAULT: errorPlacementValue;
+  ERROR_PLACEMENT_DEFAULT: ErrorPlacement;
   ALERT_SENDS_ANALYTICS: boolean;
   BUTTON_SENDS_ANALYTICS: boolean;
   DIALOG_SENDS_ANALYTICS: boolean;
@@ -19,11 +20,11 @@ const flags: flagsType = {
   HELP_DRAWER_SENDS_ANALYTICS: false,
 };
 
-export function errorPlacementDefault(): errorPlacementValue {
+export function errorPlacementDefault(): ErrorPlacement {
   return flags.ERROR_PLACEMENT_DEFAULT;
 }
 
-export function setErrorPlacementDefault(value: errorPlacementValue): void {
+export function setErrorPlacementDefault(value: ErrorPlacement): void {
   flags.ERROR_PLACEMENT_DEFAULT = value;
 }
 

--- a/packages/design-system/src/components/utilities/describeField.ts
+++ b/packages/design-system/src/components/utilities/describeField.ts
@@ -1,0 +1,17 @@
+import mergeIds from './mergeIds';
+
+interface DescribeFieldProps {
+  'aria-describedby'?: string;
+  errorId?: string;
+  hintId?: string;
+}
+
+/**
+ * Creates an `aria-describedby` string in a consistent order from optional
+ * `aria-describedby`, `errorId`, and `hintId` props.
+ */
+export function describeField(props: DescribeFieldProps) {
+  return mergeIds(props['aria-describedby'], props.errorId, props.hintId);
+}
+
+export default describeField;

--- a/packages/design-system/src/components/utilities/describeField.ts
+++ b/packages/design-system/src/components/utilities/describeField.ts
@@ -11,7 +11,7 @@ interface DescribeFieldProps {
  * `aria-describedby`, `errorId`, and `hintId` props.
  */
 export function describeField(props: DescribeFieldProps) {
-  return mergeIds(props['aria-describedby'], props.errorId, props.hintId);
+  return mergeIds(props['aria-describedby'], props.errorId, props.hintId) || undefined;
 }
 
 export default describeField;

--- a/packages/ds-healthcare-gov/src/components/index.ts
+++ b/packages/ds-healthcare-gov/src/components/index.ts
@@ -1,8 +1,5 @@
 'use strict';
 
-// Unfortunately we can't convert this module to TypeScript until we deprecate
-// the `secondary` button variation and get rid of its TS definition file.
-
 /**
  * This is the main entry file for a child design system's React components.
  * It should contain all exported JS from the core CMS design system
@@ -15,7 +12,7 @@
  *
  */
 
-import { setErrorPlacementDefault } from '@cmsgov/design-system';
+import { ErrorPlacement, setErrorPlacementDefault } from '@cmsgov/design-system';
 
 export * from '@cmsgov/design-system';
 export * from './Accordion';
@@ -28,4 +25,4 @@ export * from './flags';
 /**
  * Healthcare.gov Flags
  */
-setErrorPlacementDefault('bottom');
+setErrorPlacementDefault(ErrorPlacement.Bottom);

--- a/packages/ds-healthcare-gov/src/components/web-components/index.ts
+++ b/packages/ds-healthcare-gov/src/components/web-components/index.ts
@@ -10,7 +10,7 @@
  * modules during tree-shaking.
  */
 
-import { setErrorPlacementDefault } from '@cmsgov/design-system';
+import { ErrorPlacement, setErrorPlacementDefault } from '@cmsgov/design-system';
 
 export * from '@cmsgov/design-system/web-components';
 
@@ -19,4 +19,4 @@ export * from '../flags';
 /**
  * Healthcare.gov Flags
  */
-setErrorPlacementDefault('bottom');
+setErrorPlacementDefault(ErrorPlacement.Bottom);


### PR DESCRIPTION
## Summary

WNMGDS-2523 is about lessening the negative effects of the useFormLabel abstraction. I'm working on a feature branch that breaks `useFormLabel` up into some smaller, more focused hooks that can be mixed and matched. This is one of several pull requests to go into this feature branch.

- Creates a new `useInlineError` hook that returns...
    - `topError` and `bottomError`, only one of which will have a rendered element in it based on the error positioning
    - `errorId` for referencing by other elements
    - `invalid` boolean for applying to whatever element needs an `aria-invalid` property

## How to test

These components should be manually tested a bit, but automated tests should also cover this work.
