### PR TITLE
[WNMGDS-2745] Fix dialogs inheriting font size from ancestors

### DIFF
--- a/packages/design-system/src/styles/components/_Dialog.scss
+++ b/packages/design-system/src/styles/components/_Dialog.scss
@@ -54,6 +54,10 @@ dialog.fixed {
   box-sizing: border-box;
   color: var(--color-base); // Needed to override user-agent styles `canvasText`
   display: block;
+  font-size: var(
+    --font-size-base
+  ); // Reset so font size of ancestor elements don't affect the dialog
+
   margin: auto;
   margin-block-start: $spacer-6;
   max-width: var(--measure-base);

--- a/packages/design-system/src/styles/components/_Dialog.scss
+++ b/packages/design-system/src/styles/components/_Dialog.scss
@@ -54,10 +54,9 @@ dialog.fixed {
   box-sizing: border-box;
   color: var(--color-base); // Needed to override user-agent styles `canvasText`
   display: block;
-  font-size: var(
-    --font-size-base
-  ); // Reset so font size of ancestor elements don't affect the dialog
 
+  // Reset so font size of ancestor elements don't affect the dialog
+  font-size: var(--font-size-base);
   margin: auto;
   margin-block-start: $spacer-6;
   max-width: var(--measure-base);

--- a/packages/design-system/src/styles/components/_Drawer.scss
+++ b/packages/design-system/src/styles/components/_Drawer.scss
@@ -33,6 +33,9 @@
   background: var(--drawer__background-color);
   border: 0;
   box-shadow: -2px 0 0 var(--drawer__border-color);
+
+  // Reset so font size of ancestor elements don't affect the dialog
+  font-size: var(--font-size-base);
   height: 100%;
   inset: 0 0 0 auto;
   margin: 0;


### PR DESCRIPTION
## Summary

Protect a dialog's width and font size from inheriting from ancestors. Fix drawers too, which had the same problem.

## How to test

1. Open up a story with a dialog
2. Manually set the font size of the story div (dialog's ancestor) to have a really large or really small font size
3. Without this fix, the dialog will grow really wide or really narrow and the internal font sizes will be affected. With this fix, those two things should remain unaffected.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
