### PR TITLE
[NO-TICKET] Add uncontrolled-component support to `SingleInputDateField`

### DIFF
--- a/packages/design-system/src/components/DateField/SingleInputDateField.stories.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.stories.tsx
@@ -26,26 +26,29 @@ export default meta;
 
 type Story = StoryObj<typeof SingleInputDateField>;
 
-export const Default: Story = {
+const UncontrolledTemplate: Story = {
+  render: function Component(args) {
+    return <SingleInputDateField {...args} />;
+  },
+};
+
+const ControlledTemplate: Story = {
   render: function Component(args) {
     const [dateString, updateDate] = useState();
     const onChange = (...params) => {
       action('onChange')(...params);
       updateDate(params[0]);
     };
-    return (
-      <SingleInputDateField
-        {...args}
-        name="single-input-date-field"
-        value={dateString ?? ''}
-        onChange={onChange}
-      />
-    );
+    return <SingleInputDateField {...args} value={dateString ?? ''} onChange={onChange} />;
   },
 };
 
+export const Default: Story = {
+  ...ControlledTemplate,
+};
+
 export const WithPicker: Story = {
-  ...Default,
+  ...ControlledTemplate,
   args: {
     label: 'What day did you move?',
     hint: 'This date should be within the past 60 days in order to qualify.',
@@ -61,9 +64,14 @@ export const WithPicker: Story = {
 };
 
 export const WithError = {
-  ...Default,
+  ...ControlledTemplate,
   args: {
     errorMessage: 'This is an example error message.',
     ...WithPicker.args,
   },
+};
+
+export const UncontrolledComponent = {
+  ...WithPicker,
+  ...UncontrolledTemplate,
 };

--- a/packages/design-system/src/components/DateField/SingleInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.tsx
@@ -55,6 +55,11 @@ interface BaseSingleInputDateFieldProps {
    * handler).
    */
   value?: string;
+  /**
+   * Sets the initial value. Use this for an uncontrolled component; otherwise,
+   * use the `value` property.
+   */
+  defaultValue?: string;
 
   // From DayPicker
   // -------------------------
@@ -122,15 +127,25 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
     (toDate != null || toMonth != null || Number.isInteger(toYear));
   const [pickerVisible, setPickerVisible] = useState(false);
   const id = useId('date-field--', props.id);
+  const isControlled = remainingProps.value !== undefined;
+  const [internalValueState, setInternalValueState] = useState(remainingProps.defaultValue);
+  const value = isControlled ? remainingProps.value : internalValueState;
 
   // Set up change handlers
   function handleInputChange(event) {
     const updatedValue = event.currentTarget.value;
     onChange(updatedValue, DATE_MASK(updatedValue, true));
+    if (!isControlled) {
+      setInternalValueState(updatedValue);
+    }
   }
   function handlePickerChange(date: Date) {
     const updatedValue = `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
-    onChange(DATE_MASK(updatedValue), DATE_MASK(updatedValue, true));
+    const maskedValue = DATE_MASK(updatedValue);
+    onChange(maskedValue, DATE_MASK(updatedValue, true));
+    if (!isControlled) {
+      setInternalValueState(maskedValue);
+    }
     setPickerVisible(false);
     inputRef.current?.focus();
   }
@@ -142,6 +157,7 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
   const inputRef = useRef<HTMLInputElement>();
   const { labelMask, inputProps } = useLabelMask(DATE_MASK, {
     ...cleanFieldProps(remainingProps),
+    value,
     id,
     onChange: handleInputChange,
     type: 'text',

--- a/packages/design-system/src/components/web-components/ds-date-field/ds-date-field.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-date-field/ds-date-field.stories.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { action } from '@storybook/addon-actions';
 import type { Meta } from '@storybook/react';
 import WebComponentDocTemplate from '../../../../../../.storybook/docs/WebComponentDocTemplate.mdx';
@@ -27,14 +27,16 @@ const meta: Meta = {
 export default meta;
 
 const Template = (args) => {
-  const [dateString, updateDate] = useState<string>('');
+  // const [dateString, updateDate] = useState<string>('');
+  // console.log('story render', dateString)
 
   useEffect(() => {
     const element = document.querySelector('ds-date-field');
     if (element) {
       const handleStoryBookChange = (event: CustomEvent) => {
+        console.log('useEffect', event);
         action('ds-change')(event);
-        updateDate(event.detail.value);
+        // updateDate(event.detail.updatedValue);
       };
       element.addEventListener('ds-change', handleStoryBookChange as EventListener);
       return () => {
@@ -43,7 +45,7 @@ const Template = (args) => {
     }
   }, []);
 
-  return <ds-date-field {...args} value={dateString ?? ''} />;
+  return <ds-date-field {...args} /*value={dateString ?? ''}*/ />;
 };
 
 export const Default = Template.bind({});

--- a/packages/design-system/src/components/web-components/ds-date-field/ds-date-field.tsx
+++ b/packages/design-system/src/components/web-components/ds-date-field/ds-date-field.tsx
@@ -32,10 +32,8 @@ type IncompatibleProps =
   | 'toYear';
 
 interface WrapperProps extends Omit<SingleInputDateFieldProps, IncompatibleProps> {
-  name: string;
   rootId: string;
   inversed?: string;
-  value?: string;
   defaultMonth?: string;
   fromDate?: string;
   fromMonth?: string;
@@ -46,10 +44,8 @@ interface WrapperProps extends Omit<SingleInputDateFieldProps, IncompatibleProps
 }
 
 const Wrapper = ({
-  name,
   rootId,
   inversed,
-  value,
   defaultMonth,
   fromDate,
   fromMonth,
@@ -57,21 +53,21 @@ const Wrapper = ({
   toDate,
   toMonth,
   toYear,
+  value,
   ...otherProps
 }: WrapperProps) => {
   return (
     <SingleInputDateField
-      name={name}
       id={rootId}
       inversed={parseBooleanAttr(inversed)}
-      value={value}
+      defaultValue={value}
       defaultMonth={parseDateAttr(defaultMonth)}
       fromDate={parseDateAttr(fromDate)}
       fromMonth={parseDateAttr(fromMonth)}
       fromYear={parseIntegerAttr(fromYear)}
       toDate={parseDateAttr(toDate)}
       toMonth={parseDateAttr(toMonth)}
-      toYear={parseIntegerAttr(fromYear)}
+      toYear={parseIntegerAttr(toYear)}
       {...otherProps}
     />
   );
@@ -91,5 +87,13 @@ declare global {
 
 define('ds-date-field', () => Wrapper, {
   attributes,
-  events: ['onChange', 'onBlur'],
+  events: [
+    [
+      'onChange',
+      (updatedValue: string, formattedValue: string) => ({
+        detail: { updatedValue, formattedValue },
+      }),
+    ],
+    'onBlur',
+  ],
 } as any);


### PR DESCRIPTION
## Summary

Add uncontrolled component support to `SingleInputDateField` so it works with web components. Web components are uncontrolled by definition, and I discovered that our `SingleInputDateField` (P)react component didn't actually support an uncontrolled component behavior. Even though the underlying `TextField` component supports the uncontrolled behavior,  we need access to that internal value in the `SingleInputDateField`, so I re-implemented the uncontrolled-component internal state tracking at the `SingleInputDateField` level. We have several other components that follow a very similar pattern of optionally tracking internal state based on whether the `value` is provided.

## How to test

Try out the new `Uncontrolled` story on the `SingleInputDateField` and specifically use the calendar picker to select a date. Calendar selection should also now work on the web component. Note that some changes were made to the web component to support it, and those changes will need to be merged with @tamara-corbalt's changes.