### PR TITLE
[WNMGDS-2630] Adjust sizing and padding for single input date field

### DIFF
--- a/packages/design-system/src/styles/components/_SingleInputDateField.scss
+++ b/packages/design-system/src/styles/components/_SingleInputDateField.scss
@@ -502,7 +502,8 @@
   }
 
   .ds-c-field {
-    max-width: 108px;
+    max-width: 12ch;
+    padding: 0.5em; // override the padding from the field component to use relative sizing
   }
 
   .ds-c-single-input-date-field__button {


### PR DESCRIPTION
WNMGDS-2630

- Update `max-width` from absolute pixel value to relative value. 
  - While this field technically accepts 10 characters (each date part + the slashes), I went for a value of `12ch` to account for the padding within the field
- Changed the padding from absolute pixel value to relative value (`8px` -> `.5em`). 
  - Because the padding is absolute, the relative width isn't respond to the correct size when a smaller font is selected (see video). Basically, the width is 12ch, but the internals of the field are 16px + 10ch and that conversion is hard for the width to account for. By making all units used within the field relative units, the width is more consistently calculated.
  - I opted for a local override in our datefield SCSS instead of modifying our `--text-field__padding` token. Updating the token, or the underlying `spacer-1` token, would have a more far reaching impact than I think we're ready for. But we should consider updating our spacer tokens at some point to address this issue for all our components (as I'm imagining our layouts aren't as flexible as they should be for small font users).


https://github.com/CMSgov/design-system/assets/5159392/5f153639-0da7-4777-acae-c84ed408fe46

