### PR TITLE
[WNMGDS-2818] Prevent nested errors in choicelist

### DIFF
--- a/packages/design-system/src/components/ChoiceList/Choice.tsx
+++ b/packages/design-system/src/components/ChoiceList/Choice.tsx
@@ -45,6 +45,10 @@ export interface BaseChoiceProps {
    */
   className?: string;
   /**
+   * @hide-prop Internal prop used to determine if a Choice is the child of a ChoiceList. Used to hide excessive error messages.
+   */
+  _choiceListChild?: boolean;
+  /**
    * Additional classes to be added to the `input` element.
    */
   inputClassName?: string;
@@ -112,7 +116,7 @@ export const Choice = (props: ChoiceProps) => {
 
   let errorId;
   let errorElement;
-  if (props.errorMessage) {
+  if (!props._choiceListChild) {
     errorId = props.errorId ?? `${props.id}__error`;
     errorElement = (
       <InlineError id={errorId} inversed={props.inversed} className={props.errorMessageClassName}>
@@ -196,6 +200,10 @@ export const Choice = (props: ChoiceProps) => {
       {checked ? checkedChildren : uncheckedChildren}
     </div>
   );
+};
+
+Choice.defaultProps = {
+  _choiceListChild: false,
 };
 
 export default Choice;

--- a/packages/design-system/src/components/ChoiceList/Choice.tsx
+++ b/packages/design-system/src/components/ChoiceList/Choice.tsx
@@ -123,6 +123,8 @@ export const Choice = (props: ChoiceProps) => {
         {props.errorMessage}
       </InlineError>
     );
+  } else {
+    delete props._choiceChild;
   }
 
   // Subscribe to changes from other radio buttons in the same group

--- a/packages/design-system/src/components/ChoiceList/Choice.tsx
+++ b/packages/design-system/src/components/ChoiceList/Choice.tsx
@@ -124,7 +124,8 @@ export const Choice = (props: ChoiceProps) => {
       </InlineError>
     );
   } else {
-    delete props._choiceChild;
+    const { _choiceChild, ...rest } = props;
+    props = rest;
   }
 
   // Subscribe to changes from other radio buttons in the same group

--- a/packages/design-system/src/components/ChoiceList/Choice.tsx
+++ b/packages/design-system/src/components/ChoiceList/Choice.tsx
@@ -45,9 +45,9 @@ export interface BaseChoiceProps {
    */
   className?: string;
   /**
-   * @hide-prop Internal prop used to determine if a Choice is the child of a ChoiceList. Used to hide excessive error messages.
+   * @hide-prop Internal prop used to determine if a Choice is the child of a another component (like ChoiceList or MonthPicker). Used to hide excessive error messages.
    */
-  _choiceListChild?: boolean;
+  _choiceChild?: boolean;
   /**
    * Additional classes to be added to the `input` element.
    */
@@ -116,7 +116,7 @@ export const Choice = (props: ChoiceProps) => {
 
   let errorId;
   let errorElement;
-  if (!props._choiceListChild) {
+  if (!props._choiceChild) {
     errorId = props.errorId ?? `${props.id}__error`;
     errorElement = (
       <InlineError id={errorId} inversed={props.inversed} className={props.errorMessageClassName}>
@@ -203,7 +203,7 @@ export const Choice = (props: ChoiceProps) => {
 };
 
 Choice.defaultProps = {
-  _choiceListChild: false,
+  _choiceChild: false,
 };
 
 export default Choice;

--- a/packages/design-system/src/components/ChoiceList/Choice.tsx
+++ b/packages/design-system/src/components/ChoiceList/Choice.tsx
@@ -102,7 +102,8 @@ const dsChoiceEmitter = new EvEmitter();
  * [checkbox](https://design.cms.gov/components/checkbox/) and
  * [radio](https://design.cms.gov/components/radio/) documentation pages.
  */
-export const Choice = (props: ChoiceProps) => {
+
+export const Choice = ({ _choiceChild, ...props }: ChoiceProps) => {
   const initialCheckedState = props.checked ?? props.defaultChecked;
   const [internalCheckedState, setChecked] = useState(initialCheckedState);
   const isControlled = props.checked !== undefined;
@@ -116,16 +117,13 @@ export const Choice = (props: ChoiceProps) => {
 
   let errorId;
   let errorElement;
-  if (!props._choiceChild) {
+  if (!_choiceChild) {
     errorId = props.errorId ?? `${props.id}__error`;
     errorElement = (
       <InlineError id={errorId} inversed={props.inversed} className={props.errorMessageClassName}>
         {props.errorMessage}
       </InlineError>
     );
-  } else {
-    const { _choiceChild, ...rest } = props;
-    props = rest;
   }
 
   // Subscribe to changes from other radio buttons in the same group

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
@@ -136,7 +136,7 @@ export const ChoiceList: React.FC<ChoiceListProps> = (props: ChoiceListProps) =>
           choiceProps.inputRef(ref);
         }
       },
-      // _choiceListChild: true,
+      _choiceChild: true,
     };
 
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
@@ -19,7 +19,10 @@ export interface BaseChoiceListProps {
   /**
    * Array of objects representing the props for each Choice in the ChoiceList
    */
-  choices: Omit<ChoiceProps, 'name' | 'type'>[];
+  choices: Omit<
+    ChoiceProps,
+    'name' | 'type' | 'errorMessage' | 'errorId' | 'errorMessageClassName'
+  >[];
   /**
    * Additional classes to be added to the root element.
    */
@@ -133,7 +136,16 @@ export const ChoiceList: React.FC<ChoiceListProps> = (props: ChoiceListProps) =>
           choiceProps.inputRef(ref);
         }
       },
+      // _choiceListChild: true,
     };
+
+    if (process.env.NODE_ENV !== 'production') {
+      if ('errorMessage' in completeChoiceProps) {
+        console.warn(
+          `[Warning]: Error messages on individual child Choice components is not a valid pattern. Errors should only be displayed on the parent ChoiceList component.`
+        );
+      }
+    }
 
     return <Choice key={choiceProps.value} {...completeChoiceProps} />;
   });

--- a/packages/design-system/src/components/ChoiceList/__snapshots__/Choice.test.tsx.snap
+++ b/packages/design-system/src/components/ChoiceList/__snapshots__/Choice.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Choice accepts a node as innerHTML 1`] = `
       class="ds-c-choice-wrapper"
     >
       <input
+        aria-describedby="static-id__error"
         class="ds-c-choice"
         id="static-id"
         name="foo"
@@ -25,6 +26,12 @@ exports[`Choice accepts a node as innerHTML 1`] = `
            World
         </p>
       </label>
+      <p
+        aria-atomic="true"
+        aria-live="assertive"
+        class="ds-c-inline-error"
+        id="static-id__error"
+      />
     </div>
   </div>
 </DocumentFragment>
@@ -86,7 +93,7 @@ exports[`Choice has a hint and requirementLabel 1`] = `
       class="ds-c-choice-wrapper"
     >
       <input
-        aria-describedby="static-id__hint"
+        aria-describedby="static-id__error static-id__hint"
         class="ds-c-choice"
         id="static-id"
         name="foo"
@@ -106,6 +113,12 @@ exports[`Choice has a hint and requirementLabel 1`] = `
       >
         Optional. Hello world
       </p>
+      <p
+        aria-atomic="true"
+        aria-live="assertive"
+        class="ds-c-inline-error"
+        id="static-id__error"
+      />
     </div>
   </div>
 </DocumentFragment>
@@ -118,6 +131,7 @@ exports[`Choice is a checkbox 1`] = `
       class="ds-c-choice-wrapper"
     >
       <input
+        aria-describedby="static-id__error"
         class="ds-c-choice"
         id="static-id"
         name="foo"
@@ -131,6 +145,12 @@ exports[`Choice is a checkbox 1`] = `
       >
         George Washington
       </label>
+      <p
+        aria-atomic="true"
+        aria-live="assertive"
+        class="ds-c-inline-error"
+        id="static-id__error"
+      />
     </div>
   </div>
 </DocumentFragment>
@@ -143,6 +163,7 @@ exports[`Choice is a radio 1`] = `
       class="ds-c-choice-wrapper"
     >
       <input
+        aria-describedby="static-id__error"
         class="ds-c-choice"
         id="static-id"
         name="foo"
@@ -156,6 +177,12 @@ exports[`Choice is a radio 1`] = `
       >
         George Washington
       </label>
+      <p
+        aria-atomic="true"
+        aria-live="assertive"
+        class="ds-c-inline-error"
+        id="static-id__error"
+      />
     </div>
   </div>
 </DocumentFragment>
@@ -172,6 +199,7 @@ exports[`Choice nested content renders \`checkedChildren\` when checked 1`] = `
       class="ds-c-choice-wrapper"
     >
       <input
+        aria-describedby="static-id__error"
         class="ds-c-choice"
         id="static-id"
         name="foo"
@@ -185,6 +213,12 @@ exports[`Choice nested content renders \`checkedChildren\` when checked 1`] = `
       >
         George Washington
       </label>
+      <p
+        aria-atomic="true"
+        aria-live="assertive"
+        class="ds-c-inline-error"
+        id="static-id__error"
+      />
     </div>
     <strong
       class="checked-child"
@@ -207,6 +241,7 @@ exports[`Choice nested content renders \`uncheckedChildren\` when not checked 1`
       class="ds-c-choice-wrapper"
     >
       <input
+        aria-describedby="static-id__error"
         class="ds-c-choice"
         id="static-id"
         name="foo"
@@ -220,6 +255,12 @@ exports[`Choice nested content renders \`uncheckedChildren\` when not checked 1`
       >
         George Washington
       </label>
+      <p
+        aria-atomic="true"
+        aria-live="assertive"
+        class="ds-c-inline-error"
+        id="static-id__error"
+      />
     </div>
     <strong
       class="unchecked-child"

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
@@ -204,6 +204,7 @@ export const MonthPicker = (props: MonthPickerProps) => {
                 value={i + 1}
                 label={month}
                 id={`${id}__choice--${i + 1}`}
+                _choiceChild={true}
               />
             </li>
           ))}

--- a/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`Choice has a hint and requirementLabel 1`] = `
         class="ds-c-choice-wrapper"
       >
         <input
-          aria-describedby="choice--8__hint"
+          aria-describedby="undefined__error choice--8__hint"
           class="ds-c-choice"
           id="choice--8"
           name="foo"
@@ -97,6 +97,12 @@ exports[`Choice has a hint and requirementLabel 1`] = `
         >
           Optional. Hello world
         </p>
+        <p
+          aria-atomic="true"
+          aria-live="assertive"
+          class="ds-c-inline-error"
+          id="undefined__error"
+        />
       </div>
     </div>
     <template />
@@ -118,6 +124,7 @@ exports[`Choice is a checkbox 1`] = `
         class="ds-c-choice-wrapper"
       >
         <input
+          aria-describedby="undefined__error"
           class="ds-c-choice"
           id="choice--2"
           name="foo"
@@ -132,6 +139,12 @@ exports[`Choice is a checkbox 1`] = `
         >
           George Washington
         </label>
+        <p
+          aria-atomic="true"
+          aria-live="assertive"
+          class="ds-c-inline-error"
+          id="undefined__error"
+        />
       </div>
     </div>
     <template />
@@ -153,6 +166,7 @@ exports[`Choice is a radio 1`] = `
         class="ds-c-choice-wrapper"
       >
         <input
+          aria-describedby="undefined__error"
           class="ds-c-choice"
           id="choice--1"
           name="foo"
@@ -167,6 +181,12 @@ exports[`Choice is a radio 1`] = `
         >
           George Washington
         </label>
+        <p
+          aria-atomic="true"
+          aria-live="assertive"
+          class="ds-c-inline-error"
+          id="undefined__error"
+        />
       </div>
     </div>
     <template />
@@ -192,6 +212,7 @@ exports[`Choice nested content renders checked and unchecked children appropriat
         class="ds-c-choice-wrapper"
       >
         <input
+          aria-describedby="undefined__error"
           class="ds-c-choice"
           id="choice--23"
           name="foo"
@@ -206,6 +227,12 @@ exports[`Choice nested content renders checked and unchecked children appropriat
         >
           George Washington
         </label>
+        <p
+          aria-atomic="true"
+          aria-live="assertive"
+          class="ds-c-inline-error"
+          id="undefined__error"
+        />
       </div>
       <strong
         class="unchecked-child"

--- a/packages/design-system/src/components/web-components/preactement/parse.test.ts
+++ b/packages/design-system/src/components/web-components/preactement/parse.test.ts
@@ -56,7 +56,7 @@ describe('parse', () => {
         expect(slots).toEqual({ [testKey]: slotValue });
       });
 
-      it('should ignore slots of nested custom elements>', () => {
+      it('should ignore slots of nested custom elements', () => {
         const testHtml = `
           <section>
             <div slot="parent-slot">Hello</div>

--- a/packages/docs/content/patterns/Forms/error-validation.mdx
+++ b/packages/docs/content/patterns/Forms/error-validation.mdx
@@ -76,13 +76,13 @@ Use the [Validation on Submit](#validation-on-submit-default) pattern for most u
 An error message, in both inline errors and error summaries, must include what the user can do to fix the error.
 
 - Inline errors only state how to fix the issue so the user completes the field correctly.
-- Summary error messages include introduction text that reminds the user what's needed in order to complete the action. It also lists the fields to fix and their corresponding inline error messages - the exact same content should be used for the field title and inline error message.
+- Summary error messages include introduction text that reminds the user what's needed in order to complete the action. It also lists the fields to fix and their corresponding inline error messages&mdash;the exact same content should be used for the field title and inline error message.
 
 ### All messages must:
 
 - Be specific, short, and consistent.
 - Be in plain English/plain language.
-- Use imperative style.
+- Use imperative style (give a direct command to the user).
 - Specify what the user needs to do to fix the issue (using positive framing).
 - Give enough detail to help the user solve the problem or continue to the next step, while using the fewest words possible.
   - _Examples:_
@@ -92,11 +92,11 @@ An error message, in both inline errors and error summaries, must include what t
 - Use a single error message when there are multiple fields related to the same thing, like date (month, day, year).
 - Use sentence case.
 - End with a period.
-- Include language from the question or fieldset label - this helps match up the error message with the relevant form field.
+- Include language from the question or fieldset label&mdash;this helps match up the error message with the relevant form field.
   - _Example:_
     - Field label is "Street address." Inline error message is "Enter a street address with building number and road name." Both the label and error message include "street address" for better user comprehension on how to fix the error.
-- Sound human - read the message out loud to see if it sounds like something you would say.
-- Be tested to validation that users understand what went wrong and how to fix the error.
+- Sound human&mdash;read the message out loud to see if it sounds like something you would say.
+- Test error messages to validate that users understand what went wrong and how to fix the error.
 
 ### Error messages should never:
 

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Choice-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Choice-Docs-prop-table-matches-snapshot-1.txt
@@ -1,5 +1,10 @@
 [
   [
+    "_choiceChild",
+    "boolean",
+    "false"
+  ],
+  [
     "checked",
     "Sets the input's checked state. Use this in combination with onChange for a controlled component; otherwise, set defaultChecked.\n\nboolean",
     "-"

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-ChoiceList-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-ChoiceList-Docs-prop-table-matches-snapshot-1.txt
@@ -1,7 +1,7 @@
 [
   [
     "choices*",
-    "Array of objects representing the props for each Choice in the ChoiceList\nOmit<ChoiceProps, \"name\" | \"type\">[]",
+    "Array of objects representing the props for each Choice in the ChoiceList\nOmit<ChoiceProps, \"name\" | \"type\" | \"errorId\" | \"errorMessage\" | \"errorMessageClassName\">[]",
     "-"
   ],
   [


### PR DESCRIPTION
WNMGDS-2818

Prevent errors from being nested in ChoiceList.

- Individual Choice can have an `errorMessage`
- Choices nested within ChoiceList cannot have an `errorMessage`
- If an error exists in ChoiceList, it should only be revealed by the ChoiceList's `errorMessage`, not on its children

Also added TS checks to make sure `error*` props weren't being used and a `console.warn` to gently scold if they weren't TS users and insisted on doing the bad pattern.