### PR TITLE
[WNMGDS-2785] Fix SCSS token generation and consumption

### DIFF
--- a/packages/design-system-tokens/src/css/translate.ts
+++ b/packages/design-system-tokens/src/css/translate.ts
@@ -225,6 +225,7 @@ export function tokenFilesToScssLayoutFiles(tokensByFile: FlattenedTokensByFile)
     Object.entries(systemTokens).filter(([name]) => layoutTokenNames.includes(name))
   );
   return {
-    'layout.scss': tokensToSassVars(filteredTokens, filteredTokens, false),
+    'layout.scss': tokensToSassVars({}, filteredTokens, false),
+    'layout-default.scss': tokensToSassVars({}, filteredTokens, true),
   };
 }

--- a/packages/design-system-tokens/src/css/writeFiles.ts
+++ b/packages/design-system-tokens/src/css/writeFiles.ts
@@ -6,6 +6,10 @@ export type OutputFiles = {
 };
 
 export async function writeFiles(outputDir: string, files: OutputFiles): Promise<string[]> {
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
   // Write the files for each theme concurrently
   const filesWritten = await Promise.all(
     Object.keys(files).map(async (fileName) => {

--- a/packages/design-system/src/styles/_layout.scss
+++ b/packages/design-system/src/styles/_layout.scss
@@ -1,1 +1,1 @@
-@forward '../../../design-system-tokens/dist/css-vars/core-layout-tokens.scss';
+@forward '../../../design-system-tokens/dist/css-vars/layout-default.scss';

--- a/packages/docs/content/migration-guides/sass-to-css.mdx
+++ b/packages/docs/content/migration-guides/sass-to-css.mdx
@@ -88,8 +88,7 @@ To help teams transition to using CSS custom properties in their own time, we're
 <ThemeContent neverThemes={['healthcare', 'medicare']}>
 
 ```css
-@import '@cmsgov/design-system/dist/scss/core-tokens';
-@import '@cmsgov/design-system/dist/scss/core-component-tokens';
+@import '@cmsgov/design-system/dist/scss/core-theme';
 ```
 
 </ThemeContent>
@@ -97,8 +96,7 @@ To help teams transition to using CSS custom properties in their own time, we're
 <ThemeContent onlyThemes={['healthcare']}>
 
 ```css
-@import '@cmsgov/ds-healthcare-gov/dist/scss/healthcare-tokens';
-@import '@cmsgov/ds-healthcare-gov/dist/scss/healthcare-component-tokens';
+@import '@cmsgov/ds-healthcare-gov/dist/scss/healthcare-theme';
 ```
 
 </ThemeContent>
@@ -106,8 +104,7 @@ To help teams transition to using CSS custom properties in their own time, we're
 <ThemeContent onlyThemes={['medicare']}>
 
 ```css
-@import '@cmsgov/ds-medicare-gov/dist/scss/medicare-tokens';
-@import '@cmsgov/ds-medicare-gov/dist/scss/medicare-component-tokens';
+@import '@cmsgov/ds-medicare-gov/dist/scss/medicare-theme';
 ```
 
 </ThemeContent>

--- a/packages/docs/src/helpers/themeTokens.ts
+++ b/packages/docs/src/helpers/themeTokens.ts
@@ -57,6 +57,7 @@ export function getComponentVariables(
   variableName: string;
   value: string;
   resolvedValue: string;
+  resolvedToken: Token;
 }> {
   const filename = filenameFromTheme(themeName);
   const tokenKeys = Object.keys(tokensByFile[filename]).filter((key) =>

--- a/packages/ds-cms-gov/src/styles/_layout.scss
+++ b/packages/ds-cms-gov/src/styles/_layout.scss
@@ -1,1 +1,1 @@
-@forward '../../../design-system-tokens/dist/css-vars/cmsgov-layout-tokens.scss';
+@forward '../../../design-system-tokens/dist/css-vars/layout.scss';

--- a/packages/ds-healthcare-gov/src/styles/_layout.scss
+++ b/packages/ds-healthcare-gov/src/styles/_layout.scss
@@ -1,1 +1,1 @@
-@forward '../../../design-system-tokens/dist/css-vars/healthcare-layout-tokens.scss';
+@forward '../../../design-system-tokens/dist/css-vars/layout.scss';

--- a/packages/ds-medicare-gov/src/styles/_layout.scss
+++ b/packages/ds-medicare-gov/src/styles/_layout.scss
@@ -1,1 +1,1 @@
-@forward '../../../design-system-tokens/dist/css-vars/medicare-layout-tokens.scss';
+@forward '../../../design-system-tokens/dist/css-vars/layout.scss';


### PR DESCRIPTION
## Summary

This is one of several PRs for WNMGDS-2785

- Fixes error caused by empty `dist` directory
- Fixes usage and generation of the scss layout files
- Fixes a TypeScript error in the token-related docs code

## How to test

Try `yarn build:tokens` and running Storybook or the doc site (note that there will still be CSS issues)