### PR TITLE
[WNMGDS-2935] Make Sass token file changes backwards compatible

### DIFF
--- a/packages/design-system-tokens/src/css/translate.test.ts
+++ b/packages/design-system-tokens/src/css/translate.test.ts
@@ -39,7 +39,19 @@ describe('tokenFilesToCssFiles', () => {
 
 describe('tokenFilesToScssFiles', () => {
   it('matches snapshot', () => {
-    expect(tokenFilesToScssFiles(tokensByFile)).toMatchSnapshot();
+    const files = tokenFilesToScssFiles(tokensByFile);
+
+    // Acknowledge but don't snapshot the duplicated files
+    expect(files['core-component-tokens.scss']).toBeTruthy();
+    expect(files['core-tokens.scss']).toBeTruthy();
+    expect(files['cmsgov-component-tokens.scss']).toBeTruthy();
+    expect(files['cmsgov-tokens.scss']).toBeTruthy();
+    delete files['core-component-tokens.scss'];
+    delete files['core-tokens.scss'];
+    delete files['cmsgov-component-tokens.scss'];
+    delete files['cmsgov-tokens.scss'];
+
+    expect(files).toMatchSnapshot();
   });
 });
 

--- a/packages/design-system-tokens/src/css/translate.ts
+++ b/packages/design-system-tokens/src/css/translate.ts
@@ -226,6 +226,14 @@ export function tokenFilesToScssFiles(tokensByFile: FlattenedTokensByFile): Outp
       const scssVars = tokensToSassVars(themeTokens, systemTokens, themeName === 'core');
       const scssFileName = `${themeName}-theme.scss`;
       obj[scssFileName] = scssVars;
+
+      // TODO: We're duplicating these files for backwards compatibility so teams currently
+      // using the Sass variables don't have to change anything, but at some point we'll
+      // want to force a change. This may coincide with the removal of Sass entirely.
+      const deprecatedVars = `// Use of this file is deprecated. Please use "${scssFileName}" instead.\n${scssVars}`;
+      obj[`${themeName}-tokens.scss`] = deprecatedVars;
+      obj[`${themeName}-component-tokens.scss`] = deprecatedVars;
+
       return obj;
     }, {} as Record<string, string>);
 }


### PR DESCRIPTION
## Summary

Makes our Figma changes backwards compatible with respect to the sass var files. I had failed to adequately document the changes in https://github.com/CMSgov/design-system/pull/3100, which resulted in a failure to report the breaking change of a file-name change in our release notes. Luckily our integration tests caught it in one of the beta releases.

Note that instead of reproducing the same old contents of those files, they're just duplicates of the new file, and that's enough. It won't break anything if a product imports both of these files, because they just re-declare the same variables. It also has no effect on the final CSS bundle sizes because Sass variables are ephemeral.

## How to test

Clear all your `dist` folders and rebuild. You should see the same old file names that we used to output.

@kim-cmsds, could you also test this directly in the downstream app that had the issue?

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
