### PR TITLE
[WNMGDS-2628] Fix flash of unstyled TextField story

### DIFF
--- a/packages/design-system/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system/src/components/TextField/TextField.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import TextField from './TextField';
 import { unmaskValue } from './maskHelpers';
 import { PHONE_MASK, SSN_MASK, ZIP_MASK, CURRENCY_MASK } from './useLabelMask';
@@ -19,6 +19,7 @@ const meta: Meta<typeof TextField> = {
     errorMessage: { control: 'text' },
     hint: { control: 'text' },
     requirementLabel: { control: 'text' },
+    value: { control: 'text' },
   },
   parameters: {
     docs: {
@@ -55,17 +56,24 @@ const UncontrolledTemplate: Story = {
 
 const ControlledTemplate: Story = {
   render: function Component(args) {
-    const [_, updateArgs] = useArgs();
+    // Updating the actual args on every keystroke is hard for Storybook to keep up with,
+    // so we want to treat this story like other components of ours which can either be
+    // controlled or uncontrolled. The TextField itself is always controlled by our story,
+    // but whether this story is controlled by args depends on whether the user has
+    // supplied a new value of the `value` arg to this story.
+    const [localValue, setLocalValue] = useState();
+    const value = args.value ?? localValue ?? '';
     const onChange = (event) => {
       action('onChange')(event);
-      updateArgs({ value: event.currentTarget.value });
+      setLocalValue(event.currentTarget.value);
     };
 
-    if (args.labelMask) {
-      args.labelMask = getMaskFunction(args.labelMask as any);
+    let labelMask = args.labelMask;
+    if (labelMask) {
+      labelMask = getMaskFunction(args.labelMask as any);
     }
 
-    return <TextField {...args} onChange={onChange} />;
+    return <TextField {...args} labelMask={labelMask} value={value} onChange={onChange} />;
   },
 };
 


### PR DESCRIPTION
## Summary

WNMGDS-2628

Avoid Storybook rendering issues by making the controlled story a bit more intelligent. The symptom I'm fixing is the flashes of an unstyled component [that Sarah discovered here](https://github.com/CMSgov/design-system/pull/2863#pullrequestreview-1802611064). Updating the actual args on every keystroke is hard for Storybook to keep up with, so we want to treat this story like other components of ours which can either be controlled or uncontrolled. The TextField itself is always controlled by our story, but whether this story is controlled by args depends on whether the user has supplied a new value of the `value` arg to this story. 

## How to test

Type really fast in the controlled label-mask stories.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
