### PR TITLE
[WNMGDS-2654] Fix scroll position on dialogs using the old API

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.stories.tsx
@@ -51,22 +51,21 @@ export const DialogExample: Story = {
           Click to show modal
         </Button>
 
-        {dialogOpen && (
-          <Dialog
-            {...args}
-            onExit={hideModal}
-            actions={
-              <>
-                <Button variation="solid" className="ds-u-margin-right--1">
-                  Dialog action
-                </Button>
-                <Button variation="ghost" onClick={hideModal}>
-                  Cancel
-                </Button>
-              </>
-            }
-          />
-        )}
+        <Dialog
+          {...args}
+          onExit={hideModal}
+          actions={
+            <>
+              <Button variation="solid" className="ds-u-margin-right--1">
+                Dialog action
+              </Button>
+              <Button variation="ghost" onClick={hideModal}>
+                Cancel
+              </Button>
+            </>
+          }
+          isOpen={dialogOpen}
+        />
       </>
     );
   },
@@ -97,7 +96,7 @@ export const PreventScrollExample: Story = {
           which shall consist of a Senate and House of Representatives.
         </p>
 
-        {dialogOpen && <Dialog {...args} onExit={hideModal} />}
+        <Dialog {...args} onExit={hideModal} isOpen={dialogOpen} />
         <Button onClick={showModal} size="big" variation="solid">
           Click to show modal
         </Button>

--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -120,7 +120,7 @@ export const Dialog = (props: DialogProps) => {
     containerRef.current?.focus();
   }, [containerRef]);
 
-  useBodyScrollPrevention(modalProps.isOpen);
+  useBodyScrollPrevention(modalProps.isOpen ?? true);
 
   return (
     <NativeDialog


### PR DESCRIPTION
## Summary

WNMGDS-2654

- Fixes a bug where omitting `isOpen` results in dialogs always opening at the top of the page regardless of your current scroll position

## How to test

1. Check out 07971b5, which uses the older API for the story (where the bug can be reproduced)
2. Follow the reproduction steps with the _Prevent Scroll Example_ story. You'll see the bug
3. Check out 4c85407 to see the bug fixed

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
