### PR TITLE
[WNMGDS-2759] Refactor local preactement code

### DIFF
--- a/packages/design-system/src/components/web-components/preactement/define.ts
+++ b/packages/design-system/src/components/web-components/preactement/define.ts
@@ -13,12 +13,19 @@ import { parseHtml } from './parse';
 import { IOptions, ComponentFunction } from './model';
 import { kebabCaseIt } from 'case-it/kebab';
 
-/* -----------------------------------
+/**
+ * Registers the provided Preact component as a custom element in the browser. It can
+ * also generate a custom element with props ready for hydration if run on the server.
  *
- * Define
+ * @param tagName - a valid custom element name (must include at least one hyphen)
+ * @param componentFunction - Function that returns the Preact component factory used to
+ * render this custom element to the DOM. Can be async for dynamic imports. For example,
+ * a valid value could be `() => Alert`, where `Alert` is a Preact component.
+ * @param options - additional information used to create the custom component out of a
+ * Preact component. (See type definition for details.)
  *
- * -------------------------------- */
-
+ * @returns undefined or an SSR component (if executed in a non-browser environment)
+ */
 function define<P = {}>(
   tagName: string,
   componentFunction: ComponentFunction<P>,

--- a/packages/design-system/src/components/web-components/preactement/define.ts
+++ b/packages/design-system/src/components/web-components/preactement/define.ts
@@ -26,7 +26,7 @@ import { kebabCaseIt } from 'case-it/kebab';
  *
  * @returns undefined or an SSR component (if executed in a non-browser environment)
  */
-function define<P = {}>(
+export function define<P = {}>(
   tagName: string,
   componentFunction: ComponentFunction<P>,
   options: IOptions = {}
@@ -288,11 +288,3 @@ function renderPreactComponent(this: CustomElement) {
 
   render(h(this.__component, props), this);
 }
-
-/* -----------------------------------
- *
- * Export
- *
- * -------------------------------- */
-
-export { define };

--- a/packages/design-system/src/components/web-components/preactement/define.ts
+++ b/packages/design-system/src/components/web-components/preactement/define.ts
@@ -90,23 +90,8 @@ function createCustomElement<T>(
       onDisconnected.call(this);
     }
 
-    /**
-     * Uses Preact to render the component to this element, using props derived from the
-     * current value of `this.__properties` and `this.__children`.
-     */
     public renderPreactComponent() {
-      if (!this.__component) {
-        console.error(ErrorTypes.Missing, `: <${this.tagName.toLowerCase()}>`);
-        return;
-      }
-
-      const props = {
-        ...this.__properties,
-        parent: this,
-        children: this.__children,
-      };
-
-      render(h(this.__component, props), this);
+      renderPreactComponent.call(this);
     }
   }
 
@@ -267,6 +252,25 @@ function onAttributeChange(this: CustomElement, name: string, original: string, 
  */
 function onDisconnected(this: CustomElement) {
   render(null, this);
+}
+
+/**
+ * Render the Preact component to this element, using props derived from the current
+ * value of `this.__properties` and `this.__children`.
+ */
+function renderPreactComponent(this: CustomElement) {
+  if (!this.__component) {
+    console.error(ErrorTypes.Missing, `: <${this.tagName.toLowerCase()}>`);
+    return;
+  }
+
+  const props = {
+    ...this.__properties,
+    parent: this,
+    children: this.__children,
+  };
+
+  render(h(this.__component, props), this);
 }
 
 /* -----------------------------------

--- a/packages/design-system/src/components/web-components/preactement/shared/element.ts
+++ b/packages/design-system/src/components/web-components/preactement/shared/element.ts
@@ -1,5 +1,5 @@
 import { getAttributeProps } from './parse';
-import { IComponent, CustomElement } from './model';
+import { IComponent, CustomElement, ErrorTypes } from './model';
 
 /* -----------------------------------
  *
@@ -40,8 +40,11 @@ function getComponentResult(response: IComponent, tagName: string) {
 function getElementTag(tagName: string) {
   let result = tagName.toLowerCase();
 
-  if (result.indexOf('-') < 0) {
-    result = 'component-' + result;
+  if (!result.includes('-')) {
+    throw new Error(
+      `${ErrorTypes.Tag} : <${tagName}>` +
+        '\n\nhttps://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names\n'
+    );
   }
 
   return result;

--- a/packages/design-system/src/components/web-components/preactement/shared/model.ts
+++ b/packages/design-system/src/components/web-components/preactement/shared/model.ts
@@ -46,6 +46,8 @@ interface CustomElement<CF = any, C = any> extends HTMLElement {
   __slots?: { [index: string]: any };
   __children?: any;
   __options: IOptions;
+
+  renderPreactComponent(): void;
 }
 
 /* -----------------------------------

--- a/packages/design-system/src/components/web-components/preactement/shared/model.ts
+++ b/packages/design-system/src/components/web-components/preactement/shared/model.ts
@@ -37,13 +37,13 @@ enum ErrorTypes {
  *
  * -------------------------------- */
 
-interface CustomElement<C = any, I = any> extends HTMLElement {
+interface CustomElement<CF = any, C = any> extends HTMLElement {
   __mounted: boolean;
-  __component: C;
+  __componentFunction: CF;
+  __component?: C;
   __properties?: IProps;
   __events?: IProps;
   __slots?: { [index: string]: any };
-  __instance?: I;
   __children?: any;
   __options: IOptions;
 }

--- a/packages/design-system/src/components/web-components/preactement/shared/model.ts
+++ b/packages/design-system/src/components/web-components/preactement/shared/model.ts
@@ -29,6 +29,7 @@ enum ErrorTypes {
   Promise = 'Error: Promises cannot be used for SSR',
   Missing = 'Error: Cannot find component in provided function',
   Json = 'Error: Invalid JSON string passed to component',
+  Tag = 'Error: Invalid tag name for custom element. Must include a `-`',
 }
 
 /* -----------------------------------


### PR DESCRIPTION
## Summary

Refactors local preactement code for clarity, readability, and conciseness. My intention was to make no functional changes except that it now throws an error if you give it an invalid custom element name. The next step will be to make actual changes to hopefully fix the odd behavior when nesting custom elements.

- Renames several functions to be clearer about what they do
- Consolidates and separates some functions
- Adds documentation comments to all functions in the `define` module
- Removes code duplication in the function that defines the custom element class and constructor

## How to test

1. Run the unit tests
2. Look for regressions in the Storybook stories
3. Look for regressions in the Astro example

It's helpful to use the [split diff view](https://github.com/CMSgov/design-system/pull/3048/files?diff=split&w=0) when reviewing these code changes. You might also want to read through the commit messages.
## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone