### PR TITLE
[NO-TICKET] Sort Figma token scope values alphabetically

### DIFF
--- a/packages/design-system-tokens/src/figma/translateFigmaToTokens.ts
+++ b/packages/design-system-tokens/src/figma/translateFigmaToTokens.ts
@@ -322,7 +322,7 @@ async function tokenFromVariable(
       ...(existingToken?.$extensions ?? {}),
       'com.figma': {
         hiddenFromPublishing: variable.hiddenFromPublishing,
-        scopes: variable.scopes,
+        scopes: variable.scopes.sort(),
         codeSyntax: variable.codeSyntax,
       },
     },


### PR DESCRIPTION
## Summary

- @pwolfert and I noticed that the array of scopes for certain Figma tokens were not sorted alphabetically. Guess what? Now they are!

## How to test

1. Run `yarn sync:tokens-from-figma` locally
2. Confirm that any `scopes` arrays with more than one value are sorted alphabetically. You should see some in the file diff viewer in VS Code.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone