### PR TITLE
[WNMGDS-2696] remove live region attrs from Pagination

### DIFF
--- a/packages/design-system/src/components/Pagination/Pagination.tsx
+++ b/packages/design-system/src/components/Pagination/Pagination.tsx
@@ -245,9 +245,7 @@ function Pagination({
 
   return (
     <nav className={classes} aria-labelledby="pagination-heading" {...rest}>
-      <span aria-live="polite" role="status" className="ds-u-visibility--screen-reader">
-        {headingElement}
-      </span>
+      <span className="ds-u-visibility--screen-reader">{headingElement}</span>
 
       <Button
         variation="ghost"

--- a/packages/design-system/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/design-system/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -46,9 +46,7 @@ exports[`Pagination should render component 1`] = `
     class="ds-c-pagination"
   >
     <span
-      aria-live="polite"
       class="ds-u-visibility--screen-reader"
-      role="status"
     >
       <h2
         id="pagination-heading"
@@ -153,9 +151,7 @@ exports[`Pagination with compact prop enabled should render compact variant 1`] 
     class="ds-c-pagination ds-c-pagination--compact"
   >
     <span
-      aria-live="polite"
       class="ds-u-visibility--screen-reader"
-      role="status"
     >
       <h2
         id="pagination-heading"


### PR DESCRIPTION
WNMGDS-2696

Remove live region attributes from Pagination; the component isn't dynamic (would trigger a page reload given it uses links to navigate to different urls) and is a `nav` element (users would understand interacting with it would result in a page change).

I think we added these attrs because Storybook's example _is_ dynamic.

[Link to the Slack discussion here](https://cmsgov.slack.com/archives/CHH0381RD/p1709914079761229).