### PR TITLE
[WNMGDS-2785] Updated Accordion with Figma changes

### DIFF
--- a/packages/design-system/src/styles/components/_Accordion.scss
+++ b/packages/design-system/src/styles/components/_Accordion.scss
@@ -18,7 +18,7 @@ ds-accordion-item:not(:first-child) {
 .ds-c-accordion__button {
   background-color: var(--accordion__background-color);
   border: 0;
-  border-radius: var(--accordion__border-radius);
+  border-radius: var(--accordion__border-top-left-radius) var(--accordion__border-top-right-radius) var(--accordion__border-bottom-right-radius) var(--accordion__border-bottom-left-radius);
   color: var(--accordion-button__color);
   display: flex;
   font-weight: var(--font-weight-bold);

--- a/packages/ds-healthcare-gov/src/styles/components/_Accordion.scss
+++ b/packages/ds-healthcare-gov/src/styles/components/_Accordion.scss
@@ -60,7 +60,7 @@
 
     // This variable only exists for the Healthcare Accordion CSS override
     // We need to create tokens specific to icon sizing instead of repurposing spacer-* or font-size-* tokens
-    font-size: var(--accordion-icon__size);
+    font-size: 0.875rem;
   }
 
   .ds-c-accordion__content {


### PR DESCRIPTION
## Summary

Updated Accordion with Figma changes.

### BREAKING changes
- Removed the healthcare-only `--accordion-icon__size` variable
- Split `--accordion__border-radius` into the following variables to support Figma:
    - `--accordion__border-bottom-left-radius`
    - `--accordion__border-bottom-right-radius`
    - `--accordion__border-top-left-radius`
    - `--accordion__border-top-right-radius`