### PR TITLE
[WNMGDS-2578] Remove import for file we deleted in #2828

### DIFF
--- a/packages/ds-medicare-gov/src/components/index.ts
+++ b/packages/ds-medicare-gov/src/components/index.ts
@@ -7,8 +7,6 @@
  * CommonJS (`dist/components/`)  and ES module (`dist/esnext/`) versions of components.
  * ES modules code is necessary for webpack tree shaking bundle optimizations
  */
-import './Dialog';
-
 export * from '@cmsgov/design-system';
 
 export { default as MedicaregovLogo } from './MedicaregovLogo';


### PR DESCRIPTION

## Summary

In e9db1de, we removed the medicare override for the Dialog React component, but I failed to remove the import. It seems to have been a perfect storm that let it slip through to `main`:

1. On our local development machines, we still had copies of that module in `dist`
2. Storybook doesn't import the index files where this import was, so it can build with no errors in CI
3. We only build core in CI so that the child design systems can properly import the modules, though all other testing is done on the child design systems' src code
4. For some unknown reason, our linter didn't pick up on the missing import.

## How to test

1. Clean out your dist folders
2. Run `yarn build`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

Note that this is not in itself a breaking change, but I want it to be grouped with the original PR in the generated notes