### PR TITLE
[NO-TICKET] Expand some `string` prop types in IdleTimeout to `ReactNode`

### DIFF
--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.stories.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import IdleTimeout from './IdleTimeout';
 import IdleTimeoutDialog from './IdleTimeoutDialog';
-import { Title, Subtitle, Description, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs';
+// import { Title, Subtitle, Description, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs';
+import { Title, Subtitle, Description, ArgsTable } from '@storybook/blocks';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useArgs } from '@storybook/preview-api';
@@ -11,7 +12,7 @@ const DocsPage = () => (
     <Title />
     <Subtitle />
     <Description />
-    <ArgsTable story={PRIMARY_STORY} />
+    <ArgsTable />
   </>
 );
 
@@ -28,6 +29,11 @@ const meta: Meta<typeof IdleTimeout> = {
     timeToTimeout: 2,
     timeToWarning: 0.5,
     onTimeout: action('onTimeout'),
+  },
+  argTypes: {
+    heading: { control: 'text' },
+    continueSessionText: { control: 'text' },
+    endSessionButtonText: { control: 'text' },
   },
 };
 export default meta;

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.stories.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import IdleTimeout from './IdleTimeout';
 import IdleTimeoutDialog from './IdleTimeoutDialog';
-// import { Title, Subtitle, Description, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs';
 import { Title, Subtitle, Description, ArgsTable } from '@storybook/blocks';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeout.tsx
@@ -8,7 +8,7 @@ export interface IdleTimeoutProps {
   /**
    * The text for the 'continue session' button in warning dialog.
    */
-  continueSessionText?: string;
+  continueSessionText?: React.ReactNode;
   /**
    * The heading text for the warning dialog.
    */
@@ -16,7 +16,7 @@ export interface IdleTimeoutProps {
   /**
    * The text for the button that ends the session in warning dialog.
    */
-  endSessionButtonText?: string;
+  endSessionButtonText?: React.ReactNode;
   /**
    * The URL to direct to when the user intentionally ends the session.
    */

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeoutDialog.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeoutDialog.tsx
@@ -6,7 +6,7 @@ export interface IdleTimeoutDialogProps {
   /**
    * The text for the 'continue session' button in warning dialog.
    */
-  continueSessionText: string;
+  continueSessionText: React.ReactNode;
   /**
    * The heading text for the warning dialog.
    */
@@ -14,7 +14,7 @@ export interface IdleTimeoutDialogProps {
   /**
    * The text for the button that ends the session in warning dialog.
    */
-  endSessionButtonText?: string;
+  endSessionButtonText?: React.ReactNode;
   /**
    *
    */

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-IdleTimeout-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-IdleTimeout-Docs-prop-table-matches-snapshot-1.txt
@@ -1,15 +1,15 @@
 [
   [
     "continueSessionText",
-    "The text for the 'continue session' button in warning dialog.\nstring",
-    "\"Continue session\"",
-    "Set string"
+    "The text for the 'continue session' button in warning dialog.\nReactNode",
+    "Continue session",
+    "Set object"
   ],
   [
     "endSessionButtonText",
-    "The text for the button that ends the session in warning dialog.\nstring",
-    "\"Logout\"",
-    "Set string"
+    "The text for the button that ends the session in warning dialog.\nReactNode",
+    "Logout",
+    "Set object"
   ],
   [
     "endSessionUrl",

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-IdleTimeout-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-IdleTimeout-Docs-prop-table-matches-snapshot-1.txt
@@ -2,67 +2,56 @@
   [
     "continueSessionText",
     "The text for the 'continue session' button in warning dialog.\nReactNode",
-    "Continue session",
-    "Set object"
+    "Continue session"
   ],
   [
     "endSessionButtonText",
     "The text for the button that ends the session in warning dialog.\nReactNode",
-    "Logout",
-    "Set object"
+    "Logout"
   ],
   [
     "endSessionUrl",
     "The URL to direct to when the user intentionally ends the session.\nstring",
-    "\"/logout\"",
-    "Set string"
+    "\"/logout\""
   ],
   [
     "formatMessage",
     "A formatting function that returns the string to be used in the warning modal. The formatting function is provided the timeTilTimeout (in minutes).\n\n(timeTilTimeout: number) => ReactNode",
-    "(timeTilTimeout: number): React.ReactNode => { const unitOfTime = timeTilTimeout === 1 ? 'minute' : 'minutes'; return ( <p> You&apos;ve been inactive for a while. <br /> Your session will end in{' '} <strong> {timeTilTimeout} {unitOfTime} </strong> . <br /> <br /> Select &quot;Continue session&quot; below if you want more time. </p> ); }",
-    "-"
+    "(timeTilTimeout: number): React.ReactNode => { const unitOfTime = timeTilTimeout === 1 ? 'minute' : 'minutes'; return ( <p> You&apos;ve been inactive for a while. <br /> Your session will end in{' '} <strong> {timeTilTimeout} {unitOfTime} </strong> . <br /> <br /> Select &quot;Continue session&quot; below if you want more time. </p> ); }"
   ],
   [
     "heading",
     "The heading text for the warning dialog.\nReactNode",
-    "Are you still there?",
-    "Set object"
+    "Are you still there?"
   ],
   [
     "onSessionContinue",
     "Optional function that is called when the user chooses to keep the session alive. This function is called by the 'continue session' button or the 'close' button. The IdleTimeout component will reset the countdown internally.\n\n(...args: any[]) => any",
-    "-",
     "-"
   ],
   [
     "onSessionForcedEnd",
     "Optional function that is called when the session is manually ended by user. If not provided, the behavior of onTimeout will be used.\n\n(...args: any[]) => any",
-    "-",
     "-"
   ],
   [
     "onTimeout*",
     "Function that is called when the timeout countdown reaches zero.\n(...args: any[]) => any",
-    "-",
     "-"
   ],
   [
     "showSessionEndButton",
     "Describes if the button to manually end session should be shown in the warning dialog.\nboolean",
-    "false",
-    "Set boolean"
+    "false"
   ],
   [
     "timeToTimeout*",
     "Defines the amount of minutes of idle activity until the session is timed out\nnumber",
-    "-",
-    ""
+    "-"
   ],
   [
     "timeToWarning*",
     "Defines the amount of minutes of idle activity that will trigger the warning message.\nnumber",
-    "-",
-    ""
+    "-"
   ]
 ]


### PR DESCRIPTION
## Summary

Expand some `string` prop types in IdleTimeout to `ReactNode`. They don't really need to be restricted to strings.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
