### PR TITLE
[NO-TICKET] Prevent double firing of exit event in Modal Dialog

### DIFF
--- a/packages/design-system/src/components/NativeDialog/NativeDialog.tsx
+++ b/packages/design-system/src/components/NativeDialog/NativeDialog.tsx
@@ -108,6 +108,17 @@ export const NativeDialog = ({
 
     const dialogNode = dialogRef.current;
     const handleClick = (event) => {
+      // In Chrome and Firefox Pointer Events triggered by a key press receive a clientX & clientY value of 0 each.
+      // This puts the pointer outside of our dialog element, and so we trigger the exit() event.
+      // This causes the exit event to fire twice on keyboard presses if the button you are focusing has an event
+      // handler/listener attached to it.
+      // Note Safari is smart and actually assigns a value to the clientX and clientY values for button presses, so we
+      // don't see this error in Safari.
+      // event.detail counts the number of clicks. There are no clicks on a keyboard press, so if this function is called
+      // and the event.detail value is zero, we exit without firing the exit() event.
+      if (event.detail === 0) {
+        return;
+      }
       const boundingNode = boundingBoxRef?.current ?? dialogRef.current;
       const rect = boundingNode.getBoundingClientRect();
       const isInDialog =


### PR DESCRIPTION
## Summary

- Problem: when backdropClickExits is enabled, we see the onExit or ds-exit event called twice when exiting the Modal either via the close button or a form submit button
- This is only an issue in Chrome and Firefox and any other browsers that set clientX & clientY to zero on key press (likely Edge though I haven't tested). Safari is smart and doesn't have this issue. Maybe I'll start using Safari for more than just testing, but also probably not.
- The simplest fix that we landed on is to add a simple check for the number of clicks on the event. This information is stored in the event.detail read only property. 
- If it's 0, that means there was no click of a mouse, so a key must've been pressed (or so my logic goes) & return out of the function
- Else, check if we're in the bounding rect of the dialog element, which we won't be if you clicked outside of the dialog element.

## How to test

1. `yarn build`
2. `yarn storybook`
3. Open modal dialog (either React or Web Component version) in Storybook in Browser
4. Make sure backdropClickExits/backdrop-click-exits is true
5. Open the dialog
6. Press `TAB` to bring the close or submit buttons into focus
7. Press `ENTER` or `SPACEBAR`
8. Note that only one onExit or ds-exit event has been fired.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone