### PR TITLE
[WNMGDS-3173] Removes a stray Sketch reference on the `MaturityChecklist` component.

### DIFF
--- a/packages/docs/src/components/content/MaturityChecklist/MaturityChecklist.tsx
+++ b/packages/docs/src/components/content/MaturityChecklist/MaturityChecklist.tsx
@@ -20,7 +20,7 @@ interface MaturityChecklistProps {
 
   // Tokens
   tokensInCode: CheckStatus;
-  tokensInSketch: CheckStatus;
+  tokensInFigma: CheckStatus;
 }
 
 /**
@@ -86,8 +86,8 @@ const MaturityChecklist = (props: MaturityChecklistProps) => (
       <MaturityChecklistItem title="Code" status={props.tokensInCode}>
         Tokens implemented in code.
       </MaturityChecklistItem>
-      <MaturityChecklistItem title="Design" status={props.tokensInSketch}>
-        Tokens implemented in the Sketch.
+      <MaturityChecklistItem title="Design" status={props.tokensInFigma}>
+        Tokens implemented in Figma.
       </MaturityChecklistItem>
     </ul>
   </section>


### PR DESCRIPTION
## Summary

- Updates a stray Sketch reference on our `MaturityChecklist` component to Figma.

## How to test
Run locally:
- Run `npm run start`
- Inspect the token section in the maturity checklist for various component pages. 

Or, inspect maturity checklists for various components on [deployed branch](https://cmsgov.github.io/design-system/branch/tamara/WNMGDS-3173/remove-sketch-references-from-maturity-checklist/?theme=core) to verify that references to Sketch have been replaced with Figma.

Below is a screenshot for quick review.
<img width="588" alt="Screenshot 2025-02-12 at 4 07 33 PM" src="https://github.com/user-attachments/assets/7a7126c5-a6a3-4d45-96ae-11a671c8e59a" />

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone