### PR TITLE
[WNMGDS-2715] Add analytics to healthcare footer links

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -111,6 +111,7 @@ const analyticsSettingsDecorator = (Story, context) => {
     dialogSendsAnalytics: on,
     helpDrawerSendsAnalytics: on,
     headerSendsAnalytics: on,
+    footerSendsAnalytics: on,
     thirdPartyExternalLinkSendsAnalytics: on,
   });
 

--- a/packages/design-system/src/components/config.ts
+++ b/packages/design-system/src/components/config.ts
@@ -39,6 +39,10 @@ export interface Config {
    */
   headerSendsAnalytics: boolean;
   /**
+   * Controls whether the footer component send analytics data. Defaults to true.
+   */
+  footerSendsAnalytics: boolean;
+  /**
    * Controls whether third-party-external-link components send analytics data by default.
    * To override this setting for an individual alert instance, use the `analytics` prop.
    */
@@ -55,6 +59,7 @@ export const DEFAULTS: Config = Object.freeze({
   dialogSendsAnalytics: false,
   helpDrawerSendsAnalytics: false,
   headerSendsAnalytics: false,
+  footerSendsAnalytics: false,
   thirdPartyExternalLinkSendsAnalytics: false,
 });
 
@@ -62,6 +67,7 @@ export const HEALTHCARE_DEFAULTS: Config = {
   ...DEFAULTS,
   errorPlacementDefault: 'bottom',
   headerSendsAnalytics: true,
+  footerSendsAnalytics: true,
   thirdPartyExternalLinkSendsAnalytics: true,
 };
 

--- a/packages/ds-healthcare-gov/src/components/Footer/Footer.test.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Footer.test.tsx
@@ -1,5 +1,7 @@
 import Footer from './Footer';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
+import { config } from '../config';
+import { UtagContainer } from '@cmsgov/design-system';
 
 describe('Footer', function () {
   it('renders basic footer', () => {
@@ -12,5 +14,72 @@ describe('Footer', function () {
       <Footer className="ds-t-test-class" primaryDomain="https://www.healthcare.gov" />
     );
     expect(container).toMatchSnapshot();
+  });
+
+  describe('analytics', () => {
+    const mock = jest.fn();
+    // (window as any as UtagContainer).utag = { link: mock };
+
+    beforeAll(() => {
+      (window as any as UtagContainer).utag = { link: mock };
+    });
+
+    afterEach(() => {
+      mock.mockReset();
+    });
+
+    it('all links send analytics when analytics are enabled', () => {
+      config({ footerSendsAnalytics: true });
+      const { container } = render(<Footer />);
+      container.querySelectorAll('a').forEach((link) => {
+        if (link.closest('dialog')) {
+          // Ignore the links that are in the privacy modal
+          return;
+        }
+        fireEvent.click(link);
+        expect(mock).toHaveBeenCalledTimes(1);
+        expect(mock.mock.lastCall).toMatchSnapshot();
+        mock.mockReset();
+      });
+    });
+
+    it('links do not send analytics when analytics are disabled', () => {
+      config({ footerSendsAnalytics: false });
+      const { container } = render(<Footer />);
+      container.querySelectorAll('a').forEach((link) => {
+        if (link.closest('dialog')) {
+          // Ignore the links that are in the privacy modal
+          return;
+        }
+        fireEvent.click(link);
+        expect(mock).not.toHaveBeenCalled();
+      });
+    });
+
+    // describe('with analytics enabled', () => {
+    //   config({ footerSendsAnalytics: true });
+    //   const { container } = render(<Footer />);
+
+    //   container.querySelectorAll('a').forEach(link => {
+    //     if (link.closest('dialog')) {
+    //       // Ignore the links that are in the privacy modal
+    //       return;
+    //     }
+
+    //     test(`"${link.textContent}" link sends analytics`, () => {
+    //       fireEvent.click(link);
+    //       expect(mock).toHaveBeenCalled();
+    //       expect(mock.mock.lastCall).toMatchSnapshot();
+    //     });
+    //   })
+    // });
+
+    // describe('with analytics disabled', () => {
+    //   const { container } = render(<Footer />);
+
+    //   beforeAll(() => {
+    //     config({ thirdPartyExternalLinkSendsAnalytics: false });
+    //   });
+    // });
   });
 });

--- a/packages/ds-healthcare-gov/src/components/Footer/Footer.test.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Footer.test.tsx
@@ -18,7 +18,6 @@ describe('Footer', function () {
 
   describe('analytics', () => {
     const mock = jest.fn();
-    // (window as any as UtagContainer).utag = { link: mock };
 
     beforeAll(() => {
       (window as any as UtagContainer).utag = { link: mock };
@@ -55,31 +54,5 @@ describe('Footer', function () {
         expect(mock).not.toHaveBeenCalled();
       });
     });
-
-    // describe('with analytics enabled', () => {
-    //   config({ footerSendsAnalytics: true });
-    //   const { container } = render(<Footer />);
-
-    //   container.querySelectorAll('a').forEach(link => {
-    //     if (link.closest('dialog')) {
-    //       // Ignore the links that are in the privacy modal
-    //       return;
-    //     }
-
-    //     test(`"${link.textContent}" link sends analytics`, () => {
-    //       fireEvent.click(link);
-    //       expect(mock).toHaveBeenCalled();
-    //       expect(mock.mock.lastCall).toMatchSnapshot();
-    //     });
-    //   })
-    // });
-
-    // describe('with analytics disabled', () => {
-    //   const { container } = render(<Footer />);
-
-    //   beforeAll(() => {
-    //     config({ thirdPartyExternalLinkSendsAnalytics: false });
-    //   });
-    // });
   });
 });

--- a/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Footer.tsx
@@ -41,8 +41,8 @@ export const Footer = (props: FooterProps) => {
   return (
     <footer className={classes} role="contentinfo">
       {props.footerTop}
-      <InlineLinkLists t={t} primaryDomain={props.primaryDomain} />
-      <LogosRow t={t} />
+      <InlineLinkLists primaryDomain={props.primaryDomain} />
+      <LogosRow />
     </footer>
   );
 };

--- a/packages/ds-healthcare-gov/src/components/Footer/InlineLinkLists.test.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/InlineLinkLists.test.tsx
@@ -1,16 +1,14 @@
 import InlineLinkLists from './InlineLinkLists';
 import { render, screen } from '@testing-library/react';
 
-const t = (key: string) => key;
-
 describe('InlineLinkLists', function () {
   it('renders lists of links', () => {
-    const { container } = render(<InlineLinkLists t={t} />);
+    const { container } = render(<InlineLinkLists />);
     expect(container).toMatchSnapshot();
   });
 
   it('includes a lang attribute on language links', () => {
-    render(<InlineLinkLists t={t} />);
+    render(<InlineLinkLists />);
     const links = screen.getAllByRole('link');
     let matching = 0;
     links.forEach((l) => {
@@ -20,9 +18,7 @@ describe('InlineLinkLists', function () {
   });
 
   it('renders lists of links with absolute URLs', () => {
-    const { container } = render(
-      <InlineLinkLists t={t} primaryDomain="https://www.healthcare.gov" />
-    );
+    const { container } = render(<InlineLinkLists primaryDomain="https://www.healthcare.gov" />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/ds-healthcare-gov/src/components/Footer/InlineLinkLists.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/InlineLinkLists.tsx
@@ -1,30 +1,13 @@
 import PrivacySettingsLink from './PrivacySettingsLink';
 import languages from './languages';
-import { TFunction } from '@cmsgov/design-system';
+import { t } from '../i18n';
+import { sendFooterLinkEvent } from './analytics';
 
 interface InlineLinkListsProps {
-  t: TFunction;
   primaryDomain: string;
 }
 
 const inlineLiClasses = 'hc-c-footer__inline-item';
-
-/**
- * Create <li> nodes and inline links
- */
-const renderBasicList = function (t, links) {
-  return Object.getOwnPropertyNames(links).map(function (key, index) {
-    const link = typeof links[key] === 'string' ? <a href={links[key]}>{t(key)}</a> : links[key];
-    return (
-      <li key={key} className={inlineLiClasses}>
-        {link}
-        {index !== Object.getOwnPropertyNames(links).length - 1 ? (
-          <span aria-hidden="true" className="hc-c-footer__delimiter" />
-        ) : null}
-      </li>
-    );
-  });
-};
 
 /**
  * Inline link lists are always rendered in the footer, no matter
@@ -49,7 +32,24 @@ const InlineLinkLists = function (props: InlineLinkListsProps) {
     <div className="ds-l-container">
       <div className="hc-c-footer__site-links-row">
         <ul role="list" className="hc-c-footer__list">
-          {renderBasicList(props.t, inlineLinksTop)}
+          {Object.getOwnPropertyNames(inlineLinksTop).map(function (key, index) {
+            const entry = inlineLinksTop[key];
+            const isUrl = typeof entry === 'string';
+            const linkText = t(key);
+            const isLastItem = index !== Object.getOwnPropertyNames(inlineLinksTop).length - 1;
+            return (
+              <li key={key} className={inlineLiClasses}>
+                {isUrl ? (
+                  <a href={entry} onClick={() => sendFooterLinkEvent(linkText, entry)}>
+                    {linkText}
+                  </a>
+                ) : (
+                  entry
+                )}
+                {isLastItem ? <span aria-hidden="true" className="hc-c-footer__delimiter" /> : null}
+              </li>
+            );
+          })}
         </ul>
       </div>
 
@@ -63,10 +63,13 @@ const InlineLinkLists = function (props: InlineLinkListsProps) {
           className="hc-c-footer__list"
         >
           {Object.getOwnPropertyNames(languages).map(function (lang) {
+            const linkUrl = primaryDomain + languages[lang].href;
+            const linkText = languages[lang].label;
+            const handleClick = () => sendFooterLinkEvent(linkText, linkUrl, 'Language resources');
             return (
-              <li key={lang} className={inlineLiClasses}>
-                <a lang={lang} href={primaryDomain + languages[lang].href}>
-                  {languages[lang].label}
+              <li key={lang} className={inlineLiClasses} onClick={handleClick}>
+                <a lang={lang} href={linkUrl}>
+                  {linkText}
                 </a>
               </li>
             );

--- a/packages/ds-healthcare-gov/src/components/Footer/Logo.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/Logo.tsx
@@ -1,5 +1,7 @@
 import type * as React from 'react';
 import classnames from 'classnames';
+import { sendFooterLinkEvent } from './analytics';
+import { getLanguage } from '@cmsgov/design-system';
 
 interface LogoProps {
   children: React.ReactNode;
@@ -40,11 +42,14 @@ const Logo = (props: LogoProps) => {
     style.width = props.width;
   }
 
+  const linkText = getLanguage() === 'es' ? 'CuidadoDeSalud.gov' : 'HealthCare.gov';
+
   return (
     <a
       className={classnames('hc-c-footer__logo ds-u-display--inline-block', props.className)}
       href={props.href}
       style={style}
+      onClick={() => sendFooterLinkEvent(linkText, props.href)}
     >
       {props.children}
     </a>

--- a/packages/ds-healthcare-gov/src/components/Footer/LogosRow.test.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/LogosRow.test.tsx
@@ -1,8 +1,6 @@
 import LogosRow from './LogosRow';
 import { render } from '@testing-library/react';
 
-const t = (key) => key;
-
 describe('LogosRow', function () {
   // This is mostly here so that if you edit the logo SVG files,
   // you're made aware that the change will affect the footer.
@@ -10,8 +8,7 @@ describe('LogosRow', function () {
   // have unintended consequences, and it's worth looking at the footer
   // in the browser to confirm nothing is funky.
   it('renders logos and address', () => {
-    const { container } = render(<LogosRow t={t} />);
-
+    const { container } = render(<LogosRow />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/ds-healthcare-gov/src/components/Footer/LogosRow.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/LogosRow.tsx
@@ -1,12 +1,9 @@
 import Logo from './Logo';
 import { Logo as HCgovLogo } from '../Logo';
 import { getLanguage } from '@cmsgov/design-system';
+import { t } from '../i18n';
 
-interface LogosRowProps {
-  t: (string) => string;
-}
-
-const LogosRow = function (props: LogosRowProps) {
+const LogosRow = function () {
   return (
     <div className="ds-l-container">
       <div className="hc-c-footer__logo-row">
@@ -26,7 +23,7 @@ const LogosRow = function (props: LogosRowProps) {
             </p>
           )}
           {/* eslint-disable-next-line react/no-danger -- Known-safe source */}
-          <p dangerouslySetInnerHTML={{ __html: props.t('footer.disclaimer') }} />
+          <p dangerouslySetInnerHTML={{ __html: t('footer.disclaimer') }} />
         </div>
       </div>
     </div>

--- a/packages/ds-healthcare-gov/src/components/Footer/PrivacySettingsLink.tsx
+++ b/packages/ds-healthcare-gov/src/components/Footer/PrivacySettingsLink.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type * as React from 'react';
 import { PrivacySettingsDialog } from '@cmsgov/design-system';
-import { tWithLanguage } from '../i18n';
+import { t } from '../i18n';
 
 interface PrivacySettingsLinkProps {
   children?: React.ReactNode;
@@ -10,7 +10,6 @@ interface PrivacySettingsLinkProps {
 
 export const PrivacySettingsLink = (props: PrivacySettingsLinkProps) => {
   const [showDialog, setShowDialog] = useState(false);
-  const t = tWithLanguage();
   const openDialog = () => setShowDialog(true);
   const closeDialog = () => setShowDialog(false);
 

--- a/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -1,5 +1,272 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Footer analytics all links send analytics when analytics are enabled 1`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "link_text": "Contact us",
+    "link_url": "/contact-us",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 2`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "link_text": "Archive",
+    "link_url": "/archive",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 3`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "link_text": "Accessibility",
+    "link_url": "http://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/CMSNondiscriminationNotice.html",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 4`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "link_text": "Privacy policy",
+    "link_url": "/privacy",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 5`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "link_text": "Using this site",
+    "link_url": "/using-this-site",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 6`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "中文",
+    "link_url": "/language-resource/#chinese",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 7`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "Kreyòl",
+    "link_url": "/language-resource/#creole",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 8`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "Français",
+    "link_url": "/language-resource/#french",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 9`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "Deutsch",
+    "link_url": "/language-resource/#german",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 10`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "ગુજરાતી",
+    "link_url": "/language-resource/#gujarati",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 11`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "हिंदी",
+    "link_url": "/language-resource/#hindi",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 12`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "Italiano",
+    "link_url": "/language-resource/#italian",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 13`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "日本語",
+    "link_url": "/language-resource/#japanese",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 14`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "한국어",
+    "link_url": "/language-resource/#korean",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 15`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "Polski",
+    "link_url": "/language-resource/#polish",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 16`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "Português",
+    "link_url": "/language-resource/#portuguese",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 17`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "Русский",
+    "link_url": "/language-resource/#russian",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 18`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "Español",
+    "link_url": "/language-resource/#spanish",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 19`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "Tagalog",
+    "link_url": "/language-resource/#tagalog",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 20`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "heading": "Language resources",
+    "link_text": "Tiếng Việt",
+    "link_url": "/language-resource/#vietnamese",
+    "navigation_type": "footer",
+  },
+]
+`;
+
+exports[`Footer analytics all links send analytics when analytics are enabled 21`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "navigation_clicked",
+    "link_text": "HealthCare.gov",
+    "link_url": "https://www.healthcare.gov",
+    "navigation_type": "footer",
+  },
+]
+`;
+
 exports[`Footer renders basic footer 1`] = `
 <div>
   <footer

--- a/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/InlineLinkLists.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/InlineLinkLists.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`InlineLinkLists renders lists of links 1`] = `
           <a
             href="/contact-us"
           >
-            footer.contactUs
+            Contact us
           </a>
           <span
             aria-hidden="true"
@@ -31,7 +31,7 @@ exports[`InlineLinkLists renders lists of links 1`] = `
           <a
             href="/archive"
           >
-            footer.archive
+            Archive
           </a>
           <span
             aria-hidden="true"
@@ -44,7 +44,7 @@ exports[`InlineLinkLists renders lists of links 1`] = `
           <a
             href="http://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/CMSNondiscriminationNotice.html"
           >
-            footer.a11y
+            Accessibility
           </a>
           <span
             aria-hidden="true"
@@ -445,7 +445,7 @@ exports[`InlineLinkLists renders lists of links 1`] = `
           <a
             href="/privacy"
           >
-            footer.privacyPolicy
+            Privacy policy
           </a>
           <span
             aria-hidden="true"
@@ -458,7 +458,7 @@ exports[`InlineLinkLists renders lists of links 1`] = `
           <a
             href="/using-this-site"
           >
-            footer.usingThisSite
+            Using this site
           </a>
         </li>
       </ul>
@@ -651,7 +651,7 @@ exports[`InlineLinkLists renders lists of links with absolute URLs 1`] = `
           <a
             href="https://www.healthcare.gov/contact-us"
           >
-            footer.contactUs
+            Contact us
           </a>
           <span
             aria-hidden="true"
@@ -664,7 +664,7 @@ exports[`InlineLinkLists renders lists of links with absolute URLs 1`] = `
           <a
             href="https://www.healthcare.gov/archive"
           >
-            footer.archive
+            Archive
           </a>
           <span
             aria-hidden="true"
@@ -677,7 +677,7 @@ exports[`InlineLinkLists renders lists of links with absolute URLs 1`] = `
           <a
             href="http://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/CMSNondiscriminationNotice.html"
           >
-            footer.a11y
+            Accessibility
           </a>
           <span
             aria-hidden="true"
@@ -1078,7 +1078,7 @@ exports[`InlineLinkLists renders lists of links with absolute URLs 1`] = `
           <a
             href="https://www.healthcare.gov/privacy"
           >
-            footer.privacyPolicy
+            Privacy policy
           </a>
           <span
             aria-hidden="true"
@@ -1091,7 +1091,7 @@ exports[`InlineLinkLists renders lists of links with absolute URLs 1`] = `
           <a
             href="https://www.healthcare.gov/using-this-site"
           >
-            footer.usingThisSite
+            Using this site
           </a>
         </li>
       </ul>

--- a/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/LogosRow.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Footer/__snapshots__/LogosRow.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`LogosRow renders logos and address 1`] = `
            is a registered trademark of the Department of Health & Human Services.
         </p>
         <p>
-          footer.disclaimer
+          An official website of the U.S. Centers for Medicare & Medicaid Services.
         </p>
       </div>
     </div>

--- a/packages/ds-healthcare-gov/src/components/Footer/analytics.ts
+++ b/packages/ds-healthcare-gov/src/components/Footer/analytics.ts
@@ -7,9 +7,9 @@ export function sendFooterLinkEvent(linkText: string, linkUrl?: string, heading?
       event_name: 'navigation_clicked',
       event_extension: eventExtensionText,
       navigation_type: 'footer',
-      heading,
       link_text: linkText,
       ...(linkUrl ? { link_url: linkUrl } : {}),
+      ...(heading ? { heading } : {}),
     });
   }
 }

--- a/packages/ds-healthcare-gov/src/components/Footer/analytics.ts
+++ b/packages/ds-healthcare-gov/src/components/Footer/analytics.ts
@@ -1,0 +1,15 @@
+import { eventExtensionText } from '@cmsgov/design-system';
+import { config } from '../config';
+
+export function sendFooterLinkEvent(linkText: string, linkUrl?: string, heading?: string) {
+  if (config().footerSendsAnalytics) {
+    config().defaultAnalyticsFunction({
+      event_name: 'navigation_clicked',
+      event_extension: eventExtensionText,
+      navigation_type: 'footer',
+      heading,
+      link_text: linkText,
+      ...(linkUrl ? { link_url: linkUrl } : {}),
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Adds analytics to all footer links when the new `footerSendsAnalytics` config property is true (`true` by default for healthcare)

## How to test

Storybook testing is somewhat tricky because you have to be able to prevent default navigation. There are unit tests, though.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone