### PR TITLE
[NO-TICKET] Add missing `Hint`-component export

### DIFF
--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -11,6 +11,7 @@ export * from './Dropdown';
 export * from './FilterChip';
 export * from './FormLabel';
 export * from './HelpDrawer';
+export * from './Hint';
 export * from './IdleTimeout';
 export * from './InlineError';
 export * from './Label';


### PR DESCRIPTION
## Summary

We forgot to actually export the new `Hint` component starting in v9!