### PR TITLE
[NO-TICKET] Fix broken doc-site build

### DIFF
--- a/packages/docs/src/helpers/themeTokens.ts
+++ b/packages/docs/src/helpers/themeTokens.ts
@@ -68,19 +68,22 @@ export function getComponentVariables(
     systemTokens: tokensByFile['System.Value.json'],
     renderVariableAlias: (name: string) => `--${tokenNameToVarName(name)}`,
   };
-  return tokenKeys.map((tokenKey) => {
-    const token = tokensByFile[filename][tokenKey];
-    const resolvedToken = isAlias(token.$value.toString())
-      ? resolveTokenAlias(token, tokensByFile, filename)
-      : token;
-    return {
-      token,
-      variableName: valueRenderConfig.renderVariableAlias(tokenKey),
-      value: tokenToCssValue(token, valueRenderConfig),
-      resolvedValue: tokenToCssValue(resolvedToken, valueRenderConfig),
-      resolvedToken,
-    };
-  });
+  return tokenKeys
+    .map((tokenKey) => {
+      const token = tokensByFile[filename][tokenKey];
+      const resolvedToken = isAlias(token.$value.toString())
+        ? resolveTokenAlias(token, tokensByFile, filename)
+        : token;
+      if (resolvedToken.$type === 'boolean') return null;
+      return {
+        token,
+        variableName: valueRenderConfig.renderVariableAlias(tokenKey),
+        value: tokenToCssValue(token, valueRenderConfig),
+        resolvedValue: tokenToCssValue(resolvedToken, valueRenderConfig),
+        resolvedToken,
+      };
+    })
+    .filter((data) => data);
 }
 
 export function getSystemColorTokenFromValue(colorValue: string): string {


### PR DESCRIPTION
## Summary

Don't print any of the boolean values on the doc site. Those boolean tokens are mostly internal and are not robust enough to set to different values. They shouldn't be shown in the docs as configuration options. This fixes build because I made the CSS value function to throw an error if we try to get the value of a boolean token.
