### PR TITLE
[NO-TICKET] Remove inversed prop from label-div

### DIFF
--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -155,7 +155,6 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     defaultValue,
     value,
     inputRef,
-    inversed,
     getA11yStatusMessage,
     getA11ySelectionMessage,
     ...extraProps
@@ -257,6 +256,9 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     }),
   };
 
+  // Excluding `inversed` prop from `<div>` label because it's not a valid attr
+  const { inversed, ...divLabelProps } = labelProps;
+
   const buttonProps = {
     ...useButtonProps.buttonProps,
     ...cleanFieldProps(extraProps),
@@ -266,7 +268,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
       'ds-c-dropdown__button',
       'ds-c-field',
       props.errorMessage && 'ds-c-field--error',
-      inversed && 'ds-c-field--inverse',
+      props.inversed && 'ds-c-field--inverse',
       size && `ds-c-field--${size}`,
       fieldClassName
     ),
@@ -294,7 +296,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
       ref={wrapperRef}
     >
       {/* `<div>` is used instead of `<label>` to satisfy a11y issue. Because dropdown is a `<button>`, a `<label>` is inappropriate to use with it. */}
-      <div {...labelProps} />
+      <div {...divLabelProps} />
       {hintElement}
       {topError}
       <HiddenSelect

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -155,7 +155,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     defaultValue,
     value,
     inputRef,
-    inversed: dropdownInverse,
+    inversed,
     getA11yStatusMessage,
     getA11ySelectionMessage,
     ...extraProps
@@ -258,7 +258,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
   };
 
   // Excluding `inversed` prop from `<div>` label because it's not a valid attr
-  const { inversed, ...divLabelProps } = labelProps;
+  const { inversed: _removeInversed, ...divLabelProps } = labelProps;
 
   const buttonProps = {
     ...useButtonProps.buttonProps,
@@ -269,7 +269,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
       'ds-c-dropdown__button',
       'ds-c-field',
       props.errorMessage && 'ds-c-field--error',
-      dropdownInverse && 'ds-c-field--inverse',
+      inversed && 'ds-c-field--inverse',
       size && `ds-c-field--${size}`,
       fieldClassName
     ),

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -155,6 +155,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     defaultValue,
     value,
     inputRef,
+    inversed: dropdownInverse,
     getA11yStatusMessage,
     getA11ySelectionMessage,
     ...extraProps
@@ -268,7 +269,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
       'ds-c-dropdown__button',
       'ds-c-field',
       props.errorMessage && 'ds-c-field--error',
-      props.inversed && 'ds-c-field--inverse',
+      dropdownInverse && 'ds-c-field--inverse',
       size && `ds-c-field--${size}`,
       fieldClassName
     ),


### PR DESCRIPTION
No ticket.

`useLabelProps` spread the attr `inversed` onto the newly created label-div element (`<div>` styled as a `<label>` to skirt some Axe/Wave issues). Because the `div` doesn't have the concept of an `inversed` attr, and I'm using `classNames` to get the same effect, remove that prop from `labelProps`.