### PR TITLE
[WNMGDS-2780] Implement stricter warnings when the `isOpen` prop isn't used

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.test.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.test.tsx
@@ -56,13 +56,9 @@ describe('Dialog', function () {
     expect((screen.getByRole('dialog') as HTMLDialogElement).open).toBe(true);
   });
 
-  // TODO: Remove this when we remove this functionality in v10
-  it('opens if the isOpen prop is undefined', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => null);
-    renderDialog({ isOpen: undefined });
+  it('opens if the isOpen prop is true', () => {
+    renderDialog({ isOpen: true });
     expect((screen.getByRole('dialog') as HTMLDialogElement).open).toBe(true);
-    expect(warn).toHaveBeenCalled();
-    warn.mockReset();
   });
 
   describe('Analytics event tracking', () => {

--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -56,7 +56,7 @@ export interface BaseDialogProps extends AnalyticsOverrideProps {
   /**
    * Controls whether the dialog is in an open state
    */
-  isOpen?: boolean;
+  isOpen: boolean;
   /**
    * Called when the user triggers an exit event, like by clicking the close
    * button or pressing the ESC key. The parent of this component is

--- a/packages/design-system/src/components/Drawer/Drawer.test.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.test.tsx
@@ -39,15 +39,6 @@ describe('Drawer', () => {
     expect((screen.getByRole('dialog') as HTMLDialogElement).open).toBe(true);
   });
 
-  // TODO: Remove this when we remove this functionality in v10
-  it('opens if the isOpen prop is undefined', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => null);
-    renderDrawer({ isOpen: undefined });
-    expect((screen.getByRole('dialog') as HTMLDialogElement).open).toBe(true);
-    expect(warn).toHaveBeenCalled();
-    warn.mockReset();
-  });
-
   describe('onCloseClick', () => {
     it('calls onCloseClick on close button click', () => {
       const onCloseClick = jest.fn();

--- a/packages/design-system/src/components/Drawer/Drawer.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.tsx
@@ -54,7 +54,7 @@ export interface DrawerProps {
   /**
    * Controls whether the dialog is in an open state
    */
-  isOpen?: boolean;
+  isOpen: boolean;
   /**
    * Called when the user activates the close button or presses the ESC key if
    * focus trapping is enabled. The parent of this component is responsible for

--- a/packages/design-system/src/components/IdleTimeout/IdleTimeoutDialog.test.tsx
+++ b/packages/design-system/src/components/IdleTimeout/IdleTimeoutDialog.test.tsx
@@ -43,13 +43,4 @@ describe('IdleTimeoutDialog', () => {
     const endSessionBtn = screen.queryByText('Logout');
     expect(endSessionBtn).toBeNull();
   });
-
-  // TODO: Remove this when we remove this functionality in v10
-  it('opens if the isOpen prop is undefined', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => null);
-    renderDialog({ isOpen: undefined });
-    expect((screen.getByRole('dialog') as HTMLDialogElement).open).toBe(true);
-    expect(warn).toHaveBeenCalled();
-    warn.mockReset();
-  });
 });

--- a/packages/design-system/src/components/NativeDialog/NativeDialog.test.tsx
+++ b/packages/design-system/src/components/NativeDialog/NativeDialog.test.tsx
@@ -32,12 +32,14 @@ describe('NativeDialog', function () {
     expect((screen.getByRole('dialog') as HTMLDialogElement).open).toBe(true);
   });
 
-  // TODO: Remove this when we remove this functionality in v10
-  it('opens if the isOpen prop is undefined', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => null);
-    renderNativeDialog({ isOpen: undefined });
+  it('can be open at the start', () => {
+    renderNativeDialog({ isOpen: true });
     expect((screen.getByRole('dialog') as HTMLDialogElement).open).toBe(true);
-    expect(warn).toHaveBeenCalled();
-    warn.mockReset();
+  });
+
+  it('throws an error if the isOpen prop is undefined', () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => null);
+    expect(() => renderNativeDialog({ isOpen: undefined })).toThrow();
+    error.mockReset();
   });
 });

--- a/packages/design-system/src/components/NativeDialog/NativeDialog.tsx
+++ b/packages/design-system/src/components/NativeDialog/NativeDialog.tsx
@@ -12,7 +12,7 @@ export interface NativeDialogProps extends Omit<DialogHTMLAttributes<HTMLElement
   /**
    * Controls whether the dialog is in an open state
    */
-  isOpen?: boolean;
+  isOpen: boolean;
   /**
    * Function called to close dialog.
    */
@@ -46,12 +46,14 @@ export const NativeDialog = ({
   const dialogRef = useRef(null);
 
   if (isOpen === undefined) {
+    const missingPropMessage =
+      "The 'isOpen' prop is now used to control the state of Dialogs and Drawers. Please do not conditionally render these components to control their state. All Dialogs and Drawers will become invisible without this prop in the next major release. Using this prop will fix a focus-management issue that affects accessibility.";
     if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        "The 'isOpen' prop is now used to control the state of Dialogs and Drawers. Please do not conditionally render these components to control their state. All Dialogs and Drawers will become invisible without this prop in the next major release. Using this prop will fix a focus-management issue that affects accessibility."
-      );
+      throw new Error(missingPropMessage);
+    } else {
+      console.error(missingPropMessage);
+      isOpen = true;
     }
-    isOpen = true;
   }
 
   // Register dialog with the polyfill if necessary

--- a/packages/design-system/src/components/NativeDialog/useNativeDialogAnalytics.test.tsx
+++ b/packages/design-system/src/components/NativeDialog/useNativeDialogAnalytics.test.tsx
@@ -13,7 +13,7 @@ const defaultProps = {
   onClose: jest.fn(),
 };
 
-function renderDialog(props = {}) {
+function renderDialog(props: { isOpen: boolean }) {
   const TestDialog = ({ onOpen, onClose, ...dialogProps }: TestDialogProps) => {
     const headingRef = useNativeDialogAnalytics({
       isOpen: dialogProps.isOpen,
@@ -30,7 +30,7 @@ function renderDialog(props = {}) {
   const result = render(<TestDialog {...defaultProps} {...props} />);
   return {
     ...result,
-    rerenderDialog(newProps = {}) {
+    rerenderDialog(newProps: { isOpen: boolean }) {
       return result.rerender(<TestDialog {...defaultProps} {...newProps} />);
     },
   };

--- a/packages/docs/src/components/layout/FilterDialog/FilterDialog.tsx
+++ b/packages/docs/src/components/layout/FilterDialog/FilterDialog.tsx
@@ -44,7 +44,7 @@ export interface FilterDialogProps {
   /**
    * Controls whether the dialog is in an open state
    */
-  isOpen?: boolean;
+  isOpen: boolean;
   /**
    * Called when the user triggers an exit event, like by pressing the ESC key.
    * The parent of this component is responsible for showing or not showing the

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Dialog-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Dialog-Docs-prop-table-matches-snapshot-1.txt
@@ -63,7 +63,7 @@
     "-"
   ],
   [
-    "isOpen",
+    "isOpen*",
     "Controls whether the dialog is in an open state\nboolean",
     "-"
   ],

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Drawer-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Drawer-Docs-prop-table-matches-snapshot-1.txt
@@ -65,7 +65,7 @@
     "-"
   ],
   [
-    "isOpen",
+    "isOpen*",
     "Controls whether the dialog is in an open state\nboolean",
     "-"
   ],

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-HelpDrawer-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-HelpDrawer-Docs-prop-table-matches-snapshot-1.txt
@@ -83,7 +83,7 @@
     "-"
   ],
   [
-    "isOpen",
+    "isOpen*",
     "Controls whether the dialog is in an open state\nboolean",
     "-"
   ],

--- a/tests/browser/snapshots/storybook-docs/Docs-Medicare-HelpDrawer-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Medicare-HelpDrawer-Docs-prop-table-matches-snapshot-1.txt
@@ -83,7 +83,7 @@
     "-"
   ],
   [
-    "isOpen",
+    "isOpen*",
     "Controls whether the dialog is in an open state\nboolean",
     "-"
   ],


### PR DESCRIPTION
## Background

In [the Release 9.0 blog post](https://design.cms.gov/blog/release-9.0/?theme=core#improving-drawers-and-dialogs "Follow link"), we announced that we were changing the way applications open and close dialogs and help drawers. [Here is a code migration guide](https://github.com/CMSgov/design-system/pull/2890 "Follow link"). We added a console warning for the old behavior in development mode, but after seeing that teams are still using the old API and running into issues, we decided it's time to increase the visibility of this change.

## Summary

https://jira.cms.gov/browse/WNMGDS-2780

Implement stricter warnings when the `isOpen` prop isn't used (the new dialog API).

- Require it in TypeScript
- Up the dev warnings to throwing dev errors
- Display a console error message in prod (previously silent in prod)

## How to test

You can try it out manually if you want. Unit tests are testing for the error-throwing.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
