### PR TITLE
[NO-TICKET] Fix failing calendar-picker test

### DIFF
--- a/packages/design-system/src/components/DateField/SingleInputDateField.stories.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.stories.tsx
@@ -49,7 +49,7 @@ export const WithPicker: Story = {
   args: {
     label: 'What day did you move?',
     hint: 'This date should be within the past 60 days in order to qualify.',
-    fromYear: new Date().getFullYear(),
+    fromYear: 2023,
     // TODO: Due to some unknown issue with this story that causes us to lose args
     // defined with query parameters, we can't supply a specific date in the
     // browser interaction tests in order to get consistent screenshots. We want

--- a/packages/design-system/src/components/DateField/SingleInputDateField.stories.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.stories.tsx
@@ -56,7 +56,7 @@ export const WithPicker: Story = {
     // to set this to an arbitrary date in the past so it always takes a screenshot
     // of the same calendar view every time. If we can solve the root problem, we
     // can move this setting of the toDate to the `.test.interaction.ts` file.
-    toDate: new Date(1676498194272),
+    toDate: new Date('2023-02-15T21:56:34.272Z'),
   },
 };
 


### PR DESCRIPTION
## Summary

Fix the year to match the arbitrary fixed date for VRTs. As can be seen in the code comments, there's a problem here that once fixed will make this a lot better.
