### PR TITLE
[NO-TICKET] Update the `create-react-app-typescript` example project

### DIFF
--- a/examples/create-react-app-typescript/package.json
+++ b/examples/create-react-app-typescript/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@cmsgov/design-system": "^8.0.0",
+    "@cmsgov/design-system": "^9.0.0-beta.1",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.18.0",
     "@types/react": "^18.0.22",

--- a/examples/create-react-app-typescript/src/components/App.tsx
+++ b/examples/create-react-app-typescript/src/components/App.tsx
@@ -6,7 +6,8 @@ import AutocompleteExample from './Examples/AutocompleteExample';
 import BadgeExample from './Examples/BadgeExample';
 import ButtonExample from './Examples/ButtonExample';
 import ChoiceListExample from './Examples/ChoiceListExample';
-import DateFieldExample from './Examples/DateFieldExample';
+import SingleInputDateFieldExample from './Examples/SingleInputDateFieldExample';
+import MultiInputDateFieldExample from './Examples/MultiInputDateFieldExample';
 import DropdownExample from './Examples/DropdownExample';
 import FilterChipExample from './Examples/FilterChipExample';
 import LabelExample from './Examples/LabelExample';
@@ -28,7 +29,7 @@ function App() {
   return (
     <div className="ds-base">
       <header className="ds-u-padding--3 ds-u-sm-padding--6 ds-u-display--block ds-u-fill--primary-darkest">
-        <h1 className="ds-u-margin--0 ds-u-color--white ds-u-font-size--display ds-u-text-align--center">
+        <h1 className="ds-text-heading--5xl ds-u-margin--0 ds-u-color--white ds-u-text-align--center">
           Hello, world!
         </h1>
         <div className="ds-u-text-align--center">
@@ -46,7 +47,8 @@ function App() {
         <BadgeExample />
         <ButtonExample />
         <ChoiceListExample />
-        <DateFieldExample />
+        <SingleInputDateFieldExample />
+        <MultiInputDateFieldExample />
         <DropdownExample />
         <FilterChipExample />
         <LabelExample />

--- a/examples/create-react-app-typescript/src/components/Examples/MultiInputDateFieldExample.tsx
+++ b/examples/create-react-app-typescript/src/components/Examples/MultiInputDateFieldExample.tsx
@@ -1,11 +1,11 @@
-import { DateField } from '@cmsgov/design-system';
+import { MultiInputDateField } from '@cmsgov/design-system';
 import React from 'react';
 
-function DateFieldExample() {
+function MultiInputDateFieldExample() {
   return (
     <div>
-      <h2>DateField Example</h2>
-      <DateField
+      <h2>MultiInputDateField Example</h2>
+      <MultiInputDateField
         label="Date of birth"
         errorMessage="Please enter a year in the past"
         monthDefaultValue="10"
@@ -17,4 +17,4 @@ function DateFieldExample() {
   );
 }
 
-export default DateFieldExample;
+export default MultiInputDateFieldExample;

--- a/examples/create-react-app-typescript/src/components/Examples/SingleInputDateFieldExample.tsx
+++ b/examples/create-react-app-typescript/src/components/Examples/SingleInputDateFieldExample.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import { SingleInputDateField } from '@cmsgov/design-system';
+
+function SingleInputDateFieldExample() {
+  const [dateString, updateDate] = useState('');
+  return (
+    <div>
+      <h2>SingleInputDateField Example</h2>
+      <SingleInputDateField
+        hint="If you were born on a leap day, entering the date will either crash our servers or open a portal to an alternate dimension."
+        label="Enter your date of birth."
+        name="single-input-date-field"
+        fromYear={2023}
+        toYear={2023}
+        value={dateString}
+        onChange={updateDate}
+      />
+    </div>
+  );
+}
+
+export default SingleInputDateFieldExample;


### PR DESCRIPTION
## Summary

In order to test a specific issue we were seeing in storybook, I updated this example project to use the latest. I also found that it did not include the newer date field and used a deprecated heading class. Adding the new date field also exposed an issue with the dropdown button bleeding through the calendar picker menu, which we'll want to address in a separate PR.
