### PR TITLE
[NO TICKET] Create design resource link

### DIFF
--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -327,23 +327,7 @@ Used to show important but not as urgent messages as standard alerts.
 
 ### Design
 
-<ThemeContent neverThemes={['healthcare', 'medicare']}>
-
-<DesignResourceLink sketchId={'9P3rvwn'} />
-
-</ThemeContent>
-
-<ThemeContent onlyThemes={['healthcare']}>
-
-<DesignResourceLink sketchId={'nRKbw3z'} />
-
-</ThemeContent>
-
-<ThemeContent onlyThemes={['medicare']}>
-
-<DesignResourceLink sketchId={'1K9gg0y'} />
-
-</ThemeContent>
+<DesignResourceLink />
 
 ### Development
 

--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -324,7 +324,23 @@ Used to show important but not as urgent messages as standard alerts.
 
 ### Design
 
-Sketch symbol
+<ThemeContent neverThemes={['healthcare', 'medicare']}>
+
+<DesignResourceLink sketchId={'9P3rvwn'} />
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['healthcare']}>
+
+<DesignResourceLink sketchId={'nRKbw3z'} />
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['medicare']}>
+
+<DesignResourceLink sketchId={'1K9gg0y'} />
+
+</ThemeContent>
 
 ### Development
 

--- a/packages/docs/src/components/content/ContentRenderer.tsx
+++ b/packages/docs/src/components/content/ContentRenderer.tsx
@@ -20,6 +20,7 @@ import TextColorList from './TextColorList';
 import ThemeContent from './ThemeContent';
 import ReactDocsLinks from './ReactDocsLinks';
 import ReactDocsLink from './ReactDocsLink';
+import { FrontmatterInterface } from '../../helpers/graphQLTypes';
 
 // adds DS styling to tables from markdown
 const TableWithClassnames = (props) => {
@@ -67,14 +68,16 @@ const TextWithMaxWidth = (props: any, Component) => {
  * A mapping of custom components for mdx syntax
  * Each mapping has a key with the element name and a value of a functional component to be used for that element
  */
-const customComponents = (theme) => ({
+const customComponents = (frontmatter, theme) => ({
   ButtonMigrationTable: (props) => <ButtonMigrationTable theme={theme} {...props} />,
   ButtonVariationsTable: (props) => <ButtonVariationsTable theme={theme} {...props} />,
   code: CodeWithSyntaxHighlighting,
   ColorExampleList: (props) => <ColorExampleList theme={theme} {...props} />,
   ColorRamps,
   ComponentThemeOptions: (props) => <ComponentThemeOptions theme={theme} {...props} />,
-  DesignResourceLink: (props) => <DesignResourceLink theme={theme} {...props} />,
+  DesignResourceLink: (props) => (
+    <DesignResourceLink frontmatter={frontmatter} theme={theme} {...props} />
+  ),
   EmbeddedExample,
   MaturityChecklist,
   ol: (props) => TextWithMaxWidth(props, 'ol'),
@@ -98,6 +101,7 @@ interface ContentRendererProps {
    * Usually the `data.body.mdx` property from a `mdx` graphQL query
    */
   data: string;
+  frontmatter?: FrontmatterInterface;
   /**
    * Current theme
    */
@@ -108,9 +112,9 @@ interface ContentRendererProps {
  * ContentRenderer - a component to standardize the steps needed to display MDX content as page content
  * @see https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/#components for details
  */
-const ContentRenderer = ({ data, theme }: ContentRendererProps) => {
+const ContentRenderer = ({ data, frontmatter, theme }: ContentRendererProps) => {
   return (
-    <MDXProvider components={customComponents(theme)}>
+    <MDXProvider components={customComponents(frontmatter, theme)}>
       <MDXRenderer>{data}</MDXRenderer>
     </MDXProvider>
   );

--- a/packages/docs/src/components/content/ContentRenderer.tsx
+++ b/packages/docs/src/components/content/ContentRenderer.tsx
@@ -9,6 +9,7 @@ import ButtonVariationsTable from './ButtonVariationsTable';
 import ColorExampleList from './ColorExampleList';
 import ColorRamps from './ColorRamps';
 import ComponentThemeOptions from './ComponentThemeOptions';
+import DesignResourceLink from './DesignResourceLink';
 import EmbeddedExample from './EmbeddedExample';
 import MaturityChecklist from './MaturityChecklist';
 import ResponsiveExample from './ResponsiveExample';
@@ -73,6 +74,7 @@ const customComponents = (theme) => ({
   ColorExampleList: (props) => <ColorExampleList theme={theme} {...props} />,
   ColorRamps,
   ComponentThemeOptions: (props) => <ComponentThemeOptions theme={theme} {...props} />,
+  DesignResourceLink: (props) => <DesignResourceLink theme={theme} {...props} />,
   EmbeddedExample,
   MaturityChecklist,
   ol: (props) => TextWithMaxWidth(props, 'ol'),

--- a/packages/docs/src/components/content/DesignResourceLink.tsx
+++ b/packages/docs/src/components/content/DesignResourceLink.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { withPrefix } from 'gatsby';
+import { FrontmatterInterface } from '../../helpers/graphQLTypes';
 import { makeSketchUrl } from '../../helpers/urlUtils';
 
 interface DesignResourceLinkProps {
@@ -7,10 +8,13 @@ interface DesignResourceLinkProps {
    * Current theme name.
    */
   theme: string;
-  sketchId: string;
+  frontmatter: FrontmatterInterface;
 }
 
-const DesignResourceLink = ({ sketchId, theme }: DesignResourceLinkProps) => {
+const DesignResourceLink = ({ theme, frontmatter }: DesignResourceLinkProps) => {
+  const themeLinks = frontmatter[theme];
+  const sketchId = themeLinks?.sketchLink || null;
+
   return (
     <p>
       <a href={makeSketchUrl(sketchId, theme)} className="ds-u-display--flex">

--- a/packages/docs/src/components/content/DesignResourceLink.tsx
+++ b/packages/docs/src/components/content/DesignResourceLink.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { withPrefix } from 'gatsby';
+import { makeSketchUrl } from '../../helpers/urlUtils';
+
+interface DesignResourceLinkProps {
+  /**
+   * Current theme name.
+   */
+  theme: string;
+  sketchId: string;
+}
+
+const DesignResourceLink = ({ sketchId, theme }: DesignResourceLinkProps) => {
+  return (
+    <p>
+      <a href={makeSketchUrl(sketchId, theme)} className="ds-u-display--flex">
+        <img
+          alt=""
+          src={withPrefix('/images/sketch-icon.png')}
+          className="ds-u-display--inline ds-u-margin-right--1"
+          style={{ height: '1.25em' }}
+        />
+        Sketch symbol
+      </a>
+    </p>
+  );
+};
+
+export default DesignResourceLink;

--- a/packages/docs/src/components/content/SeeStorybookForGuidance.tsx
+++ b/packages/docs/src/components/content/SeeStorybookForGuidance.tsx
@@ -5,7 +5,7 @@ import { makeStorybookUrl } from '../../helpers/urlUtils';
 // Create a link component that uses urlUtils to create the link
 // to the storybook page for the component
 
-interface StorybookExampleFooterProps {
+interface SeeStorybookForGuidanceProps {
   /**
    * ID of the component's doc page in Storybook.
    */
@@ -24,7 +24,7 @@ const SeeStorybookForGuidance = ({
   theme,
   storyId,
   tech = 'react',
-}: StorybookExampleFooterProps) => {
+}: SeeStorybookForGuidanceProps) => {
   return (
     <p>
       <a href={makeStorybookUrl(storyId, theme, 'docs')} className="ds-u-display--flex">

--- a/packages/docs/src/components/page-templates/InfoPage.tsx
+++ b/packages/docs/src/components/page-templates/InfoPage.tsx
@@ -21,7 +21,7 @@ const InfoPage = ({ data, location }: MdxQuery) => {
       theme={theme}
       tableOfContentsData={tableOfContents?.items}
     >
-      <ContentRenderer data={body} theme={theme} />
+      <ContentRenderer frontmatter={frontmatter} data={body} theme={theme} />
     </Layout>
   );
 };


### PR DESCRIPTION
~This one annoyed me - couldn't get access to `frontmatter` and instead of continuing to bang my head into my keyboard, I hardcoded the Sketch links until I can come up with a better solution.~

Figured it out and I kinda hate it, but it works. 

I needed to pass an extra optional prop to the ContentRenderer because our InfoPage components only pass the `body` data through the ContentRenderer and frontmatter isn't accessible via this query. For a component within the InfoPage to access `frontmatter`, it also needed to be passed down to the ContentRenderer, but ContentRenderer's `data` prop wouldn't allow multiple values without reworking a bunch of TS (ugh). Simple solution was to create an optional `frontmatter` prop on ContentRenderer that allows this info to pass through. 
