### PR TITLE
[WNMGDS-2627] Add z-index to calendar

### DIFF
--- a/packages/design-system/src/styles/components/_SingleInputDateField.scss
+++ b/packages/design-system/src/styles/components/_SingleInputDateField.scss
@@ -31,6 +31,7 @@
 
 .rdp {
   margin: 1em;
+  z-index: 1;
 }
 
 /* Hide elements for devices that are not screen readers */


### PR DESCRIPTION
WNMGDS-2627

We have a problem where the calendar overlay can sometimes appear behind other form elements, like dropdown. I've applied a z-index of 1 to the calendar overlay as a short-term fix.

Did some poking around and found the dropdown has a relative position applied. This is because our dropdown is a custom made element and the menu that appears when toggled open needs its own absolute positioning 😵 I wonder if we can evaluate our current UI elements to see if more modern CSS solutions can be employed to mitigate the stacking context issues? We seem to be using relative positioning a lot in our library and I imagine if we limit the usage of positioning, we can avoid these wack-a-mole scenarios. It also makes the system more resilient imo.