### PR TITLE
[WNMGDS-2826] Update third party external link docs to include pdf guidance

### DIFF
--- a/packages/docs/content/components/third-party-external-link.mdx
+++ b/packages/docs/content/components/third-party-external-link.mdx
@@ -26,7 +26,7 @@ This component has analytics tracking available. Please see our developer docume
 
 Use this pattern when the user is in the middle of a task or application to let them know that the action they are taking will move them away from the current site and or process. This serves as a warning where the user can then decide to remain where they are in the application or process.
 
-Any PDF links, whether internal or external, is not a use case for using the third party link component.
+Any PDF link, whether internal or external, is not a use case for using the third party link component.
 
 - PDF links should use the regular [link style](/foundation/typography/links/).
 - Add "(PDF)" at the end of link.

--- a/packages/docs/content/components/third-party-external-link.mdx
+++ b/packages/docs/content/components/third-party-external-link.mdx
@@ -26,7 +26,12 @@ This component has analytics tracking available. Please see our developer docume
 
 Use this pattern when the user is in the middle of a task or application to let them know that the action they are taking will move them away from the current site and or process. This serves as a warning where the user can then decide to remain where they are in the application or process.
 
-**Any non .gov and .mil links will be treated as external whether they belong to a government agency or not, no exceptions**
+Any PDF links, whether internal or external, is not a use case for using the third party link component.
+
+- PDF links should use the regular [link style](/foundation/typography/links/).
+- Add "(PDF)" at the end of link.
+
+**Any non .gov and .mil links will be treated as external whether they belong to a government agency or not, no exceptions.**
 
 - [CMS policy on external links](https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/PolicyforLinkingtoOutsideWebsites.html)
 - [CMS external link disclaimer](https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/External-Link-Disclaimer.html)


### PR DESCRIPTION
WNMGDS-2826

Update ThirdPartyExternalLink docs to include PDF guidance.

[Demo url (building)](https://cmsgov.github.io/design-system/branch/WNMGDS-2826/update-third-party-external-link-guidance)