### PR TITLE
[WNMGDS- 2685] Privacy settings to no longer throw error when no cookie exists

### DIFF
--- a/packages/design-system/src/components/PrivacySettingsDialog/privacySettings.ts
+++ b/packages/design-system/src/components/PrivacySettingsDialog/privacySettings.ts
@@ -73,15 +73,14 @@ export function getPrivacySettings(): PrivacySettings {
   const cookieString = readCookie(COOKIE_KEY);
   if (!cookieString) {
     if (COOKIE_DOMAIN) {
-      // This is a domain where we should already have a cookie defined
-      throw new Error(
-        `Privacy settings error: ${COOKIE_KEY} is not set. Check to make sure your app has Tealium enabled.`
+      // This is a domain where we should already have a cookie defined, so let the
+      // developers know that Tealium isn't loaded.
+      console.error(
+        `Privacy settings error: ${COOKIE_KEY} cookie is not set. Check to make sure your app has Tealium enabled.`
       );
-    } else {
-      // This must be some kind of test or non-production environment, so just return
-      // some default settings.
-      return defaultSettings;
     }
+
+    return defaultSettings;
   }
 
   const pairs = cookieString.split('|');


### PR DESCRIPTION

## Summary

Don't actually throw errors when privacy settings cookie doesn't exist. Because our privacy settings dialogs can exist in non-production environments where Tealium may or may not be loaded, throwing an error can be unnecessarily disruptive. Developers should be able to pick up on logged console errors as well.

While we normally like to fail fast so issues can be discovered, there's evidence that suggests a possible race condition for Tealium loading and this component rendering among existing applications. Because this code has also recently been updated to never _set_ the cookie unless the user takes explicit action, returning default settings here does not run the risk of accidentally setting cookie values unnecessarily when Tealium hasn't finished loading.

## How to test

1. In an incognito window, visit [one of the privacy-settings-related stories](https://design.cms.gov/storybook/?path=/story/healthcare-privacysettingslink--default). It will throw an error and not render the component.
2. Because it is only supposed to show errors in domains that could possibly be production environments (`.gov` domains), the easiest way to test the changed logic locally is to alter the code. It's not a perfect test, but it might be good enough. Change the value of `COOKIE_DOMAIN` at the top of the `privacySettings` module to `"localhost"`, and then run storybook.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
