### PR TITLE
[WNMGDS-3227] Remove incorrect documentation for Dropdown

### DIFF
--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -41,7 +41,7 @@ export function generateOptions(
 ): { value: string; label: string }[] {
   let options = [];
   if (typeof optionsToMake === 'number') {
-    for (let i = 1; i < optionsToMake + 1; i++) {
+    for (let i = 1; i <= optionsToMake; i++) {
       options.push({
         value: String(i),
         label: String(i),

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -37,6 +37,14 @@ function getButton() {
   return screen.getByRole('button', { name: RegExp(defaultProps.label) });
 }
 
+function expectDropdownToBeOpen() {
+  expect(screen.getByRole('listbox')).toBeInTheDocument();
+}
+
+function expectDropdownToBeClosed() {
+  expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+}
+
 describe('Dropdown', () => {
   it('dropdown matches snapshot', () => {
     const { container } = makeDropdown(
@@ -127,6 +135,7 @@ describe('Dropdown', () => {
     makeDropdown({ value: '1', onChange, onBlur }, 5);
     const button = getButton();
     userEvent.click(button);
+    expectDropdownToBeOpen();
     userEvent.keyboard('{arrowdown}');
     userEvent.keyboard('{enter}');
     expect(onBlur).not.toHaveBeenCalled();
@@ -148,6 +157,7 @@ describe('Dropdown', () => {
     );
     const button = getButton();
     userEvent.click(button);
+    expectDropdownToBeOpen();
     userEvent.tab();
 
     const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -157,6 +167,7 @@ describe('Dropdown', () => {
 
     expect(onBlur).toHaveBeenCalled();
     expect(onChange).not.toHaveBeenCalled();
+    expectDropdownToBeClosed();
   });
 
   it('pressing Escape closes the menu without making a selection', () => {
@@ -164,11 +175,13 @@ describe('Dropdown', () => {
     makeDropdown({ value: '1', onChange }, 5);
     const button = getButton();
     userEvent.click(button);
+    expectDropdownToBeOpen();
     userEvent.keyboard('{arrowdown}');
     userEvent.keyboard('{escape}');
     const list = screen.queryByRole('listbox');
     expect(list).toBeFalsy();
     expect(onChange).not.toHaveBeenCalled();
+    expectDropdownToBeClosed();
   });
 
   it('pressing Tab selects the focused item and blurs away', async () => {
@@ -187,6 +200,7 @@ describe('Dropdown', () => {
     const button = getButton();
     userEvent.click(button);
     userEvent.keyboard('{arrowdown}');
+    expectDropdownToBeOpen();
     userEvent.tab();
 
     const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -200,12 +214,14 @@ describe('Dropdown', () => {
     expect(onChange.mock.calls[0][0].currentTarget.value).toEqual('2');
     expect(onChange.mock.calls[0][0].currentTarget.name).toEqual('dropdown');
     expect(onBlur).toHaveBeenCalled();
+    expectDropdownToBeClosed();
   });
 
   it('automatically focuses on the selected option when opening', () => {
     makeDropdown({ defaultValue: '3' }, 10);
     const button = getButton();
     userEvent.click(button);
+    expectDropdownToBeOpen();
     const options = screen.getAllByRole('option');
     expect(options[2]).toHaveFocus();
   });
@@ -330,6 +346,7 @@ describe('Dropdown', () => {
       </Dropdown>
     );
     userEvent.click(getButton());
+    expectDropdownToBeOpen();
     const groupLabel = container.querySelector('#group-label-id');
     expect(groupLabel).toHaveAttribute('data-extra-attribute', 'something');
   });
@@ -357,6 +374,7 @@ describe('Dropdown', () => {
     // Clicking an item should call `onChange` but should do nothing else
     // because this is a controlled component
     userEvent.click(button);
+    expectDropdownToBeOpen();
     userEvent.keyboard('{arrowdown}');
     userEvent.keyboard('{enter}');
     expect(onChange).toHaveBeenCalled();

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -45,6 +45,10 @@ function expectDropdownToBeClosed() {
   expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 describe('Dropdown', () => {
   it('dropdown matches snapshot', () => {
     const { container } = makeDropdown(
@@ -160,7 +164,6 @@ describe('Dropdown', () => {
     expectDropdownToBeOpen();
     userEvent.tab();
 
-    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
     await act(async () => {
       await sleep(40);
     });
@@ -203,7 +206,6 @@ describe('Dropdown', () => {
     expectDropdownToBeOpen();
     userEvent.tab();
 
-    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
     await act(async () => {
       await sleep(40);
     });

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -279,6 +279,28 @@ describe('Dropdown', () => {
     expect(options[6]).toHaveFocus();
   });
 
+  it('can focus across multiple uses of type ahead', async () => {
+    makeDropdown({}, dropdownOptions);
+    let button = getButton();
+    userEvent.click(button);
+    expectDropdownToBeOpen();
+    userEvent.keyboard('{arrowdown}');
+    userEvent.keyboard('{c}');
+    let options = screen.getAllByRole('option');
+    // First option starts with c, so it should be in focus
+    expect(options[1]).toHaveFocus();
+    userEvent.keyboard('{escape}');
+    expectDropdownToBeClosed();
+    button = getButton();
+    await sleep(10);
+    userEvent.click(button);
+    userEvent.keyboard('{arrowdown}');
+    userEvent.keyboard('{l}');
+    options = screen.getAllByRole('option');
+    // Lummi tribe option should have focus and is 7th element in array
+    expect(options[7]).toHaveFocus();
+  });
+
   it('does not move to the next item starting with the same letter', async () => {
     makeDropdown({}, dropdownOptions);
     const button = getButton();
@@ -297,15 +319,21 @@ describe('Dropdown', () => {
     expect(options[1]).toHaveFocus();
   });
 
-  it('supports multi-character type ahead', () => {
+  it('supports multi-character type ahead', async () => {
     makeDropdown({}, dropdownOptions);
     const button = getButton();
     userEvent.click(button);
     const list = screen.getByRole('listbox');
     userEvent.keyboard('{arrowdown}');
-    userEvent.type(list, 'cow');
-    const options = screen.getAllByRole('option');
-    // Cowlitz tribe option should have focus and is 4th element in options array
+    userEvent.type(list, 'c');
+    let options = screen.getAllByRole('option');
+    // Since we have only typed 'c' at this point we expect focus to be on the first element since it starts with 'c'
+    expect(options[1]).toHaveFocus();
+    await sleep(40);
+    // We are still within the 1 second type ahead window, so the search string will now be updated to 'cow'
+    userEvent.type(list, 'ow');
+    options = screen.getAllByRole('option');
+    // Focus should update to the fourth item, the Cowlitz tribe
     expect(options[4]).toHaveFocus();
   });
 

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -92,14 +92,14 @@ describe('Dropdown', () => {
   });
 
   it('applies additional classes to root element', () => {
-    const { container } = makeDropdown({ className: 'bar' }, 1);
+    const { container } = makeDropdown({ className: 'bar' });
     expect(container.firstChild).toHaveClass('bar');
     // Make sure we're not replacing the other class names
     expect(container.firstChild).toHaveClass('ds-c-dropdown');
   });
 
   it('applies additional classes to button element', () => {
-    makeDropdown({ fieldClassName: 'foo' }, 1);
+    makeDropdown({ fieldClassName: 'foo' });
 
     const button = getButton();
     expect(button).toHaveClass('foo');
@@ -108,7 +108,7 @@ describe('Dropdown', () => {
   });
 
   it('adds size classes to the appropriate elements', () => {
-    makeDropdown({ size: 'small' }, 1);
+    makeDropdown({ size: 'small' });
     const button = getButton();
     userEvent.click(button);
     const listContainer = screen.getByRole('listbox').parentElement;
@@ -117,7 +117,7 @@ describe('Dropdown', () => {
   });
 
   it('adds inverse class to button', () => {
-    makeDropdown({ inversed: true }, 1);
+    makeDropdown({ inversed: true });
     const button = getButton();
     expect(button).toHaveClass('ds-c-field--inverse');
   });
@@ -164,7 +164,7 @@ describe('Dropdown', () => {
   });
 
   it('is disabled', () => {
-    makeDropdown({ disabled: true }, 1);
+    makeDropdown({ disabled: true });
     const button = getButton();
     expect(button).toHaveAttribute('disabled');
   });
@@ -348,7 +348,7 @@ describe('Dropdown', () => {
 
   it('forwards an object inputRef', () => {
     const inputRef = createRef<HTMLButtonElement>();
-    makeDropdown({ inputRef }, 1);
+    makeDropdown({ inputRef });
     expect(inputRef.current).toBeInTheDocument();
     expect(inputRef.current.tagName).toEqual('BUTTON');
   });
@@ -368,7 +368,7 @@ describe('Dropdown', () => {
 
   it('forwards a function inputRef', () => {
     const inputRef = jest.fn();
-    makeDropdown({ inputRef }, 1);
+    makeDropdown({ inputRef });
     expect(inputRef).toHaveBeenCalled();
     expect(inputRef.mock.lastCall[0].tagName).toEqual('BUTTON');
   });

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -268,9 +268,33 @@ describe('Dropdown', () => {
     expectDropdownToBeOpen();
     userEvent.keyboard('{arrowdown}');
     userEvent.keyboard('{l}');
-    const options = screen.getAllByRole('option');
+    let options = screen.getAllByRole('option');
     // Lummi tribe option should have focus and is 7th element in array
     expect(options[7]).toHaveFocus();
+    // There is a 1 second delay on the type ahead functionality
+    await sleep(1000);
+    userEvent.keyboard('{n}');
+    options = screen.getAllByRole('option');
+    // Nisqually Indian Tribe option should have focus and is 6th element in array
+    expect(options[6]).toHaveFocus();
+  });
+
+  it('does not move to the next item starting with the same letter', async () => {
+    makeDropdown({}, dropdownOptions);
+    const button = getButton();
+    userEvent.click(button);
+    expectDropdownToBeOpen();
+    userEvent.keyboard('{arrowdown}');
+    userEvent.keyboard('{c}');
+    let options = screen.getAllByRole('option');
+    // Confederated Tribes and Bands of the Yakama Nation is the first element in the options list
+    expect(options[1]).toHaveFocus();
+    // There is a 1 second delay on the type ahead functionality
+    await sleep(1000);
+    userEvent.keyboard('{c}');
+    options = screen.getAllByRole('option');
+    // We do not support moving to the next item starting with the same letter, so expect focus to remain the same
+    expect(options[1]).toHaveFocus();
   });
 
   it('supports multi-character type ahead', () => {

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -3,6 +3,13 @@ import userEvent from '@testing-library/user-event';
 import Dropdown from './Dropdown';
 import { createRef, useEffect, useRef } from 'react';
 
+interface Option {
+  label: string;
+  value: string;
+}
+
+type Options = Array<Option>;
+
 const defaultProps = {
   name: 'dropdown',
   label: 'Select an option',
@@ -32,12 +39,7 @@ const dropdownOptions = [
 ];
 
 export function generateOptions(
-  optionsToMake:
-    | number
-    | {
-        label: string;
-        value: string;
-      }[]
+  optionsToMake: number | Options
 ): { value: string; label: string }[] {
   let options = [];
   if (typeof optionsToMake === 'number') {
@@ -54,15 +56,7 @@ export function generateOptions(
   return options;
 }
 
-function makeDropdown(
-  customProps = {},
-  options:
-    | number
-    | {
-        label: string;
-        value: string;
-      }[]
-) {
+function makeDropdown(customProps = {}, options: number | Options = 1) {
   const props = { ...defaultProps, ...customProps };
   const component = <Dropdown {...props} options={generateOptions(options)} />;
 

--- a/packages/docs/content/components/dropdown.mdx
+++ b/packages/docs/content/components/dropdown.mdx
@@ -76,14 +76,12 @@ The following CSS variables can be overridden to customize Dropdown components:
 - When the Dropdown is closed and has focus
   - Users can open the listbox by pressing <kbd>Space</kbd>, <kbd>Enter</kbd>, <kbd>Down</kbd>, <kbd>Up</kbd>, <kbd>Alt</kbd> + <kbd>Up</kbd> or <kbd>Alt</kbd> + <kbd>Down</kbd>. When the listbox opens it highlights the current option
   - If a user begins typing then the listbox will open and will highlight the first option that matches the typed character.
-  - If the same character is typed in succession, visual focus cycles among the options starting with that character.
 - When the Dropdown is open
   - <kbd>Escape</kbd> key closes the options, sets visual focus on the combobox, and retains the current
     value.
   - <kbd>Up</kbd> and <kbd>Down</kbd> keys should cycle through options.
   - <kbd>Enter</kbd> key selects the currently focused option and closes the menu.
   - <kbd>Space</kbd> key selects the currently focused option and closes the menu.
-  - If the same character is typed in succession, visual focus cycles among the options starting with that character.
   - <kbd>Home</kbd> key moves visual focus to the first option.
   - <kbd>End</kbd> key moves visual focus to the last option.
 


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/WNMGDS-3227)
- Remove lines that are no longer reflective of our dropdown type ahead functionality
- Added in a few specs that hopefully get us closer to testing our type ahead functionality

## How to test

1. Read the documentation and confirm that the line "If the same character is typed in succession, visual focus cycles among the options starting with that character." is removed from the sublists under the "Keyboard Testing" section.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone
