### PR TITLE
[WNMGDS-3228] Scopes `prefers-reduced-motion` CSS to only target design system components.

### DIFF
--- a/packages/design-system/src/styles/_reset.scss
+++ b/packages/design-system/src/styles/_reset.scss
@@ -11,17 +11,19 @@ html:focus-within {
   scroll-behavior: smooth;
 }
 
-// Remove all animations, transitions and smooth scroll
-// for people that prefer not to see them
+/**
+ * Reduced Motion Overrides:
+ * For users who prefer reduced motion, this rule overrides animations, transitions,
+ * and scroll behavior for design system components (elements with class names starting with "ds-c-").
+ */
 @media (prefers-reduced-motion: reduce) {
   html:focus-within {
     scroll-behavior: auto;
   }
-
   /* stylelint-disable declaration-no-important -- Override animations */
-  *,
-  *::before,
-  *::after {
+  [class^='ds-c-'] *,
+  [class^='ds-c-'] *::before,
+  [class^='ds-c-'] *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     scroll-behavior: auto !important;


### PR DESCRIPTION
## Summary

This update scopes our prefers-reduced-motion CSS to only target design system components—specifically, elements with class names beginning with `ds-c-`. Previously, our global reduced-motion resets inadvertently affected third-party libraries (e.g., `react-toastify`) by overriding their native animations. With this change, only our design system components are impacted, leaving it up to consuming applications to handle reduced motion for non-design-system elements.

I created the following demos using this [test branch](https://github.com/CMSgov/design-system/blob/tamara/WNMGDS-3228/prefers-reduced-motion-namespace-test/). This branch includes the same scoped CSS as in this PR, along with a few additional tweaks for testing purposes.
- **Before:** [Demo of the global prefers-reduced-motion](https://www.loom.com/share/11bc8d311f694714ba126444f4de5e25?sid=6d7550ef-5dfd-4618-a04d-75aef126add2)
- **After:** [Demo with scoped behavior](https://www.loom.com/share/3f7546728db740d3b5729d222a52f0da?sid=d5d8601b-c847-4c47-89a1-35b1580ff0e8)

For full context, see [jira story](https://jira.cms.gov/browse/WNMGDS-3228)

## How to test
I performed some manual testing using the same [test branch](https://github.com/CMSgov/design-system/blob/tamara/WNMGDS-3228/prefers-reduced-motion-namespace-test/). To verify the changes, please follow these steps:
**Experiment with Storybook:**
- Run Storybook (e.g., `npm run storybook`).
- Open the "Animated Button" story under the `Button` meta.
- Toggle the Reduce Motion setting in your macOS Accessibility preferences.
- Verify that design system components (with ds-c- classes) display the reduced-motion styles (e.g., red border and disabled animations), while non-design system elements behave normally.

**Switch Between Scoped and Global CSS:**
- In the `_reset.scss` file, comment out the [scoped prefers-reduced-motion rules (targeting [class^="ds-c-"] *)](https://github.com/CMSgov/design-system/blob/tamara/WNMGDS-3228/prefers-reduced-motion-namespace-test/packages/design-system/src/styles/_reset.scss#L16-L31).
- Uncomment the global [prefers-reduced-motion settings](https://github.com/CMSgov/design-system/blob/tamara/WNMGDS-3228/prefers-reduced-motion-namespace-test/packages/design-system/src/styles/_reset.scss#L35-L51) and reload storybook.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone