### PR TITLE
[WNMGDS-2950] Reorder Sass token files to avoid Sass compiler errors

### DIFF
--- a/packages/design-system-tokens/src/css/translate.test.ts
+++ b/packages/design-system-tokens/src/css/translate.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { readTokenFiles } from '../lib/readTokenFiles';
 import {
+  enforceSassVariableOrder,
   tokenFilesToCssFiles,
   tokenFilesToScssFiles,
   tokenFilesToScssLayoutFiles,
@@ -38,6 +39,28 @@ describe('tokenFilesToCssFiles', () => {
 });
 
 describe('tokenFilesToScssFiles', () => {
+  it('enforceSassVariableOrder makes sure no variables are used before declared', () => {
+    const vars = [
+      '$color-info: #3e94cf;',
+      '$font-weight-button-lg: $font-weight-bold;',
+      '$font-weight-button-md: $font-weight-bold;',
+      '$font-weight-button-sm: $font-weight-normal;',
+      '$font-weight-normal: 400;',
+      '$font-weight-bold: 700;',
+      '$alert__border-left-color: $color-info;',
+    ];
+
+    expect(enforceSassVariableOrder(vars)).toEqual([
+      '$color-info: #3e94cf;',
+      '$font-weight-normal: 400;',
+      '$font-weight-button-sm: $font-weight-normal;',
+      '$font-weight-bold: 700;',
+      '$font-weight-button-md: $font-weight-bold;',
+      '$font-weight-button-lg: $font-weight-bold;',
+      '$alert__border-left-color: $color-info;',
+    ]);
+  });
+
   it('matches snapshot', () => {
     const files = tokenFilesToScssFiles(tokensByFile);
 

--- a/packages/design-system-tokens/src/css/translate.ts
+++ b/packages/design-system-tokens/src/css/translate.ts
@@ -150,6 +150,66 @@ export function tokensToCssProperties(
 }
 
 /**
+ * Unlike CSS Custom Properties, Sass variables can't be used before they're defined. In
+ * order to avoid compilation errors in Sass, we need to enforce an order of declaration
+ * and then use, which may not be the natural order we get from the tokens.
+ */
+export function enforceSassVariableOrder(originalDeclarations: string[]): string[] {
+  // Matches the variable being declared (first group) and any variables being referenced (second group)
+  const declarationRegex = /(\$[\w\-_]+):\s*(\$[\w\-_]+)?.*;/;
+  const getVarNames = (line) => line.match(declarationRegex)?.slice(1) || [];
+
+  const declaredVars = new Set<string>();
+  const declarations = originalDeclarations.slice();
+
+  let i = 0;
+  while (i < declarations.length) {
+    const line = declarations[i];
+    const [declaredVar, referencedVar] = getVarNames(line);
+
+    // If this line doesn't declare anything, move on
+    if (!declaredVar) {
+      i++;
+      continue;
+    }
+
+    // See if we the variable being referenced hasn't been declared yet
+    if (referencedVar && !declaredVars.has(referencedVar)) {
+      // Extract this declaration and move it to be after it gets defined. Note
+      // that we don't want to increment the index, because we've extracted the
+      // current line from the array, so the next line that we want to look at
+      // will be at the same index.
+
+      // Delete it from the current position
+      declarations.splice(i, 1);
+
+      // Look for a place to insert it
+      let declarationPosition;
+      for (let j = i; j < declarations.length; j++) {
+        const [laterDeclaration] = getVarNames(declarations[j]);
+        if (laterDeclaration === referencedVar) {
+          declarationPosition = j;
+          break;
+        }
+      }
+
+      // Insert it if we can
+      if (declarationPosition) {
+        declarations.splice(declarationPosition + 1, 0, line);
+      } else {
+        throw new Error(`Declaration for ${referencedVar} not found`);
+      }
+    } else {
+      // This declaration is solid, so leave it in place and move on
+      declaredVars.add(declaredVar);
+      i++;
+    }
+  }
+
+  return declarations;
+}
+
+/**
  * Generates all the Sass variable definitions for a specific theme based on that theme's
  * tokens and the system tokens. This can later be dropped into a SCSS file and saved.
  */
@@ -182,7 +242,7 @@ export function tokensToSassVars(
       return `$${varName}: ${varValue}${defaultFlag};`;
     });
 
-  return vars.join('\n');
+  return enforceSassVariableOrder(vars).join('\n');
 }
 
 /**

--- a/packages/design-system-tokens/src/css/translate.ts
+++ b/packages/design-system-tokens/src/css/translate.ts
@@ -157,7 +157,7 @@ export function tokensToCssProperties(
 export function enforceSassVariableOrder(originalDeclarations: string[]): string[] {
   // Matches the variable being declared (first group) and any variables being referenced (second group)
   const declarationRegex = /(\$[\w\-_]+):\s*(\$[\w\-_]+)?.*;/;
-  const getVarNames = (line) => line.match(declarationRegex)?.slice(1) || [];
+  const getVarNames = (line: string) => line.match(declarationRegex)?.slice(1) || [];
 
   const declaredVars = new Set<string>();
   const declarations = originalDeclarations.slice();


### PR DESCRIPTION
## Summary

Unlike CSS Custom Properties, Sass variables can't be used before they're defined. Our new script for generating Sass variable (theme) files from tokens allowed for instances where a variable was assigned to another variable before it was declared, which will cause Sass compiler errors when someone tries to use those files. I've added a post-processing function that reorders the declarations when it finds variables being used before they're defined.

## How to test

There's a new unit test, but the best place to test would be in the downstream app where this problem was found.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] If necessary, updated unit-test snapshots (`yarn test:unit:update`) and browser-test snapshots (`yarn test:browser:update`)
