### PR TITLE
[NO-TICKET] Define a better return type for `defaultMenuLinks`

### DIFF
--- a/packages/ds-healthcare-gov/src/components/Header/Header.tsx
+++ b/packages/ds-healthcare-gov/src/components/Header/Header.tsx
@@ -12,8 +12,7 @@ import defaultMenuLinks from './defaultMenuLinks';
 export interface Link {
   href: string;
   label: React.ReactNode;
-  // TODO: I don't think this is necessary to require - PW
-  ariaLabel: string;
+  ariaLabel?: string;
   className?: string;
   onClick?: (...args: any[]) => any;
 }
@@ -130,7 +129,7 @@ export interface HeaderProps {
 export const VARIATION_NAMES = {
   LOGGED_IN: 'logged-in',
   LOGGED_OUT: 'logged-out',
-};
+} as const;
 
 /**
  * For information about how and when to use this component,

--- a/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
+++ b/packages/ds-healthcare-gov/src/components/Header/defaultMenuLinks.ts
@@ -23,12 +23,17 @@ export interface DefaultMenuLinkOptions {
   languageLinkClassName?: string;
 }
 
+export interface DefaultMenuLinksObject {
+  [VARIATION_NAMES.LOGGED_OUT]: Array<Link | DefaultLink>;
+  [VARIATION_NAMES.LOGGED_IN]: Array<Link | DefaultLink>;
+}
+
 /**
  * Default menu links for each header variation.
  * Apps can import this method into their app if they need to
  * extend the existing default list of menu links.
  */
-export function defaultMenuLinks(options: DefaultMenuLinkOptions = {}) {
+export function defaultMenuLinks(options: DefaultMenuLinkOptions = {}): DefaultMenuLinksObject {
   const {
     deConsumer,
     subpath = '',
@@ -44,8 +49,8 @@ export function defaultMenuLinks(options: DefaultMenuLinkOptions = {}) {
   const isSpanish = languageMatches('es');
 
   // NOTE: order matters here and links will be displayed in order added to the arrays
-  const loggedOut = [];
-  const loggedIn = [];
+  const loggedOut: Array<Link | DefaultLink> = [];
+  const loggedIn: Array<Link | DefaultLink> = [];
 
   // Links other than the ones inside this if should need to be explicitly hidden for their
   // respective variations. This means the language and login will show even if a custom set
@@ -95,9 +100,10 @@ export function defaultMenuLinks(options: DefaultMenuLinkOptions = {}) {
     });
   }
 
-  const links = {};
-  links[VARIATION_NAMES.LOGGED_OUT] = loggedOut;
-  links[VARIATION_NAMES.LOGGED_IN] = loggedIn;
+  const links: DefaultMenuLinksObject = {
+    [VARIATION_NAMES.LOGGED_OUT]: loggedOut,
+    [VARIATION_NAMES.LOGGED_IN]: loggedIn,
+  };
 
   return links;
 }


### PR DESCRIPTION
## Summary

Be more informative about what `defaultMenuLinks` returns in the types. Previously the return type was `{}`, which is useless to teams trying to use that functions themselves.

## How to test

Build the healthcare package and take a look at the typedef files. There should be a return type other than `{}` for that function.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone