### PR TITLE
[WNMGDS-2634] Update the visited link color for the cmsgov theme

### DIFF
--- a/packages/design-system-tokens/src/themes/cmsgov.ts
+++ b/packages/design-system-tokens/src/themes/cmsgov.ts
@@ -97,7 +97,7 @@ export const themeColors: ColorTokens = {
   'warn-darker':                color['dandelion-700'],
   'warn-darkest':               color['dandelion-800'],
   //
-  'visited':                    color['windsor-500'],
+  'visited':                    color['orchid-800'],
 };
 
 const font: FontTokens = {


### PR DESCRIPTION
## Summary

WNMGDS-2634

Designers on CMS.gov worked with the design system team and UX Leads to pick a color from the design system palette that would work better for visited links than the original one. Visited links are now `orchid-800`.

## How to test

Using dev tools, you can toggle on the `:visited` state to the Typography > Links story in Storybook

### Before

<img width="109" alt="Old windsor colored link" src="https://github.com/CMSgov/design-system/assets/7595652/567db02d-e138-433f-9ed5-ceb641073c13">

### After

<img width="96" alt="New orchid colored link" src="https://github.com/CMSgov/design-system/assets/7595652/e2ba95d3-7ded-4f36-899c-95d651fed0a6">
