### PR TITLE
[WNMGDS-2523] Break some `useFormLabel` functionality into a `useHint` hook

### DIFF
--- a/packages/design-system/src/components/ChoiceList/Choice.stories.tsx
+++ b/packages/design-system/src/components/ChoiceList/Choice.stories.tsx
@@ -15,6 +15,9 @@ const meta: Meta<typeof Choice> = {
     errorMessage: 'You must agree to the terms and conditions before continuing',
     defaultChecked: false,
   },
+  argTypes: {
+    requirementLabel: { control: 'text' },
+  },
   parameters: {
     docs: {
       underlyingHtmlElements: ['input'],

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.stories.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.stories.tsx
@@ -21,6 +21,8 @@ const meta: Meta<typeof ChoiceList> = {
   },
   argTypes: {
     errorMessage: { control: 'text' },
+    hint: { control: 'text' },
+    requirementLabel: { control: 'text' },
   },
 };
 export default meta;

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import useId from '../utilities/useId';
 import { useInlineError, UseInlineErrorProps } from '../InlineError/useInlineError';
 import describeField from '../utilities/describeField';
+import { useHint } from '../Hint/useHint';
 
 export type ChoiceListSize = 'small';
 export type ChoiceListType = 'checkbox' | 'radio';
@@ -118,7 +119,8 @@ export const ChoiceList: React.FC<ChoiceListProps> = (props: ChoiceListProps) =>
   };
 
   const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
-  const { labelProps, wrapperProps, hintId } = useFormLabel({
+  const { hintId, hintElement } = useHint({ ...props, id });
+  const { labelProps, wrapperProps } = useFormLabel({
     ...listProps,
     labelComponent: 'legend',
     wrapperIsFieldset: true,
@@ -159,6 +161,7 @@ export const ChoiceList: React.FC<ChoiceListProps> = (props: ChoiceListProps) =>
       aria-describedby={describeField({ ...props, hintId, errorId })}
     >
       <Label {...labelProps} />
+      {hintElement}
       {topError}
       {choiceItems}
       {bottomError}

--- a/packages/design-system/src/components/DateField/MultiInputDateField.stories.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.stories.tsx
@@ -6,6 +6,11 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta: Meta<typeof MultiInputDateField> = {
   title: 'Components/MultiInputDateField',
   component: MultiInputDateField,
+  argTypes: {
+    errorMessage: { control: 'text' },
+    hint: { control: 'text' },
+    requirementLabel: { control: 'text' },
+  },
 };
 export default meta;
 

--- a/packages/design-system/src/components/DateField/MultiInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.tsx
@@ -143,10 +143,9 @@ export interface DateFieldProps extends Omit<FormFieldProps, 'label'> {
 export function MultiInputDateField(props: DateFieldProps): React.ReactElement {
   const id = useId('date-field--', props.id);
   const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
-  const { hintId, hintElement } = useHint({ ...props, id });
+  const { hintId, hintElement } = useHint({ ...props, hint: t('dateField.hint'), id });
   const { labelProps, fieldProps, wrapperProps } = useFormLabel({
     label: t('dateField.label'),
-    hint: t('dateField.hint'),
     dayName: 'day',
     monthName: 'month',
     yearName: 'year',

--- a/packages/design-system/src/components/DateField/MultiInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.tsx
@@ -143,7 +143,7 @@ export interface DateFieldProps extends Omit<FormFieldProps, 'label'> {
 export function MultiInputDateField(props: DateFieldProps): React.ReactElement {
   const id = useId('date-field--', props.id);
   const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
-  const { hintId, hintElement } = useHint({ ...props, hint: t('dateField.hint'), id });
+  const { hintId, hintElement } = useHint({ hint: t('dateField.hint'), ...props, id });
   const { labelProps, fieldProps, wrapperProps } = useFormLabel({
     label: t('dateField.label'),
     dayName: 'day',

--- a/packages/design-system/src/components/DateField/MultiInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.tsx
@@ -7,6 +7,7 @@ import { t } from '../i18n';
 import useId from '../utilities/useId';
 import { useInlineError } from '../InlineError/useInlineError';
 import describeField from '../utilities/describeField';
+import { useHint } from '../Hint/useHint';
 
 export type DateFieldDayDefaultValue = string | number;
 export type DateFieldDayValue = string | number;
@@ -142,7 +143,8 @@ export interface DateFieldProps extends Omit<FormFieldProps, 'label'> {
 export function MultiInputDateField(props: DateFieldProps): React.ReactElement {
   const id = useId('date-field--', props.id);
   const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
-  const { labelProps, fieldProps, wrapperProps, hintId } = useFormLabel({
+  const { hintId, hintElement } = useHint({ ...props, id });
+  const { labelProps, fieldProps, wrapperProps } = useFormLabel({
     label: t('dateField.label'),
     hint: t('dateField.hint'),
     dayName: 'day',
@@ -162,6 +164,7 @@ export function MultiInputDateField(props: DateFieldProps): React.ReactElement {
       aria-describedby={describeField({ ...props, hintId, errorId })}
     >
       <Label {...labelProps} />
+      {hintElement}
       {topError}
       <DateInput {...fieldProps} />
       {bottomError}

--- a/packages/design-system/src/components/DateField/SingleInputDateField.stories.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.stories.tsx
@@ -11,6 +11,11 @@ const meta: Meta<typeof SingleInputDateField> = {
     label: 'Birthday',
     name: 'single-input-date-field',
   },
+  argTypes: {
+    errorMessage: { control: 'text' },
+    hint: { control: 'text' },
+    requirementLabel: { control: 'text' },
+  },
   parameters: {
     docs: {
       underlyingHtmlElements: ['input'],

--- a/packages/design-system/src/components/DateField/SingleInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.tsx
@@ -17,6 +17,7 @@ import useId from '../utilities/useId';
 import { useInlineError } from '../InlineError/useInlineError';
 import describeField from '../utilities/describeField';
 import mergeIds from '../utilities/mergeIds';
+import { useHint } from '../Hint/useHint';
 
 interface BaseSingleInputDateFieldProps extends FormFieldProps {
   /**
@@ -126,7 +127,8 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
 
   // Collect all the props and elements for the input and its labels
   const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
-  const { labelProps, fieldProps, wrapperProps, hintId } = useFormLabel({
+  const { hintId, hintElement } = useHint({ ...props, id });
+  const { labelProps, fieldProps, wrapperProps } = useFormLabel({
     ...remainingProps,
     className: classNames(
       'ds-c-single-input-date-field',
@@ -165,6 +167,7 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
   return (
     <div {...wrapperProps}>
       <Label {...labelProps} />
+      {hintElement}
       {topError}
       {labelMask}
       <div className="ds-c-single-input-date-field__field-wrapper">

--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
@@ -11,6 +11,11 @@ const meta: Meta<typeof Dropdown> = {
   args: {
     name: 'dropdown-field',
   },
+  argTypes: {
+    errorMessage: { control: 'text' },
+    hint: { control: 'text' },
+    requirementLabel: { control: 'text' },
+  },
   parameters: {
     docs: {
       underlyingHtmlElements: ['button'],

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -14,6 +14,7 @@ import useId from '../utilities/useId';
 import debounce from '../utilities/debounce';
 import { useInlineError } from '../InlineError/useInlineError';
 import describeField from '../utilities/describeField';
+import { useHint } from '../Hint/useHint';
 
 const caretIcon = (
   <SvgIcon title="" viewBox="0 0 448 512" className="ds-u-font-size--sm">
@@ -209,6 +210,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
   });
 
   const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
+  const { hintId, hintElement } = useHint({ ...props, id });
   const useFormLabelProps = useFormLabel({
     ...extraProps,
     id,
@@ -262,7 +264,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     'aria-controls': menuId,
     'aria-labelledby': `${buttonContentId} ${labelId}`,
     'aria-invalid': invalid,
-    'aria-describedby': describeField({ ...props, hintId: useFormLabelProps.hintId, errorId }),
+    'aria-describedby': describeField({ ...props, hintId, errorId }),
     // TODO: Someday we may want to add this `combobox` role back to the button, but right
     // now desktop VoiceOver has an issue. It seems to interpret the selected value in the
     // button as user input that needs to be checked for spelling (default setting). It
@@ -285,6 +287,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
   return (
     <div {...useFormLabelProps.wrapperProps} ref={wrapperRef}>
       <Label {...labelProps} />
+      {hintElement}
       {topError}
       <HiddenSelect
         isDisabled={props.disabled}

--- a/packages/design-system/src/components/FormLabel/useFormLabel.tsx
+++ b/packages/design-system/src/components/FormLabel/useFormLabel.tsx
@@ -89,15 +89,12 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
   // TODO: Once we're on React 18, we can use the `useId` hook
   const id = useId('field--', props.id);
   const labelId = props.labelId ?? `${id}__label`;
-  const hintId = props.hintId ?? `${id}__hint`;
 
   const {
     className,
     label,
     labelClassName,
     labelComponent,
-    hint,
-    requirementLabel,
     inversed,
     wrapperIsFieldset,
 
@@ -106,6 +103,9 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
     errorMessage,
     errorMessageClassName,
     errorPlacement,
+    hint,
+    hintId,
+    requirementLabel,
     labelId: _labelId,
     // TODO: Figure out a nice way to calculate the remaining pass-through props that still
     // allows us to break up this hook into multiple smaller hooks. There are certain props
@@ -122,10 +122,7 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
     // Avoid using `for` attribute for components with multiple inputs
     // i.e. ChoiceList, DateField, and other components that use `fieldset`
     fieldId: wrapperIsFieldset ? undefined : id,
-    hint,
-    hintId,
     id: labelId,
-    requirementLabel,
     inversed,
   };
 
@@ -144,7 +141,6 @@ export function useFormLabel<T extends UseFormLabelProps>(props: T) {
     labelProps,
     fieldProps,
     wrapperProps,
-    hintId: hint || requirementLabel ? hintId : undefined,
   };
 }
 

--- a/packages/design-system/src/components/Hint/useHint.tsx
+++ b/packages/design-system/src/components/Hint/useHint.tsx
@@ -24,6 +24,10 @@ export interface UseHintProps {
   requirementLabel?: React.ReactNode;
 }
 
+/**
+ * Hook that takes the props for a form field component, extracts the props relevant
+ * to the Hint, and conditionally renders the hint if it is needed.
+ */
 export function useHint<T extends UseHintProps>(props: T) {
   const { hint, inversed, requirementLabel } = props;
 

--- a/packages/design-system/src/components/Hint/useHint.tsx
+++ b/packages/design-system/src/components/Hint/useHint.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Hint } from './Hint';
+
+export interface UseHintProps {
+  /**
+   * Additional hint text to display
+   */
+  hint?: React.ReactNode;
+  /**
+   * The ID of the hint element
+   */
+  hintId?: string;
+  /**
+   * A unique `id` for the field element
+   */
+  id: string;
+  /**
+   * Set to `true` to apply the "inverse" color scheme
+   */
+  inversed?: boolean;
+  /**
+   * Text showing the requirement ("Required", "Optional", etc.). See [Required and Optional Fields](https://design.cms.gov/patterns/Forms/forms/#required-and-optional-fields).
+   */
+  requirementLabel?: React.ReactNode;
+}
+
+export function useHint<T extends UseHintProps>(props: T) {
+  const { hint, inversed, requirementLabel } = props;
+
+  let hintElement;
+  let hintId;
+  if (hint || requirementLabel) {
+    hintId = props.hintId ?? `${props.id}__hint`;
+    hintElement = (
+      <Hint requirementLabel={requirementLabel} inversed={inversed} id={hintId}>
+        {hint}
+      </Hint>
+    );
+  }
+
+  return {
+    hintId,
+    hintElement,
+  };
+}

--- a/packages/design-system/src/components/Label/Label.test.tsx
+++ b/packages/design-system/src/components/Label/Label.test.tsx
@@ -14,33 +14,58 @@ describe('Label', () => {
     expect(label).toMatchSnapshot();
   });
 
-  it('renders error messages', () => {
-    const props = {
-      errorMessage: <span>Nah, try again.</span>,
-      fieldId: 'name',
-    };
-    render(<Label {...props}>{labelText}</Label>);
+  describe('Deprecated hint and error functionality', () => {
+    let warn;
 
-    const error = screen.getByText('Nah, try again.');
-    expect(error).toBeInTheDocument();
-  });
+    beforeEach(() => {
+      warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
 
-  it('renders hint string', () => {
-    const props = { hint: 'President #44' };
-    render(<Label {...props}>{labelText}</Label>);
+    afterEach(() => {
+      expect(warn).toHaveBeenCalled();
+      warn.mockReset();
+    });
 
-    const hint = screen.getByText('President #44');
-    expect(hint).toBeInTheDocument();
-  });
+    it('renders error messages', () => {
+      const props = {
+        errorMessage: <span>Nah, try again.</span>,
+        fieldId: 'name',
+      };
+      render(<Label {...props}>{labelText}</Label>);
 
-  it('renders hint node', () => {
-    const props = {
-      hint: <strong>President #44</strong>,
-    };
-    render(<Label {...props}>{labelText}</Label>);
+      const error = screen.getByText('Nah, try again.');
+      expect(error).toBeInTheDocument();
+    });
 
-    const hint = screen.getByText('President #44');
-    expect(hint).toBeInTheDocument();
+    it('renders hint string', () => {
+      const props = { hint: 'President #44' };
+      render(<Label {...props}>{labelText}</Label>);
+
+      const hint = screen.getByText('President #44');
+      expect(hint).toBeInTheDocument();
+    });
+
+    it('renders hint node', () => {
+      const props = {
+        hint: <strong>President #44</strong>,
+      };
+      render(<Label {...props}>{labelText}</Label>);
+
+      const hint = screen.getByText('President #44');
+      expect(hint).toBeInTheDocument();
+    });
+
+    it('adds punctuation to requirementLabel when hint is also present', () => {
+      interface PropDef {
+        hint: React.ReactNode;
+        requirementLabel: React.ReactNode;
+      }
+      const props: PropDef = { hint: 'Hint', requirementLabel: 'Optional' };
+      const { container } = render(<Label {...props}>{labelText}</Label>);
+
+      const label = container.querySelector('label');
+      expect(label).toMatchSnapshot();
+    });
   });
 
   it('renders requirementLabel', () => {
@@ -52,18 +77,6 @@ describe('Label', () => {
     const requirement = container.querySelector('label');
     expect(requirement).toBeInTheDocument();
     expect(requirement).toMatchSnapshot();
-  });
-
-  it('adds punctuation to requirementLabel when hint is also present', () => {
-    interface PropDef {
-      hint: React.ReactNode;
-      requirementLabel: React.ReactNode;
-    }
-    const props: PropDef = { hint: 'Hint', requirementLabel: 'Optional' };
-    const { container } = render(<Label {...props}>{labelText}</Label>);
-
-    const label = container.querySelector('label');
-    expect(label).toMatchSnapshot();
   });
 
   it('renders as a legend element', () => {

--- a/packages/design-system/src/components/Label/__snapshots__/Label.test.tsx.snap
+++ b/packages/design-system/src/components/Label/__snapshots__/Label.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Label adds punctuation to requirementLabel when hint is also present 1`] = `
+exports[`Label Deprecated hint and error functionality adds punctuation to requirementLabel when hint is also present 1`] = `
 <label
   class="ds-c-label"
 >

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.stories.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.stories.tsx
@@ -9,6 +9,11 @@ const meta: Meta<typeof MonthPicker> = {
     hint: "Month Picker can receive optional help text, giving the user additional information of what's required.",
     inversed: false,
   },
+  argTypes: {
+    errorMessage: { control: 'text' },
+    hint: { control: 'text' },
+    requirementLabel: { control: 'text' },
+  },
 };
 export default meta;
 

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
@@ -12,6 +12,7 @@ import { fallbackLocale, getLanguage, t } from '../i18n';
 import { FormFieldProps, useFormLabel } from '../FormLabel';
 import { Label } from '../Label';
 import { useInlineError } from '../InlineError/useInlineError';
+import { useHint } from '../Hint/useHint';
 
 const monthNumbers = (() => {
   const months = [];
@@ -126,7 +127,8 @@ export const MonthPicker = (props: MonthPickerProps) => {
   const clearAllPressed = selectedMonths.length === 0;
 
   const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
-  const { labelProps, wrapperProps, hintId } = useFormLabel({
+  const { hintId, hintElement } = useHint({ ...props, id });
+  const { labelProps, wrapperProps } = useFormLabel({
     ...props,
     className: classNames('ds-c-month-picker', props.className),
     labelComponent: 'legend',
@@ -141,6 +143,7 @@ export const MonthPicker = (props: MonthPickerProps) => {
       aria-describedby={describeField({ ...props, hintId, errorId })}
     >
       <Label {...labelProps} />
+      {hintElement}
       {topError}
       <div className="ds-c-month-picker__buttons ds-u-clearfix">
         <Button

--- a/packages/design-system/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system/src/components/TextField/TextField.stories.tsx
@@ -15,6 +15,11 @@ const meta: Meta<typeof TextField> = {
     onBlur: action('onBlur'),
     name: 'text-field-story',
   },
+  argTypes: {
+    errorMessage: { control: 'text' },
+    hint: { control: 'text' },
+    requirementLabel: { control: 'text' },
+  },
   parameters: {
     docs: {
       underlyingHtmlElements: ['input'],

--- a/packages/design-system/src/components/TextField/TextField.tsx
+++ b/packages/design-system/src/components/TextField/TextField.tsx
@@ -8,6 +8,7 @@ import { Label } from '../Label';
 import useId from '../utilities/useId';
 import { useInlineError } from '../InlineError/useInlineError';
 import describeField from '../utilities/describeField';
+import { useHint } from '../Hint/useHint';
 
 export type TextFieldDefaultValue = string | number;
 export type TextFieldMask = 'currency' | 'phone' | 'ssn' | 'zip';
@@ -116,7 +117,8 @@ export const TextField: React.FC<TextFieldProps> = (props: TextFieldProps) => {
   }
 
   const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
-  const { labelProps, fieldProps, wrapperProps, hintId } = useFormLabel({
+  const { hintId, hintElement } = useHint({ ...props, id });
+  const { labelProps, fieldProps, wrapperProps } = useFormLabel({
     ...textFieldProps,
     labelComponent: 'label',
     wrapperIsFieldset: false,
@@ -141,6 +143,7 @@ export const TextField: React.FC<TextFieldProps> = (props: TextFieldProps) => {
   return (
     <div {...wrapperProps}>
       <Label {...labelProps} />
+      {hintElement}
       {topError}
       {mask && <Mask mask={mask}>{input}</Mask>}
       {labelMask && <LabelMask labelMask={labelMask}>{input}</LabelMask>}


### PR DESCRIPTION
## Summary

WNMGDS-2523 is about lessening the negative effects of the useFormLabel abstraction. I'm working on a feature branch that breaks `useFormLabel` up into some smaller, more focused hooks that can be mixed and matched. This is one of several pull requests to go into this feature branch.

- Adds a `useHint` hook that will conditionally render a hint and return a `hintId` if the component props contain hint data.

## How to test

These components should be manually tested a bit, but automated tests should also cover this work.
