### PR TITLE
[WNMGDS-3025] Add markdown rendering to web component Storybook docs

### DIFF
--- a/.storybook/docs/WebComponentArgsTable.tsx
+++ b/.storybook/docs/WebComponentArgsTable.tsx
@@ -1,4 +1,4 @@
-import { useOf } from '@storybook/blocks';
+import { Markdown, useOf } from '@storybook/blocks';
 
 function optToCodeBlock(opt: undefined | string) {
   const formattedOpt = opt === undefined ? 'undefined' : `"${opt}"`;
@@ -62,7 +62,9 @@ export const WebComponentArgsTable = ({ of }) => {
               <td>
                 {argType.description && (
                   <div style={{ marginBottom: '4px' }}>
-                    <p>{argType.description}</p>
+                    <p>
+                      <Markdown>{argType.description}</Markdown>
+                    </p>
                   </div>
                 )}
               </td>

--- a/.storybook/docs/WebComponentAttrs.tsx
+++ b/.storybook/docs/WebComponentAttrs.tsx
@@ -13,7 +13,7 @@ interface WebComponentAttrsProps {
  * array in `story.parameters.docs` to determine if it should show this additional
  * text and what elements' documentation it should link to.
  */
-export const WebComponentAttrs = ({ of }) => {
+export const WebComponentAttrs = ({ of }: WebComponentAttrsProps) => {
   const resolvedOf = useOf(of || 'story', ['story', 'meta']);
   if (resolvedOf.type !== 'story') {
     return null;

--- a/.storybook/docs/WebComponentEventsTable.tsx
+++ b/.storybook/docs/WebComponentEventsTable.tsx
@@ -1,4 +1,4 @@
-import { useOf } from '@storybook/blocks';
+import { Markdown, useOf } from '@storybook/blocks';
 
 /**
  * A table documenting a web component's custom events
@@ -19,10 +19,14 @@ export const WebComponentEventsTable = ({ of }) => {
         <strong>{eventName}</strong>
       </td>
       <td>
-        <p>{event?.description ?? ''}</p>
+        <p>
+          <Markdown>{event?.description ?? ''}</Markdown>
+        </p>
       </td>
       <td>
-        <p>{event.eventObjectDescription}</p>
+        <p>
+          <Markdown>{event.eventObjectDescription}</Markdown>
+        </p>
       </td>
     </tr>
   ));

--- a/packages/design-system/src/components/web-components/ds-accordion/ds-accordion-item.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-accordion/ds-accordion-item.stories.tsx
@@ -47,13 +47,8 @@ export default {
       componentEvents: {
         'ds-change': {
           description: 'Dispatched whenever the accordion is opened or closed.',
-          eventObjectDescription: (
-            <>
-              <code>event.details.target</code> - The <code>HTMLButtonElement</code> that was
-              pressed, from which you can get the expanded state through{' '}
-              <code>getAttribute(&#39;aria-expanded&#39;)</code>
-            </>
-          ),
+          eventObjectDescription:
+            '`event.details.target` - The `HTMLButtonElement` that was pressed, from which you can get the expanded state through `getAttribute("aria-expanded")`',
         },
       },
     },

--- a/packages/design-system/src/components/web-components/ds-choice/ds-choice.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-choice/ds-choice.stories.tsx
@@ -128,17 +128,8 @@ export default {
       componentEvents: {
         'ds-change': {
           description: 'Dispatched whenever the choice `checked` value changes.',
-          eventObjectDescription: (
-            <>
-              <p>
-                <code>event.details.target.value</code> - The <code>value</code> of the selected
-                option
-              </p>
-              <p>
-                <code>event.details.target.checked</code> - A boolean representing the checked state
-              </p>
-            </>
-          ),
+          eventObjectDescription:
+            '<p>`event.details.target.value` - The `value` of the selected option\n\n`event.details.target.checked` - A boolean representing the checked state',
         },
         'ds-blur': {
           description: 'Dispatched whenever the choice loses focus.',

--- a/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.stories.tsx
@@ -116,12 +116,8 @@ export default {
       componentEvents: {
         'ds-change': {
           description: 'Dispatched whenever the selected value changes.',
-          eventObjectDescription: (
-            <>
-              <code>event.details.target.value</code> - The <code>value</code> of the selected
-              option
-            </>
-          ),
+          eventObjectDescription:
+            '`event.details.target.value` - The `value` of the selected option',
         },
         'ds-blur': {
           description: 'Dispatched whenever the dropdown loses focus.',

--- a/packages/design-system/src/components/web-components/ds-pagination/ds-pagination.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-pagination/ds-pagination.stories.tsx
@@ -78,17 +78,8 @@ export default {
         'ds-page-change': {
           description:
             'Dispatched whenever page link is clicked, including the previous and next buttons.',
-          eventObjectDescription: (
-            <>
-              <p>
-                <code>event.details.target</code> - The <code>target</code> of the original event
-              </p>
-              <p>
-                <code>event.details.page</code> - An integer representing the newly active page
-                number
-              </p>
-            </>
-          ),
+          eventObjectDescription:
+            '`event.details.target` - The `target` of the original event\n\n`event.details.page` - An integer representing the newly active page number',
         },
       },
     },

--- a/packages/design-system/src/components/web-components/shared-attributes/storybook.tsx
+++ b/packages/design-system/src/components/web-components/shared-attributes/storybook.tsx
@@ -37,40 +37,16 @@ export const analyticsEventDocs = {
   'ds-analytics-event': {
     description:
       'This event is dispatched whenever the component emits an analytics event. Listening to this event will allow you to handle the analytics event yourself instead of relying on the `defaultAnalyticsFunction` defined in the design system config. [Read more about analytics.](https://design.cms.gov/components/analytics/)',
-    eventObjectDescription: (
-      <>
-        <p>
-          <code>event.details.event</code> - The analytics event object being emitted.
-        </p>
-        <p>
-          <code>event.preventDefault()</code> - Calling this prevents the{' '}
-          <code>defaultAnalyticsFunction</code> from the{' '}
-          <a href="https://design.cms.gov/components/config/">global config</a> from being called.
-        </p>
-      </>
-    ),
+    eventObjectDescription:
+      '`event.details.event` - The analytics event object being emitted.\n\n`event.preventDefault()` - Calling this prevents the `defaultAnalyticsFunction` from the [global config](https://design.cms.gov/components/config/) from being called.',
   },
 };
 
 export const alertAnalyticsEventDocs = {
   'ds-analytics-event': {
-    ...analyticsEventDocs['ds-analytics-event'],
-    eventObjectDescription: (
-      <>
-        <p>
-          <code>event.details.event</code> - The analytics event object being emitted.
-        </p>
-        <p>
-          <code>
-            <s>event.preventDefault()</s>
-          </code>{' '}
-          - Note that the alert&apos;s impression event is emitted immediately, so calling{' '}
-          <code>preventDefault</code> to stop <code>defaultAnalyticsFunction</code> from being
-          called will be too late. If you need to customize this event for a particular instance,
-          please apply the <code>analytics=&quot;false&quot;</code> attribute to your element and
-          then emit the analytics event yourself.
-        </p>
-      </>
-    ),
+    description:
+      'This event is dispatched whenever the component emits an analytics event. [Read more about analytics.](https://design.cms.gov/components/analytics/)',
+    eventObjectDescription:
+      '`event.details.event` - The analytics event object being emitted.\n\n`event.preventDefault()` - ⚠️ Note that the alert\'s impression event is emitted immediately upon render, so calling `preventDefault` within an event listener bound after first render will be too late to stop `defaultAnalyticsFunction` from being called. If you need to customize this event for a particular instance, please apply the `analytics="false"` attribute to your element and then emit the analytics event yourself.',
   },
 };


### PR DESCRIPTION
## Summary

A known limitation with our documentation tables within Storybook for web component attributes and events is that the descriptions don't render Markdown. And the TypeScript types for Storybook keep us from being able to pass JSX instead. I think there's even some kind of error in Storybook if you do pass in JSX to the argTypes to work around the issue (because the Storybook arg controls use the same descriptions).

- Add markdown rendering capabilities to the attributes and event tables
- Updates the event table descriptions, which _were_ able to have JSX workarounds before, unlike the `argTypes` rendered by the attributes table

## How to test

Open up Storybook and look at the `Description` column for both the attributes and events tables and the `Event object` column for the events tables.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone