### PR TITLE
[WNMGDS-2800] Refactor alert so headingId is on heading node, not alert body

### DIFF
--- a/packages/design-system/src/components/Alert/Alert.tsx
+++ b/packages/design-system/src/components/Alert/Alert.tsx
@@ -151,9 +151,9 @@ export const Alert: React.FC<AlertProps> = (props: AlertProps) => {
       {...alertProps}
     >
       {getIcon()}
-      <div className="ds-c-alert__body" id={headingId} ref={bodyRef}>
+      <div className="ds-c-alert__body" ref={bodyRef}>
         {heading ? (
-          <div className="ds-c-alert__header ds-c-alert__heading" ref={headingRef}>
+          <div id={headingId} className="ds-c-alert__header ds-c-alert__heading" ref={headingRef}>
             {a11yLabel}
             {headingElement}
           </div>

--- a/packages/design-system/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/packages/design-system/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -52,7 +52,6 @@ exports[`Alert renders alert 1`] = `
   </svg>
   <div
     class="ds-c-alert__body"
-    id="static-id__heading"
   >
     <span
       class="ds-c-alert__a11y-label ds-u-visibility--screen-reader"

--- a/packages/design-system/src/components/web-components/ds-alert/__snapshots__/ds-alert.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-alert/__snapshots__/ds-alert.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`Alert renders alert 1`] = `
       </svg>
       <div
         class="ds-c-alert__body"
-        id="alert--1__heading"
       >
         <span
           class="ds-c-alert__a11y-label ds-u-visibility--screen-reader"


### PR DESCRIPTION
WNMGDS-2800

The current Alert assigned `headingId` to the body element, which contained text for the heading, alert type and body text (aka, wall-o-text).

This update assigns `headingId` to the element containing just the heading text and alert type, making it easier for AT users to scan a given page. If no heading or icon are provided, the accessible label will default to announcing the alert type.

You can test these changes by comparing PROD and local builds, either by using VO or by opening your browser's accessibility tools to see what the label is.

Local readout:

![Screenshot 2024-06-20 at 10 52 18 AM](https://github.com/CMSgov/design-system/assets/5159392/5afe64f3-ed77-4659-a57e-8aae2bd4d579)

PROD:

![Screenshot 2024-06-20 at 10 53 15 AM](https://github.com/CMSgov/design-system/assets/5159392/22666c4d-e0c5-4b30-8fac-bcd40c80bd71)
