### PR TITLE
[NO-TICKET] Add documentation for web component slots

### DIFF
--- a/.storybook/docs/WebComponentDocTemplate.mdx
+++ b/.storybook/docs/WebComponentDocTemplate.mdx
@@ -2,6 +2,7 @@ import { Meta, Title, Subtitle, Description, Primary, Stories } from '@storybook
 import { HtmlElementArgs } from './HtmlElementArgs';
 import { WebComponentArgsTable } from './WebComponentArgsTable';
 import { WebComponentEventsTable } from './WebComponentEventsTable';
+import { WebComponentSlotsTable } from './WebComponentSlotsTable';
 
 <Meta isTemplate />
 
@@ -16,6 +17,8 @@ import { WebComponentEventsTable } from './WebComponentEventsTable';
 
 <WebComponentArgsTable />
 <HtmlElementArgs attributes />
+
+<WebComponentSlotsTable />
 
 <WebComponentEventsTable />
 

--- a/.storybook/docs/WebComponentEventsTable.tsx
+++ b/.storybook/docs/WebComponentEventsTable.tsx
@@ -46,6 +46,7 @@ export const WebComponentEventsTable = ({ of }) => {
         </thead>
         <tbody className="docblock-argstable-body">{rows}</tbody>
       </table>
+      <br />
     </>
   );
 };

--- a/.storybook/docs/WebComponentSlotsTable.tsx
+++ b/.storybook/docs/WebComponentSlotsTable.tsx
@@ -1,0 +1,62 @@
+import { useOf } from '@storybook/blocks';
+
+/**
+ * A table documenting a web component's available slots
+ */
+export const WebComponentSlotsTable = ({ of }) => {
+  const resolvedOf = useOf(of || 'story', ['story', 'meta']);
+  if (resolvedOf.type !== 'story') {
+    return null;
+  }
+  const slots = resolvedOf.story.parameters?.docs?.slots;
+  if (!slots) {
+    return null;
+  }
+
+  const rows = Object.entries(slots).map(([slotName, slot]: any) => (
+    <tr key={slotName}>
+      <td>
+        <strong>{slotName}</strong>
+      </td>
+      <td>
+        <p>{slot?.description ?? ''}</p>
+      </td>
+    </tr>
+  ));
+
+  return (
+    <>
+      <h2 id="slots">Slots</h2>
+      <p>
+        One limitation of element attributes is that they can only contain strings. Slots are a way
+        of passing HTML content as inputs to web components when there are multiple kinds of inputs
+        that need to be passed. For instance, the <code>&lt;ds-choice&gt;</code> element can receive
+        both HTML for "checked children" and "unchecked children", which are dynamically shown or
+        hidden depending on the checked state. To pass HTML as a slot inside your web component, use
+        either{' '}
+        <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">
+          the slot element
+        </a>{' '}
+        with a <code>name</code> attribute that matches one of the slots in the table below or{' '}
+        <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/slot">
+          the slot attribute
+        </a>{' '}
+        on an element type of your choosing.
+      </p>
+      <table className="docblock-argstable">
+        <thead className="docblock-argstable-head">
+          <tr>
+            <th style={{ minWidth: '10rem' }}>
+              <span>Name</span>
+            </th>
+            <th>
+              <span>Description</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="docblock-argstable-body">{rows}</tbody>
+      </table>
+      <br />
+    </>
+  );
+};

--- a/packages/design-system/src/components/web-components/ds-choice/ds-choice.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-choice/ds-choice.stories.tsx
@@ -109,6 +109,14 @@ export default {
         component:
           'For information about how and when to use this component, [refer to checkbox documentation](https://design.cms.gov/components/checkbox/) or [refer to radio button documentation](https://design.cms.gov/components/radio/) pages.',
       },
+      slots: {
+        'checked-children': {
+          description: 'Content to be shown when the choice is checked.',
+        },
+        'unchecked-children': {
+          description: 'Content to be shown when the choice is not checked.',
+        },
+      },
       componentEvents: {
         'ds-change': {
           description: 'Dispatched whenever the choice `checked` value changes.',


### PR DESCRIPTION
## Summary

- Adds a new `WebComponentSlotsTable` to Storybook
- Uses it in the `ds-choice` docs to explain slots generally and list the two slots

## How to test

Look at the storybook docs for `ds-choice`.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone