### PR TITLE
[WNMGDS-3147] Enable `--list` for playwright custom playwright reporter

### DIFF
--- a/tests/browser/__snapshots__/custom-reporter.test.ts.snap
+++ b/tests/browser/__snapshots__/custom-reporter.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "failingTests": Array [
     Object {
       "name": "Test 2",
-      "path": "Sample Suite",
+      "path": "[Sample Suite]",
     },
   ],
   "skippedTests": Array [],

--- a/tests/browser/custom-reporter.test.ts
+++ b/tests/browser/custom-reporter.test.ts
@@ -30,8 +30,16 @@ test('JSON report matches snapshot', () => {
   const mockSuite = {
     title: 'Sample Suite',
     allTests: () => [
-      { title: 'Test 1', parent: { title: 'Sample Suite', parent: null } },
-      { title: 'Test 2', parent: { title: 'Sample Suite', parent: null } },
+      {
+        title: 'Test 1',
+        location: { file: 'sample-suite.test.ts' },
+        parent: { title: 'Sample Suite', parent: null },
+      },
+      {
+        title: 'Test 2',
+        location: { file: 'sample-suite.test.ts' },
+        parent: { title: 'Sample Suite', parent: null },
+      },
     ],
   } as unknown as Suite;
 

--- a/tests/browser/custom-reporter.ts
+++ b/tests/browser/custom-reporter.ts
@@ -16,6 +16,8 @@ class MyReporter implements Reporter {
   private failingTests: { path: string; name: string }[] = [];
   private skippedTests: { path: string; name: string }[] = [];
   private isListMode = false;
+  private totalTests = 0;
+  private currentTestIndex = 0;
 
   private getHierarchyPath(test: TestCase): string {
     const path: string[] = [];
@@ -45,8 +47,12 @@ class MyReporter implements Reporter {
       });
       return;
     }
-
+    this.totalTests = suite.allTests().length;
     console.log(`Starting the run with ${suite.allTests().length} tests`);
+  }
+
+  onTestBegin(_: TestCase) {
+    this.currentTestIndex++;
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
@@ -68,7 +74,9 @@ class MyReporter implements Reporter {
         break;
     }
 
-    console.log(`${hierarchyPath} > ${test.title}: ${result.status}`);
+    console.log(
+      `[${this.currentTestIndex}/${this.totalTests}] ${hierarchyPath} > ${test.title}: ${result.status}`
+    );
   }
 
   onEnd(result: FullResult) {

--- a/tests/browser/custom-reporter.ts
+++ b/tests/browser/custom-reporter.ts
@@ -38,6 +38,10 @@ class MyReporter implements Reporter {
   }
 
   onBegin(_: FullConfig, suite: Suite) {
+    const totalFiles = new Set(suite.allTests().map((test) => test.location.file)).size;
+    this.totalTests = suite.allTests().length;
+
+    console.log(`Running ${totalFiles} files with ${suite.allTests().length} tests`);
     if (process.argv.includes('--list')) {
       this.isListMode = true;
       console.log('Listing matching tests with hierarchy paths:');
@@ -45,9 +49,12 @@ class MyReporter implements Reporter {
         const hierarchyPath = this.getHierarchyPath(test);
         console.log(`${hierarchyPath} > ${test.title}`);
       });
+      console.log(
+        `\nTotal: ${this.totalTests} tests in ${totalFiles} file${totalFiles > 1 ? 's' : ''}`
+      );
       return;
     }
-    this.totalTests = suite.allTests().length;
+
     console.log(`Starting the run with ${suite.allTests().length} tests`);
   }
 

--- a/tests/browser/custom-reporter.ts
+++ b/tests/browser/custom-reporter.ts
@@ -20,11 +20,19 @@ class MyReporter implements Reporter {
   private getHierarchyPath(test: TestCase): string {
     const path: string[] = [];
     let parent: Suite | undefined = test.parent;
+
     while (parent) {
-      path.unshift(parent.title || '');
+      if (parent.title) {
+        path.unshift(parent.title);
+      }
       parent = parent.parent;
     }
-    return path.filter(Boolean).join(' > ');
+
+    if (path.length > 0) {
+      path[0] = `[${path[0]}]`;
+    }
+
+    return path.join(' > ');
   }
 
   onBegin(_: FullConfig, suite: Suite) {


### PR DESCRIPTION
## Summary
This PR introduces the following improvements to the custom reporter:
- Adds a `--list` flag to display test hierarchy paths without executing tests.
- Implements logic to track and display the current test index in the logged output (e.g., `[1/160]`).
- Formats browser names with square brackets (`[]`) in the output for improved readability.

[Jira Ticket](https://jira.cms.gov/browse/WNMGDS-3147)

## How to test

1. Run tests using the `--list` flag and a `grep` pattern to filter specific test cases. 
**Example:**`% yarn test:browser --grep="ds-autocomplete" --list `
2. Disable the custom reporter in `playwright.config.ts`, run the tests and compare the logged output with the custom reporter’s output.
3. Run tests without the `--list` flag both with and without the custom reporter enabled. Check that all combinations of browsers and themes are logged as expected, including the test index format (e.g., `[1/160]`).


## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone