### PR TITLE
[NO-TICKET] Fix bug causing drawers to always trap focus

### DIFF
--- a/packages/design-system/src/components/Drawer/Drawer.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.tsx
@@ -99,7 +99,7 @@ export const Drawer = (props: DrawerProps) => {
     <NativeDialog
       className={classNames(className, 'ds-c-drawer')}
       exit={onCloseClick}
-      showModal={true}
+      showModal={hasFocusTrap}
       backdropClickExits={backdropClickExits}
       isOpen={isOpen}
       {...otherProps}


### PR DESCRIPTION
## Summary

It was introduced in [here](https://github.com/CMSgov/design-system/commit/7fee5f741b90b5599875d141a443b379fad763d1#diff-9ef68d956bbe4985a98993aa40ecbbc2f643eb437d5cbdd94cd5529587a51ac6R102) and hasn't been released yet 😅 

## How to test

1. On `main`, and look at [the drawer toggle story](https://design.cms.gov/v/main/storybook/?path=/story/components-drawer--drawer-toggle-with-drawer), you'll see that once you open the drawer you can no longer interact with the toggle
2. In this branch, you should be able to interact with things on the page (even though there's no logic in the story for the toggle doing anything when you click on it if it's already open)

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone