### PR TITLE
[WNMGDS-2645] Remove unused storybook styles, add support for font fallbacks

### DIFF
--- a/.storybook/cmsTheme.ts
+++ b/.storybook/cmsTheme.ts
@@ -3,33 +3,11 @@ import { create } from '@storybook/theming';
 export default create({
   base: 'light',
 
-  colorPrimary: '#112e51',
   colorSecondary: '#0071bc',
 
-  // UI
-  appBg: 'white',
-  appContentBg: 'white',
-  appBorderColor: 'grey',
-  appBorderRadius: 4,
-
-  // Typography
-  fontBase: '"Open Sans", sans-serif',
-  fontCode: 'monospace',
-
-  // Text colors
-  textColor: '#212121',
-  textInverseColor: '#fff',
-
-  // Toolbar default and active colors
-  barTextColor: '#212121',
-  barSelectedColor: '#0071bc',
-  barBg: '#f1f1f1',
-
-  // Form colors
-  inputBg: 'white',
-  inputBorder: 'silver',
-  inputTextColor: 'black',
-  inputBorderRadius: 4,
+  fontBase:
+    "'Open Sans', 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', 'Arial', 'sans-serif'",
+  fontCode: "Menlo, Consolas, Monaco, 'Liberation Mono', 'Lucida Console', monospace",
 
   brandTitle: 'CMS Gov Design System',
   brandUrl: 'https://design.cms.gov/',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,6 +7,7 @@ import { setLanguage as setLanguageFromPackage } from '@cmsgov/design-system';
 import themes from '../themes.json';
 import type { UtagContainer } from '@cmsgov/design-system';
 import type { Preview } from '@storybook/react';
+import cmsTheme from './cmsTheme';
 
 // Rewire analytics events to log to the console
 let originalUtag;
@@ -206,6 +207,7 @@ const preview: Preview = {
     },
     docs: {
       page: DocumentationTemplate,
+      theme: cmsTheme,
     },
   },
   decorators: [


### PR DESCRIPTION
WNMGDS-2645

In PROD, discovered the Nunito font was being downloaded for Storybook UI. Discovered the cmsTheme file we created (I believe when Storybook was first added to this project) wasn't hooked up to style the canvas area of Storybook's UI (the area where the interactive examples were). When adding the cmsTheme to Storybook's canvas area, Nunito was removed, but other styles were introduced. Turns out we had things configured that weren't actually displaying.

Discussed this with Patrick and decided that because we weren't seeing the pre-set configuration to begin with, it's best to remove those options and just configure the things we care about (brand color, names, fonts). So I simplified this config. The only change should be the font-face used on the canvas documentation.