### PR TITLE
[NO-TICKET] Remove dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ There are a lot of tests, so it can be helpful to constrain the tests you run lo
 
 The CMS Design System provides a Sketch file and Sketch Library containing components, styles, and symbols. These are regularly updated alongside our code, and updates are automatically synced for designers using the Sketch Library.
 
-[Read more on using Sketch with the CMS Design System](/design-assets/README.md)
-
 ## Examples
 
 Examples of the design system in use can be found in the [`examples` directory](examples/).


### PR DESCRIPTION
Removed dead link in README.

There was [discussion in Slack](https://adhoc.slack.com/archives/C02ENLU177S/p1719499500183449?thread_ts=1719429006.419499&cid=C02ENLU177S) about needing to also update the preceding text to talk about Figma instead of Sketch, but it was decided this piece of work should be included in a documentation-wide update (to be done after Figma migration).