### PR TITLE
[WNMGDS-2828] Update avoid error message guidance.

### DIFF
--- a/packages/docs/content/patterns/Forms/error-validation.mdx
+++ b/packages/docs/content/patterns/Forms/error-validation.mdx
@@ -98,20 +98,19 @@ An error message, in both inline errors and error summaries, must include what t
 - Sound human&mdash;read the message out loud to see if it sounds like something you would say.
 - Test error messages to validate that users understand what went wrong and how to fix the error.
 
-### Error messages should never:
+### Avoid the following in error messages:
 
-- Be too generic: General error messages don't help the user to fix the problem.
-  - _Example:_
+- Don't be too generic: General error messages don't help the user to fix the problem.
+  - _Examples:_
     - "An error occurred."
     - "Answer the question."
     - "Select an option."
     - "Required field."
-- Use the verbs "see" and "view" unless it would be awkward to use another verb. These can be used, but they should be the last choice (accessibility issue).
-- Use words like "please" or "sorry."
-- Use technical jargon like, "Unspecified error," and "Issue 567 error."
-- Use negative words like, "forbidden," "illegal," "you forgot," "you didn't," and "prohibited."
-- Use "valid" and "invalid," as these words can mean a lot of different things and are not commonly used words for non-native English speakers.
-- Use informal language like "oops."
+- Don't use the verbs "see" and "view" unless it would be awkward to use another verb. These can be used, but they should be the last choice (accessibility issue).
+- Don't use words like "please" or "sorry," or informal language like "oops."
+- Don't use technical jargon like, "Unspecified error," and "Issue 567 error."
+- Don't use negative words like, "forbidden," "illegal," "you forgot," "you didn't," and "prohibited."
+- Don't use "valid" and "invalid," as these words can mean a lot of different things and are not commonly used words for non-native English speakers.
 
 ## Validation on Submit (default)
 


### PR DESCRIPTION
WNMGDS-2828

Replace "Error message should never" guidance with "Avoid the following in error messages;" include "don't" language.