### PR TITLE
[WNMGDS-2669] Remove unique and redundant semantic variables for dialogs

### DIFF
--- a/packages/design-system-tokens/src/themes/cmsgov-component.ts
+++ b/packages/design-system-tokens/src/themes/cmsgov-component.ts
@@ -268,9 +268,9 @@ export const components: AnyTokenValues = {
   },
 
   'dialog': {
-    '__background-color':                         t.color['white'],
+    '__background-color':                         t.color['background'],
     '__padding':                                  t.spacer['4'],
-    '-overlay__background-color':                 t.color['background-dialog-mask'],
+    '-overlay__background-color':                 t.color['transparent-black-alpha50'],
     '-icon__size':                                '0.8125rem',
   },
 

--- a/packages/design-system-tokens/src/themes/cmsgov.ts
+++ b/packages/design-system-tokens/src/themes/cmsgov.ts
@@ -16,8 +16,6 @@ export const themeColors: ColorTokens = {
   'transparent-white-alpha25':  color['white-alpha25'],
   //
   'background':                 color['white-solid'],
-  'background-dialog':          color['white-solid'],
-  'background-dialog-mask':     color['black-alpha50'],
   'background-inverse':         color['deepsea-800'],
   //
   'base':                       color['granite-900'],

--- a/packages/design-system-tokens/src/themes/core-component.ts
+++ b/packages/design-system-tokens/src/themes/core-component.ts
@@ -268,9 +268,9 @@ export const components: AnyTokenValues = {
   },
 
   'dialog': {
-    '__background-color':                         t.color['white'],
+    '__background-color':                         t.color['background'],
     '__padding':                                  t.spacer['4'],
-    '-overlay__background-color':                 t.color['background-dialog-mask'],
+    '-overlay__background-color':                 t.color['transparent-black-alpha50'],
     '-icon__size':                                '0.8125rem',
   },
 

--- a/packages/design-system-tokens/src/themes/core.ts
+++ b/packages/design-system-tokens/src/themes/core.ts
@@ -16,8 +16,6 @@ export const themeColors: ColorTokens = {
   'transparent-white-alpha25':  color['white-alpha25'],
   //
   'background':                 color['white-solid'],
-  'background-dialog':          color['white-solid'],
-  'background-dialog-mask':     color['black-alpha50'],
   'background-inverse':         color['ocean-800'],
   //
   'base':                       color['granite-900'],

--- a/packages/design-system-tokens/src/themes/healthcare-component.ts
+++ b/packages/design-system-tokens/src/themes/healthcare-component.ts
@@ -270,9 +270,9 @@ export const components: AnyTokenValues = {
   },
 
   'dialog': {
-    '__background-color':                         t.color['white'],
+    '__background-color':                         t.color['background'],
     '__padding':                                  t.spacer['4'],
-    '-overlay__background-color':                 t.color['background-dialog-mask'],
+    '-overlay__background-color':                 t.color['transparent-black-alpha50'],
     '-icon__size':                                '0.8125rem',
   },
 

--- a/packages/design-system-tokens/src/themes/healthcare.ts
+++ b/packages/design-system-tokens/src/themes/healthcare.ts
@@ -16,8 +16,6 @@ export const themeColors: ColorTokens = {
   'transparent-white-alpha25':  color['white-alpha25'],
   //
   'background':                 color['white-solid'],
-  'background-dialog':          color['white-solid'],
-  'background-dialog-mask':     color['black-alpha50'],
   'background-inverse':         color['ocean-800'],
   //
   'base':                       color['granite-900'],

--- a/packages/design-system-tokens/src/themes/medicare-component.ts
+++ b/packages/design-system-tokens/src/themes/medicare-component.ts
@@ -281,9 +281,9 @@ export const components: AnyTokenValues = {
   },
   
   'dialog': {
-    '__background-color':                         t.color['white'],
+    '__background-color':                         t.color['background'],
     '__padding':                                  t.spacer['4'],
-    '-overlay__background-color':                 t.color['background-dialog-mask'],
+    '-overlay__background-color':                 t.color['transparent-black-alpha50'],
     '-icon__size':                                '1.375rem',
   },
   

--- a/packages/design-system-tokens/src/themes/medicare.ts
+++ b/packages/design-system-tokens/src/themes/medicare.ts
@@ -16,8 +16,6 @@ export const themeColors: ColorTokens = {
   'transparent-white-alpha25':  color['white-alpha25'],
   //
   'background':                 color['white-solid'],
-  'background-dialog':          color['white-solid'],
-  'background-dialog-mask':     color['black-alpha50'],
   'background-inverse':         color['teal-500'],
   //
   'base':                       color['granite-800'],

--- a/packages/design-system/src/styles/components/_SingleInputDateField.scss
+++ b/packages/design-system/src/styles/components/_SingleInputDateField.scss
@@ -461,7 +461,7 @@
   position: relative;
 
   .rdp {
-    background-color: var(--color-background-dialog);
+    background-color: var(--color-background);
     border: 1px solid var(--color-gray-dark);
     border-radius: 8px;
     box-shadow: 0 0 17px 0 var(--color-gray-light);

--- a/packages/docs/static/themes/cmsgov-theme.css
+++ b/packages/docs/static/themes/cmsgov-theme.css
@@ -381,8 +381,6 @@
 --color-transparent-white-alpha50: #ffffff80;
 --color-transparent-white-alpha25: #ffffff40;
 --color-background: #ffffff;
---color-background-dialog: #ffffff;
---color-background-dialog-mask: #00000080;
 --color-background-inverse: #07124d;
 --color-base: #262626;
 --color-base-inverse: #ffffff;

--- a/packages/docs/static/themes/core-theme.css
+++ b/packages/docs/static/themes/core-theme.css
@@ -381,8 +381,6 @@
 --color-transparent-white-alpha50: #ffffff80;
 --color-transparent-white-alpha25: #ffffff40;
 --color-background: #ffffff;
---color-background-dialog: #ffffff;
---color-background-dialog-mask: #00000080;
 --color-background-inverse: #00395e;
 --color-base: #262626;
 --color-base-inverse: #ffffff;

--- a/packages/docs/static/themes/healthcare-theme.css
+++ b/packages/docs/static/themes/healthcare-theme.css
@@ -384,8 +384,6 @@
 --color-transparent-white-alpha50: #ffffff80;
 --color-transparent-white-alpha25: #ffffff40;
 --color-background: #ffffff;
---color-background-dialog: #ffffff;
---color-background-dialog-mask: #00000080;
 --color-background-inverse: #00395e;
 --color-base: #262626;
 --color-base-inverse: #ffffff;

--- a/packages/docs/static/themes/medicare-theme.css
+++ b/packages/docs/static/themes/medicare-theme.css
@@ -212,6 +212,7 @@
 --choice-wrapper__gap: 1rem;
 --choice-wrapper__gap--small: 0.75rem;
 --datefield-separator__display: none;
+--datefield__padding: 1em;
 --day-picker-button__background-color--hover: #e8f0ef;
 --dialog__background-color: #ffffff;
 --dialog__padding: 32px;
@@ -390,8 +391,6 @@
 --color-transparent-white-alpha50: #ffffff80;
 --color-transparent-white-alpha25: #ffffff40;
 --color-background: #ffffff;
---color-background-dialog: #ffffff;
---color-background-dialog-mask: #00000080;
 --color-background-inverse: #146a5d;
 --color-base: #404040;
 --color-base-inverse: #ffffff;


### PR DESCRIPTION
## Summary

Removed `--color-background-dialog` and `--color-background-dialog-mask`. These aren't used by any other components, and arguably it's not a theme-level semantic variable. It's pretty specific to a component. It's conceivable that it could be used for multiple dialog-like components in the future, but it isn't right now, and it doesn't even differ across themes. It's just an unnecessary variable.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
