### PR TITLE
[WNMGDS-3249] NavigationOpened analytics event

### DIFF
--- a/packages/docs/src/helpers/analytics.ts
+++ b/packages/docs/src/helpers/analytics.ts
@@ -24,7 +24,7 @@ const composeNavigationOpenedAnalytics = (id: string): any => {
   const subNav = id.match(/\//);
   return {
     event_name: 'navigation_opened',
-    navigation_type: 'main_nav',
+    navigation_type: 'main nav',
     heading: subNav ? heading[1] : heading[0],
   } as any;
 };

--- a/packages/docs/src/helpers/analytics.ts
+++ b/packages/docs/src/helpers/analytics.ts
@@ -19,6 +19,20 @@ export function sendButtonAnalytics(event: React.MouseEvent<HTMLButtonElement, M
   sendLinkEvent(composeButtonAnalytics(event));
 }
 
+const composeNavigationOpenedAnalytics = (id: string): any => {
+  const heading = id.split('/');
+  const subNav = id.match(/\//);
+  return {
+    event_name: 'navigation_opened',
+    navigation_type: 'main_nav',
+    heading: subNav ? heading[1] : heading[0],
+  } as any;
+};
+
+export function sendNavigationOpenedAnalytics(id: string) {
+  sendLinkEvent(composeNavigationOpenedAnalytics(id));
+}
+
 export function composeLinkAnalyticsEvent(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
   return {
     event_name: `internal_link_clicked`,

--- a/packages/docs/src/helpers/navDataFormatUtils.ts
+++ b/packages/docs/src/helpers/navDataFormatUtils.ts
@@ -2,6 +2,7 @@ import sortBy from 'lodash.sortby';
 import { VerticalNavItemProps } from '@cmsgov/design-system';
 import { makePageUrl } from './urlUtils';
 import { ContentDirectoryGroup, NavItem, LocationInterface } from './graphQLTypes';
+import { sendNavigationOpenedAnalytics } from '../helpers/analytics';
 
 export interface DocsNavItem extends Omit<VerticalNavItemProps, 'label'> {
   label: string;
@@ -132,6 +133,9 @@ export const convertToNavItems = (
       selected: isSelected,
       id: dataItem.fieldValue,
       order: orderVal,
+      onSubnavToggle: (id) => {
+        sendNavigationOpenedAnalytics(id);
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/WNMGDS-3249)
- This adds a new analytics event for when drop downs in the side nav are opened. 
- This event will additional insight into the navigational behaviors of our users

### Open Question

The navigation type field has a number of options. Three seem possibly relevant:
- main nav
- secondary nav
- left_rail

I am leaning towards main nav since this even though our navigation element is on the left rail, it's our only and main page navigation interface. Happy to talk more about this if folks have differing opinions though!

## How to test

1. Pull down locally
2. `npm run start`
3. Add `window.utag.link = console.log` to you browser console environment. 
4. Confirm that the object shape matches that of the [tech spec](https://confluence.cms.gov/pages/viewpage.action?pageId=1185025604#Design.cms.govDataLayerSpecs&QAResults-H1-navigation_opened)

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone
