### PR TITLE
Update ToC to exclude lower level headings

### DIFF
--- a/packages/docs/src/components/layout/TableOfContents.tsx
+++ b/packages/docs/src/components/layout/TableOfContents.tsx
@@ -12,10 +12,6 @@ export interface TableOfContentsProps {
    */
   items: TableOfContentsItem[];
   /**
-   * Describes which level the list is at. Helps with styling
-   */
-  level?: number;
-  /**
    * additional className string to append to the list
    */
   className?: string;
@@ -31,18 +27,15 @@ export interface TableOfContentsProps {
 
 export type TableOfContentsFeedbackProps = Pick<TableOfContentsProps, 'slug'>;
 
-export const TableOfContentsList = ({ items, level, className = '' }: TableOfContentsProps) => {
-  const itemClasses =
-    level == 1
-      ? 'c-table-of-contents__list-item c-table-of-contents__list-item--no-marker'
-      : 'c-table-of-contents__list-item';
-
+export const TableOfContentsList = ({ items, className = '' }: TableOfContentsProps) => {
   return (
-    <ul role="list" className={`c-table-of-contents__list ds-u-padding-right--0 ${className}`}>
+    <ul role="list" className={`c-table-of-contents__list ds-u-padding-left--0 ${className}`}>
       {items.map((item) => (
-        <li key={item.title} className={itemClasses}>
+        <li
+          key={item.title}
+          className={'c-table-of-contents__list-item c-table-of-contents__list-item--no-marker'}
+        >
           <Link to={item.url}>{cleanTitle(item.title)}</Link>
-          {item.items && <TableOfContentsList items={item.items} level={level + 1} />}
         </li>
       ))}
     </ul>
@@ -54,10 +47,10 @@ export const TableOfContentsList = ({ items, level, className = '' }: TableOfCon
  */
 export const TableOfContentsFeedback = ({ slug }: TableOfContentsFeedbackProps) => (
   <>
-    <h2 className="c-table-of-contents__heading ds-u-margin-y--0 ds-u-md-margin-top--6 ds-u-font-size--base">
+    <h2 className="c-table-of-contents__heading ds-u-margin-top--0 ds-u-margin-bottom--1 ds-u-md-margin-top--6 ds-u-font-size--base">
       Have ideas?{' '}
     </h2>
-    <ul role="list" className="ds-c-list ds-c-list--bare ds-u-md-margin-y--2">
+    <ul role="list" className="ds-u-md-margin-y--2">
       <li>
         <Link to="/contact">Contact the team</Link>
       </li>
@@ -83,13 +76,12 @@ export const TableOfContentsFeedback = ({ slug }: TableOfContentsFeedbackProps) 
  * The Desktop version of the table of contents
  */
 const TableOfContents = ({ items, slug }: TableOfContentsProps) => {
-  const level = 1;
   return items.length ? (
     <div className="c-table-of-contents">
       <h2 className="c-table-of-contents__heading ds-u-margin-top--0 ds-u-margin-bottom--1 ds-u-font-size--base">
         On this page{' '}
       </h2>
-      <TableOfContentsList items={items} level={level} />
+      <TableOfContentsList items={items} />
       <TableOfContentsFeedback slug={slug} />
     </div>
   ) : null;


### PR DESCRIPTION
**This work just updates the component page's table of contents.** I've included screenshots comparing local and PROD for both desktop and mobile views.

Changes:

- Update the vertical spacing for the "Have ideas?" list items
- Remove left padding on the "On this page" list items
- Remove lower level headings from "On this page" list (only shows `<h2>` headings)

The only difference I see between this work and what's shown in [the mock](https://www.sketch.com/s/a90bdc60-5526-4f3d-88d0-98ac8eefea94) is the position of the ToC. The mock shows the ToC as being higher up in the page (aligned with the intro paragraph below the page's `<h1>` title/heading) whereas the current placement aligns the ToC with the beginning of the page's body content. The only reason I haven't moved it is it would require considerable rework of our page layout to accomplish this.

@hi-its-hailey can you give me a 👍 / 👎 on whether the ToC looks OK to you?

![Screenshot 2024-01-29 at 10 14 04 AM](https://github.com/CMSgov/design-system/assets/5159392/e0d82645-7736-404a-9fa7-6ff0169b00ed)
![Screenshot 2024-01-29 at 10 17 04 AM](https://github.com/CMSgov/design-system/assets/5159392/9af2f701-c463-4376-bdb7-f922a7e66315)
