### PR TITLE
[NO-TICKET] Fix the visual regression in #2893

### DIFF
--- a/packages/design-system/src/components/ChoiceList/Choice.tsx
+++ b/packages/design-system/src/components/ChoiceList/Choice.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useState } from 'react';
 import EvEmitter from 'ev-emitter';
 import classNames from 'classnames';
 import useId from '../utilities/useId';
+import { InlineError } from '../InlineError';
 import { Label } from '../Label';
-import { UseInlineErrorProps, useInlineError } from '../InlineError/useInlineError';
+import { UseInlineErrorProps } from '../InlineError/useInlineError';
 import { UseLabelPropsProps, useLabelProps } from '../Label/useLabelProps';
 import { UseHintProps, useHint } from '../Hint/useHint';
 import cleanFieldProps from '../utilities/cleanFieldProps';
@@ -105,9 +106,19 @@ export const Choice = (props: ChoiceProps) => {
 
   const id = useId('choice--', props.id);
 
-  const { errorId, topError, bottomError } = useInlineError({ ...props, id });
   const { hintId, hintElement } = useHint({ ...props, id });
   const labelProps = useLabelProps({ ...props, id });
+
+  let errorId;
+  let errorElement;
+  if (props.errorMessage) {
+    errorId = props.errorId ?? `${props.id}__error`;
+    errorElement = (
+      <InlineError id={errorId} inversed={props.inversed} className={props.errorMessageClassName}>
+        {props.errorMessage}
+      </InlineError>
+    );
+  }
 
   // Subscribe to changes from other radio buttons in the same group
   useEffect(() => {
@@ -179,8 +190,7 @@ export const Choice = (props: ChoiceProps) => {
         />
         <Label {...labelProps} fieldId={id} />
         {hintElement}
-        {topError}
-        {bottomError}
+        {errorElement}
       </div>
       {checked ? checkedChildren : uncheckedChildren}
     </div>


### PR DESCRIPTION
## Summary

Fixes the visual regression in #2893 where `Choice` error messages saw a slight vertical shift when viewed in the healthcare theme. The HealthCare.gov Design System sets all field errors to bottom-placement by default. When I started using the `useInlineError` hook in the `Choice` component, it began applying a bottom-placement CSS class that was causing the shift. We separated these hooks out of the one giant `useFormLabel` hook for this very reason—so that we could mix and match which features we want to use in each component. I simply stopped using that hook, because we don't need its placement logic. We can just use the `InlineError` component directly for this simpler case.

## How to test

- I ran the full suite of visual regression tests
- You can use Storybook to make sure there's no vertical shift when compared to our deployed Storybook for v9

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone