### PR TITLE
[NO-TICKET] Exclude core design system from dependency update

### DIFF
--- a/scripts/bump-child-deps-utils.ts
+++ b/scripts/bump-child-deps-utils.ts
@@ -35,7 +35,7 @@ const getPackageNamesAndLocations = (): Array<{
 }> => {
   const packageJson: any = JSON.parse(sh('npm ls -ws @cmsgov/design-system --json'));
   const deps = packageJson['dependencies'];
-  const packageNames = Object.keys(deps);
+  const packageNames = Object.keys(deps).filter((dep) => !(dep === '@cmsgov/design-system'));
   return packageNames.map((name: any) => {
     /*
      * The package location is stored relative to the root directory when returned by `npm ls`,

--- a/scripts/bump-child-deps-utils.ts
+++ b/scripts/bump-child-deps-utils.ts
@@ -36,7 +36,7 @@ const getPackageNamesAndLocations = (): Array<{
   const packageJson: any = JSON.parse(sh('npm ls -ws @cmsgov/design-system --json'));
   const deps = packageJson['dependencies'];
   // We don't want to add the core design system as a dependency to itself, so we filter it out.
-  const packageNames = Object.keys(deps).filter((dep) => !(dep === '@cmsgov/design-system'));
+  const packageNames = Object.keys(deps).filter((dep) => dep !== '@cmsgov/design-system');
   return packageNames.map((name: any) => {
     /*
      * The package location is stored relative to the root directory when returned by `npm ls`,

--- a/scripts/bump-child-deps-utils.ts
+++ b/scripts/bump-child-deps-utils.ts
@@ -35,6 +35,7 @@ const getPackageNamesAndLocations = (): Array<{
 }> => {
   const packageJson: any = JSON.parse(sh('npm ls -ws @cmsgov/design-system --json'));
   const deps = packageJson['dependencies'];
+  // We don't want to add the core design system as a dependency to itself, so we filter it out.
   const packageNames = Object.keys(deps).filter((dep) => !(dep === '@cmsgov/design-system'));
   return packageNames.map((name: any) => {
     /*


### PR DESCRIPTION
## Summary

- We were accidentally adding the core design system as a dependency to it's on package.json file when updating the child dependencies, this change fixes that.

## How to test

1. In the `release.ts` script, comment out lines [102-137](https://github.com/CMSgov/design-system/blob/jryan/no-ticket-exclude-core-design-system-from-dependency-update/scripts/release.ts#L102-L137) and comment out lines [222-224](https://github.com/CMSgov/design-system/blob/jryan/no-ticket-exclude-core-design-system-from-dependency-update/scripts/release.ts#L222-L224)
2. Run the release script: `yarn release`
3. Confirm the version number has been updated for the /packages/design-system/package.json, and that the dependencies have NOT changes for that same file.
4. All other child DS and example package.json files should be updated as normal (version and dependencies)

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone