### PR TITLE
[WNMGDS-3057] Update analytics-content-extraction method to support slots

### DIFF
--- a/packages/design-system/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
+++ b/packages/design-system/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
@@ -23,7 +23,7 @@ Array [
     "link_url": "foo",
     "parent_component_heading": " ",
     "parent_component_type": " ",
-    "text": "External site linkThis link goes to an external site",
+    "text": "External site link This link goes to an external site ",
   },
 ]
 `;

--- a/packages/design-system/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
+++ b/packages/design-system/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
@@ -23,7 +23,7 @@ Array [
     "link_url": "foo",
     "parent_component_heading": " ",
     "parent_component_type": " ",
-    "text": "External site link This link goes to an external site ",
+    "text": "External site linkThis link goes to an external site",
   },
 ]
 `;

--- a/packages/design-system/src/components/analytics/getAnalyticsContentFromRefs.ts
+++ b/packages/design-system/src/components/analytics/getAnalyticsContentFromRefs.ts
@@ -1,7 +1,34 @@
 import { RefObject } from 'react';
 
+/**
+ * Gets text content from an element and even follows `slot` elements across Shadow DOM
+ * barriers to get the full text that the user sees.
+ */
+function getTextContent(nodes: Node[]): string {
+  return nodes
+    .map((node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        return node.textContent.trim();
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        if ((node as HTMLElement).tagName === 'SLOT') {
+          // If it's a slot, it won't actually have any content in itself, so we have to
+          // follow the trail to its "assigned nodes" and look there.
+          const assignedNodes = (node as HTMLSlotElement).assignedNodes({ flatten: true });
+          return getTextContent(assignedNodes);
+        } else {
+          return getTextContent(Array.from((node as HTMLElement).childNodes));
+        }
+      } else {
+        return '';
+      }
+    })
+    .join(' ');
+}
+
 export function getAnalyticsContentFromRefs(refs: RefObject<any>[]): string | undefined {
-  return refs.map((ref) => ref.current?.textContent).find((textContent) => textContent);
+  return refs
+    .map((ref) => (ref.current ? getTextContent(Array.from(ref.current.childNodes)) : undefined))
+    .find((textContent) => textContent);
 }
 
 export default getAnalyticsContentFromRefs;

--- a/packages/design-system/src/components/analytics/getAnalyticsContentFromRefs.ts
+++ b/packages/design-system/src/components/analytics/getAnalyticsContentFromRefs.ts
@@ -8,7 +8,7 @@ function getTextContent(nodes: Node[]): string {
   return nodes
     .map((node) => {
       if (node.nodeType === Node.TEXT_NODE) {
-        return node.textContent.trim();
+        return node.textContent;
       } else if (node.nodeType === Node.ELEMENT_NODE) {
         if ((node as HTMLElement).tagName === 'SLOT') {
           // If it's a slot, it won't actually have any content in itself, so we have to
@@ -22,7 +22,7 @@ function getTextContent(nodes: Node[]): string {
         return '';
       }
     })
-    .join(' ');
+    .join('');
 }
 
 export function getAnalyticsContentFromRefs(refs: RefObject<any>[]): string | undefined {


### PR DESCRIPTION
## Summary

We need to change our React component analytics-content-extracting code to be able to follow `slot` elements across the Shadow DOM barrier. Otherwise, the analytics events will have nothing for things like alert heading when the heading content is defined with a slot.

## How to test

Run the unit tests and make sure no snapshots change.
