### PR TITLE
[WNMGDS-2785] Remove refs to z-index variables

### DIFF
--- a/packages/design-system/src/styles/components/_Drawer.scss
+++ b/packages/design-system/src/styles/components/_Drawer.scss
@@ -44,7 +44,7 @@
   padding: 0;
   position: fixed;
   width: 100%;
-  z-index: var(--z-drawer);
+  z-index: 500;
 
   // If `hasFocusTrap` enabled, `background` should
   // not be visible.

--- a/packages/design-system/src/styles/components/_Dropdown.scss
+++ b/packages/design-system/src/styles/components/_Dropdown.scss
@@ -69,7 +69,7 @@
   max-height: var(--max-height);
   position: absolute;
   width: 100%;
-  z-index: var(--z-dialog);
+  z-index: 1000;
 
   .ds-c-field--inverse + & {
     color: var(--color-base);

--- a/packages/docs/src/styles/components/filterDialog.scss
+++ b/packages/docs/src/styles/components/filterDialog.scss
@@ -15,7 +15,7 @@
   padding: var(--spacer-4);
   position: absolute;
   right: unset;
-  z-index: var(--z-drawer);
+  z-index: 500;
 
   @media (forced-colors: active) {
     outline: $spacer-2 solid WindowText;

--- a/packages/docs/static/themes/cmsgov-theme.css
+++ b/packages/docs/static/themes/cmsgov-theme.css
@@ -500,10 +500,4 @@
 --spacer-7: 56px;
 --spacer-none: 0px;
 --spacer-half: 4px;
---z-deep: -99999;
---z-default: 1;
---z-drawer: 500;
---z-dialog: 1000;
---z-popup: 6000;
---z-spinner: 9050;
 }

--- a/packages/docs/static/themes/core-theme.css
+++ b/packages/docs/static/themes/core-theme.css
@@ -500,10 +500,4 @@
 --spacer-7: 56px;
 --spacer-none: 0px;
 --spacer-half: 4px;
---z-deep: -99999;
---z-default: 1;
---z-drawer: 500;
---z-dialog: 1000;
---z-popup: 6000;
---z-spinner: 9050;
 }

--- a/packages/docs/static/themes/healthcare-theme.css
+++ b/packages/docs/static/themes/healthcare-theme.css
@@ -503,10 +503,4 @@
 --spacer-7: 56px;
 --spacer-none: 0px;
 --spacer-half: 4px;
---z-deep: -99999;
---z-default: 1;
---z-drawer: 500;
---z-dialog: 1000;
---z-popup: 6000;
---z-spinner: 9050;
 }

--- a/packages/docs/static/themes/medicare-theme.css
+++ b/packages/docs/static/themes/medicare-theme.css
@@ -512,10 +512,4 @@
 --spacer-7: 56px;
 --spacer-none: 0px;
 --spacer-half: 4px;
---z-deep: -99999;
---z-default: 1;
---z-drawer: 500;
---z-dialog: 1000;
---z-popup: 6000;
---z-spinner: 9050;
 }


### PR DESCRIPTION
## Summary

Remove references to the underused and now removed z-index variables.

## How to test

1. There are still a lot of VRT failures on this feature branch, but you can manually look through the failures in `playwright-report/index.html` like I did to verify that none of them are z-index related.
2. Can also double-check that I did indeed remove all of them.
3. Can also manually test the affected components in Storybook