### PR TITLE
[WNMGDS-2686] remove aria-labelledby from accordion; not needed

### DIFF
--- a/packages/design-system/src/components/Accordion/AccordionItem.test.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionItem.test.tsx
@@ -67,7 +67,6 @@ describe('AccordionItem', function () {
 
     expect(buttonEl).toHaveAttribute('aria-controls', contentEl.id);
     expect(buttonEl).toHaveAttribute('id');
-    expect(contentEl).toHaveAttribute('aria-labelledby', buttonEl.id);
     expect(contentEl).toHaveAttribute('id');
   });
 
@@ -79,7 +78,6 @@ describe('AccordionItem', function () {
 
     expect(buttonEl).toHaveAttribute('aria-controls', 'test-id');
     expect(buttonEl).toHaveAttribute('id', 'test-id__button');
-    expect(contentEl).toHaveAttribute('aria-labelledby', 'test-id__button');
     expect(contentEl).toHaveAttribute('id', 'test-id');
   });
 

--- a/packages/design-system/src/components/Accordion/AccordionItem.tsx
+++ b/packages/design-system/src/components/Accordion/AccordionItem.tsx
@@ -113,7 +113,6 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
         </HeadingTag>
         <div
           className={contentClasses}
-          aria-labelledby={buttonId}
           id={contentId}
           hidden={isControlled ? !isControlledOpen : !isOpen}
         >

--- a/packages/design-system/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/design-system/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`Accordion renders accordion 1`] = `
       </button>
     </h2>
     <div
-      aria-labelledby="1__button"
       class="ds-c-accordion__content"
       hidden=""
       id="1"
@@ -64,7 +63,6 @@ exports[`Accordion renders accordion 1`] = `
       </button>
     </h2>
     <div
-      aria-labelledby="2__button"
       class="ds-c-accordion__content"
       hidden=""
       id="2"

--- a/packages/design-system/src/components/Accordion/__snapshots__/AccordionItem.test.tsx.snap
+++ b/packages/design-system/src/components/Accordion/__snapshots__/AccordionItem.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`AccordionItem renders an accordion item 1`] = `
     </button>
   </h2>
   <div
-    aria-labelledby="static-id__button"
     class="ds-c-accordion__content"
     hidden=""
     id="static-id"


### PR DESCRIPTION
WNMGDS-2686

Remove `aria-labelledby` from AccordionItem. This attr is on a `div`, which has the default role of generic and generics cannot accept aria labels as part of the spec. This label is also just not needed. More details in [this Slack thread](https://cmsgov.slack.com/archives/CHH0381RD/p1708710668265149).