### PR TITLE
[NO-TICKET] Fix release tagging with private packages

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -20,7 +20,7 @@ function readLastPublishCommit() {
   const commitMessage = sh('git log -1 --pretty=%B');
   // Only make tags for the actual design system packages
   const tags = commitMessage.match(/@cmsgov\/(?:design-system@|ds-).*$/gm);
-  console.log(tags);
+
   if (!tags) {
     throw Error('The previous commit was not a publish commit. Cannot read tags!');
   }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -18,8 +18,9 @@ function getCurrentBranch() {
 function readLastPublishCommit() {
   const commitHash = getCurrentCommit();
   const commitMessage = sh('git log -1 --pretty=%B');
-  const tags = commitMessage.match(/@.*$/gm);
-
+  // Only make tags for the actual design system packages
+  const tags = commitMessage.match(/@cmsgov\/(?:design-system@|ds-).*$/gm);
+  console.log(tags);
   if (!tags) {
     throw Error('The previous commit was not a publish commit. Cannot read tags!');
   }


### PR DESCRIPTION
## Summary

https://github.com/CMSgov/design-system/pull/2987 fixed one problem but created another 😅. Including the private packages in the bump also included them in Lerna's publish commit message, like so:

```
    Publish
    
     - astro-example@10.0.0-beta.1
     - preact-app-example@10.0.0-beta.1
     - preact-react-app-example@10.0.0-beta.1
     - react-app-example@10.0.0-beta.1
     - @cmsgov/design-system@10.0.0-beta.1
     - @cmsgov/cms-design-system-docs@10.0.0-beta.1
     - @cmsgov/ds-cms-gov@10.0.0-beta.1
     - @cmsgov/ds-healthcare-gov@14.0.0-beta.1
     - @cmsgov/ds-medicare-gov@12.0.0-beta.1
```

Our release script parsed this message to get the git tags to create, but it didn't take into account package names that don't start with `@cmsgov`.

Along with fixing the regex pattern so it doesn't break the release script, I made it only match the four design system packages so we reduce the tag noise. This really only removes our private docs package from the tags, but I think that's an improvement.

Note that our Jenkins script appears to already be smart enough to ignore the new package names and just pay attention to the packages we want to publish.

## How to test

1. `yarn release`, selecting the alpha option when bumping (because it is easy and obviously not a real tag) and saying "no" when it asks you if you want to create a bump PR and create notes
2. Check [tags on GitHub](https://github.com/CMSgov/design-system/tags) to make sure the four tags were created
3. `yarn release --undo`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone