### PR TITLE
[WNMGDS-2775] Restore additional screen-reader context for calendar-picker days

### DIFF
--- a/packages/design-system/src/components/DateField/CustomDayPicker.tsx
+++ b/packages/design-system/src/components/DateField/CustomDayPicker.tsx
@@ -4,6 +4,7 @@ import { DayPicker, DayPickerSingleProps } from 'react-day-picker';
 import { ArrowsStackedIcon } from '../Icons';
 import { t } from '../i18n';
 import type { Locale } from 'date-fns';
+import { CustomDayPickerDayContent } from './CustomDayPickerDayContent';
 
 /**
  * The default formatter for the Month caption.
@@ -35,7 +36,11 @@ export function CustomDayPicker(props: CustomDayPickerProps) {
         </span>
       }
       captionLayout="dropdown"
-      components={{ Caption: CustomDayPickerCaption, IconDropdown: ArrowsStackedIcon }}
+      components={{
+        Caption: CustomDayPickerCaption,
+        IconDropdown: ArrowsStackedIcon,
+        DayContent: CustomDayPickerDayContent,
+      }}
       formatters={{ formatMonthCaption }}
       {...props}
     />

--- a/packages/design-system/src/components/DateField/CustomDayPickerDayContent.tsx
+++ b/packages/design-system/src/components/DateField/CustomDayPickerDayContent.tsx
@@ -1,0 +1,34 @@
+import { ActiveModifiers, useDayPicker } from 'react-day-picker';
+
+/** Represent the props for the {@link DayContent} component. */
+interface DayContentProps {
+  /** The date representing the day. */
+  date: Date;
+  /** The month where the day is displayed. */
+  displayMonth: Date;
+  /** The active modifiers for the given date. */
+  activeModifiers: ActiveModifiers;
+}
+
+/**
+ * Render the content of the day cell.
+ */
+/** Render the content of the day cell. */
+export function CustomDayPickerDayContent(props: DayContentProps) {
+  const {
+    locale,
+    classNames,
+    styles,
+    labels: { labelDay },
+    formatters: { formatDay },
+  } = useDayPicker();
+
+  return (
+    <>
+      <span aria-hidden="true">{formatDay(props.date, { locale })}</span>
+      <span className={classNames.vhidden} style={styles.vhidden}>
+        {labelDay(props.date, props.activeModifiers, { locale })}
+      </span>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Restores screen-reader context lost in [react-day-picker pull request #1537](https://github.com/gpbl/react-day-picker/pull/1537/files). That change was originally made [to fix an issue with Google Translate](https://github.com/gpbl/react-day-picker/issues/1490); however, the component is still pretty broken with Google Translate running even with that fix; therefore, we don't gain anything by accepting it, and we lose screen-reader context when we do.

## How to test

In the `main` branch, you'll find that each day button just has the number as its inner HTML content. With this fix, there are two spans inside, and screen readers get more information.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [ ] Created or updated unit tests to cover any new or modified code
- [ ] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)