### PR TITLE
[WNMGDS-2511] Update hgov footer html

### DIFF
--- a/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
@@ -39,7 +39,7 @@ export const Footer = (props: FooterProps) => {
   const classes = classnames('hc-c-footer', props.className);
 
   return (
-    <footer className={classes} role="contentinfo">
+    <footer className={classes} role="contentinfo" aria-label="global">
       {props.footerTop}
       <InlineLinkLists t={t} primaryDomain={props.primaryDomain} />
       <LogosRow t={t} />

--- a/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
@@ -39,7 +39,7 @@ export const Footer = (props: FooterProps) => {
   const classes = classnames('hc-c-footer', props.className);
 
   return (
-    <footer className={classes} role="contentinfo" aria-label="global">
+    <footer className={classes} role="contentinfo">
       {props.footerTop}
       <InlineLinkLists t={t} primaryDomain={props.primaryDomain} />
       <LogosRow t={t} />

--- a/packages/ds-healthcare-gov/src/components/Footer/InlineLinkLists.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/InlineLinkLists.tsx
@@ -55,9 +55,9 @@ const InlineLinkLists = function (props: InlineLinkListsProps) {
       </div>
 
       <div className="hc-c-footer__language-resource-links-row">
-        <h4 id="hc-c-footer__language-resources" className="ds-u-visibility--screen-reader">
+        <p id="hc-c-footer__language-resources" className="ds-u-visibility--screen-reader">
           Language resources
-        </h4>
+        </p>
         <ul
           role="list"
           aria-labelledby="hc-c-footer__language-resources"

--- a/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Footer renders basic footer 1`] = `
 <div>
   <footer
+    aria-label="global"
     class="hc-c-footer"
     role="contentinfo"
   >
@@ -470,12 +471,12 @@ exports[`Footer renders basic footer 1`] = `
       <div
         class="hc-c-footer__language-resource-links-row"
       >
-        <h4
+        <p
           class="ds-u-visibility--screen-reader"
           id="hc-c-footer__language-resources"
         >
           Language resources
-        </h4>
+        </p>
         <ul
           aria-labelledby="hc-c-footer__language-resources"
           class="hc-c-footer__list"
@@ -742,6 +743,7 @@ exports[`Footer renders basic footer 1`] = `
 exports[`Footer renders basic footer with props 1`] = `
 <div>
   <footer
+    aria-label="global"
     class="hc-c-footer ds-t-test-class"
     role="contentinfo"
   >
@@ -1209,12 +1211,12 @@ exports[`Footer renders basic footer with props 1`] = `
       <div
         class="hc-c-footer__language-resource-links-row"
       >
-        <h4
+        <p
           class="ds-u-visibility--screen-reader"
           id="hc-c-footer__language-resources"
         >
           Language resources
-        </h4>
+        </p>
         <ul
           aria-labelledby="hc-c-footer__language-resources"
           class="hc-c-footer__list"

--- a/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`Footer renders basic footer 1`] = `
 <div>
   <footer
-    aria-label="global"
     class="hc-c-footer"
     role="contentinfo"
   >
@@ -743,7 +742,6 @@ exports[`Footer renders basic footer 1`] = `
 exports[`Footer renders basic footer with props 1`] = `
 <div>
   <footer
-    aria-label="global"
     class="hc-c-footer ds-t-test-class"
     role="contentinfo"
   >

--- a/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/InlineLinkLists.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/InlineLinkLists.test.tsx.snap
@@ -466,12 +466,12 @@ exports[`InlineLinkLists renders lists of links 1`] = `
     <div
       class="hc-c-footer__language-resource-links-row"
     >
-      <h4
+      <p
         class="ds-u-visibility--screen-reader"
         id="hc-c-footer__language-resources"
       >
         Language resources
-      </h4>
+      </p>
       <ul
         aria-labelledby="hc-c-footer__language-resources"
         class="hc-c-footer__list"
@@ -1099,12 +1099,12 @@ exports[`InlineLinkLists renders lists of links with absolute URLs 1`] = `
     <div
       class="hc-c-footer__language-resource-links-row"
     >
-      <h4
+      <p
         class="ds-u-visibility--screen-reader"
         id="hc-c-footer__language-resources"
       >
         Language resources
-      </h4>
+      </p>
       <ul
         aria-labelledby="hc-c-footer__language-resources"
         class="hc-c-footer__list"


### PR DESCRIPTION
WNMGDS-2511

- Replace `h4` with `p` tag in hgov footer
    - Why? The current markup uses `h4` and it sometimes causes issues with the heading structure when `h2` or `h3` aren't used. This tag doesn't need to be a heading at all and only exists as a label for the list of language resources, so it's been replaced with a `p`
    - This needs to be an `aria-labelledby` to take advantage of browser translation features
- ~Add `aria-label="global"` to hgov footer~
    - ~This wasn't part of the original ticket, but hgov's footer should _probably_ have an `aria-label` to indicate it's the global footer for the site. I mirrored the same label used on hgov's header~
    - Footer doesn't need a label because it's the only element of its kind on a page ([source](https://adhoc.slack.com/archives/C049H6KSE6Q/p1707495223073149?thread_ts=1707492217.292529&cid=C049H6KSE6Q))