### PR TITLE
[WNMGDS-3037] Adds web component section to Accordion doc site page

### DIFF
--- a/packages/docs/content/components/accordion.mdx
+++ b/packages/docs/content/components/accordion.mdx
@@ -30,6 +30,10 @@ medicare:
 
 <SeeStorybookForGuidance storyId={'components-accordion--docs'} />
 
+### Web Component
+
+<SeeStorybookForGuidance tech="wc" storyId={'web-components-ds-accordion--docs'} />
+
 ### Style customization
 
 The following CSS variables can be overridden to customize Accordion components:


### PR DESCRIPTION
## Summary

- This pull request is part of a series aimed at adding missing "Web Component" sections to component pages on the documentation site. By including these sections, we ensure developers have quick access to code examples and guidance for the web component version of each component.

Jira story: [WNMGDS-3027](https://jira.cms.gov/browse/WNMGDS-3027)

## How to test

Test the storybook link in the Web Component section: [here](https://cmsgov.github.io/design-system/branch/tamara/WNMGDS-3027/add-wc-section-to-accordion-doc-page/components/accordion/?theme=core#code)

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
