### PR TITLE
[NO-TICKET] Add live-analytics option to Storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -166,8 +166,8 @@ const preview: Preview = {
       toolbar: {
         icon: 'graphline',
         items: [
-          { value: 'log', title: 'Log to Actions' },
-          { value: 'on', title: 'Live (for QA)' },
+          { value: 'log', title: 'Log to Actions (Debug)' },
+          { value: 'on', title: 'On (Live)' },
           { value: 'off', title: 'Off' },
         ],
       },

--- a/packages/docs/src/components/layout/Layout.tsx
+++ b/packages/docs/src/components/layout/Layout.tsx
@@ -6,7 +6,7 @@ import TableOfContents from './TableOfContents';
 import TableOfContentsMobile from './TableOfContentsMobile';
 import HeaderFullWidth from './HeaderFullWidth';
 import { Helmet } from 'react-helmet';
-import { SkipNav, UsaBanner, config } from '@cmsgov/design-system';
+import { SkipNav, UsaBanner } from '@cmsgov/design-system';
 import {
   LocationInterface,
   FrontmatterInterface,
@@ -18,16 +18,6 @@ import '../../styles/index.scss';
 import { getThemeData } from './SideNav/themeVersionData';
 import ThemeVersionSection from './SideNav/ThemeVersionSection';
 import FilterDialogManager from './FilterDialog/FilterDialogManager';
-
-config({
-  alertSendsAnalytics: true,
-  buttonSendsAnalytics: true,
-  dialogSendsAnalytics: true,
-  helpDrawerSendsAnalytics: true,
-  headerSendsAnalytics: true,
-  footerSendsAnalytics: true,
-  thirdPartyExternalLinkSendsAnalytics: true,
-});
 
 interface LayoutProps {
   /**

--- a/packages/docs/src/components/layout/Layout.tsx
+++ b/packages/docs/src/components/layout/Layout.tsx
@@ -6,7 +6,7 @@ import TableOfContents from './TableOfContents';
 import TableOfContentsMobile from './TableOfContentsMobile';
 import HeaderFullWidth from './HeaderFullWidth';
 import { Helmet } from 'react-helmet';
-import { SkipNav, UsaBanner } from '@cmsgov/design-system';
+import { SkipNav, UsaBanner, config } from '@cmsgov/design-system';
 import {
   LocationInterface,
   FrontmatterInterface,
@@ -18,6 +18,16 @@ import '../../styles/index.scss';
 import { getThemeData } from './SideNav/themeVersionData';
 import ThemeVersionSection from './SideNav/ThemeVersionSection';
 import FilterDialogManager from './FilterDialog/FilterDialogManager';
+
+config({
+  alertSendsAnalytics: true,
+  buttonSendsAnalytics: true,
+  dialogSendsAnalytics: true,
+  helpDrawerSendsAnalytics: true,
+  headerSendsAnalytics: true,
+  footerSendsAnalytics: true,
+  thirdPartyExternalLinkSendsAnalytics: true,
+});
 
 interface LayoutProps {
   /**


### PR DESCRIPTION
## Summary

In order to test analytics with the analytics team before new analytics features get released, we were thinking we'd enable analytics for specific components on the doc site, which already sends analytics. However, this would require that we make specific test pages for features we're trying to test. If we add it to Storybook, we have all our components already available to test. Therefore I'm adding a new config option to be able to choose live analytics for validating the actual events sent to our analytics provider. This can be run either locally or on a deployed copy.

## How to test

Select the new analytics config option and try out one of the analytics-enabled components.

<img width="217" alt="Screenshot of new 'On (Live)' analytics option in the analytics config menu of our Storybook" src="https://github.com/CMSgov/design-system/assets/7595652/51a12241-c4e0-413a-9dc5-2400f7ae8722">

Also try turning it off and on again and switching between the different options.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone