### PR TITLE
[NO-TICKET] Fix `hintClassName` being applied to DOM elements

### DIFF
--- a/packages/design-system/src/components/utilities/cleanFieldProps.ts
+++ b/packages/design-system/src/components/utilities/cleanFieldProps.ts
@@ -22,6 +22,7 @@ export function cleanFieldProps<T extends PropsToExclude>(props: T): Omit<T, key
   delete newProps.errorPlacement;
   delete newProps.hint;
   delete newProps.hintId;
+  delete newProps.hintClassName;
   delete newProps.requirementLabel;
   delete newProps.labelId;
   delete newProps.label;


### PR DESCRIPTION
## Summary

Fixes an error found by the TextField "applies custom hintClassName to the hint element" unit test where React is complaining that the `hintClassName` is being applied directly to a DOM element.

## How to test

Run `yarn test:unit packages/design-system/src/components/TextField/TextField.test.tsx` and make sure no errors are printed to the console.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

