### PR TITLE
[WNMGDS-2808] Fix Firefox scrolling pages to the top when a dialog opens

### DIFF
--- a/packages/design-system/src/styles/components/_Dialog.scss
+++ b/packages/design-system/src/styles/components/_Dialog.scss
@@ -1,40 +1,6 @@
 @use '../layout' as *;
 @use '../base';
 
-// Start polyfill styles
-// dialog {
-//   background-color: var(--dialog__background-color);
-//   height: fit-content;
-//   left: 0;
-//   margin: auto;
-//   padding: 1em;
-//   position: absolute;
-//   right: 0;
-// }
-
-// dialog:not([open]) {
-//   display: none;
-// }
-
-// dialog + .backdrop {
-//   background: var(--dialog-overlay__background-color);
-//   inset: 0;
-//   position: fixed;
-// }
-
-// ._dialog_overlay {
-//   inset: 0;
-//   position: fixed;
-// }
-
-// dialog.fixed {
-//   position: fixed;
-//   top: 50%;
-//   transform: translate(0, -50%);
-// }
-
-// End polyfill styles
-
 .ds-c-dialog {
   background: transparent;
   border: none;

--- a/packages/design-system/src/styles/components/_Dialog.scss
+++ b/packages/design-system/src/styles/components/_Dialog.scss
@@ -2,36 +2,36 @@
 @use '../base';
 
 // Start polyfill styles
-dialog {
-  background-color: var(--dialog__background-color);
-  height: fit-content;
-  left: 0;
-  margin: auto;
-  padding: 1em;
-  position: absolute;
-  right: 0;
-}
+// dialog {
+//   background-color: var(--dialog__background-color);
+//   height: fit-content;
+//   left: 0;
+//   margin: auto;
+//   padding: 1em;
+//   position: absolute;
+//   right: 0;
+// }
 
-dialog:not([open]) {
-  display: none;
-}
+// dialog:not([open]) {
+//   display: none;
+// }
 
-dialog + .backdrop {
-  background: var(--dialog-overlay__background-color);
-  inset: 0;
-  position: fixed;
-}
+// dialog + .backdrop {
+//   background: var(--dialog-overlay__background-color);
+//   inset: 0;
+//   position: fixed;
+// }
 
-._dialog_overlay {
-  inset: 0;
-  position: fixed;
-}
+// ._dialog_overlay {
+//   inset: 0;
+//   position: fixed;
+// }
 
-dialog.fixed {
-  position: fixed;
-  top: 50%;
-  transform: translate(0, -50%);
-}
+// dialog.fixed {
+//   position: fixed;
+//   top: 50%;
+//   transform: translate(0, -50%);
+// }
 
 // End polyfill styles
 


### PR DESCRIPTION
## Summary

Fix Firefox scrolling pages to the top when a dialog opens in race condition.

On one of the apps, opening a dialog in Firefox would scroll the page to the top. We weren't able to reproduce this in our Storybook, but we could see the behavior that caused it by disabling our code that applied the body classes and properties that freeze it. The polyfill styles by themselves were causing the page to scroll to the top in Firefox. In the race condition, the page would scroll to the top before our JavaScript could poll the document to find its scroll position, so the scroll position was always zero.

We don't need these polyfill styles anymore. We have to keep the skeleton of a JavaScript polyfill around to support testing frameworks, but those don't need any CSS. The dialog element has Baseline 2022 support.

## How to test

We tested the fix in the downstream app that experienced the bug.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone