### PR TITLE
[NO-TICKET] Use new docgen union sorting

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,6 @@
 import { dirname, join } from 'path';
 import type { StorybookConfig } from '@storybook/react-webpack5';
+import { typescript as typescriptPresets } from '@storybook/core-server/dist/presets/common-preset';
 
 const extensionGlob = '*.stories.@(js|jsx|ts|tsx)';
 
@@ -23,6 +24,10 @@ const config: StorybookConfig = {
   staticDirs: ['../packages/design-system-tokens/dist/css-vars'],
   typescript: {
     reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      ...typescriptPresets().reactDocgenTypescriptOptions,
+      shouldSortUnions: true,
+    },
   },
   framework: {
     name: getAbsolutePath('@storybook/react-webpack5'),

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "prettier": "^2.6.1",
     "react": "17.0.2",
     "react-app-polyfill": "^3.0.0",
+    "react-docgen-typescript": "2.3.0-beta.0",
     "react-dom": "17.0.2",
     "react-test-renderer": "17.0.2",
     "sass": "^1.53.0",
@@ -166,5 +167,8 @@
   "engines": {
     "node": ">=11.0.0",
     "yarn": ">=1.22.4"
+  },
+  "resolutions": {
+    "react-docgen-typescript": "2.3.0-beta.0"
   }
 }

--- a/packages/design-system/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.stories.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
-import { Description, Subtitle, Title } from '@storybook/blocks';
+import { Button } from '../Button';
 import { action } from '@storybook/addon-actions';
 import Drawer from './Drawer';
-import { Button } from '../Button';
+import NoStoryDocTemplate from '../../../../../.storybook/docs/NoStoryDocTemplate.mdx';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Drawer> = {
   title: 'Components/Drawer',
-  component: Drawer as any,
+  component: Drawer,
   argTypes: {
     backdropClickExits: {
       // Until this pattern has solidified, we're not going to advertize this feature.
@@ -24,13 +24,7 @@ const meta: Meta<typeof Drawer> = {
   // The Drawer was overlapping the docs page, so customizing the docs page to remove the examples
   parameters: {
     docs: {
-      page: () => (
-        <>
-          <Title />
-          <Subtitle />
-          <Description />
-        </>
-      ),
+      page: NoStoryDocTemplate,
       underlyingHtmlElements: ['dialog'],
     },
   },

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Button-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Button-Docs-prop-table-matches-snapshot-1.txt
@@ -76,12 +76,12 @@
   ],
   [
     "type",
-    "Button type attribute\n\"button\"\n\"submit\"\n\"reset\"",
+    "Button type attribute\n\"button\"\n\"reset\"\n\"submit\"",
     "\"'button' as const\""
   ],
   [
     "variation",
-    "A string corresponding to Button variation classes.\n\"solid\"\n\"ghost\"",
+    "A string corresponding to Button variation classes.\n\"ghost\"\n\"solid\"",
     "-"
   ]
 ]

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Choice-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Choice-Docs-prop-table-matches-snapshot-1.txt
@@ -121,7 +121,7 @@
   ],
   [
     "type*",
-    "Sets the type to render checkbox fields or radio buttons\n\"radio\"\n\"checkbox\"",
+    "Sets the type to render checkbox fields or radio buttons\n\"checkbox\"\n\"radio\"",
     "-"
   ],
   [

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-ChoiceList-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-ChoiceList-Docs-prop-table-matches-snapshot-1.txt
@@ -31,7 +31,7 @@
   ],
   [
     "errorPlacement",
-    "Location of the error message relative to the field input\n\"top\"\n\"bottom\"",
+    "Location of the error message relative to the field input\n\"bottom\"\n\"top\"",
     "-"
   ],
   [
@@ -106,7 +106,7 @@
   ],
   [
     "type*",
-    "Sets the type to render checkbox fields or radio buttons\n\"radio\"\n\"checkbox\"",
+    "Sets the type to render checkbox fields or radio buttons\n\"checkbox\"\n\"radio\"",
     "-"
   ]
 ]

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Dialog-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Dialog-Docs-prop-table-matches-snapshot-1.txt
@@ -76,7 +76,7 @@
   ],
   [
     "size",
-    "The Dialog's size parameter.\n\"narrow\"\n\"wide\"\n\"full\"",
+    "The Dialog's size parameter.\n\"full\"\n\"narrow\"\n\"wide\"",
     "-"
   ]
 ]

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Drawer-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Drawer-Docs-prop-table-matches-snapshot-1.txt
@@ -16,7 +16,7 @@
   ],
   [
     "closeButtonVariation",
-    "\"solid\"\n\"ghost\"",
+    "\"ghost\"\n\"solid\"",
     "-"
   ],
   [

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Dropdown-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Dropdown-Docs-prop-table-matches-snapshot-1.txt
@@ -47,7 +47,7 @@
   ],
   [
     "errorPlacement",
-    "Location of the error message relative to the field input\n\"top\"\n\"bottom\"",
+    "Location of the error message relative to the field input\n\"bottom\"\n\"top\"",
     "-"
   ],
   [
@@ -137,7 +137,7 @@
   ],
   [
     "size",
-    "Sets the max-width of the input either to 'small' or 'medium'.\n\"small\"\n\"medium\"",
+    "Sets the max-width of the input either to 'small' or 'medium'.\n\"medium\"\n\"small\"",
     "-"
   ],
   [

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-HelpDrawer-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-HelpDrawer-Docs-prop-table-matches-snapshot-1.txt
@@ -26,7 +26,7 @@
   ],
   [
     "closeButtonVariation",
-    "\"solid\"\n\"ghost\"",
+    "\"ghost\"\n\"solid\"",
     "-"
   ],
   [

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-MonthPicker-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-MonthPicker-Docs-prop-table-matches-snapshot-1.txt
@@ -1,7 +1,7 @@
 [
   [
     "buttonVariation",
-    "Variation string to be applied to buttons. See Button component\n\"solid\"\n\"ghost\"",
+    "Variation string to be applied to buttons. See Button component\n\"ghost\"\n\"solid\"",
     "-"
   ],
   [
@@ -41,7 +41,7 @@
   ],
   [
     "errorPlacement",
-    "Location of the error message relative to the field input\n\"top\"\n\"bottom\"",
+    "Location of the error message relative to the field input\n\"bottom\"\n\"top\"",
     "-"
   ],
   [

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-MultiInputDateField-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-MultiInputDateField-Docs-prop-table-matches-snapshot-1.txt
@@ -61,7 +61,7 @@
   ],
   [
     "errorPlacement",
-    "Location of the error message relative to the field input\n\"top\"\n\"bottom\"",
+    "Location of the error message relative to the field input\n\"bottom\"\n\"top\"",
     "-"
   ],
   [

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-SingleInputDateField-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-SingleInputDateField-Docs-prop-table-matches-snapshot-1.txt
@@ -26,7 +26,7 @@
   ],
   [
     "errorPlacement",
-    "Location of the error message relative to the field input\n\"top\"\n\"bottom\"",
+    "Location of the error message relative to the field input\n\"bottom\"\n\"top\"",
     "-"
   ],
   [
@@ -130,7 +130,7 @@
   ],
   [
     "size",
-    "Set the max-width of the input either to 'small' or 'medium'.\n\"small\"\n\"medium\"",
+    "Set the max-width of the input either to 'small' or 'medium'.\n\"medium\"\n\"small\"",
     "-"
   ],
   [

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Table-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Table-Docs-prop-table-matches-snapshot-1.txt
@@ -36,7 +36,7 @@
   ],
   [
     "stackableBreakpoint",
-    "Applies responsive styles to vertically stacked rows at different viewport sizes.\n\"sm\"\n\"md\"\n\"lg\"",
+    "Applies responsive styles to vertically stacked rows at different viewport sizes.\n\"lg\"\n\"md\"\n\"sm\"",
     "\"sm\""
   ],
   [

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-TextField-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-TextField-Docs-prop-table-matches-snapshot-1.txt
@@ -41,7 +41,7 @@
   ],
   [
     "errorPlacement",
-    "Location of the error message relative to the field input\n\"top\"\n\"bottom\"",
+    "Location of the error message relative to the field input\n\"bottom\"\n\"top\"",
     "-"
   ],
   [
@@ -146,7 +146,7 @@
   ],
   [
     "size",
-    "Set the max-width of the input either to 'small' or 'medium'.\n\"small\"\n\"medium\"",
+    "Set the max-width of the input either to 'small' or 'medium'.\n\"medium\"\n\"small\"",
     "-"
   ],
   [

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Tooltip-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Tooltip-Docs-prop-table-matches-snapshot-1.txt
@@ -76,7 +76,7 @@
   ],
   [
     "placement",
-    "Placement of the tooltip body relative to the trigger. See the popperjs docs for more info.\n\"top\"\n\"bottom\"\n\"auto\"\n\"auto-start\"\n\"auto-end\"\n\"right\"\n\"left\"\n\"top-start\"\nShow 7 more...",
+    "Placement of the tooltip body relative to the trigger. See the popperjs docs for more info.\n\"auto-end\"\n\"auto-start\"\n\"auto\"\n\"bottom-end\"\n\"bottom-start\"\n\"bottom\"\n\"left-end\"\n\"left-start\"\nShow 7 more...",
     "\"top\""
   ],
   [

--- a/tests/browser/snapshots/storybook-docs/Docs-Medicare-HelpDrawer-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Medicare-HelpDrawer-Docs-prop-table-matches-snapshot-1.txt
@@ -26,7 +26,7 @@
   ],
   [
     "closeButtonVariation",
-    "\"solid\"\n\"ghost\"",
+    "\"ghost\"\n\"solid\"",
     "-"
   ],
   [

--- a/tests/browser/snapshots/storybook-docs/Docs-components-Alert-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-components-Alert-Docs-prop-table-matches-snapshot-1.txt
@@ -71,7 +71,7 @@
   ],
   [
     "variation",
-    "A string corresponding to the Alert variation classes (error, warn, success)\n\"success\"\n\"warn\"\n\"error\"",
+    "A string corresponding to the Alert variation classes (error, warn, success)\n\"error\"\n\"success\"\n\"warn\"",
     "-"
   ]
 ]

--- a/tests/browser/snapshots/storybook-docs/Docs-components-Badge-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-components-Badge-Docs-prop-table-matches-snapshot-1.txt
@@ -21,7 +21,7 @@
   ],
   [
     "variation",
-    "A string corresponding to the badge-component variation classes\n\"info\"\n\"success\"\n\"warn\"\n\"alert\"",
+    "A string corresponding to the badge-component variation classes\n\"alert\"\n\"info\"\n\"success\"\n\"warn\"",
     "-"
   ]
 ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "baseUrl": ".",
     "skipLibCheck": true
   },
-  "include": ["packages/**/src/**/*"]
+  "include": ["packages/**/src/**/*", ".storybook/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22069,10 +22069,10 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-react-docgen-typescript@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
-  integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==
+react-docgen-typescript@2.3.0-beta.0, react-docgen-typescript@^2.2.2:
+  version "2.3.0-beta.0"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.3.0-beta.0.tgz#f7725a1a76afec30c636b3e538f4aff05cd269ca"
+  integrity sha512-Uh2ZHWNDF4TJZRodJ2+yN13k4vlzPya+6VqDDS+9F4fEdZDBvQvCkowyHQQNZ1If8688hHbSJYHXYNiD3kml3A==
 
 react-docgen@^7.0.0:
   version "7.0.3"
@@ -26680,6 +26680,7 @@ wordwrap@^1.0.0:
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Summary

- Uses the new react-docgen-typescript feature [referenced here](https://github.com/CMSgov/design-system/pull/3003#issuecomment-2239465345)
- Is a follow-up to https://github.com/CMSgov/design-system/pull/3080

## How to test

1. `yarn clean && yarn install && yarn build`
2. `yarn test:browser:storybook-docs` and make sure it doesn't try to change the order of union-type members from what the snapshots show now (string-stort (somewhat alphabetical) order)