### PR TITLE
[NO-TICKET] Fix web component custom events missing the default `event.detail.target`

### DIFF
--- a/packages/design-system/src/components/web-components/preactement/define.ts
+++ b/packages/design-system/src/components/web-components/preactement/define.ts
@@ -147,7 +147,10 @@ function proxyEvents(props, events: IOptions['events'], CustomElement) {
     const name: string = Array.isArray(nameOrArray) ? nameOrArray[0] : nameOrArray;
     const getEventFromCallbackArgs = Array.isArray(nameOrArray)
       ? nameOrArray[1]
-      : (event: CustomEventInit<unknown>) => event;
+      : (event: CustomEventInit<unknown>) => ({
+          ...event,
+          detail: { target: (event as UIEvent).target },
+        });
 
     // Convert the event name to a kebab-case format and replace 'on' with 'ds'
     // This prevents the custom events from conflicting with the native events


### PR DESCRIPTION
## Summary

- Fix regression from aa6ef9e where I lost the default `event.detail.target`
- Test for it

## How to test

1. Run the tests
2. Look at the actions in Storybook. To get the true details, you might have to console log the `event.details.target` in a story's event handler.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code