### PR TITLE
[NO-TICKET] Fix alert body content flowing out of bounds

### DIFF
--- a/packages/design-system/src/styles/components/_Alert.scss
+++ b/packages/design-system/src/styles/components/_Alert.scss
@@ -73,6 +73,7 @@
 }
 
 .ds-c-alert__body {
+  min-width: 0; // Allows it to shrink as necessary to fit in the parent
   padding-inline-start: $spacer-2;
 }
 


### PR DESCRIPTION
## Summary

In cases where a decendent element inside the alert body wants to be very wide, the body element won't properly restrict the width, as can be seen in the screenshot below, which is from https://github.com/CMSgov/design-system/commit/e36bd9cd91f7046ae61a68d03637ec3aa6dfecd5:

<img width="782" alt="Code example in an alert flows out of the bounds of the alert's padding" src="https://github.com/CMSgov/design-system/assets/7595652/ea21fd32-d2ca-4379-8e44-4ad7c51a3044">

The fix in this branch, discovered by @zarahzachz, sets the minimum width of the `ds-c-alert__body` element to a value other than the `auto` value [that flex-box children receive by default](https://drafts.csswg.org/css-flexbox/#content-based-minimum-size).

## How to test

1. Check out 916257df7
2. `yarn start`
3. Navigate to [the headings page](http://localhost:8000/foundation/typography/headings/?theme=core) and see that the code example in the alert is bounded correctly.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone