### PR TITLE
[WNMGDS-2785] Fix reference to system-only token that doesn't exist in theme

### DIFF
--- a/packages/ds-medicare-gov/src/styles/components/_HelpDrawer.scss
+++ b/packages/ds-medicare-gov/src/styles/components/_HelpDrawer.scss
@@ -2,7 +2,7 @@
 $mct-drawer-close-button-size: 26px;
 
 .ds-c-drawer__header-heading {
-  font-family: var(--font-montserrat);
+  font-family: var(--font-family-heading);
   font-size: var(--font-size-xl);
   font-weight: var(--font-weight-bold);
   line-height: var(--font-line-height-base);


### PR DESCRIPTION
## Summary

We no longer have direct access to this Montserrat font variable at the theme level, so use a token that we do have and is semantically relevant.