### PR TITLE
[NO-TICKET] Fix the bug caused by the first fix to Gatsby image paths

### DIFF
--- a/packages/docs/src/components/content/ContentRenderer.tsx
+++ b/packages/docs/src/components/content/ContentRenderer.tsx
@@ -63,6 +63,20 @@ const TextWithMaxWidth = (props: any, Component) => {
 };
 
 /**
+ * Hack to fix missing path prefixes on static images imported from src
+ */
+const PrefixedImg = (props) => {
+  // When navigating from another page, the Gatsby client dynamically pulls the new page
+  // information and renders with the prefix correctly, so we only want to apply the
+  // path prefix manually if it isn't already there. When we load fresh with a new HTTP
+  // request to a static HTML file, it'll use what's in the HTML, so we add the prefix
+  // when statically rendering, which seems to be where Gatsby fails to use it normally.
+  const pathPrefix = withPrefix('/');
+  const src = props.src.includes(pathPrefix) ? props.src : withPrefix(props.src);
+  return <img {...props} src={src} />;
+};
+
+/**
  * A mapping of custom components for mdx syntax
  * Each mapping has a key with the element name and a value of a functional component to be used for that element
  */
@@ -74,8 +88,7 @@ const customComponents = (theme) => ({
   ColorRamps,
   ComponentThemeOptions: (props) => <ComponentThemeOptions theme={theme} {...props} />,
   EmbeddedExample,
-  // Hack to fix missing path prefixes on static images imported from src
-  img: (props) => <img {...props} src={withPrefix(props.src)} />,
+  img: PrefixedImg,
   MaturityChecklist,
   ol: (props) => TextWithMaxWidth(props, 'ol'),
   p: (props) => TextWithMaxWidth(props, 'p'),


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/CMSgov/design-system/pull/3176, where I attempted to fix a bug and caused its equal and opposite bug. See added code comments for details.

## How to test

I re-deployed [this demo](https://cmsgov.github.io/design-system/branch/pwolfert/release-11-blog-post/blog/release-11.0?theme=core) with the fix. Loading that page from the link should successfully show the image, and also navigating away through the "See other releases" link and then back using the "Release 11.0" link should show the image too. Without this fix, it would have failed to load the image in that second scenario, which was the opposite of what it was before the first fix.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone