### PR TITLE
[NO-TICKET] Remove the `onEnter` prop from `Dialog`

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -58,10 +58,6 @@ export interface BaseDialogProps extends AnalyticsOverrideProps {
    */
   isOpen?: boolean;
   /**
-   * This function is called after the modal opens
-   */
-  onEnter?(): void;
-  /**
    * Called when the user triggers an exit event, like by clicking the close
    * button or pressing the ESC key. The parent of this component is
    * responsible for showing or not showing the dialog, so you need to use this
@@ -96,7 +92,6 @@ export const Dialog = (props: DialogProps) => {
     headerClassName,
     heading,
     id,
-    onEnter,
     onExit,
     size,
     ...modalProps
@@ -112,10 +107,6 @@ export const Dialog = (props: DialogProps) => {
   const actionsClassNames = classNames('ds-c-dialog__actions', actionsClassName);
 
   const containerRef = useRef<HTMLDivElement>();
-
-  useEffect(() => {
-    if (onEnter) onEnter();
-  }, []);
 
   // Set initial focus
   useEffect(() => {

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Dialog-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Dialog-Docs-prop-table-matches-snapshot-1.txt
@@ -70,11 +70,6 @@
     "-"
   ],
   [
-    "onEnter",
-    "This function is called after the modal opens\n() => void",
-    "-"
-  ],
-  [
     "onExit*",
     "Called when the user triggers an exit event, like by clicking the close button or pressing the ESC key. The parent of this component is responsible for showing or not showing the dialog, so you need to use this callback to make that happen. The dialog does not hide or remove itself.\n\n(event: MouseEvent<Element, MouseEvent> | KeyboardEvent<Element>) => void",
     "-"


### PR DESCRIPTION
## Summary

Removes the `onEnter` prop from `Dialog`, which doesn't really serve a purpose. I can find no evidence of people using it, and it has the same defect as https://github.com/CMSgov/design-system/pull/3055. 

## How to test

1. Instructions on how to test the changes in this PR.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone