### PR TITLE
[WNMGDS-2614] Remove Firefox focus styles added in #510

### DIFF
--- a/packages/design-system/src/styles/components/_Dropdown.scss
+++ b/packages/design-system/src/styles/components/_Dropdown.scss
@@ -18,12 +18,6 @@
   justify-content: space-between;
   text-align: start;
 
-  // Removes inner outline on select elements in Firefox.
-  &:-moz-focusring {
-    color: transparent;
-    text-shadow: 0 0 0 #000;
-  }
-
   // Due to the shadow overlay, the border needs to be transparent to avoid a light gray line divider
   &[aria-expanded='true'] {
     border-block-end-color: transparent;


### PR DESCRIPTION
WNMGDS-2614

Focus styles were added to override the select element in Firefox. Because the dropdown's been refactored to NOT be a select element, these styles are no longer applicable. In fact, they cause a fun little bug that turns the SVG inside white when focus-visible happens. What a journey! [This is the context in which it was originally added](https://github.com/CMSgov/design-system/pull/510/files#diff-be195afbb32878f98661d965a1e5565af48defe54f8a89bd585eab496d1bff7a).