### PR TITLE
[NO-TICKET] Make new example package private

### DIFF
--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -1,7 +1,8 @@
 {
   "name": "astro-example",
   "type": "module",
-  "version": "0.0.1",
+  "version": "9.0.2",
+  "private": true,
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/examples/preact-app/package.json
+++ b/examples/preact-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preact-app-example",
-  "version": "1.0.0",
+  "version": "9.0.2",
   "private": true,
   "dependencies": {
     "@cmsgov/design-system": "9.0.2",

--- a/examples/preact-react-app/package.json
+++ b/examples/preact-react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preact-react-app-example",
-  "version": "1.0.0",
+  "version": "9.0.2",
   "private": true,
   "dependencies": {
     "@cmsgov/design-system": "9.0.2",

--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-app-example",
-  "version": "1.0.0",
+  "version": "9.0.2",
   "private": true,
   "dependencies": {
     "@cmsgov/design-system": "9.0.2",


### PR DESCRIPTION
## Summary

- Make the new example package private so it doesn't mess up the release
- Make all the example version numbers match core to make things simpler