### PR TITLE
[WNMGDS-2675] Show accurate colors in theme-colors page

### DIFF
--- a/packages/docs/src/components/content/ColorExampleList.tsx
+++ b/packages/docs/src/components/content/ColorExampleList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ColorExampleRow from './ColorExampleRow';
 import { getThemeColorValue, ThemeName } from '../../helpers/themeTokens';
+import { clientOnly } from '../../helpers/clientOnly';
 
 interface ColorExampleListProps {
   /**
@@ -22,17 +23,18 @@ interface ColorExampleListProps {
  * items. Note that this does not show a special transparency background to
  * support semi-transparent colors like the `ColorRamps` component does.
  */
-const ColorExampleList = ({ colorNames, preface, theme }: ColorExampleListProps) => (
-  <div className="ds-u-measure--wide ds-u-margin-top--2">
-    {colorNames.map((name) => (
-      <ColorExampleRow
-        name={name}
-        displayName={`${preface}${name}`}
-        value={getThemeColorValue(theme as ThemeName, name)}
-        key={name}
-      />
-    ))}
-  </div>
-);
+const ColorExampleList = ({ colorNames, preface, theme }: ColorExampleListProps) =>
+  clientOnly(
+    <div className="ds-u-measure--wide ds-u-margin-top--2">
+      {colorNames.map((name) => (
+        <ColorExampleRow
+          name={name}
+          displayName={`${preface}${name}`}
+          value={getThemeColorValue(theme as ThemeName, name)}
+          key={name}
+        />
+      ))}
+    </div>
+  );
 
 export default ColorExampleList;

--- a/packages/docs/src/helpers/clientOnly.ts
+++ b/packages/docs/src/helpers/clientOnly.ts
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+export function clientOnly<T extends ReactNode>(node: T): T | null {
+  // If we're in a non-browser environment, assume it's an SSR build and return nothing.
+  // Source: https://www.gatsbyjs.com/docs/using-client-side-only-packages/
+  if (typeof window === 'undefined') {
+    return null;
+  } else {
+    return node;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2199,27 +2199,6 @@
   resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.5.4.tgz#1a89069978734e132fa4a59414ddb64e4b94fde7"
   integrity sha512-qnikpQgi30AS01aFlNQV6l8/qdZIcP76mp90ti+u4rucXHsn4afSKivQXApqxvrQG9+Ibv45STyvHizvxef/7A==
 
-"@cmsgov/design-system@9.0.1":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@cmsgov/design-system/-/design-system-9.0.1.tgz#3050c6bb5305138080e96742b08d4e4a15fdbabb"
-  integrity sha512-lQIqthiHYrPg2VEBECyQfB4m4YR2UjAT4SI26HdGcjw71ngNyiKqz7uraYKn+HGDCBWRZZ9emDeQMa2ix+TxbQ==
-  dependencies:
-    "@popperjs/core" "^2.4.4"
-    "@types/react" "^18.2.6"
-    "@types/react-dom" "^17.0.10"
-    "@types/react-transition-group" "^4.4.5"
-    classnames "^2.2.5"
-    date-fns "^2.28.0"
-    ev-emitter "^1.1.1"
-    focus-trap-react "^10.0.0"
-    lodash "^4.17.21"
-    preactement "1.8.5"
-    prop-types "^15.8.1"
-    react-aria "^3.27.0"
-    react-day-picker "8.0.5"
-    react-stately "^3.25.0"
-    react-transition-group "^4.4.5"
-
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2199,6 +2199,27 @@
   resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.5.4.tgz#1a89069978734e132fa4a59414ddb64e4b94fde7"
   integrity sha512-qnikpQgi30AS01aFlNQV6l8/qdZIcP76mp90ti+u4rucXHsn4afSKivQXApqxvrQG9+Ibv45STyvHizvxef/7A==
 
+"@cmsgov/design-system@9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@cmsgov/design-system/-/design-system-9.0.1.tgz#3050c6bb5305138080e96742b08d4e4a15fdbabb"
+  integrity sha512-lQIqthiHYrPg2VEBECyQfB4m4YR2UjAT4SI26HdGcjw71ngNyiKqz7uraYKn+HGDCBWRZZ9emDeQMa2ix+TxbQ==
+  dependencies:
+    "@popperjs/core" "^2.4.4"
+    "@types/react" "^18.2.6"
+    "@types/react-dom" "^17.0.10"
+    "@types/react-transition-group" "^4.4.5"
+    classnames "^2.2.5"
+    date-fns "^2.28.0"
+    ev-emitter "^1.1.1"
+    focus-trap-react "^10.0.0"
+    lodash "^4.17.21"
+    preactement "1.8.5"
+    prop-types "^15.8.1"
+    react-aria "^3.27.0"
+    react-day-picker "8.0.5"
+    react-stately "^3.25.0"
+    react-transition-group "^4.4.5"
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"


### PR DESCRIPTION

## Background

A while back, we identified an architectural problem that resulted in [bugs like this](https://github.com/CMSgov/design-system/pull/2752). The problem is that design-system theming introduces dynamic information into our statically-built site. We have one copy of each page, but each page can be viewed from the context of one of four design-system themes. Different themes show different content in some pages—different guidance, different descriptions, different examples, etc. Since we only build one HTML file for each page, we build as if we're viewing it in the _core_ theme, but the HTML spat out for the _core_ theme doesn't necessarily match 1-1 with the HTML for every other theme. When the client-side JavaScript loads, React renders the page with the actual current theme and then tries to reconcile with the static HTML loaded from our website host. That reconciliation process is called "rehydration". If there are differences that can't be reconciled, things go sideways, and we get weird visual bugs.

## Summary

This small change works around an issue in the theme-colors page where improper rehydration of the colors table results in the table displaying the correct text values but not the right colors. Rehydration of our dynamic, theme-specific content in the doc site is a much larger issue that won't be solved with a little JavaScript; however, we can work around this specific page's issue with a little JavaScript. We can opt-out of rehydration entirely by never "dehydrating" the component in the first place. In other words, we make it client-side-only.

## How to test

1. To see the problem in `main`, run `yarn build:docs` and then `yarn serve:docs` and visit...
    - http://localhost:9000/foundation/theme-colors/?theme=core
    - http://localhost:9000/foundation/theme-colors/?theme=cmsgov (will look like it has the same primary colors as core even though the text is correct)
2. To see it fixed, check out this branch, run `yarn build:docs` and then `yarn serve:docs` and visit...
    - http://localhost:9000/foundation/theme-colors/?theme=core
    - http://localhost:9000/foundation/theme-colors/?theme=cmsgov (will look like it has the same primary colors as core even though the text is correct)
    
## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
