### PR TITLE
[NO-TICKET] Make accordion SVG hidden to AT users

### DIFF
--- a/packages/design-system/src/components/Accordion/AccordionItem.test.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionItem.test.tsx
@@ -56,7 +56,7 @@ describe('AccordionItem', function () {
     renderAccordionItem({ heading: 'Foo' });
 
     const headingEl = screen.getByRole('heading');
-    expect(headingEl.textContent).toBe('FooOpen');
+    expect(headingEl.textContent).toBe('Foo');
   });
 
   it('renders an id automatically', () => {

--- a/packages/design-system/src/components/Accordion/AccordionItem.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionItem.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { AddIcon, RemoveIcon } from '../Icons';
 import classNames from 'classnames';
-import { t } from '../i18n';
 import useId from '../utilities/useId';
 
 export interface AccordionItemProps {
@@ -90,20 +89,10 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
   const CloseIconComponent = closeIconComponent;
   const OpenIconComponent = openIconComponent;
   const closeIcon = (
-    <CloseIconComponent
-      className="ds-c-accordion__button-icon"
-      title={t('accordion.close')}
-      ariaHidden={false}
-      id={`${contentId}__icon`}
-    />
+    <CloseIconComponent className="ds-c-accordion__button-icon" id={`${contentId}__icon`} />
   );
   const openIcon = (
-    <OpenIconComponent
-      className="ds-c-accordion__button-icon"
-      title={t('accordion.open')}
-      ariaHidden={false}
-      id={`${contentId}__icon`}
-    />
+    <OpenIconComponent className="ds-c-accordion__button-icon" id={`${contentId}__icon`} />
   );
 
   if (heading) {

--- a/packages/design-system/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/design-system/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -17,19 +17,12 @@ exports[`Accordion renders accordion 1`] = `
       >
         First amendment
         <svg
-          aria-hidden="false"
-          aria-labelledby="1__icon__title"
+          aria-hidden="true"
           class="ds-c-icon ds-c-icon--add ds-c-accordion__button-icon"
           id="1__icon"
-          role="img"
           viewBox="3 3 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="1__icon__title"
-          >
-            Open
-          </title>
           <path
             d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
           />
@@ -58,19 +51,12 @@ exports[`Accordion renders accordion 1`] = `
       >
         Second amendment
         <svg
-          aria-hidden="false"
-          aria-labelledby="2__icon__title"
+          aria-hidden="true"
           class="ds-c-icon ds-c-icon--add ds-c-accordion__button-icon"
           id="2__icon"
-          role="img"
           viewBox="3 3 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="2__icon__title"
-          >
-            Open
-          </title>
           <path
             d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
           />

--- a/packages/design-system/src/components/Accordion/__snapshots__/AccordionItem.test.tsx.snap
+++ b/packages/design-system/src/components/Accordion/__snapshots__/AccordionItem.test.tsx.snap
@@ -14,19 +14,12 @@ exports[`AccordionItem renders an accordion item 1`] = `
     >
       Heading for accordion item
       <svg
-        aria-hidden="false"
-        aria-labelledby="static-id__icon__title"
+        aria-hidden="true"
         class="ds-c-icon ds-c-icon--add ds-c-accordion__button-icon"
         id="static-id__icon"
-        role="img"
         viewBox="3 3 18 18"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="static-id__icon__title"
-        >
-          Open
-        </title>
         <path
           d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
         />

--- a/packages/design-system/src/components/locale/en.json
+++ b/packages/design-system/src/components/locale/en.json
@@ -1,8 +1,4 @@
 {
-  "accordion": {
-    "close": "Close",
-    "open": "Open"
-  },
   "alert": {
     "defaultLabel": "Notice",
     "error": "Alert",

--- a/packages/design-system/src/components/locale/es.json
+++ b/packages/design-system/src/components/locale/es.json
@@ -1,8 +1,4 @@
 {
-  "accordion": {
-    "close": "Cerrar",
-    "open": "Abrir"
-  },
   "alert": {
     "defaultLabel": "Aviso",
     "error": "Alerta",


### PR DESCRIPTION
Icons used in AccordionItem are decorative and the button uses `aria-expand` to announce if the button's open or not, so removing the SVG title and associated i18n text.