### PR TITLE
[WNMGDS-3027] Adds web component sections to 6 doc site pages

### DIFF
--- a/packages/docs/content/components/month-picker.mdx
+++ b/packages/docs/content/components/month-picker.mdx
@@ -24,6 +24,10 @@ The Month Picker component renders a grid of checkboxes with shortened month nam
 
 <SeeStorybookForGuidance storyId={'components-monthpicker--docs'} />
 
+### Web Component
+
+<SeeStorybookForGuidance tech="wc" storyId={'web-components-ds-month-picker--docs'} />
+
 ### Style customization
 
 The following CSS variables can be overridden to customize MonthPicker fields:

--- a/packages/docs/content/components/pagination.mdx
+++ b/packages/docs/content/components/pagination.mdx
@@ -27,6 +27,10 @@ Pagination also comes in two styles: default, which is compact on mobile viewpor
 
 <SeeStorybookForGuidance storyId={'components-pagination--docs'} />
 
+### Web Component
+
+<SeeStorybookForGuidance tech="wc" storyId={'web-components-ds-pagination--docs'} />
+
 ### Style customization
 
 The following CSS variables can be overridden to customize Pagination components:

--- a/packages/docs/content/components/review.mdx
+++ b/packages/docs/content/components/review.mdx
@@ -25,6 +25,10 @@ The `Review` component wraps up the styles and markup required to make a single 
 
 <SeeStorybookForGuidance storyId={'components-review--docs'} />
 
+### Web Component
+
+<SeeStorybookForGuidance tech="wc" storyId={'web-components-ds-review--docs'} />
+
 ### Style customization
 
 The following CSS variables can be overridden to customize Review:

--- a/packages/docs/content/components/skip-nav.mdx
+++ b/packages/docs/content/components/skip-nav.mdx
@@ -25,6 +25,10 @@ Make sure you include an `id` at the beginning of your main content and that it 
 
 <SeeStorybookForGuidance storyId={'components-skipnav--docs'} />
 
+### Web Component
+
+<SeeStorybookForGuidance tech="wc" storyId={'web-components-ds-skip-nav--docs'} />
+
 ## Guidance
 
 ### When to use

--- a/packages/docs/content/components/spinner.mdx
+++ b/packages/docs/content/components/spinner.mdx
@@ -79,6 +79,10 @@ To provide more contrast when being rendered over other content, the `.ds-c-spin
 
 <SeeStorybookForGuidance storyId={'components-spinner--docs'} />
 
+### Web Component
+
+<SeeStorybookForGuidance tech="wc" storyId={'web-components-ds-spinner--docs'} />
+
 ### Style customization
 
 The following CSS variables can be overridden to customize Spinner components:

--- a/packages/docs/content/components/text-field/text-field.mdx
+++ b/packages/docs/content/components/text-field/text-field.mdx
@@ -37,6 +37,10 @@ A `TextField` component renders an input field as well as supporting UI elements
 
 <SeeStorybookForGuidance storyId={'components-textfield--docs'} />
 
+### Web Component
+
+<SeeStorybookForGuidance tech="wc" storyId={'web-components-ds-text-field--docs'} />
+
 ### Style customization
 
 The following CSS variables can be overridden to customize Input/Form components:


### PR DESCRIPTION
## Summary
This pull request is part of a series aimed at adding missing "Web Component" sections to component pages on the documentation site. By including these sections, we ensure developers have quick access to code examples and guidance for the web component version of each component.

## How to test

Verify the Storybook links on the following pages:
- [MonthPicker](https://cmsgov.github.io/design-system/branch/tamara/WNMGDS-3027/add-wc-sections-to-component-pages-2/components/month-picker/?theme=core#code)
- [Pagination](https://cmsgov.github.io/design-system/branch/tamara/WNMGDS-3027/add-wc-sections-to-component-pages-2/components/pagination/?theme=core#code)
- [Review](https://cmsgov.github.io/design-system/branch/tamara/WNMGDS-3027/add-wc-sections-to-component-pages-2/components/review/?theme=core#code)
- [SkipNav](https://cmsgov.github.io/design-system/branch/tamara/WNMGDS-3027/add-wc-sections-to-component-pages-2/components/skip-nav/?theme=core#code)
- [Spinner](https://cmsgov.github.io/design-system/branch/tamara/WNMGDS-3027/add-wc-sections-to-component-pages-2/components/spinner/?theme=core#code)
- [TextField](https://cmsgov.github.io/design-system/branch/tamara/WNMGDS-3027/add-wc-sections-to-component-pages-2/components/text-field/text-field/?theme=core#code)

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone