### PR TITLE
[WNMGDS-2785] Fix border radii for cmsgov badges

### DIFF
--- a/packages/design-system-tokens/src/tokens/Theme.cmsgov.json
+++ b/packages/design-system-tokens/src/tokens/Theme.cmsgov.json
@@ -1629,7 +1629,7 @@
         }
       },
       "border-radius": {
-        "$value": "{radius.pill}",
+        "$value": "{radius.medium}",
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": false,


### PR DESCRIPTION
## Summary

Fix border radii for cmsgov badges so they match production. I'm pretty sure they were given this border radius so they wouldn't get confused with the pill-shaped buttons. Hailey agrees.