### PR TITLE
[WNMGDS-2748] Removes deprecated aria-invalid from fieldset container for `MultiInputDateField`

### DIFF
--- a/packages/design-system/src/components/DateField/MultiInputDateField.test.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.test.tsx
@@ -36,6 +36,27 @@ describe('MultiInputDateField', () => {
     });
   });
 
+  it('renders with aria-invalid set to true on specific invalid inputs only', () => {
+    const errorProps = {
+      errorMessage: 'Please enter a valid date',
+      monthDefaultValue: '12',
+      dayDefaultValue: '35',
+      yearDefaultValue: '2050',
+      dayInvalid: true,
+      yearInvalid: true,
+    };
+
+    render(<MultiInputDateField label="A date field" {...errorProps} />);
+
+    const monthInput = screen.getByLabelText(/month/i);
+    const dayInput = screen.getByLabelText(/day/i);
+    const yearInput = screen.getByLabelText(/year/i);
+
+    expect(monthInput).toHaveAttribute('aria-invalid', 'false');
+    expect(dayInput).toHaveAttribute('aria-invalid', 'true');
+    expect(yearInput).toHaveAttribute('aria-invalid', 'true');
+  });
+
   it('applies custom `hintClassName` to the hint element', () => {
     const customHintClass = 'my-custom-hint-class';
     render(

--- a/packages/design-system/src/components/DateField/MultiInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.tsx
@@ -161,7 +161,6 @@ export function MultiInputDateField(props: DateFieldProps): React.ReactElement {
 
   return (
     <fieldset
-      aria-invalid={invalid}
       aria-describedby={describeField({ ...props, hintId, errorId })}
       className={classNames('ds-c-fieldset', props.className)}
     >


### PR DESCRIPTION
## Summary

W3C suggests that the [aria-invalid state](https://www.w3.org/TR/wai-aria/#aria-invalid) is deprecated as a global state in ARIA 1.2. 
This change removes `aria-invalid` from the `<fieldset>` in the `MultiInputDateField` component. 
Jira ticket: [WNMGDS-2748](https://jira.cms.gov/browse/WNMGDS-2748)

- `aria-invalid` is intended for actionable elements (such as input fields) where it provides meaningful feedback. Since a `<fieldset>` is a container rather than an interactive element, `aria-invalid` does not effectively convey error information to screen readers when placed on the `<fieldset>` itself.
- `aria-invalid` is now applied only to specific inputs (day, month, or year) that are in an error state.
- Added unit tests to confirm that `aria-invalid` is correctly applied to invalid input fields only, ensuring compliance with ARIA 1.2 standards.


## How to test

- Try out the `MultiInputDateField` component with a screen reader in Storybook to confirm that fields with errors are announced correctly.
- Run unit tests: `yarn unit:test`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
