### PR TITLE
[WNMGDS-3175] Remove outdated `humanize-react` library

### DIFF
--- a/.storybook/docs/HtmlElementArgs.tsx
+++ b/.storybook/docs/HtmlElementArgs.tsx
@@ -1,4 +1,4 @@
-import humanizeList from 'humanize-react';
+import { humanizeList } from '../../packages/docs/src/helpers/humanizeList';
 import { useOf } from '@storybook/blocks';
 
 interface HtmlElementArgsProps {
@@ -14,7 +14,7 @@ interface HtmlElementArgsProps {
  * determine if it should show this additional text and what elements' documentation
  * it should link to.
  */
-export const HtmlElementArgs = ({ of }) => {
+export const HtmlElementArgs = ({ of }: HtmlElementArgsProps) => {
   const resolvedOf = useOf(of || 'story', ['story', 'meta']);
   if (resolvedOf.type !== 'story') {
     return null;

--- a/.storybook/docs/WebComponentAttrs.tsx
+++ b/.storybook/docs/WebComponentAttrs.tsx
@@ -1,4 +1,4 @@
-import humanizeList from 'humanize-react';
+import { humanizeList } from '../../packages/docs/src/helpers/humanizeList';
 import { useOf } from '@storybook/blocks';
 
 interface WebComponentAttrsProps {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "gulp-svgmin": "^4.1.0",
     "gulp-typescript": "^6.0.0-alpha.1",
     "http-server": "^14.1.1",
-    "humanize-react": "^1.0.0",
     "husky": "^7.0.0",
     "jest": "^27.5.1",
     "lint-staged": "^10.0.8",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -39,7 +39,6 @@
     "gatsby-plugin-sitemap": "^5.11.1",
     "gatsby-remark-autolink-headers": "^5.19.0",
     "gatsby-source-filesystem": "^4.11.1",
-    "humanize-react": "1.0.0",
     "lodash.sortby": "^4.7.0",
     "prettier": "^2.6.2",
     "prismjs": "^1.11.0",

--- a/packages/docs/src/components/content/StorybookDocLinks.tsx
+++ b/packages/docs/src/components/content/StorybookDocLinks.tsx
@@ -1,6 +1,6 @@
 import { Children } from 'react';
 import type * as React from 'react';
-import humanizeList from 'humanize-react';
+import { humanizeList } from '../../helpers/humanizeList';
 
 interface StorybookDocLinksProps {
   children: React.ReactElement<any>;

--- a/packages/docs/src/helpers/humanizeList.tsx
+++ b/packages/docs/src/helpers/humanizeList.tsx
@@ -1,0 +1,41 @@
+import type * as React from 'react';
+import { Fragment } from 'react';
+
+interface HumanizeListOptions {
+  conjunction?: string;
+  oxfordComma?: boolean;
+}
+
+/**
+ * Humanizes a list of React nodes by joining them with a conjunction. Originally from
+ * https://github.com/chadly/humanize-react/, but the package is no longer maintained.
+ */
+export function humanizeList(list: React.ReactNode[], options: HumanizeListOptions = {}) {
+  if (!Array.isArray(list)) {
+    throw new TypeError('humanizeReactList expected an array');
+  }
+
+  const { conjunction = 'and', oxfordComma = true } = options;
+
+  const listLength = list.length;
+  if (listLength === 1) {
+    return list[0];
+  }
+
+  const humanizedList = [];
+  for (let i = 0; i < listLength; i++) {
+    if (i === listLength - 1) {
+      if (listLength > 2 && oxfordComma) {
+        humanizedList.push(<Fragment key={`${i}-comma`}>,</Fragment>);
+      }
+
+      humanizedList.push(<Fragment key={`${i}-conjunction`}> {conjunction} </Fragment>);
+    } else if (i !== 0) {
+      humanizedList.push(<Fragment key={`${i}-comma`}>, </Fragment>);
+    }
+
+    humanizedList.push(<Fragment key={i}>{list[i]}</Fragment>);
+  }
+
+  return <>{humanizedList}</>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17693,11 +17693,6 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-humanize-react@1.0.0, humanize-react@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/humanize-react/-/humanize-react-1.0.0.tgz#542c78db7c919b9b8e8c095487469c8868b8c26f"
-  integrity sha512-d68v6HGH4EnYgH/YgbRKj1+4KYi3TLkMXlZgk4On1ee18XbCQO1Eb/ur0BOZvmEgu8TES5G9Cqu7a4lQng4Sig==
-
 husky@^7.0.0:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
@@ -23577,15 +23572,10 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-react-docgen-typescript@2.3.0-beta.0:
+react-docgen-typescript@2.3.0-beta.0, react-docgen-typescript@^2.2.2:
   version "2.3.0-beta.0"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.3.0-beta.0.tgz#f7725a1a76afec30c636b3e538f4aff05cd269ca"
   integrity sha512-Uh2ZHWNDF4TJZRodJ2+yN13k4vlzPya+6VqDDS+9F4fEdZDBvQvCkowyHQQNZ1If8688hHbSJYHXYNiD3kml3A==
-
-react-docgen-typescript@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
-  integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==
 
 react-docgen@^7.0.0:
   version "7.0.3"


### PR DESCRIPTION
## Summary

Remove the `humanize-react` library and put a modified version of its source code into our project. It's a nice little library, but it was made with a single commit 5 years ago and never updated since. It still requires React 16 as a peer dependency. This causes errors when we try to use other package managers.

## How to test

1. Try the doc site
2. Try Storybook

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone