### PR TITLE
[WNMGDS-2673] Deprecate scrollableNotice prop

### DIFF
--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -5,6 +5,7 @@ import TableContext from './TableContext';
 import classNames from 'classnames';
 import debounce from '../utilities/debounce';
 import useId from '../utilities/useId';
+import { t } from '../i18n';
 
 /**
  * Determine if a ReactNode is a TableCaption
@@ -47,10 +48,9 @@ interface BaseTableProps {
    */
   scrollable?: boolean;
   /**
-   * Additional text or content to display when the horizontal scrollbar is visible to give the user notice of the scroll behavior.
-   * This prop will only be used when the `Table` `scrollable` prop is set and the table width is wider than the viewport.
+   * Sets the text that appears in the Alert that appears when the table becomes scrollable.
    */
-  scrollableNotice?: React.ReactNode;
+  scrollableNoticeText?: string;
   /**
    * A stackable variation of the table.
    * When `stackable` is set, `id` or `headers` prop is required in `Table`
@@ -87,16 +87,16 @@ export type TableProps = Omit<React.ComponentPropsWithoutRef<'table'>, OmitProps
  */
 export const Table = ({
   borderless,
+  children,
   className,
   compact,
+  id,
+  scrollable,
+  scrollableNoticeText,
   stackable,
   stackableBreakpoint,
   striped,
-  scrollable,
-  scrollableNotice,
   warningDisabled,
-  children,
-  id,
   ...tableProps
 }: TableProps) => {
   const [scrollActive, setScrollActive] = useState(false);
@@ -164,7 +164,13 @@ export const Table = ({
         return React.cloneElement(child, {
           _id: captionId,
           _scrollActive: scrollActive,
-          _scrollableNotice: scrollableNotice,
+          _scrollableNotice: (
+            <Alert className="ds-c-table__scroll-alert" role="status">
+              <p className="ds-c-alert__text">
+                {scrollableNoticeText ?? t('table.scrollableNoticeText')}
+              </p>
+            </Alert>
+          ),
         });
       }
     }
@@ -189,11 +195,6 @@ export const Table = ({
 };
 
 Table.defaultProps = {
-  scrollableNotice: (
-    <Alert className="ds-c-table__scroll-alert" role="status">
-      <p className="ds-c-alert__text">Scroll using arrow keys to see more</p>
-    </Alert>
-  ),
   stackableBreakpoint: 'sm',
 };
 

--- a/packages/design-system/src/components/locale/en.json
+++ b/packages/design-system/src/components/locale/en.json
@@ -128,6 +128,9 @@
   "spinner": {
     "ariaText": "Loading"
   },
+  "table": {
+    "scrollableNoticeText": "Scroll using arrow keys to see more"
+  },
   "thirdPartyExternalLink": {
     "dialogHeading": "You are leaving {{origin}}.",
     "dialogBody": "You're about to connect to a third-party site. Select CONTINUE to proceed or CANCEL to stay on this site.",

--- a/packages/design-system/src/components/locale/es.json
+++ b/packages/design-system/src/components/locale/es.json
@@ -128,6 +128,9 @@
   "spinner": {
     "ariaText": "Cargando"
   },
+  "table": {
+    "scrollableNoticeText": "Desplácese usando las teclas de flecha para ver más"
+  },
   "thirdPartyExternalLink": {
     "dialogHeading": "Está saliendo de {{origin}}.",
     "dialogBody": "Está a punto de conectarse a un sitio de terceros. Seleccione CONTINUAR para continuar o CANCELAR para permanecer en este sitio.",

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Table-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Table-Docs-prop-table-matches-snapshot-1.txt
@@ -25,9 +25,9 @@
     "-"
   ],
   [
-    "scrollableNotice",
-    "Additional text or content to display when the horizontal scrollbar is visible to give the user notice of the scroll behavior. This prop will only be used when the Table scrollable prop is set and the table width is wider than the viewport.\n\nReactNode",
-    "<Alert />"
+    "scrollableNoticeText",
+    "Sets the text that appears in the Alert that appears when the table becomes scrollable.\nstring",
+    "-"
   ],
   [
     "stackable",


### PR DESCRIPTION
WNMGDS-2673

The `defaultProps` for Table has an Alert component with specific text and CSS classes applied. Discussed with Patrick and it seems this was an over-optimization situation; Would be better to hard-code the styled Alert and provide a prop to overwrite the Alert text instead of the whole component.

Oh! Also, the default Alert wasn't translated and that needed to be done.

Todos:
- Need official Spanish translation for Alert
- Need guidance for how the Alert should appear on small breakpoints - is this pattern even useful/accessible as it references arrow keys?