### PR TITLE
[WNMGDS-2570] Remove redundant table role to fix axe-core error

### DIFF
--- a/packages/design-system/src/components/PrivacySettingsDialog/__snapshots__/PrivacySettingsTable.test.jsx.snap
+++ b/packages/design-system/src/components/PrivacySettingsDialog/__snapshots__/PrivacySettingsTable.test.jsx.snap
@@ -7,7 +7,6 @@ Object {
     <div>
       <table
         class="ds-c-table ds-c-table--borderless ds-c-md-table--stacked ds-c-privacy-settings-table ds-u-margin-top--2 ds-u-lg-margin--0"
-        role="table"
       >
         <thead
           role="rowgroup"
@@ -291,7 +290,6 @@ Object {
   "container": <div>
     <table
       class="ds-c-table ds-c-table--borderless ds-c-md-table--stacked ds-c-privacy-settings-table ds-u-margin-top--2 ds-u-lg-margin--0"
-      role="table"
     >
       <thead
         role="rowgroup"

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -175,14 +175,14 @@ export const Table = ({
   return scrollable ? (
     <div ref={containerRef} aria-live="polite" aria-relevant="additions" {...attributeScrollable}>
       <TableContext.Provider value={contextValue}>
-        <table className={classes} role="table" {...tableProps}>
+        <table className={classes} {...tableProps}>
           {renderedChildren}
         </table>
       </TableContext.Provider>
     </div>
   ) : (
     <TableContext.Provider value={contextValue}>
-      <table className={classes} role="table" {...tableProps}>
+      <table className={classes} {...tableProps}>
         {renderedChildren}
       </table>
     </TableContext.Provider>

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -172,20 +172,20 @@ export const Table = ({
     return child;
   });
 
-  return scrollable ? (
-    <div ref={containerRef} aria-live="polite" aria-relevant="additions" {...attributeScrollable}>
-      <TableContext.Provider value={contextValue}>
-        <table className={classes} {...tableProps}>
-          {renderedChildren}
-        </table>
-      </TableContext.Provider>
-    </div>
-  ) : (
+  const table = (
     <TableContext.Provider value={contextValue}>
       <table className={classes} {...tableProps}>
         {renderedChildren}
       </table>
     </TableContext.Provider>
+  );
+
+  return scrollable ? (
+    <div ref={containerRef} aria-live="polite" aria-relevant="additions" {...attributeScrollable}>
+      {table}
+    </div>
+  ) : (
+    table
   );
 };
 

--- a/packages/design-system/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/packages/design-system/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`Table accepts custom id 1`] = `
 >
   <table
     class="ds-c-table"
-    role="table"
   >
     <caption
       class="ds-c-table__caption"
@@ -25,7 +24,6 @@ exports[`Table accepts custom id 1`] = `
 exports[`Table applies responsive stacked table 1`] = `
 <table
   class="ds-c-table ds-c-lg-table--stacked"
-  role="table"
 >
   <caption
     class="ds-c-table__caption"
@@ -45,7 +43,6 @@ exports[`Table applies scrollable prop to table 1`] = `
 >
   <table
     class="ds-c-table"
-    role="table"
   >
     <caption
       class="ds-c-table__caption"

--- a/tests/browser/stories.test.ts
+++ b/tests/browser/stories.test.ts
@@ -83,10 +83,6 @@ stories.forEach((story) => {
             case 'components-drawer--drawer-with-sticky-positioning':
               await page.waitForTimeout(1000);
               break;
-            case 'components-table--scrollable-table':
-              // Temporarily skip this until we can solve the error
-              test.skip();
-              break;
             default:
               // Slight delay needed for all tests to account for false positives with color-contrast
               await page.waitForTimeout(100);


### PR DESCRIPTION
## Summary

WNMGDS-2570

We asked our a11y experts, and they could not figure out why this explicit `role="table"` would have been added. My only hunch was that Safari was doing something weird like what it does with lists because people "overuse lists". However, our a11y experts tested it with and without the role in VoiceOver, JAWS, and NVDA and did not find any differences. I checked it in VoiceOver + Safari as well. We've decided to remove it, because causes Axe to throw errors regarding the "scrollable table" alert.

## How to test

### Steps to reproduce the original error

1. Go [to this story](https://design.cms.gov/storybook/iframe.html?args=&id=components-table--scrollable-table&viewMode=story)
2. Resize the screen until it’s small enough for a blue alert to show up at the top
3. Run Axe core and look at the error:
    ```
    To solve this problem, you need to fix at least (1) of the following:
    - Element has children which are not allowed: [role=region]
    - Element uses aria-busy="true" while showing a loader

    Related Node:
    <div class="ds-c-alert ds-c-table__scroll-alert" role="region" aria-labelledby="alert--3__a11y-label">
    ```

### Verification

Before the fix, the axe-core errors would throw. You could test this by...
1. Checking out `main`
2. `yarn install && yarn build:storybook`
3. Checking out this branch where the test has been re-enabled
4. `yarn test:browser:smoke`

To verify that this branch fixes the error, you can build again and test again on this branch:
1. `yarn build:storybook`
2. `yarn test:browser:smoke`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)
