### PR TITLE
[WNMGDS-2524] Create/update docs for label, hint, and inline error

### DIFF
--- a/packages/design-system/src/components/Hint/Hint.tsx
+++ b/packages/design-system/src/components/Hint/Hint.tsx
@@ -27,6 +27,14 @@ export interface HintProps {
   requirementLabel?: React.ReactNode;
 }
 
+/**
+ * Hints are used in conjunction with a Label to describe individual form fields
+ * or fieldsets. They are built in to all form fields in the design system, but
+ * they can also be used on their own to create custom fields.
+ *
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/hint/).
+ */
 export const Hint = ({
   children,
   className,

--- a/packages/design-system/src/components/InlineError/InlineError.tsx
+++ b/packages/design-system/src/components/InlineError/InlineError.tsx
@@ -23,6 +23,14 @@ interface InlineErrorProps {
   inversed?: boolean;
 }
 
+/**
+ * Inline errors are error messages that are paired directly with form fields.
+ * They are built in to all form fields in the design system, but they can also
+ * be used on their own to create custom fields.
+ *
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/inline-error/).
+ */
 export function InlineError({
   children,
   className,

--- a/packages/design-system/src/components/Label/Label.tsx
+++ b/packages/design-system/src/components/Label/Label.tsx
@@ -68,8 +68,12 @@ type LabelComponentProps = React.ComponentPropsWithRef<'label'> &
   LabelProps;
 
 /**
+ * Labels describe individual form fields or fieldsets. They are built in to all
+ * form fields in the design system, but they can also be used on their own to
+ * create custom fields.
+ *
  * For information about how and when to use this component,
- * [refer to its full documentation page](https://design.cms.gov/components/form-label/).
+ * [refer to its full documentation page](https://design.cms.gov/components/label/).
  */
 export const Label = (props: LabelComponentProps) => {
   const {

--- a/packages/design-system/src/components/Label/Label.tsx
+++ b/packages/design-system/src/components/Label/Label.tsx
@@ -68,9 +68,9 @@ type LabelComponentProps = React.ComponentPropsWithRef<'label'> &
   LabelProps;
 
 /**
- * Labels describe individual form fields or fieldsets. They are built in to all
- * form fields in the design system, but they can also be used on their own to
- * create custom fields.
+ * The Label component describes individual form fields (as a `<label>`) or fieldsets (as
+ * a `<legend>`). They are built in to all form fields in the design system, but they can
+ * also be used on their own to create custom fields.
  *
  * For information about how and when to use this component,
  * [refer to its full documentation page](https://design.cms.gov/components/label/).

--- a/packages/docs/content/components/hint.mdx
+++ b/packages/docs/content/components/hint.mdx
@@ -1,24 +1,24 @@
 ---
-title: Label & Legend
-intro: Labels & legends describe individual form fields or fieldsets.
+title: Hint
+intro: Hint text is used in combination with a Label to provide extra instructions or context for form fields.
 core:
-  githubLink: design-system/src/components/Label
-  storybookLink: components-label--docs
+  githubLink: design-system/src/components/Hint
+  storybookLink: components-hint--docs
 ---
 
 ## Examples
 
 <StorybookExample
-  componentName="formLabel"
-  sourceFilePath="components/Label/Label.tsx"
-  storyId="components-label--default"
+  componentName="hint"
+  sourceFilePath="components/Hint/Hint.tsx"
+  storyId="components-hint--default"
 />
 
 ## Code
 
 ### React
 
-<SeeStorybookForGuidance storyId={'components-label--docs'} />
+<SeeStorybookForGuidance storyId={'components-hint--docs'} />
 
 ### Style customization
 
@@ -27,21 +27,6 @@ The following CSS variables can be overridden to customize Form components:
 <ComponentThemeOptions componentname="form" />
 
 ## Guidance
-
-### Label
-
-- Each form field should have a `<label>`. Never use a field's placeholder attribute as the primary way to label the field.
-- Each form field should have a clear, brief, and descriptive label.
-- Labels should have a `for` attribute, referencing the corresponding input's unique `id` attribute. Only one label can be associated to each unique form element.
-- Labels should be placed above their fields.
-- Label text should be short and in sentence case.
-- Avoid colons at the end of labels.
-- Don't use a field's placeholder attribute as the primary way to label the field.
-
-### Legend
-
-- Use a single legend for fieldset (this is required). One example of a common use of fieldset and legend is a question with radio button options for answers. The question text and radio buttons are wrapped in a fieldset, with the question itself being inside the legend tag.
-- Avoid links in legends when possible. Links inside legends are not read by some screen readers, namely JAWS. If you need a pattern like this, put the link outside of the legend element, but keep all other useful hint text in the legend.
 
 #### Content
 

--- a/packages/docs/content/components/hint.mdx
+++ b/packages/docs/content/components/hint.mdx
@@ -28,33 +28,20 @@ The following CSS variables can be overridden to customize Form components:
 
 ## Guidance
 
-#### Content
-
-- Describe what the user needs to do when the field is selected
-- Use a phrase or complete sentence
-- Start with an action verb and pair it with a noun to help it be clearer. Example: Enter your age.
-- Use the fewest words possible (i.e. don't use "please")
-- Use sentence case
-- Be consistent with punctuation at the end of a phrase or sentence
-- Be consistent with phrase and sentence structure
-
-### Hint text
-
-- Place hint text within the field's `<label>` element.
-- Place hint text where appropriate depending on what content it's helping to explain
-- Use hint text for supporting contextual help, which will always be shown.
+- Hints are built in to all design-system form fields but can be used on their own to create custom fields.
+- Use hint text for supporting contextual help that is always visible.
 - Hint text should sit between a form label and the input.
 - Use lower visual style (i.e., lighter gray than the form label or the input option) so it won't compete for users' attention with the field label.
 - Use hint text to indicate which inputs are optional when there are more required fields than optional.
 - Hint text can also appear after an input box when the text is being used to show the value someone should be entering in the field (e.g., income amount input box displays text after the input box to highlight the amount should be "monthly income".)
 
-#### Content
+### Content
 
-- Use when appropriate to support a form label (Goes below the form label in a lighter weight font)
-- Describe how to best answer the question/form label
-- Use the fewest words possible (i.e. don't use "please")
-- Use sentence case
-- End with a period
+- Use when appropriate to support a field [label](/components/label).
+- Describe how to best answer the question/form label.
+- Use the fewest words possible (i.e. don't use "please").
+- Use sentence case.
+- End with a period.
 
 ## Learn More
 

--- a/packages/docs/content/components/hint.mdx
+++ b/packages/docs/content/components/hint.mdx
@@ -42,6 +42,7 @@ The following CSS variables can be overridden to customize Form components:
 - Use the fewest words possible (i.e. don't use "please").
 - Use sentence case.
 - End with a period.
+- Be consistent with phrase and sentence structure.
 
 ## Learn More
 

--- a/packages/docs/content/components/inline-error.mdx
+++ b/packages/docs/content/components/inline-error.mdx
@@ -1,24 +1,24 @@
 ---
-title: Label & Legend
-intro: Labels & legends describe individual form fields or fieldsets.
+title: Inline Error
+intro: Inline errors are error messages that are paired directly with form fields.
 core:
-  githubLink: design-system/src/components/Label
-  storybookLink: components-label--docs
+  githubLink: design-system/src/components/InlineError
+  storybookLink: components-inlineerror--docs
 ---
 
 ## Examples
 
 <StorybookExample
-  componentName="formLabel"
-  sourceFilePath="components/Label/Label.tsx"
-  storyId="components-label--default"
+  componentName="inline-error"
+  sourceFilePath="components/InlineError/InlineError.tsx"
+  storyId="components-inlineerror--default"
 />
 
 ## Code
 
 ### React
 
-<SeeStorybookForGuidance storyId={'components-label--docs'} />
+<SeeStorybookForGuidance storyId={'components-inlineerror--docs'} />
 
 ### Style customization
 

--- a/packages/docs/content/components/inline-error.mdx
+++ b/packages/docs/content/components/inline-error.mdx
@@ -1,6 +1,6 @@
 ---
 title: Inline Error
-intro: Inline errors are error messages that are paired directly with form fields.
+intro: Inline errors give validation feedback for specific form fields.
 core:
   githubLink: design-system/src/components/InlineError
   storybookLink: components-inlineerror--docs
@@ -28,48 +28,18 @@ The following CSS variables can be overridden to customize Form components:
 
 ## Guidance
 
-### Label
-
-- Each form field should have a `<label>`. Never use a field's placeholder attribute as the primary way to label the field.
-- Each form field should have a clear, brief, and descriptive label.
-- Labels should have a `for` attribute, referencing the corresponding input's unique `id` attribute. Only one label can be associated to each unique form element.
-- Labels should be placed above their fields.
-- Label text should be short and in sentence case.
-- Avoid colons at the end of labels.
-- Don't use a field's placeholder attribute as the primary way to label the field.
-
-### Legend
-
-- Use a single legend for fieldset (this is required). One example of a common use of fieldset and legend is a question with radio button options for answers. The question text and radio buttons are wrapped in a fieldset, with the question itself being inside the legend tag.
-- Avoid links in legends when possible. Links inside legends are not read by some screen readers, namely JAWS. If you need a pattern like this, put the link outside of the legend element, but keep all other useful hint text in the legend.
+- Inline errors are built in to all design-system form fields but can be used on their own to create custom fields.
+- Inline errors should sit either directly above or below the input, depending on the theme defaults.
+- Visually align inline validation messages with the input fields, so people using screen magnifiers can read them quickly.
+- The form field should have an `aria-describedby` attribute that references the `id` of the error message.
 
 #### Content
 
-- Describe what the user needs to do when the field is selected
-- Use a phrase or complete sentence
-- Start with an action verb and pair it with a noun to help it be clearer. Example: Enter your age.
-- Use the fewest words possible (i.e. don't use "please")
-- Use sentence case
-- Be consistent with punctuation at the end of a phrase or sentence
-- Be consistent with phrase and sentence structure
-
-### Hint text
-
-- Place hint text within the field's `<label>` element.
-- Place hint text where appropriate depending on what content it's helping to explain
-- Use hint text for supporting contextual help, which will always be shown.
-- Hint text should sit between a form label and the input.
-- Use lower visual style (i.e., lighter gray than the form label or the input option) so it won't compete for users' attention with the field label.
-- Use hint text to indicate which inputs are optional when there are more required fields than optional.
-- Hint text can also appear after an input box when the text is being used to show the value someone should be entering in the field (e.g., income amount input box displays text after the input box to highlight the amount should be "monthly income".)
-
-#### Content
-
-- Use when appropriate to support a form label (Goes below the form label in a lighter weight font)
-- Describe how to best answer the question/form label
-- Use the fewest words possible (i.e. don't use "please")
-- Use sentence case
-- End with a period
+- Describe what the user still needs to do in a mandatory field that has been left incomplete or unanswered,  or answered incorrectly.
+- Repeat what the form label is asking the user to do, but with slightly more detail.
+- Use sentence case.
+- End with a period.
+- Use the fewest words possible (i.e., don't use "please").
 
 ## Learn More
 

--- a/packages/docs/content/components/inline-error.mdx
+++ b/packages/docs/content/components/inline-error.mdx
@@ -37,9 +37,9 @@ The following CSS variables can be overridden to customize Form components:
 
 - Describe what the user still needs to do in a mandatory field that has been left incomplete or unanswered,  or answered incorrectly.
 - Repeat what the form label is asking the user to do, but with slightly more detail.
+- Use the fewest words possible (i.e., don't use "please").
 - Use sentence case.
 - End with a period.
-- Use the fewest words possible (i.e., don't use "please").
 
 ## Learn More
 

--- a/packages/docs/content/components/label.mdx
+++ b/packages/docs/content/components/label.mdx
@@ -51,8 +51,6 @@ The following CSS variables can be overridden to customize Form components:
 - Start with an action verb and pair it with a noun to help it be clearer. Example: `Enter your age.`
 - Use the fewest words possible (i.e. don't use "please").
 - Use sentence case.
-- Be consistent with punctuation at the end of a phrase or sentence.
-- Be consistent with phrase and sentence structure.
 
 ## Learn More
 

--- a/packages/docs/content/components/label.mdx
+++ b/packages/docs/content/components/label.mdx
@@ -28,48 +28,31 @@ The following CSS variables can be overridden to customize Form components:
 
 ## Guidance
 
+- Labels/Legends are built in to all design-system form fields but can be used on their own to create custom fields.
+- Label/Legend text should be short and in sentence case.
+- Avoid colons at the end of labels and legends.
+- Don't place links or other interactive text in labels or legends. Those should go in the [hint text](/components/hint).
+- Don't use a field's placeholder attribute as the primary way to label the field.
+
 ### Label
 
-- Each form field should have a `<label>`. Never use a field's placeholder attribute as the primary way to label the field.
 - Each form field should have a clear, brief, and descriptive label.
 - Labels should have a `for` attribute, referencing the corresponding input's unique `id` attribute. Only one label can be associated to each unique form element.
 - Labels should be placed above their fields.
-- Label text should be short and in sentence case.
-- Avoid colons at the end of labels.
-- Don't use a field's placeholder attribute as the primary way to label the field.
 
 ### Legend
 
 - Use a single legend for fieldset (this is required). One example of a common use of fieldset and legend is a question with radio button options for answers. The question text and radio buttons are wrapped in a fieldset, with the question itself being inside the legend tag.
-- Avoid links in legends when possible. Links inside legends are not read by some screen readers, namely JAWS. If you need a pattern like this, put the link outside of the legend element, but keep all other useful hint text in the legend.
 
-#### Content
+### Content
 
-- Describe what the user needs to do when the field is selected
-- Use a phrase or complete sentence
-- Start with an action verb and pair it with a noun to help it be clearer. Example: Enter your age.
-- Use the fewest words possible (i.e. don't use "please")
-- Use sentence case
-- Be consistent with punctuation at the end of a phrase or sentence
-- Be consistent with phrase and sentence structure
-
-### Hint text
-
-- Place hint text within the field's `<label>` element.
-- Place hint text where appropriate depending on what content it's helping to explain
-- Use hint text for supporting contextual help, which will always be shown.
-- Hint text should sit between a form label and the input.
-- Use lower visual style (i.e., lighter gray than the form label or the input option) so it won't compete for users' attention with the field label.
-- Use hint text to indicate which inputs are optional when there are more required fields than optional.
-- Hint text can also appear after an input box when the text is being used to show the value someone should be entering in the field (e.g., income amount input box displays text after the input box to highlight the amount should be "monthly income".)
-
-#### Content
-
-- Use when appropriate to support a form label (Goes below the form label in a lighter weight font)
-- Describe how to best answer the question/form label
-- Use the fewest words possible (i.e. don't use "please")
-- Use sentence case
-- End with a period
+- Describe what the user needs to do when the field is selected.
+- Use a phrase or complete sentence.
+- Start with an action verb and pair it with a noun to help it be clearer. Example: `Enter your age.`
+- Use the fewest words possible (i.e. don't use "please").
+- Use sentence case.
+- Be consistent with punctuation at the end of a phrase or sentence.
+- Be consistent with phrase and sentence structure.
 
 ## Learn More
 

--- a/packages/docs/content/patterns/Forms/validation.mdx
+++ b/packages/docs/content/patterns/Forms/validation.mdx
@@ -4,12 +4,8 @@ title: Form validation
 
 ## Guidance
 
-- Place inline validation messages within the field's `<label>` element.
-- Visually align inline validation messages with the input fields, so people using screen magnifiers can read them quickly.
-- Either place an icon next to the error, labeling the icon as error with ARIA or off-screen text, or use text in front of the message itself. Like: "Error: The email address is not a valid email address." The use of the icon or text not only clearly labels the following text as an error, but allows users to know that the message is an error without relying on color alone.
-- The form field receives an `aria-describedby` attribute that references the `id` of the error message.
-- The error message should be wrapped in an `role="alert"` so that screen readers users receive the message, and can act on it.
-  If the page is fully refreshed, add ‘Error: ’ to the beginning of the page `<title>` so screen readers read it out as soon as possible.
+- Use [inline errors](/components/inline-error) to give validation feedback for specific form fields. See that page for specific guidance around inline errors.
+- If the page is fully refreshed, add ‘Error: ’ to the beginning of the page `<title>` so screen readers read it out as soon as possible.
 
 ### Validation types
 
@@ -17,7 +13,7 @@ title: Form validation
 
 - Visually associate inline validation messages with the input fields (e.g., place validation closely to the input field).
 - Place an icon in front of an error to draw attention to an error.
-- Use color as a secondary way to draw attention to an error. 
+- Use color as a secondary way to draw attention to an error.
 
 #### Success
 


### PR DESCRIPTION
## Summary

- Created new doc pages for `hint` and `inline-error`
- Added doc comments for these components that will show up in Storybook
- Pulled error-message guidance from the _Form validation_ page and directed readers to go to the new _Inline error_ page
- Refined documentation across all four affected pages. (Look specifically in 78df509c610748bf6d6a5231131dec51ac3f2ee3 for details on what changed)
- Made sure users know not to put interactive elements in the label text

## How to test

1. `yarn start`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to documentation:

- [ ] Checked for spelling and grammatical errors
