### PR TITLE
[NO-TICKET] Export the `useDialog` hook

### DIFF
--- a/packages/design-system/src/components/Dialog/index.ts
+++ b/packages/design-system/src/components/Dialog/index.ts
@@ -1,1 +1,2 @@
 export * from './Dialog';
+export * from './useDialog';

--- a/packages/docs/src/components/content/MaturityChecklist/MaturityChecklist.tsx
+++ b/packages/docs/src/components/content/MaturityChecklist/MaturityChecklist.tsx
@@ -1,5 +1,4 @@
 import MaturityChecklistItem, { CheckStatus } from './MaturityChecklistItem';
-import { Button, Dialog, useDialog } from '@cmsgov/design-system';
 
 interface MaturityChecklistProps {
   // Accessibility
@@ -26,71 +25,49 @@ interface MaturityChecklistProps {
 /**
  *
  */
-const MaturityChecklist = (props: MaturityChecklistProps) => {
-  const { dialog, openDialog } = useDialog(({ resolveClose, isOpen }) => (
-    <Dialog
-      heading="Hello World"
-      onExit={resolveClose}
-      actions={
-        <>
-          <Button variation="ghost" onClick={resolveClose}>
-            Cancel
-          </Button>
-        </>
-      }
-      isOpen={isOpen}
-    >
-      Are you sure you want to delete your account? All in-progress applications will be deleted and
-      your information cleared from the system.
-    </Dialog>
-  ));
+const MaturityChecklist = (props: MaturityChecklistProps) => (
+  <section>
+    <p>
+      For more information about how we tested and validated our work for each checklist item,{' '}
+      <a href="https://github.com/CMSgov/design-system/blob/main/COMPONENT_MATURITY.md">
+        read our component maturity documentation
+      </a>
+      .
+    </p>
 
-  return (
-    <section>
-      <p>
-        For more information about how we tested and validated our work for each checklist item,{' '}
-        <a href="https://github.com/CMSgov/design-system/blob/main/COMPONENT_MATURITY.md">
-          read our component maturity documentation
-        </a>
-        .
-      </p>
+    <h3>Accessibility</h3>
+    <ul className="ds-c-list--bare">
+      <MaturityChecklistItem title="Color" status={props.color}>
+        Meets AA color contrast standards for accessibility and color blindness.
+      </MaturityChecklistItem>
+      <MaturityChecklistItem title="Forced Colors Mode (FCM)" status={props.forcedColors}>
+        While using FCM the components text is legible and improves readability.
+      </MaturityChecklistItem>
+      <MaturityChecklistItem title="WCAG 2.1 Level AA Conformance" status={props.a11yStandards}>
+        All Axe checks for WCAG AA compliance have passed.
+      </MaturityChecklistItem>
+      <MaturityChecklistItem title="Screen readers" status={props.screenReaders}>
+        VoiceOver, NVDA, and JAWS screen readers provide concise communication and interaction.
+      </MaturityChecklistItem>
+      <MaturityChecklistItem title="Keyboard navigation" status={props.keyboardNavigable}>
+        Component is fully navigable with a keyboard.
+      </MaturityChecklistItem>
+    </ul>
 
-      <h3>Accessibility</h3>
-      <ul className="ds-c-list--bare">
-        <MaturityChecklistItem title="Color" status={props.color}>
-          Meets AA color contrast standards for accessibility and color blindness.
-        </MaturityChecklistItem>
-        <MaturityChecklistItem title="Forced Colors Mode (FCM)" status={props.forcedColors}>
-          While using FCM the components text is legible and improves readability.
-        </MaturityChecklistItem>
-        <MaturityChecklistItem title="WCAG 2.1 Level AA Conformance" status={props.a11yStandards}>
-          All Axe checks for WCAG AA compliance have passed.
-        </MaturityChecklistItem>
-        <MaturityChecklistItem title="Screen readers" status={props.screenReaders}>
-          VoiceOver, NVDA, and JAWS screen readers provide concise communication and interaction.
-        </MaturityChecklistItem>
-        <MaturityChecklistItem title="Keyboard navigation" status={props.keyboardNavigable}>
-          Component is fully navigable with a keyboard.
-        </MaturityChecklistItem>
-      </ul>
+    <h3>Code</h3>
+    <ul className="ds-c-list--bare">
+      <MaturityChecklistItem title="Storybook" status={props.storybook}>
+        Component has stories to cover all defined props.
+      </MaturityChecklistItem>
+      <MaturityChecklistItem title="Responsive" status={props.responsive}>
+        Component designed to work in all responsive breakpoints.
+      </MaturityChecklistItem>
+      <MaturityChecklistItem title="Spanish translations" status={props.spanish}>
+        Includes Spanish translations for default text content.
+      </MaturityChecklistItem>
+    </ul>
 
-      <Button onClick={openDialog}>Open dialog</Button>
-      {dialog}
-
-      <h3>Code</h3>
-      <ul className="ds-c-list--bare">
-        <MaturityChecklistItem title="Storybook" status={props.storybook}>
-          Component has stories to cover all defined props.
-        </MaturityChecklistItem>
-        <MaturityChecklistItem title="Responsive" status={props.responsive}>
-          Component designed to work in all responsive breakpoints.
-        </MaturityChecklistItem>
-        <MaturityChecklistItem title="Spanish translations" status={props.spanish}>
-          Includes Spanish translations for default text content.
-        </MaturityChecklistItem>
-      </ul>
-
-      {/* <h3>Design</h3>
+    {/* <h3>Design</h3>
     <ul className="ds-c-list--bare">
       <MaturityChecklistItem title="Sketch UI-kit" status={props.completeUiKit}>
         Includes all Sketch symbols for defined options.
@@ -100,17 +77,16 @@ const MaturityChecklist = (props: MaturityChecklistProps) => {
       </MaturityChecklistItem>
     </ul> */}
 
-      <h3>Tokens</h3>
-      <ul className="ds-c-list--bare">
-        <MaturityChecklistItem title="Code" status={props.tokensInCode}>
-          Tokens implemented in code.
-        </MaturityChecklistItem>
-        <MaturityChecklistItem title="Design" status={props.tokensInSketch}>
-          Tokens implemented in the Sketch.
-        </MaturityChecklistItem>
-      </ul>
-    </section>
-  );
-};
+    <h3>Tokens</h3>
+    <ul className="ds-c-list--bare">
+      <MaturityChecklistItem title="Code" status={props.tokensInCode}>
+        Tokens implemented in code.
+      </MaturityChecklistItem>
+      <MaturityChecklistItem title="Design" status={props.tokensInSketch}>
+        Tokens implemented in the Sketch.
+      </MaturityChecklistItem>
+    </ul>
+  </section>
+);
 
 export default MaturityChecklist;

--- a/packages/docs/src/components/content/MaturityChecklist/MaturityChecklist.tsx
+++ b/packages/docs/src/components/content/MaturityChecklist/MaturityChecklist.tsx
@@ -1,4 +1,5 @@
 import MaturityChecklistItem, { CheckStatus } from './MaturityChecklistItem';
+import { Button, Dialog, useDialog } from '@cmsgov/design-system';
 
 interface MaturityChecklistProps {
   // Accessibility
@@ -25,49 +26,71 @@ interface MaturityChecklistProps {
 /**
  *
  */
-const MaturityChecklist = (props: MaturityChecklistProps) => (
-  <section>
-    <p>
-      For more information about how we tested and validated our work for each checklist item,{' '}
-      <a href="https://github.com/CMSgov/design-system/blob/main/COMPONENT_MATURITY.md">
-        read our component maturity documentation
-      </a>
-      .
-    </p>
+const MaturityChecklist = (props: MaturityChecklistProps) => {
+  const { dialog, openDialog } = useDialog(({ resolveClose, isOpen }) => (
+    <Dialog
+      heading="Hello World"
+      onExit={resolveClose}
+      actions={
+        <>
+          <Button variation="ghost" onClick={resolveClose}>
+            Cancel
+          </Button>
+        </>
+      }
+      isOpen={isOpen}
+    >
+      Are you sure you want to delete your account? All in-progress applications will be deleted and
+      your information cleared from the system.
+    </Dialog>
+  ));
 
-    <h3>Accessibility</h3>
-    <ul className="ds-c-list--bare">
-      <MaturityChecklistItem title="Color" status={props.color}>
-        Meets AA color contrast standards for accessibility and color blindness.
-      </MaturityChecklistItem>
-      <MaturityChecklistItem title="Forced Colors Mode (FCM)" status={props.forcedColors}>
-        While using FCM the components text is legible and improves readability.
-      </MaturityChecklistItem>
-      <MaturityChecklistItem title="WCAG 2.1 Level AA Conformance" status={props.a11yStandards}>
-        All Axe checks for WCAG AA compliance have passed.
-      </MaturityChecklistItem>
-      <MaturityChecklistItem title="Screen readers" status={props.screenReaders}>
-        VoiceOver, NVDA, and JAWS screen readers provide concise communication and interaction.
-      </MaturityChecklistItem>
-      <MaturityChecklistItem title="Keyboard navigation" status={props.keyboardNavigable}>
-        Component is fully navigable with a keyboard.
-      </MaturityChecklistItem>
-    </ul>
+  return (
+    <section>
+      <p>
+        For more information about how we tested and validated our work for each checklist item,{' '}
+        <a href="https://github.com/CMSgov/design-system/blob/main/COMPONENT_MATURITY.md">
+          read our component maturity documentation
+        </a>
+        .
+      </p>
 
-    <h3>Code</h3>
-    <ul className="ds-c-list--bare">
-      <MaturityChecklistItem title="Storybook" status={props.storybook}>
-        Component has stories to cover all defined props.
-      </MaturityChecklistItem>
-      <MaturityChecklistItem title="Responsive" status={props.responsive}>
-        Component designed to work in all responsive breakpoints.
-      </MaturityChecklistItem>
-      <MaturityChecklistItem title="Spanish translations" status={props.spanish}>
-        Includes Spanish translations for default text content.
-      </MaturityChecklistItem>
-    </ul>
+      <h3>Accessibility</h3>
+      <ul className="ds-c-list--bare">
+        <MaturityChecklistItem title="Color" status={props.color}>
+          Meets AA color contrast standards for accessibility and color blindness.
+        </MaturityChecklistItem>
+        <MaturityChecklistItem title="Forced Colors Mode (FCM)" status={props.forcedColors}>
+          While using FCM the components text is legible and improves readability.
+        </MaturityChecklistItem>
+        <MaturityChecklistItem title="WCAG 2.1 Level AA Conformance" status={props.a11yStandards}>
+          All Axe checks for WCAG AA compliance have passed.
+        </MaturityChecklistItem>
+        <MaturityChecklistItem title="Screen readers" status={props.screenReaders}>
+          VoiceOver, NVDA, and JAWS screen readers provide concise communication and interaction.
+        </MaturityChecklistItem>
+        <MaturityChecklistItem title="Keyboard navigation" status={props.keyboardNavigable}>
+          Component is fully navigable with a keyboard.
+        </MaturityChecklistItem>
+      </ul>
 
-    {/* <h3>Design</h3>
+      <Button onClick={openDialog}>Open dialog</Button>
+      {dialog}
+
+      <h3>Code</h3>
+      <ul className="ds-c-list--bare">
+        <MaturityChecklistItem title="Storybook" status={props.storybook}>
+          Component has stories to cover all defined props.
+        </MaturityChecklistItem>
+        <MaturityChecklistItem title="Responsive" status={props.responsive}>
+          Component designed to work in all responsive breakpoints.
+        </MaturityChecklistItem>
+        <MaturityChecklistItem title="Spanish translations" status={props.spanish}>
+          Includes Spanish translations for default text content.
+        </MaturityChecklistItem>
+      </ul>
+
+      {/* <h3>Design</h3>
     <ul className="ds-c-list--bare">
       <MaturityChecklistItem title="Sketch UI-kit" status={props.completeUiKit}>
         Includes all Sketch symbols for defined options.
@@ -77,16 +100,17 @@ const MaturityChecklist = (props: MaturityChecklistProps) => (
       </MaturityChecklistItem>
     </ul> */}
 
-    <h3>Tokens</h3>
-    <ul className="ds-c-list--bare">
-      <MaturityChecklistItem title="Code" status={props.tokensInCode}>
-        Tokens implemented in code.
-      </MaturityChecklistItem>
-      <MaturityChecklistItem title="Design" status={props.tokensInSketch}>
-        Tokens implemented in the Sketch.
-      </MaturityChecklistItem>
-    </ul>
-  </section>
-);
+      <h3>Tokens</h3>
+      <ul className="ds-c-list--bare">
+        <MaturityChecklistItem title="Code" status={props.tokensInCode}>
+          Tokens implemented in code.
+        </MaturityChecklistItem>
+        <MaturityChecklistItem title="Design" status={props.tokensInSketch}>
+          Tokens implemented in the Sketch.
+        </MaturityChecklistItem>
+      </ul>
+    </section>
+  );
+};
 
 export default MaturityChecklist;


### PR DESCRIPTION
## Summary

We forgot to export the new `useDialog` hook in v9, and nobody has caught it until now when I noticed I couldn't import it into the doc site.

## How to test

1. Check out [01dfe21](https://github.com/CMSgov/design-system/pull/3130/commits/01dfe2158f1907c8e5b84056a5db60dae942f756)
2. Build the doc site and look at the maturity checklist on a component page. There will be a new button in there for opening a dialog, which uses the new hook

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone