### PR TITLE
[NO-TICKET] Uncheck that IdleTimeout has Spanish translations

### DIFF
--- a/packages/docs/content/components/idle-timeout.mdx
+++ b/packages/docs/content/components/idle-timeout.mdx
@@ -46,7 +46,7 @@ The following CSS variables can be overridden to customize Dialog components:
   keyboardNavigable={true}
   storybook={true}
   responsive={true}
-  spanish={true}
+  spanish={false}
   completeUiKit={false}
   responsiveUiKit={false}
   tokensInCode={true}


### PR DESCRIPTION
## Summary

We must have missed this, but `IdleTimeout` doesn't have Spanish translations even though it has default English content. Unchecking that checkbox in its maturity checklist