### PR TITLE
[NO-TICKET] Fix headings on blog posts not getting any heading styles

### DIFF
--- a/packages/docs/src/components/layout/Layout.tsx
+++ b/packages/docs/src/components/layout/Layout.tsx
@@ -23,7 +23,7 @@ interface LayoutProps {
   /**
    * The elements to appear in the main page content, below the page heading
    */
-  children: React.ReactElement;
+  children: React.ReactNode;
   /**
    * page metadata
    */

--- a/packages/docs/src/components/page-templates/BlogPage.tsx
+++ b/packages/docs/src/components/page-templates/BlogPage.tsx
@@ -38,11 +38,9 @@ const BlogPage = ({ data, location }: MdxQuery) => {
         </header>
       }
     >
-      <div>
-        <ContentRenderer data={body} theme={theme} />
-        <PageFeedback />
-        <div className="ds-u-margin-top--4">{backLink}</div>
-      </div>
+      <ContentRenderer data={body} theme={theme} />
+      <PageFeedback />
+      <div className="ds-u-margin-top--4">{backLink}</div>
     </Layout>
   );
 };


### PR DESCRIPTION
## Summary

Fix headings on blog posts not getting any heading styles

### Before

<img width="712" alt="Screenshot 2024-03-28 at 1 44 29 PM" src="https://github.com/CMSgov/design-system/assets/7595652/fe1e5865-8c37-4298-bab7-0b68aa0f1c09">

### After

<img width="716" alt="Screenshot 2024-03-28 at 1 44 22 PM" src="https://github.com/CMSgov/design-system/assets/7595652/44a965a5-fcc7-4c6f-b04e-c48b994986c0">

## How to test

1. Run the doc site locally and look at one of the blog posts

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
