### PR TITLE
[NO-TICKET] Use isPossibleValue util function in more places and add spec

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -11,6 +11,8 @@ import { useBodyScrollPrevention } from './useBodyScrollPrevention';
 
 export type DialogSize = 'narrow' | 'wide' | 'full';
 
+export const availableSizes: DialogSize[] = ['narrow', 'wide', 'full'];
+
 export interface BaseDialogProps extends AnalyticsOverrideProps {
   /**
    * Buttons or other HTML to be rendered in the "actions" bar

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -114,6 +114,24 @@ type OtherProps = Omit<
 
 export type TooltipProps = BaseTooltipProps & OtherProps;
 
+export const placements: Placement[] = [
+  'auto',
+  'auto-start',
+  'auto-end',
+  'top',
+  'top-start',
+  'top-end',
+  'bottom',
+  'bottom-start',
+  'bottom-end',
+  'right',
+  'right-start',
+  'right-end',
+  'left',
+  'left-start',
+  'left-end',
+] as const;
+
 /**
  * Tooltips provide additional information upon hover, focus or click.
  * For information about how and when to use this component,

--- a/packages/design-system/src/components/web-components/ds-modal-dialog/ds-modal-dialog.tsx
+++ b/packages/design-system/src/components/web-components/ds-modal-dialog/ds-modal-dialog.tsx
@@ -1,7 +1,8 @@
 import { define } from '../preactement/define';
-import { Dialog, DialogProps, DialogSize } from '../../Dialog';
+import { availableSizes, Dialog, DialogProps, DialogSize } from '../../Dialog';
 import { parseBooleanAttr } from '../wrapperUtils';
 import { analyticsOverrideAttrs } from '../shared-attributes/analytics';
+import { isPossibleValue } from '../utils';
 
 const attributes = [
   'actions-class-name',
@@ -54,7 +55,7 @@ const Wrapper = ({
     ariaCloseLabel={dialogCloseLabel}
     backdropClickExits={parseBooleanAttr(backdropClickExits)}
     isOpen={parseBooleanAttr(isOpen)}
-    size={isAcceptableSize(size) ? size : null}
+    size={isPossibleValue(size, availableSizes) ? size : undefined}
     {...otherProps}
     analytics={parseBooleanAttr(analytics)}
   >

--- a/packages/design-system/src/components/web-components/ds-modal-dialog/ds-modal-dialog.tsx
+++ b/packages/design-system/src/components/web-components/ds-modal-dialog/ds-modal-dialog.tsx
@@ -34,10 +34,6 @@ interface WrapperProps
   size: string;
 }
 
-const isAcceptableSize = (size: string): size is DialogSize => {
-  return ['narrow', 'wide', 'full'].includes(size);
-};
-
 const Wrapper = ({
   alert,
   analytics,

--- a/packages/design-system/src/components/web-components/ds-tooltip/ds-tooltip.tsx
+++ b/packages/design-system/src/components/web-components/ds-tooltip/ds-tooltip.tsx
@@ -1,7 +1,8 @@
 import { define } from '../preactement/define';
-import { Tooltip, TooltipProps } from '../../Tooltip';
+import { placements, Tooltip, TooltipProps } from '../../Tooltip';
 import { Placement } from '@popperjs/core';
 import { parseBooleanAttr } from '../wrapperUtils';
+import { isPossibleValue } from '../utils';
 
 const attributes = [
   'active-class-name',
@@ -58,26 +59,6 @@ interface WrapperProps
   title: string;
 }
 
-const isPlacementValue = (location: string): location is Placement => {
-  return [
-    'auto',
-    'auto-start',
-    'auto-end',
-    'top',
-    'top-start',
-    'top-end',
-    'bottom',
-    'bottom-start',
-    'bottom-end',
-    'right',
-    'right-start',
-    'right-end',
-    'left',
-    'left-start',
-    'left-end',
-  ].includes(location);
-};
-
 const Wrapper = ({
   contentHeading,
   dialog,
@@ -96,7 +77,7 @@ const Wrapper = ({
     id={rootId}
     title={title}
     placement={
-      isPlacementValue(otherProps.placement)
+      isPossibleValue(otherProps.placement, placements)
         ? otherProps.placement
         : (Tooltip.defaultProps.placement as Placement)
     }

--- a/packages/design-system/src/components/web-components/utils.test.ts
+++ b/packages/design-system/src/components/web-components/utils.test.ts
@@ -1,0 +1,28 @@
+import { isPossibleValue } from './utils';
+
+type Fruit = 'apple' | 'banana' | 'cherry';
+
+const acceptableFruit: Fruit[] = ['apple', 'banana', 'cherry'] as const;
+
+describe('isPossibleValue', () => {
+  it('should return true if the value is in the possibleValues array', () => {
+    const value = 'apple' as Fruit;
+    expect(isPossibleValue(value, acceptableFruit)).toBe(true);
+  });
+
+  it('should return false if the value is not in the possibleValues array', () => {
+    const value = 'orange';
+    expect(isPossibleValue(value, acceptableFruit)).toBe(false);
+  });
+
+  it('should return false if the possibleValues array is empty', () => {
+    const value = 'apple' as Fruit;
+    const possibleValues: readonly string[] = [];
+    expect(isPossibleValue(value, possibleValues)).toBe(false);
+  });
+
+  it('should return false if the value is an empty string', () => {
+    const value = '';
+    expect(isPossibleValue(value, acceptableFruit)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- In [3331](https://github.com/CMSgov/design-system/pull/3331) I added a cute little function that serves as a type predicate for some of our attributes on our web components
- Here we use it more broadly, introducing the needed constants and types in the ModalDialog and Tooltip components
- I also added a spec. Which isn't the best spec since it doesn't do the type predicate stuff that we use this function for, but maybe it's sufficient to ensure the basic functionality of the thing. 

## How to test

1. Confirm tests pass locally
2. Fire up Storybook or one of the example apps and confirm that ModalDialog and Tooltip web components operate as expected.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone