### PR TITLE
[WNMGDS-2878] Render Doc Site stories for Modal Dialog and Drawer

### DIFF
--- a/packages/docs/content/components/drawer.mdx
+++ b/packages/docs/content/components/drawer.mdx
@@ -22,11 +22,7 @@ Render the drawer below the toggle button that triggers it. This way the markup 
 
 <ThemeContent neverThemes={['medicare']}>
 
-<StorybookExample
-  componentName="drawer"
-  storyId="components-drawer--drawer-toggle-with-drawer"
-  minHeight={500}
-/>
+<StorybookExample componentName="drawer" storyId="components-drawer--default" minHeight={500} />
 
 </ThemeContent>
 
@@ -49,8 +45,9 @@ A header and/or footer can have a "sticky" position if the following properties 
 
 <StorybookExample
   componentName="sticky-drawer"
-  storyId="components-drawer--drawer-with-sticky-positioning"
+  storyId="components-drawer--default"
   minHeight={300}
+  controls="isHeaderSticky:!true"
 />
 
 ### Managing multiple drawers

--- a/packages/docs/content/components/modal-dialog.mdx
+++ b/packages/docs/content/components/modal-dialog.mdx
@@ -17,18 +17,10 @@ medicare:
 ## Examples
 
 <ThemeContent neverThemes={['medicare']}>
-  <StorybookExample
-    componentName="dialog"
-    storyId="components-dialog--dialog-example"
-    minHeight={400}
-  />
+  <StorybookExample componentName="dialog" storyId="components-dialog--default" minHeight={400} />
 </ThemeContent>
 <ThemeContent onlyThemes={['medicare']}>
-  <StorybookExample
-    componentName="dialog"
-    storyId="medicare-dialog--dialog-example"
-    minHeight={400}
-  />
+  <StorybookExample componentName="dialog" storyId="components-dialog--default" minHeight={400} />
 </ThemeContent>
 
 ### Dialog size variants

--- a/packages/docs/src/components/content/StorybookExample.tsx
+++ b/packages/docs/src/components/content/StorybookExample.tsx
@@ -10,6 +10,10 @@ interface StorybookExampleProps {
    */
   componentName: string;
   /**
+   * optional values supplied to alter controls on the story.
+   */
+  controls?: string;
+  /**
    * min height of example container. Use for examples that have elements appear on interactivity that need more room
    */
   minHeight?: number;
@@ -31,12 +35,19 @@ interface StorybookExampleProps {
  * If you need to show responsiveness, use the `ResponsiveExample`.
  * If you don't need a story, but can use regular HTML or React components, use an Embedded example.
  */
-const StorybookExample = ({ theme, componentName, minHeight, storyId }: StorybookExampleProps) => {
+const StorybookExample = ({
+  theme,
+  componentName,
+  minHeight,
+  storyId,
+  controls,
+}: StorybookExampleProps) => {
   const [iframeHeight, setiFrameHeight] = useState<number>(200);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const iframeRef = useRef<HTMLIFrameElement>();
+  const controlArgs = controls ? `&args=${controls}` : '';
   const iframeUrl = withPrefix(
-    `/storybook/iframe.html?id=${storyId}&viewMode=story&globals=theme:${theme}`
+    `/storybook/iframe.html?id=${storyId}${controlArgs}&viewMode=story&globals=theme:${theme}`
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

[Ticket](https://jira.cms.gov/browse/WNMGDS-2878)

- Updated component stories referenced in drawer and modal-dialog doc site pages
- Added new argument to the StorybookExample file to handle control arguments

## How to test

1. Pull down changes locally
2. Build the docsite
3. Run locally and confirm that the stories are displaying properly for the Drawer and Modal Dialog pages

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone