### PR TITLE
[NO-TICKET] Fix error placement types

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -15,7 +15,6 @@ import {
 import { t } from '../i18n';
 import { useComboBox } from '../react-aria'; // from react-aria
 import { useComboBoxState } from '../react-aria'; // from react-stately
-import { ErrorPlacement } from '../InlineError/useInlineError';
 
 export interface AutocompleteItem extends Omit<React.HTMLAttributes<'option'>, 'name'> {
   /**
@@ -242,8 +241,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
   // The display of bottom placed errorMessages in TextField breaks the Autocomplete's UI design.
   // Add errorMessageClassName to fix the styles for bottom placed errors
   const bottomError =
-    (textField.props.errorPlacement === ErrorPlacement.Bottom ||
-      config().errorPlacementDefault === ErrorPlacement.Bottom) &&
+    (textField.props.errorPlacement === 'bottom' || config().errorPlacementDefault === 'bottom') &&
     textField.props.errorMessage != null;
 
   const errorMessageClassName = classNames(

--- a/packages/design-system/src/components/InlineError/useInlineError.tsx
+++ b/packages/design-system/src/components/InlineError/useInlineError.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import InlineError from './InlineError';
 import classNames from 'classnames';
-import { ErrorPlacement, config } from '../config';
+import { ErrorPlacement, ErrorPlacementType, config } from '../config';
 
 export { ErrorPlacement };
 
@@ -17,7 +17,7 @@ export interface UseInlineErrorProps {
   /**
    * Location of the error message relative to the field input
    */
-  errorPlacement?: ErrorPlacement;
+  errorPlacement?: ErrorPlacementType;
   /**
    * Enable the error state by providing an error message.
    */

--- a/packages/design-system/src/components/InlineError/useInlineError.tsx
+++ b/packages/design-system/src/components/InlineError/useInlineError.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import InlineError from './InlineError';
 import classNames from 'classnames';
-import { ErrorPlacement, ErrorPlacementType, config } from '../config';
+import { config } from '../config';
 
-export { ErrorPlacement };
+export type ErrorPlacement = 'top' | 'bottom';
 
 // TODO: We should conditionally return an errorId, because we want to be able
 // to include it in the aria-describedby without conditional logic in the component
@@ -17,7 +17,7 @@ export interface UseInlineErrorProps {
   /**
    * Location of the error message relative to the field input
    */
-  errorPlacement?: ErrorPlacementType;
+  errorPlacement?: ErrorPlacement;
   /**
    * Enable the error state by providing an error message.
    */
@@ -57,7 +57,7 @@ export function useInlineError<T extends UseInlineErrorProps>(props: T) {
       inversed={inversed}
       className={classNames(
         errorMessageClassName,
-        errorPlacement === ErrorPlacement.Bottom && 'ds-c-inline-error--bottom'
+        errorPlacement === 'bottom' && 'ds-c-inline-error--bottom'
       )}
     >
       {errorMessage}
@@ -66,7 +66,7 @@ export function useInlineError<T extends UseInlineErrorProps>(props: T) {
 
   let topError;
   let bottomError;
-  if (errorPlacement === ErrorPlacement.Top) {
+  if (errorPlacement === 'top') {
     topError = errorElement;
   } else {
     bottomError = errorElement;

--- a/packages/design-system/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system/src/components/TextField/TextField.stories.tsx
@@ -91,6 +91,7 @@ export const ErrorField: Story = {
   args: {
     errorMessage: 'This is an example error message.',
     hint: 'This is where you put helpful hint text.',
+    errorPlacement: 'bottom',
   },
 };
 

--- a/packages/design-system/src/components/TextField/TextField.stories.tsx
+++ b/packages/design-system/src/components/TextField/TextField.stories.tsx
@@ -91,7 +91,6 @@ export const ErrorField: Story = {
   args: {
     errorMessage: 'This is an example error message.',
     hint: 'This is where you put helpful hint text.',
-    errorPlacement: 'bottom',
   },
 };
 

--- a/packages/design-system/src/components/config.ts
+++ b/packages/design-system/src/components/config.ts
@@ -1,10 +1,5 @@
 import { AnalyticsFunction, sendLinkEvent } from './analytics';
-
-export enum ErrorPlacement {
-  Top = 'top',
-  Bottom = 'bottom',
-}
-export type ErrorPlacementType = `${ErrorPlacement}`;
+import type { ErrorPlacement } from './InlineError/useInlineError';
 
 export interface Config {
   /**
@@ -12,7 +7,7 @@ export interface Config {
    * of the error message relative to the field input. Accepts string values of 'top' or
    * 'bottom'.
    */
-  errorPlacementDefault: ErrorPlacementType;
+  errorPlacementDefault: ErrorPlacement;
   /**
    * Changing this setting allows applications to override the default `onAnalyticsEvent`
    * handler function for all analytics-enabled components. To override it for a single
@@ -48,7 +43,7 @@ export interface Config {
 export type PartialConfig = Partial<Config>;
 
 export const DEFAULTS: Config = Object.freeze({
-  errorPlacementDefault: ErrorPlacement.Top,
+  errorPlacementDefault: 'top',
   defaultAnalyticsFunction: sendLinkEvent,
   alertSendsAnalytics: false,
   buttonSendsAnalytics: false,
@@ -59,7 +54,7 @@ export const DEFAULTS: Config = Object.freeze({
 
 export const HEALTHCARE_DEFAULTS: Config = {
   ...DEFAULTS,
-  errorPlacementDefault: ErrorPlacement.Bottom,
+  errorPlacementDefault: 'bottom',
   headerSendsAnalytics: true,
 };
 
@@ -90,12 +85,12 @@ export function setDefaultAnalyticsFunction(analyticsFunction: AnalyticsFunction
 
 export const defaultAnalyticsFunction = config().defaultAnalyticsFunction;
 
-export function errorPlacementDefault(): ErrorPlacementType {
+export function errorPlacementDefault(): ErrorPlacement {
   depWarning('setDefaultAnalyticsFunction');
   return config().errorPlacementDefault;
 }
 
-export function setErrorPlacementDefault(value: ErrorPlacementType): void {
+export function setErrorPlacementDefault(value: ErrorPlacement): void {
   depWarning('setErrorPlacementDefault');
   config({ errorPlacementDefault: value });
 }

--- a/packages/design-system/src/components/config.ts
+++ b/packages/design-system/src/components/config.ts
@@ -4,6 +4,7 @@ export enum ErrorPlacement {
   Top = 'top',
   Bottom = 'bottom',
 }
+export type ErrorPlacementType = `${ErrorPlacement}`;
 
 export interface Config {
   /**
@@ -11,7 +12,7 @@ export interface Config {
    * of the error message relative to the field input. Accepts string values of 'top' or
    * 'bottom'.
    */
-  errorPlacementDefault: ErrorPlacement;
+  errorPlacementDefault: ErrorPlacementType;
   /**
    * Changing this setting allows applications to override the default `onAnalyticsEvent`
    * handler function for all analytics-enabled components. To override it for a single
@@ -89,12 +90,12 @@ export function setDefaultAnalyticsFunction(analyticsFunction: AnalyticsFunction
 
 export const defaultAnalyticsFunction = config().defaultAnalyticsFunction;
 
-export function errorPlacementDefault(): ErrorPlacement {
+export function errorPlacementDefault(): ErrorPlacementType {
   depWarning('setDefaultAnalyticsFunction');
   return config().errorPlacementDefault;
 }
 
-export function setErrorPlacementDefault(value: ErrorPlacement): void {
+export function setErrorPlacementDefault(value: ErrorPlacementType): void {
   depWarning('setErrorPlacementDefault');
   config({ errorPlacementDefault: value });
 }

--- a/packages/docs/content/components/config.mdx
+++ b/packages/docs/content/components/config.mdx
@@ -23,10 +23,10 @@ config({ alertSendsAnalytics: true });
 Note that the return value of the function is the design system's current global configuration (see the example below).
 
 ```js
-import { config, ErrorPlacement } from '@cmsgov/design-system';
+import { config } from '@cmsgov/design-system';
 
-if (config().errorPlacementDefault === ErrorPlacement.Top) {
-  console.log('Be careful up there, errors!');
+if (config().alertSendsAnalytics) {
+  alert('Verify that no PII is logged by alerts!');
 }
 ```
 


### PR DESCRIPTION
## Summary

We were getting errors downstream that strings like "bottom" weren't being accepted. We had a fix for it in 924dbfb82441c721232df3cbcfdf7d5b6037fc5e, but really I don't think we need to make this an enum, at least not right now. We don't use enums for any other prop types that are unions of different string literals, like the `variation` or `size` props.

## How to test

See 0d135b2f4f201f6761963f1986c11eafa53f8e74 for the line that will cause the type to be checked.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
