### PR TITLE
[WNMGDS-3215] Allow for date entry format to switch between MM/DD and DD/MM per page language

### DIFF
--- a/packages/design-system/src/components/DateField/DateInput.test.tsx
+++ b/packages/design-system/src/components/DateField/DateInput.test.tsx
@@ -11,6 +11,7 @@ const defaultProps: DateInputProps = {
   yearName: 'year',
   yearLabel: 'Year',
   id: 'static-id',
+  language: 'en',
 };
 
 function renderDateInput(customProps: Partial<DateInputProps> = {}) {
@@ -103,6 +104,26 @@ describe('DateInput', () => {
     expect((dayFieldRef.current as HTMLInputElement).value).toBe(dayDefaultValue);
     expect((monthFieldRef.current as HTMLInputElement).value).toBe(monthDefaultValue);
     expect((yearFieldRef.current as HTMLInputElement).value).toBe(yearDefaultValue);
+  });
+
+  it('renders DD/MM/YYYY for non-English language pages', () => {
+    renderDateInput({ language: 'es' });
+
+    const monthLabel = screen.getByLabelText(/month/i);
+    const dayLabel = screen.getByLabelText(/day/i);
+
+    // A return value of 4 from compareDocumentPosition means the monthLabel follows the dayLabel in the DOM
+    expect(dayLabel.compareDocumentPosition(monthLabel)).toBe(4);
+  });
+
+  it('renders MM/DD/YYYY for English language pages', () => {
+    renderDateInput();
+
+    const monthLabel = screen.getByLabelText(/month/i);
+    const dayLabel = screen.getByLabelText(/day/i);
+
+    // A return value of 4 from compareDocumentPosition means the dayLabel follows the monthLabel in the DOM
+    expect(monthLabel.compareDocumentPosition(dayLabel)).toBe(4);
   });
 
   describe('event handlers', () => {

--- a/packages/design-system/src/components/DateField/DateInput.tsx
+++ b/packages/design-system/src/components/DateField/DateInput.tsx
@@ -4,6 +4,7 @@ import type * as React from 'react';
 import TextField from '../TextField/TextField';
 import classNames from 'classnames';
 import { t } from '../i18n';
+import type { Language } from '../i18n';
 import uniqueId from 'lodash/uniqueId';
 
 export type DateInputDayDefaultValue = string | number;
@@ -81,6 +82,10 @@ export interface DateInputProps {
    * for a controlled component; otherwise, set `dayDefaultValue`.
    */
   dayValue?: DateInputDayValue;
+  /**
+   * Sets the display format for the month and days input fields based on document language. For English documents, month precedes day, for Spanish documents day precedes month.
+   */
+  language: Language;
   /**
    * Label for the month field
    */
@@ -230,9 +235,9 @@ export class DateInput extends PureComponent<DateInputProps> {
   render() {
     return (
       <div className="ds-c-datefield__container ds-l-form-row">
-        {this.renderField('month', 2)}
+        {this.props.language === 'en' ? this.renderField('month', 2) : this.renderField('day', 2)}
         <span className="ds-c-datefield__separator">/</span>
-        {this.renderField('day', 2)}
+        {this.props.language === 'en' ? this.renderField('day', 2) : this.renderField('month', 2)}
         <span className="ds-c-datefield__separator">/</span>
         {this.renderField('year', 4)}
       </div>

--- a/packages/design-system/src/components/DateField/MultiInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/MultiInputDateField.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import describeField from '../utilities/describeField';
 import useId from '../utilities/useId';
 import { Label } from '../Label';
-import { t } from '../i18n';
+import { t, getLanguage } from '../i18n';
 import { useLabelProps, UseLabelPropsProps } from '../Label/useLabelProps';
 import { useHint, UseHintProps } from '../Hint/useHint';
 import { useInlineError, UseInlineErrorProps } from '../InlineError/useInlineError';
@@ -157,6 +157,7 @@ export function MultiInputDateField(props: DateFieldProps): React.ReactElement {
     dateFormatter: defaultDateFormatter,
     ...cleanFieldProps(props),
     id,
+    language: getLanguage(),
   };
 
   return (


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/WNMGDS-3215)
- Changes presentation of multi-input date field based on page language
- Shows MM/DD/YYYY for English pages and DD/MM/YYYY for non-English language pages

## How to test

1. Locally, run in Storybook
2. Change the language via the circular, globe/basketball shaped icon in the top bar over the component
3. Confirm that the format of the inputs changes based on the language selected and that it follows this format:
English: MM/DD/YYYY
Espanol: DD/MM/YYYY

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone