### PR TITLE
[WMNGD-3011] Fix `ds-tab-panel` attribute parsing in `ds-tabs`

### DIFF
--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tab-panel.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tab-panel.stories.tsx
@@ -32,6 +32,10 @@ const meta: Meta = {
       description: 'Disables the `ds-tab-panel`. If true, this panel will not be selectable.',
       control: 'boolean',
     },
+    id: {
+      description: 'A unique `id`, to be used on the rendered panel element.',
+      control: 'text',
+    },
     tab: {
       description: 'The label to display for the associated tab.',
       control: 'text',

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tab-panel.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tab-panel.test.tsx
@@ -3,7 +3,7 @@ import './ds-tab-panel';
 
 const defaultChildren = 'Content';
 const defaultAttrs = {
-  'root-id': 'panel-1',
+  id: 'panel-1',
   'tab-id': 'tab-1',
 };
 

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tab-panel.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tab-panel.tsx
@@ -6,7 +6,7 @@ import { ReactNode } from 'react';
 
 const tabPanelAttributes = [
   'class-name',
-  'root-id',
+  'id',
   'selected',
   'disabled',
   'tab',
@@ -16,7 +16,6 @@ const tabPanelAttributes = [
 ] as const;
 
 interface WrapperProps extends Omit<TabPanelProps, 'selected' | 'disabled' | 'tab'> {
-  rootId: string;
   selected: string;
   disabled: string;
   tab: string;
@@ -24,9 +23,9 @@ interface WrapperProps extends Omit<TabPanelProps, 'selected' | 'disabled' | 'ta
 
 const Wrapper = ({
   className,
-  rootId,
   selected,
   disabled,
+  id,
   tab,
   tabClassName,
   tabHref,
@@ -37,7 +36,7 @@ const Wrapper = ({
   return (
     <TabPanel
       className={className}
-      id={rootId}
+      id={id}
       selected={parseBooleanAttr(selected)}
       disabled={parseBooleanAttr(disabled)}
       tab={parseJsonAttr(tab)}

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.stories.tsx
@@ -65,10 +65,15 @@ const Template = (args) => {
   }, []);
   return (
     <ds-tabs {...args}>
-      <ds-tab-panel key="summary" id="summary" tab="Summary" tab-class-name="custom-class-name">
+      <ds-tab-panel
+        key="summary"
+        root-id="summary"
+        tab="Summary"
+        tab-class-name="custom-class-name"
+      >
         The Bill of Rights is the first ten amendments to the United States Constitution.
       </ds-tab-panel>
-      <ds-tab-panel key="preamble" id="preamble" tab="Preamble">
+      <ds-tab-panel key="preamble" root-id="preamble" tab="Preamble">
         <p>
           We the People of the United States, in Order to form a more perfect Union, establish
           Justice, insure domestic Tranquility, provide for the common defence, promote the general
@@ -76,7 +81,7 @@ const Template = (args) => {
           establish this Constitution for the United States of America.
         </p>
       </ds-tab-panel>
-      <ds-tab-panel key="amendments" id="amendments" tab="Amendments">
+      <ds-tab-panel key="amendments" root-id="amendments" tab="Amendments">
         <h2 className="ds-text-heading--lg">Bill of Rights</h2>
 
         <ol className="ds-c-list">

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.stories.tsx
@@ -65,15 +65,10 @@ const Template = (args) => {
   }, []);
   return (
     <ds-tabs {...args}>
-      <ds-tab-panel
-        key="summary"
-        root-id="summary"
-        tab="Summary"
-        tab-class-name="custom-class-name"
-      >
+      <ds-tab-panel key="summary" id="summary" tab="Summary" tab-class-name="custom-class-name">
         The Bill of Rights is the first ten amendments to the United States Constitution.
       </ds-tab-panel>
-      <ds-tab-panel key="preamble" root-id="preamble" tab="Preamble">
+      <ds-tab-panel key="preamble" id="preamble" tab="Preamble">
         <p>
           We the People of the United States, in Order to form a more perfect Union, establish
           Justice, insure domestic Tranquility, provide for the common defence, promote the general
@@ -81,7 +76,7 @@ const Template = (args) => {
           establish this Constitution for the United States of America.
         </p>
       </ds-tab-panel>
-      <ds-tab-panel key="amendments" root-id="amendments" tab="Amendments">
+      <ds-tab-panel key="amendments" id="amendments" tab="Amendments">
         <h2 className="ds-text-heading--lg">Bill of Rights</h2>
 
         <ol className="ds-c-list">

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.stories.tsx
@@ -65,7 +65,7 @@ const Template = (args) => {
   }, []);
   return (
     <ds-tabs {...args}>
-      <ds-tab-panel key="summary" id="summary" tab="Summary">
+      <ds-tab-panel key="summary" id="summary" tab="Summary" tab-class-name="custom-class-name">
         The Bill of Rights is the first ten amendments to the United States Constitution.
       </ds-tab-panel>
       <ds-tab-panel key="preamble" id="preamble" tab="Preamble">

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.test.tsx
@@ -9,13 +9,13 @@ function renderTabs(props = {}, children = []) {
   return render(<ds-tabs {...(props as any)}>{children}</ds-tabs>);
 }
 const children = [
-  <ds-tab-panel key="1" id="panel-1" tab="Tab 1">
+  <ds-tab-panel key="1" root-id="panel-1" tab="Tab 1">
     Some content for tab 1
     <ol>
       <li>Nested content for tab 1.</li>
     </ol>
   </ds-tab-panel>,
-  <ds-tab-panel key="2" id="panel-2" tab="Tab 2">
+  <ds-tab-panel key="2" root-id="panel-2" tab="Tab 2">
     Some content for tab 2.
   </ds-tab-panel>,
 ];
@@ -197,10 +197,10 @@ describe('ds-tabs', () => {
 
   it('applies the tabId to the tab element', () => {
     renderTabs(undefined, [
-      <ds-tab-panel key="lunch" id="lunch" tab-id="lunch-tab" tab="Lunch Menu">
+      <ds-tab-panel key="lunch" root-id="lunch" tab-id="lunch-tab" tab="Lunch Menu">
         Food
       </ds-tab-panel>,
-      <ds-tab-panel key="dinner" id="dinner" tab-id="dinner-tab" tab="Dinner menu">
+      <ds-tab-panel key="dinner" root-id="dinner" tab-id="dinner-tab" tab="Dinner menu">
         Food
       </ds-tab-panel>,
     ]);
@@ -235,5 +235,39 @@ describe('ds-tabs', () => {
     expect(panelEls[1].getAttribute('aria-hidden')).toBe('false');
     expect(tabEls[0].getAttribute('aria-selected')).toBe('false');
     expect(tabEls[1].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('converts root-id to id correctly', () => {
+    const attrs = { 'root-id': 'panel-123', tab: 'Test Tab' };
+    renderTabs({}, [
+      <ds-tab-panel key="1" {...attrs}>
+        Test Content
+      </ds-tab-panel>,
+    ]);
+
+    const tabPanel = screen.getByRole('tabpanel', { hidden: true });
+    expect(tabPanel.id).toBe('panel-123');
+  });
+
+  it('parses all ds-tab-panel props correctly', () => {
+    const attrs = {
+      'root-id': 'panel-1',
+      'tab-id': 'panel-1-tab',
+      'tab-class-name': 'custom-tab',
+      'aria-label': 'Panel One',
+    };
+    renderTabs({}, [
+      <ds-tab-panel key="1" {...attrs}>
+        Some content
+      </ds-tab-panel>,
+    ]);
+
+    const tabs = screen.getAllByRole('tab');
+    const panel = screen.getByRole('tabpanel', { hidden: true });
+
+    expect(tabs[0].id).toBe('panel-1-tab');
+    expect(panel.id).toBe('panel-1');
+    expect(tabs[0].classList).toContain('custom-tab');
+    expect(panel).toHaveAttribute('aria-labelledby', 'panel-1-tab');
   });
 });

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.test.tsx
@@ -9,28 +9,28 @@ function renderTabs(props = {}, children = []) {
   return render(<ds-tabs {...(props as any)}>{children}</ds-tabs>);
 }
 const children = [
-  <ds-tab-panel key="1" root-id="panel-1" tab="Tab 1">
+  <ds-tab-panel key="1" id="panel-1" tab="Tab 1">
     Some content for tab 1
     <ol>
       <li>Nested content for tab 1.</li>
     </ol>
   </ds-tab-panel>,
-  <ds-tab-panel key="2" root-id="panel-2" tab="Tab 2">
+  <ds-tab-panel key="2" id="panel-2" tab="Tab 2">
     Some content for tab 2.
   </ds-tab-panel>,
 ];
 
 const childrenWithDisabledTabPanel = [
-  <ds-tab-panel key="1" root-id="panel-1" tab="Tab 1">
+  <ds-tab-panel key="1" id="panel-1" tab="Tab 1">
     Some content for tab 1
     <ol>
       <li>Nested content for tab 1.</li>
     </ol>
   </ds-tab-panel>,
-  <ds-tab-panel key="2" root-id="panel-2" tab="Tab 2" disabled="true">
+  <ds-tab-panel key="2" id="panel-2" tab="Tab 2" disabled="true">
     Some content for disabled tab.
   </ds-tab-panel>,
-  <ds-tab-panel key="3" root-id="panel-3" tab="Tab 3">
+  <ds-tab-panel key="3" id="panel-3" tab="Tab 3">
     Some content for tab 3.
   </ds-tab-panel>,
 ];
@@ -197,10 +197,10 @@ describe('ds-tabs', () => {
 
   it('applies the tabId to the tab element', () => {
     renderTabs(undefined, [
-      <ds-tab-panel key="lunch" root-id="lunch" tab-id="lunch-tab" tab="Lunch Menu">
+      <ds-tab-panel key="lunch" id="lunch" tab-id="lunch-tab" tab="Lunch Menu">
         Food
       </ds-tab-panel>,
-      <ds-tab-panel key="dinner" root-id="dinner" tab-id="dinner-tab" tab="Dinner menu">
+      <ds-tab-panel key="dinner" id="dinner" tab-id="dinner-tab" tab="Dinner menu">
         Food
       </ds-tab-panel>,
     ]);
@@ -237,21 +237,9 @@ describe('ds-tabs', () => {
     expect(tabEls[1].getAttribute('aria-selected')).toBe('true');
   });
 
-  it('converts root-id to id correctly', () => {
-    const attrs = { 'root-id': 'panel-123', tab: 'Test Tab' };
-    renderTabs({}, [
-      <ds-tab-panel key="1" {...attrs}>
-        Test Content
-      </ds-tab-panel>,
-    ]);
-
-    const tabPanel = screen.getByRole('tabpanel', { hidden: true });
-    expect(tabPanel.id).toBe('panel-123');
-  });
-
   it('parses all ds-tab-panel props correctly', () => {
     const attrs = {
-      'root-id': 'panel-1',
+      id: 'panel-1',
       'tab-id': 'panel-1-tab',
       'tab-class-name': 'custom-tab',
       'aria-label': 'Panel One',

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.test.tsx
@@ -21,16 +21,16 @@ const children = [
 ];
 
 const childrenWithDisabledTabPanel = [
-  <ds-tab-panel key="1" id="panel-1" tab="Tab 1">
+  <ds-tab-panel key="1" root-id="panel-1" tab="Tab 1">
     Some content for tab 1
     <ol>
       <li>Nested content for tab 1.</li>
     </ol>
   </ds-tab-panel>,
-  <ds-tab-panel key="2" id="panel-2" tab="Tab 2" disabled="true">
+  <ds-tab-panel key="2" root-id="panel-2" tab="Tab 2" disabled="true">
     Some content for disabled tab.
   </ds-tab-panel>,
-  <ds-tab-panel key="3" id="panel-3" tab="Tab 3">
+  <ds-tab-panel key="3" root-id="panel-3" tab="Tab 3">
     Some content for tab 3.
   </ds-tab-panel>,
 ];
@@ -206,8 +206,8 @@ describe('ds-tabs', () => {
     ]);
 
     const tabs = screen.getAllByRole('tab');
-    expect(tabs[0].id).toEqual('lunch__tab');
-    expect(tabs[1].id).toEqual('dinner__tab');
+    expect(tabs[0].id).toEqual('lunch-tab');
+    expect(tabs[1].id).toEqual('dinner-tab');
 
     const panels = screen.getAllByRole('tabpanel');
     expect(panels[0].getAttribute('aria-labelledby')).toEqual(tabs[0].id);

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
@@ -16,12 +16,6 @@ function parseChildren(node) {
   return elements.map((element) => {
     const { children, ...attrs } = element.props || {};
 
-    // Rename `root-id` to `id` if it exists.
-    if ('root-id' in attrs) {
-      attrs.id = attrs['root-id'];
-      delete attrs['root-id'];
-    }
-
     /**
      * Convert kebab-cased keys to camelCase.
      * E.g., `tab-class-name` becomes `tabClassName`.

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
@@ -7,7 +7,8 @@ import { createElement } from 'react';
 /**
  * Parses custom web components that are `ds-tab-panel` elements and converts them into React components.
  * This is necessary for the `Tabs` interface, which expects `TabPanel` children to be React components.
- * The function handles `ds-tab-panel` elements by converting their kebab-cased attributes into camelCased React props.
+ * The function handles `ds-tab-panel` elements by converting their kebab-cased attributes to camelCasing,
+ * which is the convention React expects for props.
  */
 function parseChildren(node) {
   const elements = findElementsOfType(['ds-tab-panel'], node);
@@ -22,7 +23,7 @@ function parseChildren(node) {
     }
 
     /**
-     * Convert kebab-cased attributes to camelCased props.
+     * Convert kebab-cased keys to camelCase.
      * E.g., `tab-class-name` becomes `tabClassName`.
      */
     const camelCaseAttrs = Object.keys(attrs).reduce((acc, key) => {

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
@@ -12,7 +12,7 @@ import { createElement } from 'react';
 function parseChildren(node) {
   const elements = findElementsOfType(['ds-tab-panel'], node);
 
-  const mappedElements = elements.map((element) => {
+  return elements.map((element) => {
     const { children, ...attrs } = element.props || {};
 
     // Rename `root-id` to `id` if it exists.
@@ -31,12 +31,8 @@ function parseChildren(node) {
       return acc;
     }, {} as Partial<TabPanelProps>);
 
-    const reactElem = createElement(TabPanel, camelCaseAttrs as TabPanelProps, children);
-
-    return reactElem;
+    return createElement(TabPanel, camelCaseAttrs as TabPanelProps, children);
   });
-
-  return mappedElements;
 }
 
 const attributes = ['default-selected-id', 'selected-id', 'tablist-class-name', 'tabs-aria-label'];

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
@@ -1,5 +1,6 @@
 import { define } from '../preactement/define';
 import { Tabs, TabPanel } from '../../Tabs';
+import { TabPanelProps } from '../../Tabs/TabPanel';
 import { findElementsOfType } from '../../utilities/findElementsOfType';
 import { createElement } from 'react';
 
@@ -9,10 +10,22 @@ const Wrapper = ({ tabsAriaLabel, ...props }) => {
   function parseChildren(node) {
     const elements = findElementsOfType(['ds-tab-panel'], node);
 
-    return elements.map((element) => {
+    const mappedElements = elements.map((element) => {
       const { children, ...attrs } = element.props || {};
-      return createElement(TabPanel, { ...attrs }, children);
+
+      // Parse kebab-cased attributes into cameCased props.
+      const camelCaseAttrs = Object.keys(attrs).reduce((acc, key) => {
+        const camelCaseKey = key.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
+        acc[camelCaseKey] = attrs[key];
+        return acc;
+      }, {} as Partial<TabPanelProps>);
+
+      const reactElem = createElement(TabPanel, camelCaseAttrs as TabPanelProps, children);
+
+      return reactElem;
     });
+
+    return mappedElements;
   }
 
   return (

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
@@ -13,6 +13,12 @@ const Wrapper = ({ tabsAriaLabel, ...props }) => {
     const mappedElements = elements.map((element) => {
       const { children, ...attrs } = element.props || {};
 
+      // Rename `root-id` to `id` if it exists.
+      if ('root-id' in attrs) {
+        attrs.id = attrs['root-id'];
+        delete attrs['root-id'];
+      }
+
       // Parse kebab-cased attributes into cameCased props.
       const camelCaseAttrs = Object.keys(attrs).reduce((acc, key) => {
         const camelCaseKey = key.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());

--- a/tests/browser/snapshots/storybook-docs/Docs-Web-Components-ds-tab-panel-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Web-Components-ds-tab-panel-Docs-prop-table-matches-snapshot-1.txt
@@ -10,6 +10,11 @@
     "\"true\"\"false\""
   ],
   [
+    "id",
+    "A unique `id`, to be used on the rendered panel element.",
+    "string"
+  ],
+  [
     "selected",
     "Sets the selected state of the `ds-tab-panel`. If true, this panel will be displayed.",
     "\"true\"\"false\""


### PR DESCRIPTION
## Summary

- Refactored the `ds-tabs` parsing logic to ensure attributes of `ds-tab-panel` children are correctly converted into React components. (See [jira ticket](https://jira.cms.gov/browse/WNMGDS-3011))
- Specifically, added logic to handle special cases like converting `root-id` to `id` and converting kebab-cased attributes (e.g., `tab-class-name`) to camelCased props (e.g., `tabClassName`).
- Updated unit tests to confirm that the attribute conversion is working as expected.

## How to test

1. Run unit tests for Tabs: `yarn test:unit:wc -t Tabs`. 
2. Optionally, add logging in the `parseChildren` function within `ds-tabs.tsx` to inspect the attribute-to-prop conversion.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone