### PR TITLE
[WNMGDS-2656] Make `case-it` a direct dependency

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -58,6 +58,7 @@
     "@types/react": "^18.2.6",
     "@types/react-dom": "^17.0.10",
     "@types/react-transition-group": "^4.4.5",
+    "case-it": "^1.0.1",
     "classnames": "^2.2.5",
     "date-fns": "^2.28.0",
     "ev-emitter": "^1.1.1",
@@ -71,7 +72,6 @@
     "react-transition-group": "^4.4.5"
   },
   "devDependencies": {
-    "case-it": "^1.0.1",
     "chalk": "^5.0.1",
     "globby": "^13.1.2",
     "inquirer": "^9.0.2",


### PR DESCRIPTION
## Summary

WNMGDS-2656

Make `case-it` a direct dependency. This dependency is actually a true dependency of our web components. If we don't move it, web component builds fail for downstream projects.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
