### PR TITLE
[WNMGDS-2790] Fix the `MultiInputDateField` overwriting some props with defaults

### DIFF
--- a/packages/design-system/src/components/DateField/MultiInputDateField.test.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.test.tsx
@@ -1,6 +1,7 @@
 jest.mock('lodash/uniqueId', () => (str) => `${str}snapshot`);
 import { MultiInputDateField } from './MultiInputDateField';
 import defaultDateFormatter from './defaultDateFormatter';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 
 describe('MultiInputDateField', () => {
@@ -33,6 +34,26 @@ describe('MultiInputDateField', () => {
       expect(input).toHaveAttribute('pattern', '[0-9]*');
       expect(input).toHaveAttribute('type', 'text');
     });
+  });
+
+  it('accepts a custom dateFormatter', () => {
+    const dateFormatter = ({ day, month, year }) => `${year}-${month}-${day}`;
+    const onChange = jest.fn();
+    render(
+      <MultiInputDateField
+        label="hi"
+        dateFormatter={dateFormatter}
+        monthValue=""
+        dayValue="3"
+        yearValue="1111"
+        onChange={onChange}
+      />
+    );
+
+    const monthInput = screen.getByLabelText(/month/i);
+    userEvent.type(monthInput, '2');
+
+    expect(onChange.mock.calls[0][1]).toEqual('1111-2-3');
   });
 
   describe('defaultDateFormatter', () => {

--- a/packages/design-system/src/components/DateField/MultiInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.tsx
@@ -151,12 +151,12 @@ export function MultiInputDateField(props: DateFieldProps): React.ReactElement {
   const { hintId, hintElement } = useHint({ hint: t('dateField.hint'), ...props, id });
   const labelProps = useLabelProps({ label: t('dateField.label'), ...props, id });
   const fieldProps = {
-    ...cleanFieldProps(props),
-    id,
     dayName: 'day',
     monthName: 'month',
     yearName: 'year',
     dateFormatter: defaultDateFormatter,
+    ...cleanFieldProps(props),
+    id,
   };
 
   return (


### PR DESCRIPTION
## Summary

Fixes the `MultiInputDateField` overwriting a subset of user-supplied props with defaults.

## How to test

1. Instructions on how to test the changes in this PR.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code