### PR TITLE
[WNMGDS-2744] Make the web components bundle split backwards compatible

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,9 @@ function generateWebpackConfig(options) {
     // we're just ignoring that and creating our own entry config here.
     entry = {
       all: options.entryPath,
+      // TODO: To maintain backwards compatibility, duplicate the `all` bundle with its
+      // old name, but we can remove this in the next breaking change.
+      'web-components': options.entryPath,
       base: [
         // Not going to bother supporting config and i18n side-effects (importing local
         // config and i18n override files) in child design systems until we know we need


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/CMSgov/design-system/pull/3070 to make it backwards compatible so we can include it in a feature release.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
