### PR TITLE
[WNMGDS-2629] Fix bug in NativeDialog where ESC doesn't call exit handler

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.stories.tsx
@@ -74,7 +74,10 @@ export const PreventScrollExample: Story = {
   render: function Component(args) {
     const [dialogOpen, updateOpen] = useState(false);
     const showModal = () => updateOpen(true);
-    const hideModal = () => updateOpen(false);
+    const hideModal = (...params) => {
+      action('onExit')(...params);
+      updateOpen(false);
+    };
 
     return (
       <div className="ds-u-measure--base">

--- a/packages/design-system/src/components/NativeDialog/NativeDialog.tsx
+++ b/packages/design-system/src/components/NativeDialog/NativeDialog.tsx
@@ -46,29 +46,32 @@ export const NativeDialog = ({
     dialogPolyfill.registerDialog(dialogRef.current);
   });
 
-  // Open and close the dialog with the appropriate method on mount and unmount
+  // Call imperative show and close functions on mount/unmount
   useEffect(() => {
     const dialogNode = dialogRef.current;
+
+    // Show the modal
     showModal ? dialogNode.showModal() : dialogNode.show();
-    return () => {
-      dialogNode.close();
-    };
-  }, [showModal]);
 
-  // Bind and unbind close event listeners on mount and unmount
-  useEffect(() => {
-    const dialogNode = dialogRef.current;
-    const handleCancel = (event) => {
+    // Bind close event listener for ESC press
+    const handleClose = (event) => {
       event.preventDefault();
-      exit();
+      exit(event);
     };
-    dialogNode.addEventListener('close', handleCancel);
-    return () => {
-      dialogNode.removeEventListener('close', handleCancel);
-    };
-  }, [exit]);
+    dialogNode.addEventListener('close', handleClose);
 
-  // Bind and unbind click event listeners on mount and unmount
+    return () => {
+      // Remove the close event handler first, or it will be tripped by our manual close call
+      dialogNode.removeEventListener('close', handleClose);
+
+      // It's possible for the element to already be closed, so check first to avoid an error
+      if (dialogNode.open) {
+        dialogNode.close();
+      }
+    };
+  }, [showModal, exit]);
+
+  // Bind and unbind backdrop click event listeners on mount and unmount
   useEffect(() => {
     if (!backdropClickExits) {
       return;

--- a/packages/design-system/src/components/NativeDialog/NativeDialog.tsx
+++ b/packages/design-system/src/components/NativeDialog/NativeDialog.tsx
@@ -55,16 +55,16 @@ export const NativeDialog = ({
     };
   }, [showModal]);
 
-  // Bind and unbind cancel event listeners on mount and unmount
+  // Bind and unbind close event listeners on mount and unmount
   useEffect(() => {
     const dialogNode = dialogRef.current;
     const handleCancel = (event) => {
       event.preventDefault();
       exit();
     };
-    dialogNode.addEventListener('cancel', handleCancel);
+    dialogNode.addEventListener('close', handleCancel);
     return () => {
-      dialogNode.removeEventListener('cancel', handleCancel);
+      dialogNode.removeEventListener('close', handleCancel);
     };
   }, [exit]);
 


### PR DESCRIPTION


## Summary

It looks like between the [cancel event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/cancel_event) and the [close event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/close_event), the close event won. The `close` event has broad browser support, whereas the cancel event seems to have been abandoned. Switching the event name fixes the bug where if you press ESC after opening the dialog in [this story](https://design.cms.gov/v/8.0.5/storybook/?path=/story/components-dialog--prevent-scroll-example), you won't be able to open it again because the element remained in the DOM and the story thinks it's still open.

## How to test

1. Start storybook locally
2. Open [this story](http://localhost:6006/?path=/story/components-dialog--prevent-scroll-example)
3. Click the button to open the dialog
4. Press <kbd>ESC</kbd> to close it
5. Click the button to open it again. On this branch, you should be able to open it again.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)