### PR TITLE
[WNMGDS-2350] Fix background color of docs vertical nav on hover

### DIFF
--- a/packages/docs/src/components/layout/SideNav/SideNav.tsx
+++ b/packages/docs/src/components/layout/SideNav/SideNav.tsx
@@ -106,9 +106,9 @@ const SideNav = ({ location }: SideNavProps) => {
       })}
     >
       <UsaBanner className="ds-u-display--block ds-u-md-display--none" />
-      <header className="c-navigation__header ds-u-md-display--block ds-u-md-display--none">
+      <header className="c-navigation__header ds-u-md-display--none">
         <Button
-          className="ds-u-md-display--none ds-u-padding-left--0 ds-u-padding-right--1"
+          className="ds-u-padding-left--0 ds-u-padding-right--1"
           variation="ghost"
           aria-expanded={isMobileNavOpen}
           aria-controls="c-navigation__menu"

--- a/packages/docs/src/styles/components/navigation.scss
+++ b/packages/docs/src/styles/components/navigation.scss
@@ -141,7 +141,6 @@
 .ds-c-vertical-nav__label {
   &:hover,
   :visited:hover {
-    // --vertical-nav-item__background-color--hover: var(--color-primary-lightest);
     --vertical-nav-item__background-color--hover: color-mix(
       in srgb,
       var(--color-primary-lightest),

--- a/packages/docs/src/styles/components/navigation.scss
+++ b/packages/docs/src/styles/components/navigation.scss
@@ -11,8 +11,13 @@
     gap: $spacer-2;
     padding: $spacer-2;
 
-    button {
+    > button {
       color: currentColor;
+
+      &:hover,
+      &:focus:hover {
+        color: currentColor;
+      }
     }
   }
 
@@ -133,42 +138,24 @@
   }
 }
 
+.ds-c-vertical-nav__label {
+  &:hover,
+  :visited:hover {
+    // --vertical-nav-item__background-color--hover: var(--color-primary-lightest);
+    --vertical-nav-item__background-color--hover: color-mix(
+      in srgb,
+      var(--color-primary-lightest),
+      transparent 50%
+    );
+  }
+}
+
 // Desktop
 @media (min-width: $media-width-md) {
   .c-navigation {
     // Set it to a fixed width that is wide enough for most links so that it
     // doesn't jump around when we open and close subsections.
     width: 17rem;
-
-    .c-navigation__header {
-      padding-block-end: $spacer-1;
-      padding-block-start: $spacer-4;
-    }
-
-    .c-navigation__link-list {
-      .ds-c-vertical-nav__label {
-        background-color: transparent;
-        text-align: start;
-
-        &:hover,
-        &:visited:hover {
-          position: relative;
-          z-index: 1;
-
-          &:before {
-            background-color: var(--vertical-nav-item__color--hover);
-            bottom: 0;
-            content: '';
-            filter: opacity(0.05);
-            left: 0;
-            position: absolute;
-            right: 0;
-            top: 0;
-            z-index: -1;
-          }
-        }
-      }
-    }
   }
 }
 


### PR DESCRIPTION
WNMGDS-2350

I thought we needed to refactor our vertical nav CSS due to how complex the docs site CSS overrides were, but I was wrong and the solution turned out to be much simpler 🎉 

- Removed clever CSS in favor of redefining vertical nav token in docs site
- Removed unnecessary util classes from docs header
- Fixed `:hover:focus` state of hamburger icon