### PR TITLE
[WNMGDS-3171] Adds Typography overview guidance to docs site

### DIFF
--- a/packages/docs/content/foundation/typography/overview.mdx
+++ b/packages/docs/content/foundation/typography/overview.mdx
@@ -1,0 +1,14 @@
+---
+title: Typography overview
+order: 20
+cmsgov:
+  figmaNodeId: 6-78
+core:
+  figmaNodeId: 6-78
+  githubLink: design-system/src/styles/_base.scss
+  storybookLink: foundations-typography
+healthcare:
+  figmaNodeId: 6-78
+medicare:
+  figmaNodeId: 6-78
+---

--- a/packages/docs/content/foundation/typography/overview.mdx
+++ b/packages/docs/content/foundation/typography/overview.mdx
@@ -86,7 +86,7 @@ For pages that are mainly about written content or places where you want to use 
 
 ### Responsive typography
 
-To apply responsive typography elsewhere, use the <a href="/utilities/font/font-size/?theme=medicare#responsive-font-sizes">font size utility class</a>. Since the base typography margins and line height is measured in em units, they'll automatically adjust as you change the font size.
+To apply responsive typography elsewhere, use the <a href="/utilities/font/font-size/#responsive-font-sizes">font size utility class</a>. Since the base typography margins and line height is measured in em units, they'll automatically adjust as you change the font size.
 
 ### Accessibility
 

--- a/packages/docs/content/foundation/typography/overview.mdx
+++ b/packages/docs/content/foundation/typography/overview.mdx
@@ -32,7 +32,7 @@ CMS.gov uses Lexend for headings and Public Sans for all other text.
 
 <ThemeContent onlyThemes={['healthcare']}>
 
-Healthcare uses Open Sans as the base font for the site.
+Healthcare.gov uses Open Sans as the base font for the site.
 
 The full Open Sans type family consists of a variety of weights including light, regular, semibold, bold, and extrabold which allows for a wide range of type treatments and hierarchies within a page while still maintaining a unified look and feel.
 
@@ -56,9 +56,9 @@ Medicare.gov uses Montserrat for headings and Rubik for all other text.
 
 <ThemeContent onlyThemes={['cmsgov']}>
 
-**Headings font stack:** Lexend > Inter > Roboto > “Helvetica Neue" > “Arial Nova” > “Nimbus Sans” > Arial > “sans-serif”
+**Headings font stack:** Lexend > Inter > Roboto > Helvetica Neue > Arial Nova > Nimbus Sans > Arial > sans-serif
 
-**Body copy font stack:** “Public Sans” > Inter > Roboto > “Helvetica Neue” > “Arial Nova” > “Nimbus Sans” > Arial > “sans-serif”
+**Body copy font stack:** Public Sans > Inter > Roboto > Helvetica Neue > Arial Nova > Nimbus Sans > Arial > sans-serif
 
 </ThemeContent>
 
@@ -70,15 +70,15 @@ Medicare.gov uses Montserrat for headings and Rubik for all other text.
 
 <ThemeContent onlyThemes={['medicare']}>
 
-**Headings font stack:** Montserrat > Avenir > Corbel > “URW Gothic” > source-sans-pro > “sans-serif”
+**Headings font stack:** Montserrat > Avenir > Corbel > URW Gothic > source-sans-pro > sans-serif
 
-**Body copy font stack:** Rubik > Seravek > “Gill Sans Nova” > Ubuntu > Calibri > “DejaVu Sans” > source-sans-pro > “sans-serif”
+**Body copy font stack:** Rubik > Seravek > Gill Sans Nova > Ubuntu > Calibri > DejaVu Sans > source-sans-pro > sans-serif
 
 </ThemeContent>
 
 ## Working with these fonts
 
-The design system provides guidance for <a href="/foundation/typography/headings/">headings</a>, <a href="/foundation/typography/body/">body copy</a>, <a href="foundation/typography/links">links</a>, and <a href="foundation/typography/lists">lists</a>.
+The design system provides guidance for <a href="/foundation/typography/headings/">headings</a>, <a href="/foundation/typography/body/">body copy</a>, <a href="/foundation/typography/links/">links</a>, and <a href="/foundation/typography/lists/">lists</a>.
 
 ### The `ds-content` class
 
@@ -120,7 +120,7 @@ Sans-serifs have been proven to be easier to read on-screen and are incredibly a
 
 - Standard body text is Open Sans Regular, 16px, #333, 24px line-height, 32px bottom-margin on paragraphs.
 
-- Smallest paragraph text for legibility reasons is Open Sans Regular, 14px, #333, 20px line-height, 28px bottom-margin on paragraphs (except for legal/caption text)
+- Smallest paragraph text for legibility reasons is Open Sans Regular, 14px, #333, 20px line-height, 28px bottom-margin on paragraphs (except for legal/caption text).
 
 - Uppercase font should not be used.
 
@@ -132,7 +132,7 @@ Sans-serifs have been proven to be easier to read on-screen and are incredibly a
 
 - Standard body text is Rubik Regular, 16px, #333, 24px line-height, 32px bottom-margin on paragraphs.
 
-- Smallest paragraph text for legibility reasons is Rubik Regular, 14px, #333, 20px line-height, 28px bottom-margin on paragraphs (except for legal/caption text)
+- Smallest paragraph text for legibility reasons is Rubik Regular, 14px, #333, 20px line-height, 28px bottom-margin on paragraphs (except for legal/caption text).
 
 - Uppercase font should not be used.
 

--- a/packages/docs/content/foundation/typography/overview.mdx
+++ b/packages/docs/content/foundation/typography/overview.mdx
@@ -12,3 +12,129 @@ healthcare:
 medicare:
   figmaNodeId: 6-78
 ---
+
+## Font Families
+
+<ThemeContent onlyThemes={['core']}>
+
+Core uses Open Sans as the base font for the site.
+
+The full Open Sans type family consists of a variety of weights including light, regular, semibold, bold, and extrabold which allows for a wide range of type treatments and hierarchies within a page while still maintaining a unified look and feel.
+
+- Open Sans font is used for headings and body content.
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['cmsgov']}>
+
+CMS.gov uses Lexend for headings and Public Sans for all other text.
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['healthcare']}>
+
+Healthcare uses Open Sans as the base font for the site.
+
+The full Open Sans type family consists of a variety of weights including light, regular, semibold, bold, and extrabold which allows for a wide range of type treatments and hierarchies within a page while still maintaining a unified look and feel.
+
+- Open Sans font is used for headings and body content.
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['medicare']}>
+
+Medicare.gov uses Montserrat for headings and Rubik for all other text.
+
+</ThemeContent>
+
+## Web font stack
+
+<ThemeContent onlyThemes={['core']}>
+
+**Web font stack:** Open Sans > Helvetica > Arial > Verdana > Sans-Serif
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['cmsgov']}>
+
+**Headings font stack:** Lexend > Inter > Roboto > “Helvetica Neue" > “Arial Nova” > “Nimbus Sans” > Arial > “sans-serif”
+
+**Body copy font stack:** “Public Sans” > Inter > Roboto > “Helvetica Neue” > “Arial Nova” > “Nimbus Sans” > Arial > “sans-serif”
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['healthcare']}>
+
+**Web font stack:** Open Sans > Helvetica > Arial > Verdana > Sans-Serif
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['medicare']}>
+
+**Headings font stack:** Montserrat > Avenir > Corbel > “URW Gothic” > source-sans-pro > “sans-serif”
+
+**Body copy font stack:** Rubik > Seravek > “Gill Sans Nova” > Ubuntu > Calibri > “DejaVu Sans” > source-sans-pro > “sans-serif”
+
+</ThemeContent>
+
+## Working with these fonts
+
+The design system provides guidance for <a href="/foundation/typography/headings/">headings</a>, <a href="/foundation/typography/body/">body copy</a>, <a href="foundation/typography/links">links</a>, and <a href="foundation/typography/lists">lists</a>.
+
+### The `ds-content` class
+
+For pages that are mainly about written content or places where you want to use a standard mapping of heading-level styles to semantic heading levels, consider using the <a href="/foundation/typography/content">`ds-content` class</a>.
+
+### Responsive typography
+
+To apply responsive typography elsewhere, use the <a href="/utilities/font/font-size/?theme=medicare#responsive-font-sizes">font size utility class</a>. Since the base typography margins and line height is measured in em units, they'll automatically adjust as you change the font size.
+
+### Accessibility
+
+<ThemeContent onlyThemes={['core']}>
+
+Sans-serifs have been proven to be easier to read on-screen and are incredibly adaptable when resized and displayed across different platforms and browsers. Accordingly, Open Sans is used for body type, secondary and tertiary headlines, and instructional text.
+
+- Standard body text is Open Sans Regular, 16px, #333, 24px line-height, 32px bottom-margin on paragraphs.
+
+- Smallest paragraph text for legibility reasons is Open Sans Regular, 14px, #333, 20px line-height, 28px bottom-margin on paragraphs (except for legal/caption text).
+
+- Uppercase font should not be used.
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['cmsgov']}>
+
+Sans-serifs have been proven to be easier to read on-screen and are incredibly adaptable when resized and displayed across different platforms and browsers. Accordingly, Public Sans is used for body type, secondary and tertiary headlines, and instructional text.
+
+- Standard body text is Public Sans Regular, 16px, #333, 24px line-height, 32px bottom-margin on paragraphs.
+
+- Smallest paragraph text for legibility reasons is Public Sans Regular, 14px, #333, 20px line-height, 28px bottom-margin on paragraphs (except for legal/caption text).
+
+- Uppercase font should not be used.
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['healthcare']}>
+
+Sans-serifs have been proven to be easier to read on-screen and are incredibly adaptable when resized and displayed across different platforms and browsers. Accordingly, Open Sans is used for body type, secondary and tertiary headlines, and instructional text.
+
+- Standard body text is Open Sans Regular, 16px, #333, 24px line-height, 32px bottom-margin on paragraphs.
+
+- Smallest paragraph text for legibility reasons is Open Sans Regular, 14px, #333, 20px line-height, 28px bottom-margin on paragraphs (except for legal/caption text)
+
+- Uppercase font should not be used.
+
+</ThemeContent>
+
+<ThemeContent onlyThemes={['medicare']}>
+
+Sans-serifs have been proven to be easier to read on-screen and are incredibly adaptable when resized and displayed across different platforms and browsers. Accordingly, Rubik is used for body type, secondary and tertiary headlines, and instructional text.
+
+- Standard body text is Rubik Regular, 16px, #333, 24px line-height, 32px bottom-margin on paragraphs.
+
+- Smallest paragraph text for legibility reasons is Rubik Regular, 14px, #333, 20px line-height, 28px bottom-margin on paragraphs (except for legal/caption text)
+
+- Uppercase font should not be used.
+
+</ThemeContent>

--- a/packages/docs/content/foundation/typography/overview.mdx
+++ b/packages/docs/content/foundation/typography/overview.mdx
@@ -6,7 +6,6 @@ cmsgov:
 core:
   figmaNodeId: 6-78
   githubLink: design-system/src/styles/_base.scss
-  storybookLink: foundations-typography
 healthcare:
   figmaNodeId: 6-78
 medicare:


### PR DESCRIPTION
## Summary

- Adds general and per theme guidance to the docs site
- [Jira Ticket](https://jira.cms.gov/browse/WNMGDS-3171)

## How to test

1. Pull down the changes locally and go to http://localhost:8000/foundation/typography/overview/
2. Switch themes and verify that the content contains relevant information

Alternatively, go to https://cmsgov.github.io/design-system/branch/kcn/WNMGDS-3171/typography-overview/foundation/typography/overview/ and then switch themes and verify that the content contains relevant information

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to documentation:

- [x] Checked for spelling and grammatical errors
