### PR TITLE
[NO-TICKET] Fix release script not bumping versions in private packages

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -56,7 +56,7 @@ async function undoLastCommit() {
 async function bumpVersions() {
   console.log(c.green('Bumping package versions for release...'));
   const preBumpHash = getCurrentCommit();
-  shI('./node_modules/.bin/lerna', ['version', '--no-push', '--no-private', '--exact']);
+  shI('./node_modules/.bin/lerna', ['version', '--no-push', '--exact']);
   const postBumpHash = getCurrentCommit();
 
   if (preBumpHash === postBumpHash) {


### PR DESCRIPTION
## Summary

This recent lerna config change was incorrect, so revert it. If we ignore all private packages during the bump, we're actually failing to bump the version of the design system packages in the dependencies for those private packages, which means that the doc site won't get the new version of the design system, and neither will the examples. I guess the tradeoff is that we have to choose an option for those private packages while we're going through the bump workflow.