### PR TITLE
[WNMGDS-2890] Fix `onAnalyticsEvent` attribute rendering to DOM through `HelpDrawer`

### DIFF
--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.test.tsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.test.tsx
@@ -120,5 +120,13 @@ describe('HelpDrawer', () => {
       renderHelpDrawer({ analyticsLabelOverride: 'other heading', onCloseClick: jest.fn() });
       expect(tealiumMock.mock.lastCall).toMatchSnapshot();
     });
+
+    it('handles custom onAnalyticsEvent prop', () => {
+      const onAnalyticsEvent = jest.fn();
+      const { rerenderHelpDrawer } = renderHelpDrawer({ isOpen: false, onAnalyticsEvent });
+      rerenderHelpDrawer({ isOpen: true, onAnalyticsEvent });
+      expect(tealiumMock).not.toHaveBeenCalled();
+      expect(onAnalyticsEvent).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.tsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.tsx
@@ -10,7 +10,8 @@ export interface HelpDrawerProps extends DrawerProps, AnalyticsOverrideProps {}
  * [refer to its full documentation page](https://design.cms.gov/components/drawer/).
  */
 export const HelpDrawer = (props: HelpDrawerProps) => {
-  const { analytics, analyticsLabelOverride, children, className, ...others } = props;
+  const { analytics, analyticsLabelOverride, onAnalyticsEvent, children, className, ...others } =
+    props;
   const headingRef = useHelpDrawerAnalytics(props);
 
   return (


### PR DESCRIPTION
## Summary

Fix `onAnalyticsEvent` prop bleeding into `dialog` DOM elements through `HelpDrawer`. Pulls that custom handler out of the `other` props that get passed through to the `Drawer` and then the `NativeDialog` element.

Without this fix, the unit test I added will print errors to the console like this:

```
console.error
    Warning: Unknown event handler property `onAnalyticsEvent`. It will be ignored.
        at dialog
        at NativeDialog (/Users/patrickwolfert/Projects/design-system/packages/design-system/src/components/NativeDialog/NativeDialog.tsx:38:3)
        at Drawer (/Users/patrickwolfert/Projects/design-system/packages/design-system/src/components/Drawer/Drawer.tsx:73:5)
        at HelpDrawer (/Users/patrickwolfert/Projects/design-system/packages/design-system/src/components/HelpDrawer/HelpDrawer.tsx:13:11)
```

## Checklist

- [ ] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
