### PR TITLE
[WNMGDS-2784] Change end to flex-end to quiet another teams console warn

### DIFF
--- a/packages/design-system/src/styles/components/_UsaBanner.scss
+++ b/packages/design-system/src/styles/components/_UsaBanner.scss
@@ -104,7 +104,7 @@
   position: absolute;
   display: flex;
   align-items: stretch;
-  justify-content: end;
+  justify-content: flex-end;
   padding: 0;
 
   // Mobile/tablet, button is full-size of banner


### PR DESCRIPTION
WNMGDS-2784

UsaBanner had a style using `justify-content: end` and another team was receiving a support warning for it. [This style is widely supported](https://caniuse.com/?search=justify-content%3A%20end), but I think the team supports an older browser or something. Regardless, [because the element this style's applied to has a `display: flex`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content#flex-end) also applied, changing this to `flex-end` seemed appropriate.