### PR TITLE
[WNMGDS-2633] Add the missing `ds-u-color--gray-dark` util that we said existed

### DIFF
--- a/packages/design-system/src/styles/utilities/_text-color.scss
+++ b/packages/design-system/src/styles/utilities/_text-color.scss
@@ -60,6 +60,10 @@
   color: var(--color-gray-light) !important;
 }
 
+.ds-u-color--gray-dark:not(:focus) {
+  color: var(--color-gray-dark) !important;
+}
+
 .ds-u-color--muted:not(:focus) {
   color: var(--color-muted) !important;
 }


### PR DESCRIPTION
## Summary

WNMGDS-2633

Add the missing `ds-u-color--gray-dark` util that we said existed [in our docs](https://design.cms.gov/utilities/text/text-color/).

## How to test

The screenshots below show that the `gray-dark` color wasn't actually being applied to the `ds-u-color--gray-dark` text in the table because that utility class didn't actually exist in our CSS. It worked in the circle swatch because that was pulling directly from the token variable.

### Before
<img width="698" alt="Before screenshot showing that the dark gray text is actually the default black" src="https://github.com/CMSgov/design-system/assets/7595652/df695e6f-87a0-4a88-be0c-5efabc98dd67">


### After
<img width="703" alt="After screenshow showing that the dark gray text is actually dark gray" src="https://github.com/CMSgov/design-system/assets/7595652/0b0bd1a6-69a8-4ab7-8606-519643bee056">

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
