### PR TITLE
[NO-TICKET] Add a migration script for the old to new typography classes

### DIFF
--- a/packages/design-system/scripts/cmsds-migrate/configs/deprecated-semantic-typography-classes.mjs
+++ b/packages/design-system/scripts/cmsds-migrate/configs/deprecated-semantic-typography-classes.mjs
@@ -1,0 +1,87 @@
+
+const substitutions = [
+  ['display', '5xl'],
+  ['title', '4xl'],
+  ['h1', '3xl'],
+  ['h2', '2xl'],
+  ['h3', 'xl'],
+  ['h4', 'lg'],
+  ['h5', 'md'],
+  ['h6', 'sm'],
+  ['lead', 'md'],
+  ['small', 'sm'],
+];
+
+export default {
+  description:
+    "Replaces older, semantic typography classes with their newer class equivalent. See https://design.cms.gov/migration-guides/agnostic-typography-classes/ for more details.",
+  patterns: ['**/*'],
+  globbyConfig: {
+    ignore: ['**/cmsds-migrate/**/*'],
+  },
+  expressions: [
+    {
+      from: /ds-display/gi,
+      to: 'ds-text-heading--5xl',
+    },
+    {
+      from: /ds-title/gi,
+      to: 'ds-text-heading--4xl',
+    },
+    {
+      from: /ds-h1/gi,
+      to: 'ds-text-heading--3xl',
+    },
+    {
+      from: /ds-h2/gi,
+      to: 'ds-text-heading--2xl',
+    },
+    {
+      from: /ds-h3/gi,
+      to: 'ds-text-heading--xl',
+    },
+    {
+      from: /ds-h4/gi,
+      to: 'ds-text-heading--lg',
+    },
+    {
+      from: /ds-h5/gi,
+      to: 'ds-text-heading--md',
+    },
+    {
+      from: /ds-h6/gi,
+      to: 'ds-text-heading--sm',
+    },
+    {
+      from: /ds-text--lead/gi,
+      to: 'ds-text-body--lg',
+    },
+    {
+      // Only match when "ds-text" is the entire class name
+      from: /ds-text([^-])/gi,
+      to: 'ds-text-body--md$1',
+    },
+    // Font size utilities
+    ...substitutions.map(([from, to]) => ({
+      from: new RegExp(`ds-u-font-size--${from}`, 'gi'),
+      to: `ds-u-font-size--${to}`,
+    })),
+    // Responsive font size utilities
+    ...substitutions.map(([from, to]) => ({
+      from: new RegExp(`ds-u-sm-font-size--${from}`, 'gi'),
+      to: `ds-u-sm-font-size--${to}`,
+    })),
+    ...substitutions.map(([from, to]) => ({
+      from: new RegExp(`ds-u-md-font-size--${from}`, 'gi'),
+      to: `ds-u-md-font-size--${to}`,
+    })),
+    ...substitutions.map(([from, to]) => ({
+      from: new RegExp(`ds-u-lg-font-size--${from}`, 'gi'),
+      to: `ds-u-lg-font-size--${to}`,
+    })),
+    ...substitutions.map(([from, to]) => ({
+      from: new RegExp(`ds-u-xl-font-size--${from}`, 'gi'),
+      to: `ds-u-xl-font-size--${to}`,
+    })),
+  ],
+};


### PR DESCRIPTION
## Summary

A long, long time ago, we replaced typography classes tied to semantic heading levels with class names that were independent of heading levels. Later on, we added [a migration guide](https://design.cms.gov/migration-guides/agnostic-typography-classes/) to help folks make the change in their code. We still found they were in use, so in #2801 we finally officially deprecated them now that we have a method of warning people of deprecated CSS. In #2982, we removed the deprecated classes, but I'm not convinced we won't leave some stragglers behind. Therefore, I've added a migration script people can run to update their classes once and for all.

## How to test

1. Add one of the old classes somewhere in the core package
2. Run `yarn cmsds-migrate` from the core package root and select the option about typography classes
3. It should update the files that reference those old classes

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
