### PR TITLE
[NO-TICKET] Use only a single version of Storybook "doc blocks"

### DIFF
--- a/packages/design-system/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Title, Subtitle, Description, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs';
+import { Title, Subtitle, Description, ArgsTable } from '@storybook/blocks';
 import { action } from '@storybook/addon-actions';
 import Drawer from './Drawer';
 import { Button } from '../Button';
@@ -22,7 +22,7 @@ const meta: Meta<typeof Drawer> = {
           <Title />
           <Subtitle />
           <Description />
-          <ArgsTable story={PRIMARY_STORY} />
+          <ArgsTable />
         </>
       ),
     },

--- a/packages/design-system/src/components/PrivacySettingsDialog/PrivacySettingsDialog.stories.tsx
+++ b/packages/design-system/src/components/PrivacySettingsDialog/PrivacySettingsDialog.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PrivacySettingsDialog from './PrivacySettingsDialog';
-import { Title, Subtitle, Description, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs';
+import { Title, Subtitle, Description, ArgsTable } from '@storybook/blocks';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof PrivacySettingsDialog> = {
@@ -18,7 +18,7 @@ const meta: Meta<typeof PrivacySettingsDialog> = {
           <Title />
           <Subtitle />
           <Description />
-          <ArgsTable story={PRIMARY_STORY} />
+          <ArgsTable />
         </>
       ),
     },

--- a/packages/ds-medicare-gov/src/components/HelpDrawer/HelpDrawer.stories.tsx
+++ b/packages/ds-medicare-gov/src/components/HelpDrawer/HelpDrawer.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Title, Subtitle, Description, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs';
+import { Title, Subtitle, Description, ArgsTable } from '@storybook/blocks';
 import HelpDrawerToggle from './HelpDrawerToggle';
 import HelpDrawer from './HelpDrawer';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -19,7 +19,7 @@ const meta: Meta<typeof HelpDrawer> = {
           <Title />
           <Subtitle />
           <Description />
-          <ArgsTable story={PRIMARY_STORY} />
+          <ArgsTable />
         </>
       ),
     },

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Drawer-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Drawer-Docs-prop-table-matches-snapshot-1.txt
@@ -2,91 +2,76 @@
   [
     "ariaLabel",
     "Gives more context to screen readers on the Drawer close button.\nstring",
-    "-",
-    "Set string"
+    "-"
   ],
   [
     "className",
     "string",
-    "-",
-    "Set string"
+    "-"
   ],
   [
     "closeButtonText",
     "ReactNode",
-    "-",
-    "Set object"
+    "-"
   ],
   [
     "closeButtonVariation",
     "\"solid\"\n\"ghost\"",
-    "-",
-    "solid\nghost"
+    "-"
   ],
   [
     "footerBody",
     "ReactNode",
-    "-",
-    "RAW\nfooterBody : {\ntype : \"p\"\nprops : {...} 3 keys\nkey : undefined\nref : undefined\n__k : null\n__ : null\n__b : 0\n__e : null\n__d : undefined\n__c : null\n__h : null\nconstructor : undefined\n__v : -1\n__source : undefined\n__self : undefined\n$$typeof : Symbol(react.element)\n}"
+    "-"
   ],
   [
     "footerTitle",
     "ReactNode",
-    "-",
-    ""
+    "-"
   ],
   [
     "hasFocusTrap",
     "Enables focus trap functionality within Drawer.\nboolean",
-    "false",
-    "Set boolean"
+    "false"
   ],
   [
     "heading*",
     "Text for the Drawer heading. Required because the heading will be focused on mount.\nReactNode",
-    "-",
-    ""
+    "-"
   ],
   [
     "headingId",
     "A unique id to be used on heading element to label multiple instances of Drawer.\nstring",
-    "-",
-    "Set string"
+    "-"
   ],
   [
     "headingLevel",
     "Heading type to override default <h3>\n\"1\"\n\"2\"\n\"3\"\n\"4\"\n\"5\"",
-    "\"3\"",
-    "1\n2\n3\n4\n5"
+    "\"3\""
   ],
   [
     "headingRef",
     "Ref to heading element\nMutableRefObject<any>",
-    "-",
-    "Set object"
+    "-"
   ],
   [
     "isFooterSticky",
     "Enables \"sticky\" position of Drawer footer element.\nboolean",
-    "-",
-    "Set boolean"
+    "-"
   ],
   [
     "isHeaderSticky",
     "Enables \"sticky\" position of Drawer header element.\nboolean",
-    "-",
-    "Set boolean"
+    "-"
   ],
   [
     "isOpen",
     "Controls whether the dialog is in an open state\nboolean",
-    "-",
-    "Set boolean"
+    "-"
   ],
   [
     "onCloseClick*",
     "Called when the user activates the close button or presses the ESC key if focus trapping is enabled. The parent of this component is responsible for showing or not showing the drawer, so you need to use this callback to make that happen. The dialog does not hide itself.\n\n(event: MouseEvent<Element, MouseEvent> | KeyboardEvent<Element>) => void",
-    "-",
     "-"
   ]
 ]

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-PrivacySettingsDialog-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-PrivacySettingsDialog-Docs-prop-table-matches-snapshot-1.txt
@@ -2,31 +2,26 @@
   [
     "domain*",
     "string",
-    "-",
-    ""
+    "-"
   ],
   [
     "isOpen",
     "Controls whether the dialog is in an open state\nboolean",
-    "-",
-    "Set boolean"
+    "-"
   ],
   [
     "onExit*",
     "() => void",
-    "-",
     "-"
   ],
   [
     "privacyPolicyUrl*",
     "string",
-    "-",
-    ""
+    "-"
   ],
   [
     "thirdPartyPoliciesUrl",
     "string",
-    "-",
-    "Set string"
+    "-"
   ]
 ]

--- a/tests/browser/snapshots/storybook-docs/Docs-Medicare-HelpDrawer-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Medicare-HelpDrawer-Docs-prop-table-matches-snapshot-1.txt
@@ -1,8 +1,1 @@
-[
-  [
-    "heading",
-    "",
-    "-",
-    ""
-  ]
-]
+no args table


### PR DESCRIPTION
## Summary

We were mixing and matching the packages that our doc blocks were coming from. The arg tables created by using the other package were showing controls, which we don't want (see screenshot below).

<img width="684" alt="Storybook args tables with an extra column we don't want" src="https://github.com/CMSgov/design-system/assets/7595652/e7fc4046-c680-4696-806b-3283b298c047">

## How to test

Start Storybook and look at the affected doc pages.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone