### PR TITLE
[WNMGDS-2638] Publish the drawer manager feature

### DIFF
--- a/packages/design-system/src/components/Drawer/DrawerManager.stories.tsx
+++ b/packages/design-system/src/components/Drawer/DrawerManager.stories.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { Title, Subtitle, Description } from '@storybook/addon-docs';
-
 import Drawer from './Drawer';
 import { DrawerManager, useDrawerManager } from './DrawerManager';
 import { Button } from '../Button';
@@ -9,17 +7,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta: Meta<typeof DrawerManager> = {
   title: 'Components/DrawerManager',
   component: DrawerManager,
-  parameters: {
-    docs: {
-      page: () => (
-        <>
-          <Title />
-          <Subtitle />
-          <Description />
-        </>
-      ),
-    },
-  },
 };
 export default meta;
 
@@ -86,24 +73,24 @@ const drawerContent3 = {
 
 const SingleDrawerWithToggle = (...args) => {
   const { heading, children } = args[0];
-  const { toggleClick, closeClick, isOpen } = useDrawerManager();
+  const { toggleDrawer, closeDrawer, isDrawerOpen } = useDrawerManager();
 
   return (
     <>
       <Drawer
         {...args}
-        onCloseClick={closeClick}
+        onCloseClick={closeDrawer}
         footerTitle="Footer Title"
         footerBody={<p className="ds-text ds-u-margin--0">Footer content</p>}
         heading={heading}
-        isOpen={isOpen}
+        isOpen={isDrawerOpen}
       >
         {children}
       </Drawer>
       <Button
         className="ds-c-drawer__toggle ds-u-margin-bottom--2"
         variation="ghost"
-        onClick={toggleClick}
+        onClick={toggleDrawer}
       >
         {heading}
       </Button>

--- a/packages/design-system/src/components/Drawer/DrawerManager.test.tsx
+++ b/packages/design-system/src/components/Drawer/DrawerManager.test.tsx
@@ -7,17 +7,17 @@ import { Drawer } from './Drawer';
 import { DrawerManager, useDrawerManager } from './DrawerManager';
 
 const SingleDrawer = ({ heading }) => {
-  const { toggleClick, closeClick, isOpen } = useDrawerManager();
+  const { openDrawer, toggleDrawer, closeDrawer, isDrawerOpen } = useDrawerManager();
 
   return (
     <>
-      <Drawer isOpen={isOpen} onCloseClick={closeClick} heading={heading}>
+      <Drawer isOpen={isDrawerOpen} onCloseClick={closeDrawer} heading={heading}>
         A drawer for {heading}
       </Drawer>
 
-      <Button className="ds-c-drawer__toggle" variation="ghost" onClick={toggleClick}>
-        toggle {heading}
-      </Button>
+      <Button onClick={toggleDrawer}>toggle {heading}</Button>
+
+      <Button onClick={openDrawer}>open {heading}</Button>
     </>
   );
 };
@@ -48,11 +48,24 @@ function closeActiveDrawer() {
 }
 
 describe('DrawerManager', () => {
+  it('opens a single dialog', () => {
+    renderDrawerManager();
+
+    // Open the first one
+    userEvent.click(screen.getByText('open drawer one'));
+
+    // And close it
+    closeActiveDrawer();
+
+    // Make sure it's closed
+    expect(screen.queryByRole('dialog')).toBe(null);
+  });
+
   it('toggles active state of single dialog', () => {
     renderDrawerManager();
 
     // Open the first one
-    userEvent.click(screen.getAllByRole('button')[0]);
+    userEvent.click(screen.getByText('toggle drawer one'));
 
     // And close it
     closeActiveDrawer();

--- a/packages/design-system/src/components/Drawer/DrawerManager.tsx
+++ b/packages/design-system/src/components/Drawer/DrawerManager.tsx
@@ -5,11 +5,54 @@ import useId from '../utilities/useId';
 export const DrawerContext = createContext(null);
 
 /**
- * If you have multiple `<Drawer>`'s on a page, you can utilize the `<DrawerManager>`
- * context provider along with the `useDrawerManager()` hook to manage the state of these
- * drawers so that only one will remain open at a time. The hook provides functions to
- * open the drawer, close the drawer, and toggle it as well as a boolean that represents
- * its open status. This is the object the `useDrawerManager` hook returns:
+ * The `DrawerManager` feature is useful when there are multiple help drawer links on a
+ * page, as it defines the behavior of what happens when a user already has one open and
+ * tries to open another. The `DrawerManager` manages the simplest behavior of closing
+ * all other drawers when a new one opens.
+ *
+ * At the top level of your app or page, you can
+ * define a `<DrawerManager>` [_context provider_](https://react.dev/learn/passing-data-deeply-with-context)
+ * and then in specific parts of your app that manage individual drawers, you can tap into
+ * the management behavior by calling the `useDrawerManager` hook. The hook provides the
+ * open/closed status of the drawer as well as functions for opening, closing, or toggling
+ * the drawer.
+ *
+ * Here is a minimal example of implementation:
+ *
+ * ```tsx
+ * import { Button, DrawerManager, useDrawerManager } from '@cmsgov/design-system';
+ *
+ * const ManagedDrawer = (props) => {
+ *   const { toggleDrawer, closeDrawer, isDrawerOpen } = useDrawerManager();
+ *
+ *   return (
+ *     <>
+ *       <Drawer
+ *         {...props}
+ *         onCloseClick={closeDrawer}
+ *         isOpen={isDrawerOpen}
+ *       >
+ *       <Button onClick={toggleDrawer}>Click to open drawer</Button>
+ *     </>
+ *   );
+ * }
+ *
+ * // Using components that use the `useDrawerManager` hook inside an app that is
+ * // wrapped in a `DrawerManager` context provider:
+ *
+ * function App() {
+ *   return (
+ *     <DrawerManager>
+ *       ... any content
+ *       <ManagedDrawer {...propsForDrawer1} />
+ *       <ManagedDrawer {...propsForDrawer2} />
+ *       <ManagedDrawer {...propsForDrawer3} />
+ *     </DrawerManager>
+ *   );
+ * }
+ * ```
+ *
+ * Here is a description of the object that the hook returns:
  *
  * ```ts
  * {
@@ -20,12 +63,7 @@ export const DrawerContext = createContext(null);
  * }
  * ```
  *
- * Since this component utilizes React [Context](https://react.dev/learn/passing-data-deeply-with-context),
- * any number of components/content items can be within the `DrawerManager` provider and
- * will not be effected by it.
- *
- * For information about how and when to use this component,
- * [refer to its full documentation page](https://design.cms.gov/components/drawer/).
+ * [See also the documentation on the drawer component](https://design.cms.gov/components/drawer/).
  */
 export const DrawerManager = (props: any) => {
   const [currentID, setCurrentID] = useState(null);

--- a/packages/design-system/src/components/Drawer/DrawerManager.tsx
+++ b/packages/design-system/src/components/Drawer/DrawerManager.tsx
@@ -4,6 +4,29 @@ import useId from '../utilities/useId';
 
 export const DrawerContext = createContext(null);
 
+/**
+ * If you have multiple `<Drawer>`'s on a page, you can utilize the `<DrawerManager>`
+ * context provider along with the `useDrawerManager()` hook to manage the state of these
+ * drawers so that only one will remain open at a time. The hook provides functions to
+ * open the drawer, close the drawer, and toggle it as well as a boolean that represents
+ * its open status. This is the object the `useDrawerManager` hook returns:
+ *
+ * ```ts
+ * {
+ *   isDrawerOpen: boolean; // whether it's open
+ *   openDrawer: () => any; // function that opens it
+ *   closeDrawer: () => any; // function that closes it
+ *   toggleDrawer: () => any; // funcntion that toggles it
+ * }
+ * ```
+ *
+ * Since this component utilizes React [Context](https://react.dev/learn/passing-data-deeply-with-context),
+ * any number of components/content items can be within the `DrawerManager` provider and
+ * will not be effected by it.
+ *
+ * For information about how and when to use this component,
+ * [refer to its full documentation page](https://design.cms.gov/components/drawer/).
+ */
 export const DrawerManager = (props: any) => {
   const [currentID, setCurrentID] = useState(null);
 
@@ -14,11 +37,12 @@ export const useDrawerManager = () => {
   const { currentID, setCurrentID } = useContext(DrawerContext);
   const id = useId();
 
-  const isOpen = currentID === id;
-  const toggleClick = () => setCurrentID(isOpen ? null : id);
-  const closeClick = () => setCurrentID(null);
+  const isDrawerOpen = currentID === id;
+  const openDrawer = () => setCurrentID(id);
+  const closeDrawer = () => setCurrentID(null);
+  const toggleDrawer = () => (isDrawerOpen ? closeDrawer() : openDrawer());
 
-  return { toggleClick, closeClick, isOpen };
+  return { openDrawer, closeDrawer, toggleDrawer, isDrawerOpen };
 };
 
 export default DrawerManager;

--- a/packages/design-system/src/components/Drawer/index.ts
+++ b/packages/design-system/src/components/Drawer/index.ts
@@ -1,4 +1,3 @@
 export * from './Drawer';
 export * from './DrawerToggle';
-// Can't release it right now with a focus-management bug
-// export * from './DrawerManager';
+export * from './DrawerManager';

--- a/packages/docs/content/components/drawer.mdx
+++ b/packages/docs/content/components/drawer.mdx
@@ -53,39 +53,7 @@ A header and/or footer can have a "sticky" position if the following properties 
 
 ### Managing multiple drawers
 
-If you have multiple `<Drawer>`'s on a page, you can utilize the `<DrawerManager>` context provider along with the `useDrawerManager()` hook to manage the state of these drawers so that only one will remain open at a time. The hook provides functions to toggle state of the drawer via click, to close the drawer and to get the open status of the drawer.
-
-Since this component utilizes React [Context](https://react.dev/learn/passing-data-deeply-with-context), any number of components/content items can be within the `DrawerManager` provider and will not be effected by it.
-
-A minimal example of implementation:
-
-```js
-import { Button, DrawerManager, useDrawerManager } from '@cmsgov/design-system';
-
-const ManagedDrawer = (props) => {
-  const { toggleDrawer, closeDrawer, isDrawerOpen } = useDrawerManager();
-
-  return (
-    <>
-      <Drawer
-        {...props}
-        onCloseClick={closeDrawer}
-        isOpen={isDrawerOpen}
-      >
-      <Button onClick={toggleDrawer}>Click to open drawer</Button>
-    </>
-  );
-}
-
-export default function App() {
-  <DrawerManager>
-    ... any content
-    <ManagedDrawer {...propsForDrawer1} />
-    <ManagedDrawer {...propsForDrawer2} />
-    <ManagedDrawer {...propsForDrawer3} />
-  </DrawerManager>
-}
-```
+What do you do when there are multiple drawers on a page? The simplest behavior—which may not be appropriate for all use cases—is that when one drawer opens, any open drawers get closes. While this logic can be written into your application, [we have a React component to manage simple drawer behavior](/storybook/?path=/docs/components-drawermanager--docs).
 
 ## Code
 

--- a/packages/docs/content/components/drawer.mdx
+++ b/packages/docs/content/components/drawer.mdx
@@ -51,9 +51,6 @@ A header and/or footer can have a "sticky" position if the following properties 
   minHeight={300}
 />
 
-<!--
-DrawerManager documentation commented out until we're ready to release the component
-
 ### Managing multiple drawers
 
 If you have multiple `<Drawer>`'s on a page, you can utilize the `<DrawerManager>` context provider along with the `useDrawerManager()` hook to manage the state of these drawers so that only one will remain open at a time. The hook provides functions to toggle state of the drawer via click, to close the drawer and to get the open status of the drawer.
@@ -63,25 +60,21 @@ Since this component utilizes React [Context](https://react.dev/learn/passing-da
 A minimal example of implementation:
 
 ```js
-import { DrawerManager, useDrawerManager } from '@cmsgov/design-system';
+import { Button, DrawerManager, useDrawerManager } from '@cmsgov/design-system';
 
 const ManagedDrawer = (props) => {
-  const { toggleClick, closeClick, isOpen } = useDrawerManager();
+  const { toggleDrawer, closeDrawer, isDrawerOpen } = useDrawerManager();
 
   return (
     <>
-      {isOpen && (
-        <Drawer onCloseClick={closeClick} {...props} />
-      )}
-      <Button
-        className="ds-c-drawer__toggle"
-        variation="ghost"
-        onClick={toggleClick}
+      <Drawer
+        {...props}
+        onCloseClick={closeDrawer}
+        isOpen={isDrawerOpen}
       >
-        Toggle {props.heading}
-      </Button>
+      <Button onClick={toggleDrawer}>Click to open drawer</Button>
     </>
-  )
+  );
 }
 
 export default function App() {
@@ -93,7 +86,6 @@ export default function App() {
   </DrawerManager>
 }
 ```
--->
 
 ## Code
 


### PR DESCRIPTION
## Summary

WNMGDS-2638

[Based on this recent RFC](https://github.com/CMSgov/design-system/discussions/2897)

Previously we held back on releasing our `DrawerManager` / `useDrawerManager` feature ([see this old RFC](https://github.com/CMSgov/design-system/discussions/1951)) because of [this focus-management bug](https://github.com/CMSgov/design-system/pull/2890). Now that the bug is fixed, we can roll this new feature out, and app teams will be able to offload some of their logic to the design system.

- Started exporting `DrawerManager` and `useDrawerManager` from our design system packages
- Updated all the documentation and made it visible
- Changed the names of the return-value properties to be general about their usage context (not just for click-handling) but more specific about being for a drawer (so they don't get lost in a parent component's code)

## How to test

Take a look at Storybook and the doc site

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone