### PR TITLE
[WNMGDS-3201] Add link tracking events to doc site

### DIFF
--- a/packages/docs/src/components/content/ContentRenderer.tsx
+++ b/packages/docs/src/components/content/ContentRenderer.tsx
@@ -91,7 +91,7 @@ const customComponents = (theme) => ({
   a: (props) => {
     const { href, ...restProps } = props;
     if (href.startsWith('http') && !RE_INTERNAL_URL.test(href)) {
-      return <ThirdPartyExternalLink origin="design.cms.gov" {...restProps} />;
+      return <ThirdPartyExternalLink analytics={true} origin="design.cms.gov" {...props} />;
     }
     if (href.includes('github.com/CMSgov/design-system') || href.startsWith('https:')) {
       return <a href={href} {...restProps} />;

--- a/packages/docs/src/components/content/ContentRenderer.tsx
+++ b/packages/docs/src/components/content/ContentRenderer.tsx
@@ -3,7 +3,7 @@ import { ThirdPartyExternalLink } from '@cmsgov/design-system';
 
 import { MDXRenderer } from 'gatsby-plugin-mdx';
 import { MDXProvider } from '@mdx-js/react';
-import { withPrefix } from 'gatsby';
+import { Link, withPrefix } from 'gatsby';
 
 import ButtonMigrationTable from './ButtonMigrationTable';
 import ButtonVariationsTable from './ButtonVariationsTable';
@@ -20,6 +20,7 @@ import TextColorList from './TextColorList';
 import ThemeContent from './ThemeContent';
 import StorybookDocLinks from './StorybookDocLinks';
 import StorybookDocLink from './StorybookDocLink';
+import linkAnalytics from '../../helpers/linkAnalytics';
 
 // adds DS styling to tables from markdown
 const TableWithClassnames = (props) => {
@@ -82,17 +83,21 @@ const PrefixedImg = (props) => {
  */
 const RE_INTERNAL_URL =
   /^(?:https?:\/\/)?(?:[a-zA-Z\-]+\.)?(?:[a-zA-Z\-]+\.(?:gov)|github\.com\/CMSgov\/design-system)(?:\/|:|\?|\&|\s|$)\/?/;
-
 /**
  * A mapping of custom components for mdx syntax
  * Each mapping has a key with the element name and a value of a functional component to be used for that element
  */
 const customComponents = (theme) => ({
   a: (props) => {
-    if (props.href.startsWith('http') && !RE_INTERNAL_URL.test(props.href)) {
-      return <ThirdPartyExternalLink origin="design.cms.gov" {...props} />;
+    const { href, ...restProps } = props;
+    if (href.startsWith('http') && !RE_INTERNAL_URL.test(href)) {
+      return <ThirdPartyExternalLink origin="design.cms.gov" {...restProps} />;
     }
-    return <a {...props} />;
+    if (href.includes('github.com/CMSgov/design-system') || href.startsWith('https:')) {
+      return <a href={href} {...restProps} />;
+    } else {
+      return <Link onClick={linkAnalytics} to={href} {...restProps} />;
+    }
   },
   ButtonMigrationTable: (props) => <ButtonMigrationTable theme={theme} {...props} />,
   ButtonVariationsTable: (props) => <ButtonVariationsTable theme={theme} {...props} />,

--- a/packages/docs/src/components/content/MaturityChecklist/MaturityChecklist.tsx
+++ b/packages/docs/src/components/content/MaturityChecklist/MaturityChecklist.tsx
@@ -1,4 +1,5 @@
 import MaturityChecklistItem, { CheckStatus } from './MaturityChecklistItem';
+import linkAnalytics from '../../../helpers/linkAnalytics';
 
 interface MaturityChecklistProps {
   // Accessibility
@@ -29,7 +30,10 @@ const MaturityChecklist = (props: MaturityChecklistProps) => (
   <section>
     <p>
       For more information about how we tested and validated our work for each checklist item,{' '}
-      <a href="https://github.com/CMSgov/design-system/blob/main/COMPONENT_MATURITY.md">
+      <a
+        onClick={linkAnalytics}
+        href="https://github.com/CMSgov/design-system/blob/main/COMPONENT_MATURITY.md"
+      >
         read our component maturity documentation
       </a>
       .

--- a/packages/docs/src/components/content/SeeStorybookForGuidance.tsx
+++ b/packages/docs/src/components/content/SeeStorybookForGuidance.tsx
@@ -1,4 +1,5 @@
 import { makeStorybookUrl } from '../../helpers/urlUtils';
+import linkAnalytics from '../../helpers/linkAnalytics';
 
 // Create a link component that uses urlUtils to create the link
 // to the storybook page for the component
@@ -25,7 +26,7 @@ const SeeStorybookForGuidance = ({
 }: StorybookExampleFooterProps) => {
   return (
     <p>
-      <a href={makeStorybookUrl(storyId, theme, 'docs')}>
+      <a onClick={linkAnalytics} href={makeStorybookUrl(storyId, theme, 'docs')}>
         {tech === 'react' ? 'Review' : 'Go to'} Storybook for{' '}
         {tech === 'react' ? 'React' : 'Web Component'} guidance of this component.
       </a>

--- a/packages/docs/src/components/content/StorybookDocLink.tsx
+++ b/packages/docs/src/components/content/StorybookDocLink.tsx
@@ -1,5 +1,5 @@
 import { makeStorybookUrl } from '../../helpers/urlUtils';
-
+import linkAnalytics from '../../helpers/linkAnalytics';
 interface StorybookDocLinkProps {
   /**
    * Name of component
@@ -17,7 +17,9 @@ interface StorybookDocLinkProps {
 }
 
 const StorybookDocLink = ({ storyId, theme, children, tech = 'react' }: StorybookDocLinkProps) => (
-  <a href={makeStorybookUrl(storyId, theme, 'docs')}>Storybook &quot;{children}&quot; page</a>
+  <a onClick={linkAnalytics} href={makeStorybookUrl(storyId, theme, 'docs')}>
+    Storybook &quot;{children}&quot; page
+  </a>
 );
 
 export default StorybookDocLink;

--- a/packages/docs/src/components/content/Video.tsx
+++ b/packages/docs/src/components/content/Video.tsx
@@ -1,4 +1,5 @@
 import { withPrefix } from 'gatsby';
+import linkAnalytics from '../../helpers/linkAnalytics';
 
 export interface VideoProps {
   name: string;
@@ -16,7 +17,10 @@ const Video = ({ name }: VideoProps) => {
       <track kind="captions" src={`${path}.vtt`} srcLang="en" />
       <p>
         Your browser does not support HTML video. Here is a
-        <a href={`${path}.mp4`}>link to the video</a> instead.
+        <a onClick={linkAnalytics} href={`${path}.mp4`}>
+          link to the video
+        </a>{' '}
+        instead.
       </p>
     </video>
   );

--- a/packages/docs/src/components/layout/PageHeader.tsx
+++ b/packages/docs/src/components/layout/PageHeader.tsx
@@ -1,4 +1,5 @@
 import { FrontmatterInterface } from '../../helpers/graphQLTypes';
+import linkAnalytics from '../../helpers/linkAnalytics';
 import { withPrefix } from 'gatsby';
 import { makeFigmaUrl, makeGithubUrl, makeStorybookUrl } from '../../helpers/urlUtils';
 import GithubIcon from '../icons/GithubIcon';
@@ -48,7 +49,11 @@ const PageHeader = ({ frontmatter = { title: '' }, theme }: PageHeaderProps) => 
       {showLinkBar && (
         <div className="ds-u-margin-top--1 ds-u-margin-bottom--0">
           {figmaNodeId && (
-            <a href={makeFigmaUrl(figmaNodeId, figmaTheme)} className="c-page-header__link">
+            <a
+              onClick={linkAnalytics}
+              href={makeFigmaUrl(figmaNodeId, figmaTheme)}
+              className="c-page-header__link"
+            >
               <img
                 alt="Figma logo"
                 src={withPrefix('/images/figma-icon.png')}
@@ -58,13 +63,21 @@ const PageHeader = ({ frontmatter = { title: '' }, theme }: PageHeaderProps) => 
             </a>
           )}
           {ghPath && (
-            <a href={makeGithubUrl(`tree/main/packages/${ghPath}`)} className="c-page-header__link">
+            <a
+              onClick={linkAnalytics}
+              href={makeGithubUrl(`tree/main/packages/${ghPath}`)}
+              className="c-page-header__link"
+            >
               <GithubIcon />
               Github
             </a>
           )}
           {storyId && (
-            <a href={makeStorybookUrl(storyId, theme, 'docs')} className="c-page-header__link">
+            <a
+              onClick={linkAnalytics}
+              href={makeStorybookUrl(storyId, theme, 'docs')}
+              className="c-page-header__link"
+            >
               <img
                 alt="Storybook logo"
                 src={withPrefix('/images/storybook-icon.png')}

--- a/packages/docs/src/components/layout/SideNav/SideNav.tsx
+++ b/packages/docs/src/components/layout/SideNav/SideNav.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../helpers/navDataFormatUtils';
 import GithubIcon from '../../icons/GithubIcon';
 import NewsIcon from '../../icons/NewsIcon';
+import linkAnalytics from '../../../helpers/linkAnalytics';
 
 interface SideNavProps {
   location: LocationInterface;
@@ -22,7 +23,7 @@ interface SideNavProps {
  * A wrapper for the gatsby link to handle internal site navigation
  */
 const GatsbyLink = (props: any /* See VerticalNavItemLabel.tsx */) => (
-  <Link to={props.href} {...props}>
+  <Link onClick={linkAnalytics} to={props.href} {...props}>
     {props.children}
   </Link>
 );
@@ -120,9 +121,9 @@ const SideNav = ({ location }: SideNavProps) => {
           )}
         </Button>
         <div>
-          <a className="c-navigation__title" href="/">
+          <Link onClick={linkAnalytics} className="c-navigation__title" to="/">
             CMS Design System
-          </a>
+          </Link>
         </div>
       </header>
 
@@ -143,13 +144,18 @@ const SideNav = ({ location }: SideNavProps) => {
             selectedId={location ? location.pathname : ''}
           />
           <p>
-            <Link to="/blog/" className="c-navigation__bottom-link ds-c-link">
+            <Link
+              onClick={linkAnalytics}
+              to="/blog/"
+              className="c-navigation__bottom-link ds-c-link"
+            >
               <NewsIcon />
               What&apos;s new?
             </Link>
           </p>
           <p>
             <a
+              onClick={linkAnalytics}
               href="https://github.com/CMSgov/design-system"
               className="c-navigation__bottom-link ds-c-link"
             >

--- a/packages/docs/src/components/layout/TableOfContents.tsx
+++ b/packages/docs/src/components/layout/TableOfContents.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'gatsby';
 import { TableOfContentsItem } from '../../helpers/graphQLTypes';
+import linkAnalytics from '../../helpers/linkAnalytics';
 
 function cleanTitle(title: string) {
   return title.replace(/<[^>]*>/g, '');
@@ -58,16 +59,19 @@ export const TableOfContentsFeedback = ({ slug }: TableOfContentsFeedbackProps) 
     </h2>
     <ul role="list" className="ds-c-list ds-c-list--bare ds-u-md-margin-y--2">
       <li>
-        <Link to="/contact">Contact the team</Link>
+        <Link onClick={linkAnalytics} to="/contact">
+          Contact the team
+        </Link>
       </li>
       <li>
-        <a href="https://github.com/CMSgov/design-system/discussions">
+        <a onClick={linkAnalytics} href="https://github.com/CMSgov/design-system/discussions">
           Start a discussion on GitHub
         </a>
       </li>
       {typeof slug !== 'undefined' ? (
         <li>
           <a
+            onClick={linkAnalytics}
             href={`https://github.com/CMSgov/design-system/edit/main/packages/docs/content/${slug}.mdx`}
           >
             Edit this page

--- a/packages/docs/src/helpers/linkAnalytics.ts
+++ b/packages/docs/src/helpers/linkAnalytics.ts
@@ -1,0 +1,27 @@
+import { sendLinkEvent } from '@cmsgov/design-system';
+
+type LinkType = 'internal' | 'external';
+
+function composeAnalyticsEvent(
+  event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+  type: LinkType
+) {
+  return {
+    event_name: `${type}_link_clicked`,
+    link_url: (event.target as HTMLAnchorElement).baseURI,
+    link_type: 'link_other',
+    parent_component_heading:
+      (event.target as HTMLAnchorElement).parentElement.innerText ?? undefined,
+    parent_component_type: (event.target as HTMLAnchorElement).parentElement.tagName ?? undefined,
+    text: (event.target as HTMLAnchorElement).innerText,
+  } as any;
+}
+
+function linkAnalytics(
+  event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+  type: LinkType = 'internal'
+) {
+  sendLinkEvent(composeAnalyticsEvent(event, type));
+}
+
+export default linkAnalytics;


### PR DESCRIPTION
## Summary

[Ticket](https://jira.cms.gov/browse/WNMGDS-3201)

## How to test

- `yarn start`
- Open http://localhost:8000/
- In the JavaScript console, execute window.utag.link = console.log to be able to intercept the analytics events and see them printed to the console.
- In your console settings, enable the preserving of logs between navigation requests. We'll be performing actions that both send analytics and go to a new page, so we don't want the page refresh to clear the console before we can see the event printed
- Click on some links both internal and external
- You should see the content of the object provided to the link function printed in the console. It should look similar in shape to this:
```
event_name: "internal_link_clicked",
link_url: https:/design.cms.gov/etc,
link_type: 'link_other',
parent_component_heading: "Some text from the heading"
parent_component_type: "P"
text: "The link text",
```

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone