### PR TITLE
[WNMGDS-2639] Add new `useDialog` hook

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.stories.tsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React, { FormEvent, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Dialog } from './Dialog';
 import { Button } from '@cmsgov/design-system';
 import { action } from '@storybook/addon-actions';
+import { useDialog } from './useDialog';
+import { TextField } from '../index';
 
 const meta: Meta<typeof Dialog> = {
   title: 'Components/Dialog',
@@ -54,12 +56,12 @@ export const DialogExample: Story = {
           onExit={hideModal}
           actions={
             <>
-              <button className="ds-c-button ds-c-button--solid ds-u-margin-right--1" key="solid">
+              <Button variation="solid" className="ds-u-margin-right--1">
                 Dialog action
-              </button>
-              <button className="ds-c-button ds-c-button--ghost" key="cancel" onClick={hideModal}>
+              </Button>
+              <Button variation="ghost" onClick={hideModal}>
                 Cancel
-              </button>
+              </Button>
             </>
           }
           isOpen={dialogOpen}
@@ -133,6 +135,54 @@ export const PreventScrollExample: Story = {
           the sole Power of Impeachment.
         </p>
       </div>
+    );
+  },
+};
+
+export const UseDialogExample: Story = {
+  name: 'useDialog Example',
+  render: function Component() {
+    const { dialog, openDialog } = useDialog<boolean>(({ resolveClose, isOpen }) => (
+      <Dialog
+        heading="Confirm deletion"
+        onExit={() => resolveClose(false)}
+        actions={
+          <>
+            <Button
+              variation="solid"
+              onClick={() => resolveClose(true)}
+              className="ds-u-margin-right--1"
+            >
+              Delete
+            </Button>
+            <Button variation="ghost" onClick={() => resolveClose(false)}>
+              Cancel
+            </Button>
+          </>
+        }
+        isOpen={isOpen}
+      >
+        Are you sure you want to delete your account? All in-progress applications will be deleted
+        and your information cleared from the system.
+      </Dialog>
+    ));
+
+    async function handleDelete() {
+      const result = await openDialog();
+      if (result) {
+        alert(
+          'Pretend you have been redirected to a page that confirms that your account was deleted.'
+        );
+      }
+    }
+
+    return (
+      <>
+        <Button onClick={handleDelete} variation="solid">
+          Delete account
+        </Button>
+        {dialog}
+      </>
     );
   },
 };

--- a/packages/design-system/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.stories.tsx
@@ -139,6 +139,26 @@ export const PreventScrollExample: Story = {
   },
 };
 
+/**
+ * The `useDialog` hook provides an alternative imperative interface for managing the
+ * open state of a modal dialog and waiting asynchronously for the final result of the
+ * user's interaction with the modal. While React leans heavily on declarative
+ * programming for building maintainable apps, there are cases where a more imperative
+ * style can save a lot of code. In those cases, being able to call a function to open
+ * the dialog and then wait on the response before performing the next action can make
+ * application logic a lot easier to read, reason about, and manage.
+ *
+ * To use the `useDialog` hook, you pass it a render function for the dialog, and it
+ * returns the rendered dialog and a function for opening the dialog and getting back
+ * a resolution when the dialog is closed.
+ *
+ * Note that you need to render the returned `dialog` element even if it's not open at
+ * the moment. It needs to be in the DOM in order for the browser and assistive tech to
+ * be able to properly interact with it.
+ *
+ * Note also that you're in complete control over what value the `openDialog` promise
+ * resolves to by what you pass to the `resolveClose` function in your render function.
+ */
 export const UseDialogExample: Story = {
   name: 'useDialog Example',
   render: function Component() {

--- a/packages/design-system/src/components/Dialog/useDialog.test.tsx
+++ b/packages/design-system/src/components/Dialog/useDialog.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { Dialog } from './Dialog';
+import { useDialog } from './useDialog';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+enum ResolveValue {
+  onExit,
+  yesClick,
+  noClick,
+}
+
+const defaultRenderFn = ({ resolveClose, isOpen }) => (
+  <Dialog
+    heading="Are we there yet?"
+    onExit={() => resolveClose(ResolveValue.onExit)}
+    actions={
+      <>
+        <button onClick={() => resolveClose(ResolveValue.yesClick)}>Yes</button>
+        <button onClick={() => resolveClose(ResolveValue.noClick)}>No</button>
+      </>
+    }
+    isOpen={isOpen}
+  >
+    I know I just asked five minutes ago, but I really need to know.
+  </Dialog>
+);
+
+function openDialog(hookRenderResult) {
+  let promise;
+  act(() => {
+    promise = hookRenderResult.result.current.openDialog();
+  });
+  hookRenderResult.rerender();
+  return promise;
+}
+
+function expectClosed(hookRenderResult, dialogRenderResult) {
+  hookRenderResult.rerender();
+  dialogRenderResult.rerender(hookRenderResult.result.current.dialog);
+  expect(dialogRenderResult.container.querySelector('dialog').open).toBe(false);
+}
+
+describe('useDialog', () => {
+  it('should render an unopen dialog at first', () => {
+    const hookRenderResult = renderHook(() => useDialog(defaultRenderFn));
+    const { container } = render(hookRenderResult.result.current.dialog);
+    expect(container.querySelector('dialog').open).toBe(false);
+  });
+
+  it('should open the dialog when `openDialog` is called', () => {
+    const hookRenderResult = renderHook(() => useDialog(defaultRenderFn));
+    openDialog(hookRenderResult);
+    render(hookRenderResult.result.current.dialog);
+    expect((screen.getByRole('dialog') as HTMLDialogElement).open).toBe(true);
+  });
+
+  it('should resolve promise and close dialog when ESC is pressed', async () => {
+    const hookRenderResult = renderHook(() => useDialog(defaultRenderFn));
+    const promise = openDialog(hookRenderResult);
+    const dialogRenderResult = render(hookRenderResult.result.current.dialog);
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    act(() => {
+      userEvent.keyboard('{escape}');
+    });
+    const resolvedValue = await promise;
+    expect(resolvedValue).toEqual(ResolveValue.onExit);
+    expectClosed(hookRenderResult, dialogRenderResult);
+  });
+
+  it('should resolve promise and close dialog when dialog close button clicked', async () => {
+    const hookRenderResult = renderHook(() => useDialog(defaultRenderFn));
+    const promise = openDialog(hookRenderResult);
+    const dialogRenderResult = render(hookRenderResult.result.current.dialog);
+    const closeButton = screen.getByRole('button', { name: /Close/ });
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    act(() => {
+      userEvent.click(closeButton);
+    });
+    const resolvedValue = await promise;
+    expect(resolvedValue).toEqual(ResolveValue.onExit);
+    expectClosed(hookRenderResult, dialogRenderResult);
+  });
+
+  it('should resolve promise and close dialog when "Yes" button is clicked', async () => {
+    const hookRenderResult = renderHook(() => useDialog(defaultRenderFn));
+    const promise = openDialog(hookRenderResult);
+    const dialogRenderResult = render(hookRenderResult.result.current.dialog);
+    const closeButton = screen.getByRole('button', { name: /Yes/ });
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    act(() => {
+      userEvent.click(closeButton);
+    });
+    const resolvedValue = await promise;
+    expect(resolvedValue).toEqual(ResolveValue.yesClick);
+    expectClosed(hookRenderResult, dialogRenderResult);
+  });
+
+  it('should resolve promise and close dialog when "No" button is clicked', async () => {
+    const hookRenderResult = renderHook(() => useDialog(defaultRenderFn));
+    const promise = openDialog(hookRenderResult);
+    const dialogRenderResult = render(hookRenderResult.result.current.dialog);
+    const closeButton = screen.getByRole('button', { name: /No/ });
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    act(() => {
+      userEvent.click(closeButton);
+    });
+    const resolvedValue = await promise;
+    expect(resolvedValue).toEqual(ResolveValue.noClick);
+    expectClosed(hookRenderResult, dialogRenderResult);
+  });
+});

--- a/packages/design-system/src/components/Dialog/useDialog.ts
+++ b/packages/design-system/src/components/Dialog/useDialog.ts
@@ -5,6 +5,21 @@ export interface UseDialogRenderProps<ReturnType> {
   resolveClose: (returnValue: ReturnType) => any;
 }
 
+/**
+ * The `useDialog` hook provides an alternative imperative interface for managing the
+ * open state of a modal dialog and waiting asynchronously for the final result of the
+ * user's interaction with the modal. You pass it a render function for the dialog,
+ * and it returns the rendered dialog and a function for opening the dialog and getting
+ * back a resolution when the dialog is closed. Please see the Storybook example for
+ * more information.
+ *
+ * Note that you need to render the returned `dialog` element even if it's not open at
+ * the moment. It needs to be in the DOM in order for the browser and assistive tech to
+ * be able to properly interact with it.
+ *
+ * Note also that you're in complete control over what value the `openDialog` promise
+ * resolves to by what you pass to the `resolveClose` function in your render function.
+ */
 export function useDialog<ReturnType = any>(
   renderDialog: (renderProps: UseDialogRenderProps<ReturnType>) => React.ReactElement
 ) {

--- a/packages/design-system/src/components/Dialog/useDialog.ts
+++ b/packages/design-system/src/components/Dialog/useDialog.ts
@@ -1,0 +1,32 @@
+import { useRef, useState } from 'react';
+
+export interface UseDialogRenderProps<ReturnType> {
+  isOpen: boolean;
+  resolveClose: (returnValue: ReturnType) => any;
+}
+
+export function useDialog<ReturnType = any>(
+  renderDialog: (renderProps: UseDialogRenderProps<ReturnType>) => React.ReactElement
+) {
+  const [isOpen, setIsOpen] = useState(false);
+  const resolveRef = useRef<(returnValue: ReturnType) => any>();
+
+  const resolveClose = (returnValue: ReturnType) => {
+    setIsOpen(false);
+    resolveRef.current?.(returnValue);
+  };
+
+  const dialog = renderDialog({
+    isOpen,
+    resolveClose,
+  });
+
+  function openDialog() {
+    setIsOpen(true);
+    return new Promise<ReturnType>((resolve) => {
+      resolveRef.current = resolve;
+    });
+  }
+
+  return { dialog, openDialog };
+}

--- a/tests/browser/stories.test.ts
+++ b/tests/browser/stories.test.ts
@@ -5,6 +5,7 @@ import expectNoAxeViolations from './expectNoAxeViolations';
 
 const storySkipList = [
   'components-dialog--prevent-scroll-example', // Redundant
+  'components-dialog--use-dialog-example', // Redundant
   'components-dropdown--option-groups', // Redundant in its unopened state
   'components-dropdown--html-option-groups', // Redundant
   'components-dropdown--html-options', // Redundant


### PR DESCRIPTION
## Summary

[See RFC for the why](https://github.com/CMSgov/design-system/discussions/2897).

- Adds a new `useDialog` hook that provides an imperative interface for opening a modal dialog and waiting asynchronously for the final result of the user's interaction with the modal

## How to test

There's a Storybook story and unit tests.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)

### If this is a change to documentation:

- [ ] Checked for spelling and grammatical errors
