### PR TITLE
[WNMGDS-2797] Remove the unused `--autocomplete*` and `--dropdown*` variables

### DIFF
--- a/packages/design-system-tokens/src/tokens/Theme.cmsgov.json
+++ b/packages/design-system-tokens/src/tokens/Theme.cmsgov.json
@@ -1461,72 +1461,6 @@
         }
       }
     },
-    "autocomplete": {
-      "background-color": {
-        "$value": "{theme.color.white}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      },
-      "item": {
-        "font-color": {
-          "$value": "{theme.color.primary}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "background-color--active": {
-          "$value": "{theme.color.primary}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "font-color--active": {
-          "$value": "{theme.color.white}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        }
-      },
-      "item-message": {
-        "font-color": {
-          "$value": "{theme.color.primary}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        }
-      },
-      "border-color": {
-        "$value": "{theme.color.gray-lighter}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      }
-    },
     "badge": {
       "background-color--alert": {
         "$value": "{theme.color.error}",
@@ -3577,30 +3511,6 @@
             "hiddenFromPublishing": false,
             "scopes": ["ALL_SCOPES"],
             "codeSyntax": {}
-          }
-        }
-      }
-    },
-    "dropdown": {
-      "background-color": {
-        "$value": "{theme.color.white}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      },
-      "option-group": {
-        "padding": {
-          "$value": "{spacer.3}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
           }
         }
       }

--- a/packages/design-system-tokens/src/tokens/Theme.core.json
+++ b/packages/design-system-tokens/src/tokens/Theme.core.json
@@ -1460,73 +1460,6 @@
         }
       }
     },
-    "autocomplete": {
-      "background-color": {
-        "$value": "{theme.color.white}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      },
-      "item": {
-        "font-color": {
-          "$value": "{theme.color.primary}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "background-color--active": {
-          "$value": "{theme.color.primary-darkest}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "font-color--active": {
-          "$value": "{theme.color.white}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        }
-      },
-      "item-message": {
-        "font-color": {
-          "$value": "#ffffff",
-          "$type": "color",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        }
-      },
-      "border-color": {
-        "$value": "{theme.color.gray-lighter}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      }
-    },
     "badge": {
       "background-color--alert": {
         "$value": "{theme.color.error}",
@@ -3577,30 +3510,6 @@
             "hiddenFromPublishing": false,
             "scopes": ["ALL_SCOPES"],
             "codeSyntax": {}
-          }
-        }
-      }
-    },
-    "dropdown": {
-      "background-color": {
-        "$value": "{theme.color.white}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      },
-      "option-group": {
-        "padding": {
-          "$value": "{spacer.3}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
           }
         }
       }

--- a/packages/design-system-tokens/src/tokens/Theme.healthcare.json
+++ b/packages/design-system-tokens/src/tokens/Theme.healthcare.json
@@ -1460,75 +1460,6 @@
         }
       }
     },
-    "autocomplete": {
-      "background-color": {
-        "$value": "{theme.color.white}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      },
-      "item": {
-        "font-color": {
-          "$value": "#ffffff",
-          "$type": "color",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "background-color--active": {
-          "$value": "#ffffff",
-          "$type": "color",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "font-color--active": {
-          "$value": "{theme.color.white}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        }
-      },
-      "item-message": {
-        "font-color": {
-          "$value": "#ffffff",
-          "$type": "color",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        }
-      },
-      "border-color": {
-        "$value": "{theme.color.gray-lighter}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      }
-    },
     "badge": {
       "background-color--alert": {
         "$value": "{theme.color.error}",
@@ -3579,30 +3510,6 @@
             "hiddenFromPublishing": false,
             "scopes": ["ALL_SCOPES"],
             "codeSyntax": {}
-          }
-        }
-      }
-    },
-    "dropdown": {
-      "background-color": {
-        "$value": "{theme.color.white}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      },
-      "option-group": {
-        "padding": {
-          "$value": "{spacer.3}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
           }
         }
       }

--- a/packages/design-system-tokens/src/tokens/Theme.medicare.json
+++ b/packages/design-system-tokens/src/tokens/Theme.medicare.json
@@ -1469,75 +1469,6 @@
         }
       }
     },
-    "autocomplete": {
-      "background-color": {
-        "$value": "{theme.color.white}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      },
-      "item": {
-        "font-color": {
-          "$value": "#ffffff",
-          "$type": "color",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "background-color--active": {
-          "$value": "#ffffff",
-          "$type": "color",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "font-color--active": {
-          "$value": "{theme.color.white}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        }
-      },
-      "item-message": {
-        "font-color": {
-          "$value": "#ffffff",
-          "$type": "color",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
-          }
-        }
-      },
-      "border-color": {
-        "$value": "{theme.color.gray-lighter}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      }
-    },
     "badge": {
       "background-color--alert": {
         "$value": "{theme.color.error}",
@@ -3588,30 +3519,6 @@
             "hiddenFromPublishing": false,
             "scopes": ["ALL_SCOPES"],
             "codeSyntax": {}
-          }
-        }
-      }
-    },
-    "dropdown": {
-      "background-color": {
-        "$value": "{theme.color.white}",
-        "$extensions": {
-          "com.figma": {
-            "hiddenFromPublishing": false,
-            "scopes": ["ALL_SCOPES"],
-            "codeSyntax": {}
-          }
-        }
-      },
-      "option-group": {
-        "padding": {
-          "$value": "{spacer.4}",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": false,
-              "scopes": ["ALL_SCOPES"],
-              "codeSyntax": {}
-            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Removed the unused `--autocomplete*` and `--dropdown*` variables, which we didn't actually use in the CSS.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone