### PR TITLE
[NO-TICKET] Manually updates "@cmsgov/design-system" version in package dependencies

### DIFF
--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -14,7 +14,7 @@
     "@astrojs/check": "^0.5.6",
     "@astrojs/preact": "^3.1.0",
     "@astrojs/react": "^3.0.10",
-    "@cmsgov/design-system": "10.1.2",
+    "@cmsgov/design-system": "11.0.0-beta.0",
     "astro": "^4.4.8",
     "typescript": "^5.4.3"
   }

--- a/examples/preact-app/package.json
+++ b/examples/preact-app/package.json
@@ -3,7 +3,7 @@
   "version": "11.0.0-beta.0",
   "private": true,
   "dependencies": {
-    "@cmsgov/design-system": "10.1.2",
+    "@cmsgov/design-system": "11.0.0-beta.0",
     "preact": "10.11.3"
   },
   "devDependencies": {

--- a/examples/preact-react-app/package.json
+++ b/examples/preact-react-app/package.json
@@ -3,7 +3,7 @@
   "version": "11.0.0-beta.0",
   "private": true,
   "dependencies": {
-    "@cmsgov/design-system": "10.1.2",
+    "@cmsgov/design-system": "11.0.0-beta.0",
     "preact": "10.11.3"
   },
   "devDependencies": {

--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -3,7 +3,7 @@
   "version": "11.0.0-beta.0",
   "private": true,
   "dependencies": {
-    "@cmsgov/design-system": "10.1.2",
+    "@cmsgov/design-system": "11.0.0-beta.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -24,7 +24,7 @@
     "iOS >= 15"
   ],
   "dependencies": {
-    "@cmsgov/design-system": "10.1.2",
+    "@cmsgov/design-system": "11.0.0-beta.0",
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
     "classnames": "^2.3.1",

--- a/packages/ds-cms-gov/package.json
+++ b/packages/ds-cms-gov/package.json
@@ -57,7 +57,7 @@
     "src"
   ],
   "dependencies": {
-    "@cmsgov/design-system": "10.1.2",
+    "@cmsgov/design-system": "11.0.0-beta.0",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^17.0.10"
   }

--- a/packages/ds-healthcare-gov/package.json
+++ b/packages/ds-healthcare-gov/package.json
@@ -56,7 +56,7 @@
     "src"
   ],
   "dependencies": {
-    "@cmsgov/design-system": "10.1.2",
+    "@cmsgov/design-system": "11.0.0-beta.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
     "classnames": "^2.2.5"

--- a/packages/ds-medicare-gov/package.json
+++ b/packages/ds-medicare-gov/package.json
@@ -58,7 +58,7 @@
     "src"
   ],
   "dependencies": {
-    "@cmsgov/design-system": "10.1.2",
+    "@cmsgov/design-system": "11.0.0-beta.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0"
   }


### PR DESCRIPTION
## Summary

A quick fix to resolve how `@cmsgov/design-system` is imported as dependency in packages