### PR TITLE
[NO-TICKET] Fix regression in max-width of USA banner on doc site

### DIFF
--- a/packages/docs/src/styles/pages/layout.scss
+++ b/packages/docs/src/styles/pages/layout.scss
@@ -3,7 +3,7 @@ body {
 }
 
 .ds-c-usa-banner__header {
-  --usa-banner__max-width: initial;
+  --usa-banner__max-width: none;
 }
 
 .full-height {


### PR DESCRIPTION
## Summary

Fix regression in max-width of USA banner on doc site. For some reason a value of `initial` seems to trigger the `var()` fallback mechanism instead of just removing the max width. I guess that's how custom properties work?

## How to test

Make sure the doc site's USA banner content spans the full width like the production one.
