### PR TITLE
[WIP] [NO-TICKET] Shift content around

### DIFF
--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -326,8 +326,6 @@ Used to show important but not as urgent messages as standard alerts.
 
 Sketch symbol
 
-Figma component
-
 ### Development
 
 This component has analytics tracking available. Please see our developer documentation about [using analytics in the design system](/getting-started/for-developers/#analytics).
@@ -336,7 +334,7 @@ This component has analytics tracking available. Please see our developer docume
 
 <SeeStorybookForGuidance tech="wc" storyId={'web-components-alert--docs'} />
 
-<Accordion>
+<Accordion className="ds-u-margin-top--2">
   <AccordionItem heading="CSS variable overrides to customize this component">
     <ComponentThemeOptions componentname="alert" />
   </AccordionItem>

--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -11,125 +11,11 @@ medicare:
   sketchLink: 1K9gg0y
 ---
 
-import { Badge } from '@cmsgov/design-system';
-
-## Examples
-
-### Informational (Default)
-
-<ThemeContent onlyThemes={['healthcare']}>
-
-Provides supplementary information, or highlights a tool or step available to the user, that may be helpful to users regarding their current action or task, but is optional or not critical. Can provide guidance on what the user needs to do to proceed. Provides additional information, such as definitions, explanations, or criteria, that the user may find helpful as they answer questions with unfamiliar terminology or policy considerations.
-
-</ThemeContent>
-
-<ThemeContent onlyThemes={['medicare']}>
-
-Does not require an icon.
-
-Provides supplementary information, or highlights a tool or step available to the user, that may be helpful to users regarding their current action or task, but is optional or not critical. Can provide guidance on what the user needs to do to proceed.
-
-</ThemeContent>
+import { Accordion, AccordionItem, Badge } from '@cmsgov/design-system';
 
 <StorybookExample componentName="alert" storyId="components-alert--default" />
 
-### Error
-
-<ThemeContent onlyThemes={['healthcare']}>
-
-Informs users of an error or critical failure. Often used to block them from proceeding until they resolve the issue including system alerts.
-
-</ThemeContent>
-
-<ThemeContent onlyThemes={['medicare']}>
-
-Requires an icon.
-
-Informs users of an error or critical failure. Often used to block them from proceeding until they resolve the issue including system alerts.
-
-</ThemeContent>
-
-<StorybookExample componentName="error alert" storyId="components-alert--error" />
-
-### Warning
-
-<ThemeContent onlyThemes={['healthcare']}>
-
-Informs users that their entry or selection may have unexpected or undesirable results, some of which may not be easily undone. Highlights information a user should be aware of in order to help them avoid taking an action that is likely to result in a negative outcome or understand when content/data is missing from the page.
-
-</ThemeContent>
-
-<ThemeContent onlyThemes={['medicare']}>
-
-Requires an icon.
-
-Informs users that their entry or selection may have unexpected or undesirable results, some of which may not be easily undone.
-
-</ThemeContent>
-
-<StorybookExample componentName="warning alert" storyId="components-alert--warning" />
-
-### Success
-
-<ThemeContent onlyThemes={['healthcare']}>
-
-Confirms the successful completion of a step or task, or receipt of information provided by the user. Suggests a path forward that may be beneficial to the user, based on their selections or entries.
-
-</ThemeContent>
-
-<ThemeContent onlyThemes={['medicare']}>
-
-Does not require an icon.
-
-Confirms the successful completion of a step or task, or receipt of information provided by the user.
-
-</ThemeContent>
-
-<StorybookExample componentName="success alert" storyId="components-alert--success" />
-
-<ThemeContent onlyThemes={['medicare']}>
-
-### Note
-
-Not in the design system yet.
-
-Does not require an icon.
-
-Explains concepts which may include math or maybe not.
-
-</ThemeContent>
-
-### Lightweight
-
-<ThemeContent onlyThemes={['medicare']}>
-
-<Badge variation="alert">
-  <CloseIconThin /> Unused by Medicare.
-</Badge>
-
-</ThemeContent>
-
-<ThemeContent onlyThemes={['healthcare']}>
-
-Used to show important but not as urgent messages as standard alerts.
-
-</ThemeContent>
-
-<ThemeContent neverThemes={['medicare']}>
-
-<StorybookExample componentName="lightweight alert" storyId="components-alert--lightweight" />
-
-</ThemeContent>
-
-## Guidance
-
-### Usage
-
-- Don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
-- Write the message in concise, human readable language; avoid jargon and computer code.
-- Don’t include notifications that aren’t related to the user’s current goal.
-- When the user is required to do something in response to an alert, let them know what they need to do and make that task as easy as possible.
-- Be mindful of other elements on the page that may compete for the user’s attention.
+## How it works
 
 ### When to use
 
@@ -139,21 +25,30 @@ Used to show important but not as urgent messages as standard alerts.
 - Confirming the successful competition of a task.
 - Providing key supplementary or contextual information to support the successful completion of tasks or aid overall comprehension.
 
-<ThemeContent onlyThemes={['medicare']}>
-
-### Don't use
-
-- You need to display alerts that aren’t related to the user’s current goal.
-
-</ThemeContent>
-
 ### When to consider alternatives
 
 - On long forms, always include in-line validation in addition to any error messages that appear at the top of the form. When possible, simplify forms by rewriting and where possible, splitting long forms across multiple pages
 - If an action will result in destroying a user’s work (for example, deleting an application) use a more intrusive pattern, such as a confirmation modal dialogue, to allow the user to confirm that this is what they want.
 - When you need to display content that isn't related to the user’s current goal.
 
-**When the alert is for an error:**
+### Dos
+
+- Do write the message in concise, human readable language; avoid jargon and computer code.
+- Do let the user know what they need to do when they're required to do something in response to an alert and make that task as easy as possible.
+- Do be mindful of other elements on the page that may compete for the user’s attention.
+
+### Don'ts
+
+- Don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
+- Don’t include notifications that aren’t related to the user’s current goal.
+
+<ThemeContent onlyThemes={['medicare']}>
+
+- Don't display alerts that aren’t related to the user’s current goal.
+
+</ThemeContent>
+
+## For error alerts
 
 - Be polite in error messages — don’t place blame on the user.
 - Users generally won’t read documentation but will read a message that helps them resolve an error; include some educational material in your error message.
@@ -296,9 +191,113 @@ When using a screen reader (NVDA, JAWS, VoiceOver, TalkBack):
 
 </ThemeContent>
 
-## Learn more
+## Examples
 
-- [18F Content Guide \- Active voice](https://content-guide.18f.gov/active-voice/)
+### Informational (Default)
+
+<ThemeContent onlyThemes={['healthcare']}>
+
+Provides supplementary information, or highlights a tool or step available to the user, that may be helpful to users regarding their current action or task, but is optional or not critical. Can provide guidance on what the user needs to do to proceed. Provides additional information, such as definitions, explanations, or criteria, that the user may find helpful as they answer questions with unfamiliar terminology or policy considerations.
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['medicare']}>
+
+Does not require an icon.
+
+Provides supplementary information, or highlights a tool or step available to the user, that may be helpful to users regarding their current action or task, but is optional or not critical. Can provide guidance on what the user needs to do to proceed.
+
+</ThemeContent>
+
+<StorybookExample componentName="alert" storyId="components-alert--default" />
+
+### Error
+
+<ThemeContent onlyThemes={['healthcare']}>
+
+Informs users of an error or critical failure. Often used to block them from proceeding until they resolve the issue including system alerts.
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['medicare']}>
+
+Requires an icon.
+
+Informs users of an error or critical failure. Often used to block them from proceeding until they resolve the issue including system alerts.
+
+</ThemeContent>
+
+<StorybookExample componentName="error alert" storyId="components-alert--error" />
+
+### Warning
+
+<ThemeContent onlyThemes={['healthcare']}>
+
+Informs users that their entry or selection may have unexpected or undesirable results, some of which may not be easily undone. Highlights information a user should be aware of in order to help them avoid taking an action that is likely to result in a negative outcome or understand when content/data is missing from the page.
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['medicare']}>
+
+Requires an icon.
+
+Informs users that their entry or selection may have unexpected or undesirable results, some of which may not be easily undone.
+
+</ThemeContent>
+
+<StorybookExample componentName="warning alert" storyId="components-alert--warning" />
+
+### Success
+
+<ThemeContent onlyThemes={['healthcare']}>
+
+Confirms the successful completion of a step or task, or receipt of information provided by the user. Suggests a path forward that may be beneficial to the user, based on their selections or entries.
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['medicare']}>
+
+Does not require an icon.
+
+Confirms the successful completion of a step or task, or receipt of information provided by the user.
+
+</ThemeContent>
+
+<StorybookExample componentName="success alert" storyId="components-alert--success" />
+
+<ThemeContent onlyThemes={['medicare']}>
+
+### Note
+
+Not in the design system yet.
+
+Does not require an icon.
+
+Explains concepts which may include math or maybe not.
+
+</ThemeContent>
+
+### Lightweight
+
+<ThemeContent onlyThemes={['medicare']}>
+
+<Badge variation="alert">
+  <CloseIconThin /> Unused by Medicare.
+</Badge>
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['healthcare']}>
+
+Used to show important but not as urgent messages as standard alerts.
+
+</ThemeContent>
+
+<ThemeContent neverThemes={['medicare']}>
+
+<StorybookExample componentName="lightweight alert" storyId="components-alert--lightweight" />
+
+</ThemeContent>
 
 ## Component maturity
 
@@ -317,22 +316,28 @@ When using a screen reader (NVDA, JAWS, VoiceOver, TalkBack):
   tokensInSketch={true}
 />
 
-## Code
+## Learn more
 
-### React
+[18F Content Guide \- Active voice](https://content-guide.18f.gov/active-voice/)
+
+## Resources
+
+### Design
+
+Sketch symbol
+
+Figma component
+
+### Development
+
+This component has analytics tracking available. Please see our developer documentation about [using analytics in the design system](/getting-started/for-developers/#analytics).
 
 <SeeStorybookForGuidance storyId={'components-alert--docs'} />
 
-### Experimental Web Components
-
 <SeeStorybookForGuidance tech="wc" storyId={'web-components-alert--docs'} />
 
-### Style customization
-
-The following CSS variables can be overridden to customize Alert components:
-
-<ComponentThemeOptions componentname="alert" />
-
-### Analytics
-
-This component has analytics tracking available. Please see our developer documentation about [using analytics in the design system](/getting-started/for-developers/#analytics).
+<Accordion>
+  <AccordionItem heading="CSS variable overrides to customize this component">
+    <ComponentThemeOptions componentname="alert" />
+  </AccordionItem>
+</Accordion>

--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -13,7 +13,7 @@ medicare:
 
 import { Accordion, AccordionItem, Badge } from '@cmsgov/design-system';
 
-<StorybookExample componentName="alert" storyId="components-alert--default" />
+<StorybookExample componentName="alert" storyId="components-alert--default" hideFooter="true" />
 
 ## How it works
 

--- a/packages/docs/src/components/content/SeeStorybookForGuidance.tsx
+++ b/packages/docs/src/components/content/SeeStorybookForGuidance.tsx
@@ -25,10 +25,9 @@ const SeeStorybookForGuidance = ({
   tech = 'react',
 }: StorybookExampleFooterProps) => {
   return (
-    <p>
-      See <a href={makeStorybookUrl(storyId, theme, 'docs')}>Storybook</a> for{' '}
-      {tech === 'react' ? 'React' : 'Web Component'} guidance of this component.
-    </p>
+    <a href={makeStorybookUrl(storyId, theme, 'docs')}>
+      {tech === 'react' ? 'Preact/React' : 'Web component'} documentation for Storybook
+    </a>
   );
 };
 

--- a/packages/docs/src/components/content/SeeStorybookForGuidance.tsx
+++ b/packages/docs/src/components/content/SeeStorybookForGuidance.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withPrefix } from 'gatsby';
 import { makeStorybookUrl } from '../../helpers/urlUtils';
 
 // Create a link component that uses urlUtils to create the link
@@ -25,9 +26,17 @@ const SeeStorybookForGuidance = ({
   tech = 'react',
 }: StorybookExampleFooterProps) => {
   return (
-    <a href={makeStorybookUrl(storyId, theme, 'docs')}>
-      {tech === 'react' ? 'Preact/React' : 'Web component'} documentation for Storybook
-    </a>
+    <p>
+      <a href={makeStorybookUrl(storyId, theme, 'docs')} className="ds-u-display--flex">
+        <img
+          alt=""
+          src={withPrefix('/images/storybook-icon.png')}
+          className="ds-u-display--inline ds-u-margin-right--1"
+          style={{ height: '1.25em' }}
+        />{' '}
+        {tech === 'react' ? 'Preact/React' : 'Web component'} documentation for Storybook
+      </a>
+    </p>
   );
 };
 

--- a/packages/docs/src/components/content/StorybookExample.tsx
+++ b/packages/docs/src/components/content/StorybookExample.tsx
@@ -23,6 +23,7 @@ interface StorybookExampleProps {
    * Current theme
    */
   theme: string;
+  hideFooter?: boolean;
 }
 
 /**
@@ -32,7 +33,13 @@ interface StorybookExampleProps {
  * If you need to show responsiveness, use the `ResponsiveExample`.
  * If you don't need a story, but can use regular HTML or React components, use an Embedded example.
  */
-const StorybookExample = ({ theme, componentName, minHeight, storyId }: StorybookExampleProps) => {
+const StorybookExample = ({
+  theme,
+  componentName,
+  minHeight,
+  storyId,
+  hideFooter = false,
+}: StorybookExampleProps) => {
   const [iframeHeight, setiFrameHeight] = useState<number>(200);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const iframeRef = useRef<HTMLIFrameElement>();
@@ -109,7 +116,7 @@ const StorybookExample = ({ theme, componentName, minHeight, storyId }: Storyboo
           />
         </div>
       </section>
-      <StorybookExampleFooter storyId={storyId} theme={theme} />
+      <StorybookExampleFooter hidden={hideFooter} storyId={storyId} theme={theme} />
     </>
   );
 };

--- a/packages/docs/src/components/content/StorybookExampleFooter.tsx
+++ b/packages/docs/src/components/content/StorybookExampleFooter.tsx
@@ -13,15 +13,16 @@ interface StorybookExampleFooterProps {
    * Current theme
    */
   theme: string;
+  hidden?: boolean;
 }
 
 /**
  * Goes below storybook-based examples and allows people to click a link to go directly
  * to the story within Storybook.
  */
-const StorybookExampleFooter = ({ theme, storyId }: StorybookExampleFooterProps) => {
+const StorybookExampleFooter = ({ theme, storyId, hidden }: StorybookExampleFooterProps) => {
   return (
-    <div className="c-storybook-example-footer">
+    <div hidden={hidden} className="c-storybook-example-footer">
       <ExampleFooter
         sourceLink={
           <Button

--- a/packages/docs/src/components/layout/PageHeader.tsx
+++ b/packages/docs/src/components/layout/PageHeader.tsx
@@ -48,7 +48,7 @@ const PageHeader = ({ frontmatter = { title: '' }, theme }: PageHeaderProps) => 
           {storyId && (
             <a href={makeStorybookUrl(storyId, theme, 'docs')} className="c-page-header__link">
               <img
-                alt="Storybook logo"
+                alt=""
                 src={withPrefix('/images/storybook-icon.png')}
                 className="ds-u-display--inline c-page-header__icon"
               />
@@ -58,7 +58,7 @@ const PageHeader = ({ frontmatter = { title: '' }, theme }: PageHeaderProps) => 
           {sketchId && (
             <a href={makeSketchUrl(sketchId, theme)} className="c-page-header__link">
               <img
-                alt="Sketch logo"
+                alt=""
                 src={withPrefix('/images/sketch-icon.png')}
                 className="ds-u-display--inline c-page-header__icon"
               />


### PR DESCRIPTION
- Reorganizing content in Alert
- Update Storybook example component to allow for optional link footer (for the first visible example on the page)
- Create "Resources section"
- Update StorybookGuidance component to use different label and include Storybook image
- Remove alt text from all resource link images - these images are decorative, so having alt text isn't needed
- More...?