### PR TITLE
[WNMGDS-2785] Add full support for font-family tokens

### DIFF
--- a/packages/design-system-tokens/src/css/translate.ts
+++ b/packages/design-system-tokens/src/css/translate.ts
@@ -76,6 +76,9 @@ export function tokenToCssValue(
     return tokenToCssValue(aliasedToken, config);
   } else if (token.$type === 'number' || token.$type === 'fontWeight') {
     return token.$value + '';
+  } else if (token.$type === 'fontFamily') {
+    const fontList = Array.isArray(token.$value) ? token.$value : [token.$value];
+    return fontList.map((fontFamily) => `'${fontFamily}'`).join(', ');
   } else if (typeof token.$value === 'string') {
     if (token.$value.match(/#[a-z0-9]{6}00/i)) {
       return 'transparent';

--- a/packages/design-system-tokens/src/figma/translateFigmaToTokens.ts
+++ b/packages/design-system-tokens/src/figma/translateFigmaToTokens.ts
@@ -146,7 +146,7 @@ function tokenTypeFromVariable(variable: Variable): Token['$type'] {
     case 'FLOAT':
       return 'number';
     case 'STRING':
-      return 'string';
+      return 'fontFamily';
   }
 }
 
@@ -229,6 +229,10 @@ async function tokenFromVariable(
       case 'number':
         break;
     }
+  } else if ($type === 'fontFamily') {
+    const fontList = Array.isArray(existingToken?.$value) ? existingToken.$value : [];
+    fontList[0] = $value;
+    $value = fontList;
   }
 
   const $description = variable.description;

--- a/packages/design-system-tokens/src/figma/translateTokensToFigma.ts
+++ b/packages/design-system-tokens/src/figma/translateTokensToFigma.ts
@@ -28,14 +28,15 @@ function variableResolvedTypeFromToken(token: Token) {
       return 'COLOR';
     case 'number':
     case 'dimension':
+    case 'duration':
     case 'fontWeight':
       return 'FLOAT';
-    case 'string':
+    case 'fontFamily':
       return 'STRING';
     case 'boolean':
       return 'BOOLEAN';
     default:
-      throw new Error(`Invalid token $type: ${token.$type}`);
+      throw new Error(`Invalid token $type: ${(token as any)?.$type}`);
   }
 }
 
@@ -82,6 +83,8 @@ function variableValueFromToken(
     return dimensionToPixelNumber(token.$value + '');
   } else if (token.$type === 'duration') {
     return durationToNumber(token.$value + '');
+  } else if (token.$type === 'fontFamily') {
+    return Array.isArray(token.$value) ? token.$value[0] : token.$value;
   } else {
     return token.$value;
   }

--- a/packages/design-system-tokens/src/lib/tokens.ts
+++ b/packages/design-system-tokens/src/lib/tokens.ts
@@ -1,57 +1,12 @@
 import { VariableCodeSyntax, VariableScope } from '@figma/rest-api-spec';
 
 /**
- * We're attempting to align with this standard: https://tr.designtokens.org/, but we're
- * also supporting an additional `boolean` type because Figma has a boolean type.
+ * Using this draft Design Token JSON format standard: https://tr.designtokens.org/
  */
-// interface BaseToken {
-//   $description?: string;
-//   $extensions?: {
-//     /**
-//      * The `com.figma` namespace stores Figma-specific variable properties
-//      */
-//     'com.figma'?: {
-//       hiddenFromPublishing?: boolean;
-//       scopes?: VariableScope[];
-//       codeSyntax?: VariableCodeSyntax;
-//     };
-//   };
-// }
-
-// interface AliasToken extends BaseToken {
-//   $type?: undefined;
-//   $value: string;
-// }
-
-// interface StringToken extends BaseToken {
-//   $type: 'color' | 'dimension' | 'duration';
-//   $value: string;
-// }
-
-// interface NumberToken extends BaseToken {
-//   $type: 'number' | 'fontWeight';
-//   $value: number;
-// }
-
-// interface BooleanToken extends BaseToken {
-//   $type: 'boolean';
-//   $value: boolean;
-// }
-
-// interface FontFamilyToken extends BaseToken {
-//   $type: 'fontFamily';
-//   $value: string | string[];
-// }
-
-// export type Token = AliasToken | StringToken | NumberToken | BooleanToken | FontFamilyToken;
-
 export interface Token {
   /**
-   * The [type](https://tr.designtokens.org/format/#type-0) of the token.
-   *
-   * We allow `string` and `boolean` types in addition to the draft W3C spec's `color` and `number` types
-   * to align with the resolved types for Figma variables. Note that it doesn't need a $type if it's an
-   * alias, because the type will come from the aliased variable.
+   * In addition to the standard, we're also supporting an additional `boolean` type
+   * because Figma has a boolean type.
    */
   $type?:
     | 'color'

--- a/packages/design-system-tokens/src/lib/tokens.ts
+++ b/packages/design-system-tokens/src/lib/tokens.ts
@@ -1,12 +1,49 @@
 import { VariableCodeSyntax, VariableScope } from '@figma/rest-api-spec';
 
 /**
- * This file defines what design tokens and design token files look like in the codebase.
- *
- * Tokens are distinct from variables, in that a [token](https://tr.designtokens.org/format/#design-token)
- * is a name/value pair (with other properties), while a variable in Figma stores multiple values,
- * one for each mode.
+ * We're attempting to align with this standard: https://tr.designtokens.org/, but we're
+ * also supporting an additional `boolean` type because Figma has a boolean type.
  */
+// interface BaseToken {
+//   $description?: string;
+//   $extensions?: {
+//     /**
+//      * The `com.figma` namespace stores Figma-specific variable properties
+//      */
+//     'com.figma'?: {
+//       hiddenFromPublishing?: boolean;
+//       scopes?: VariableScope[];
+//       codeSyntax?: VariableCodeSyntax;
+//     };
+//   };
+// }
+
+// interface AliasToken extends BaseToken {
+//   $type?: undefined;
+//   $value: string;
+// }
+
+// interface StringToken extends BaseToken {
+//   $type: 'color' | 'dimension' | 'duration';
+//   $value: string;
+// }
+
+// interface NumberToken extends BaseToken {
+//   $type: 'number' | 'fontWeight';
+//   $value: number;
+// }
+
+// interface BooleanToken extends BaseToken {
+//   $type: 'boolean';
+//   $value: boolean;
+// }
+
+// interface FontFamilyToken extends BaseToken {
+//   $type: 'fontFamily';
+//   $value: string | string[];
+// }
+
+// export type Token = AliasToken | StringToken | NumberToken | BooleanToken | FontFamilyToken;
 
 export interface Token {
   /**
@@ -16,7 +53,15 @@ export interface Token {
    * to align with the resolved types for Figma variables. Note that it doesn't need a $type if it's an
    * alias, because the type will come from the aliased variable.
    */
-  $type?: 'color' | 'number' | 'string' | 'boolean' | 'dimension' | 'duration' | 'fontWeight';
+  $type?:
+    | 'color'
+    | 'number'
+    | 'string'
+    | 'boolean'
+    | 'dimension'
+    | 'duration'
+    | 'fontWeight'
+    | 'fontFamily';
   $value: string | number | boolean;
   $description?: string;
   $extensions?: {

--- a/packages/design-system-tokens/src/tokens/System.Value.json
+++ b/packages/design-system-tokens/src/tokens/System.Value.json
@@ -3526,7 +3526,14 @@
     "family": {
       "open-sans": {
         "$value": [
-          "Open Sans"
+          "Open Sans",
+          "Inter",
+          "Roboto",
+          "Helvetica Neue",
+          "Arial Nova",
+          "Nimbus Sans",
+          "Arial",
+          "sans-serif"
         ],
         "$type": "fontFamily",
         "$extensions": {
@@ -3541,7 +3548,8 @@
       },
       "montserrat": {
         "$value": [
-          "Montserrat"
+          "Montserrat",
+          "Avenir", "Corbel", "URW Gothic", "source-sans-pro", "sans-serif"
         ],
         "$type": "fontFamily",
         "$extensions": {
@@ -3556,7 +3564,8 @@
       },
       "rubik": {
         "$value": [
-          "Rubik"
+          "Rubik",
+          "Seravek", "Gill Sans Nova", "Ubuntu", "Calibri", "DejaVu Sans", "source-sans-pro", "sans-serif"
         ],
         "$type": "fontFamily",
         "$extensions": {

--- a/packages/design-system-tokens/src/tokens/System.Value.json
+++ b/packages/design-system-tokens/src/tokens/System.Value.json
@@ -3525,8 +3525,10 @@
     },
     "family": {
       "open-sans": {
-        "$value": "Open Sans",
-        "$type": "string",
+        "$value": [
+          "Open Sans"
+        ],
+        "$type": "fontFamily",
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": false,
@@ -3538,8 +3540,10 @@
         }
       },
       "montserrat": {
-        "$value": "Montserrat",
-        "$type": "string",
+        "$value": [
+          "Montserrat"
+        ],
+        "$type": "fontFamily",
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": false,
@@ -3551,8 +3555,10 @@
         }
       },
       "rubik": {
-        "$value": "Rubik",
-        "$type": "string",
+        "$value": [
+          "Rubik"
+        ],
+        "$type": "fontFamily",
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": false,


### PR DESCRIPTION
## Summary

This is one of several PRs for [WNMGDS-2785](https://jira.cms.gov/browse/WNMGDS-2785). Rebase after https://github.com/CMSgov/design-system/pull/3100 is merged.

- Add support for syncing font (STRING) variables down from Figma
- Add support for syncing `fontFamily` tokens up to Figma
- Add support for rendering `fontFamily` tokens to CSS

## How to test

`yarn build:tokens` and take a look at the font variables inside `dist/css-vars/core-theme.css`