### PR TITLE
[NO-TICKET] Fix changing themes in web component stories

### DIFF
--- a/packages/design-system/src/components/web-components/ds-alert/ds-alert.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-alert/ds-alert.stories.tsx
@@ -1,4 +1,5 @@
 import WebComponentDocTemplate from '../../../../../../.storybook/docs/WebComponentDocTemplate.mdx';
+import { webComponentDecorator } from '../storybook';
 import './ds-alert';
 
 export default {
@@ -50,10 +51,11 @@ export default {
       },
     },
   },
+  decorators: [webComponentDecorator],
 };
 
 const Template = (args) => (
-  <ds-alert {...args} key={JSON.stringify(args)}>
+  <ds-alert {...args}>
     {args.children ?? (
       <>
         This is an example of a success alert. If you want to see an error alert, click the button

--- a/packages/design-system/src/components/web-components/ds-badge/ds-badge.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-badge/ds-badge.stories.tsx
@@ -1,4 +1,5 @@
 import WebComponentDocTemplate from '../../../../../../.storybook/docs/WebComponentDocTemplate.mdx';
+import { webComponentDecorator } from '../storybook';
 import './ds-badge';
 
 export default {
@@ -34,12 +35,11 @@ export default {
       underlyingHtmlElements: ['span'],
     },
   },
+  decorators: [webComponentDecorator],
 };
 
 const Template = (args) => (
-  <ds-badge {...args} key={JSON.stringify(args)}>
-    {args.children ?? <>Default badge text</>}
-  </ds-badge>
+  <ds-badge {...args}>{args.children ?? <>Default badge text</>}</ds-badge>
 );
 
 export const Default = Template.bind({});

--- a/packages/design-system/src/components/web-components/ds-button/ds-button.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-button/ds-button.stories.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import WebComponentDocTemplate from '../../../../../../.storybook/docs/WebComponentDocTemplate.mdx';
 import { action } from '@storybook/addon-actions';
 import './ds-button';
+import { webComponentDecorator } from '../storybook';
 
 export default {
   title: 'Web Components/Button',
@@ -36,6 +37,7 @@ export default {
       underlyingHtmlElements: ['a', 'button'],
     },
   },
+  decorators: [webComponentDecorator],
 };
 
 const Template = (args) => {
@@ -49,11 +51,7 @@ const Template = (args) => {
       button.removeEventListener('ds-click', onClick);
     };
   });
-  return (
-    <ds-button {...args} key={JSON.stringify(args)}>
-      {args.children ?? <>Your button text is here</>}
-    </ds-button>
-  );
+  return <ds-button {...args}>{args.children ?? <>Your button text is here</>}</ds-button>;
 };
 
 export const Default = Template.bind({});

--- a/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.stories.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import WebComponentDocTemplate from '../../../../../../.storybook/docs/WebComponentDocTemplate.mdx';
 import { action } from '@storybook/addon-actions';
 import './ds-dropdown';
+import { webComponentDecorator } from '../storybook';
 
 const options = [
   { label: 'Confederated Tribes and Bands of the Yakama Nation', value: '1' },
@@ -108,6 +109,7 @@ export default {
       underlyingHtmlElements: ['button'],
     },
   },
+  decorators: [webComponentDecorator],
 };
 
 const Template = (args) => {
@@ -127,7 +129,7 @@ const Template = (args) => {
     };
   });
 
-  return <ds-dropdown {...args} key={JSON.stringify(args)} />;
+  return <ds-dropdown {...args} />;
 };
 
 export const Default = Template.bind({});

--- a/packages/design-system/src/components/web-components/ds-usa-banner/ds-usa-banner.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-usa-banner/ds-usa-banner.stories.tsx
@@ -1,4 +1,5 @@
 import WebComponentDocTemplate from '../../../../../../.storybook/docs/WebComponentDocTemplate.mdx';
+import { webComponentDecorator } from '../storybook';
 import './ds-usa-banner';
 
 export default {
@@ -18,8 +19,9 @@ export default {
       },
     },
   },
+  decorators: [webComponentDecorator],
 };
 
-const Template = (args) => <ds-usa-banner {...args} key={JSON.stringify(args)} />;
+const Template = (args) => <ds-usa-banner {...args} />;
 
 export const Default = Template.bind({});

--- a/packages/design-system/src/components/web-components/storybook.tsx
+++ b/packages/design-system/src/components/web-components/storybook.tsx
@@ -1,0 +1,9 @@
+import { Fragment } from 'react';
+
+export function webComponentDecorator(Story, context) {
+  return (
+    <Fragment key={JSON.stringify({ ...context.args, ...context.globals })}>
+      <Story />
+    </Fragment>
+  );
+}


### PR DESCRIPTION
## Summary

In order for updates made to web components by React to correctly re-render the component, we've had to force React to re-render the component whenever the args change by adding a `key` prop. This is unnecessary boilerplate code for each story, and we want to also expand the functionality to take into account changes to global Storybook variables like our theme variable, so I've codified it into a Storybook _decorator_ that can be reused in each web-component Story.

What doesn't seem to work is changing language. I haven't figured out why.

## How to test

Play with the web component stories and change props and themes.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone