### PR TITLE
[WNMGDS-3138] Make Medicare URLs language-aware in `SimpleFooter`

### DIFF
--- a/packages/ds-medicare-gov/src/components/SimpleFooter/SimpleFooter.spec.tsx
+++ b/packages/ds-medicare-gov/src/components/SimpleFooter/SimpleFooter.spec.tsx
@@ -1,10 +1,60 @@
 import { render, screen, cleanup } from '@testing-library/react';
 import SimpleFooter from './SimpleFooter';
 
-afterEach(cleanup);
+describe('SimpleFooter', () => {
+  it('renders without crashing', () => {
+    render(<SimpleFooter aboutMedicareLabel="About SimpleFooter" />);
 
-it('renders without crashing', () => {
-  render(<SimpleFooter aboutMedicareLabel="About SimpleFooter" />);
+    expect(screen.getByText(/about SimpleFooter/i)).toBeInTheDocument();
+  });
 
-  expect(screen.getByText(/about SimpleFooter/i)).toBeInTheDocument();
+  it('uses Spanish Medicare URLs when language="es"', () => {
+    render(<SimpleFooter language="es" aboutMedicareLabel="About Medicare" />);
+
+    expect(screen.getByText('About Medicare')).toHaveAttribute(
+      'href',
+      'https://es.medicare.gov/about-us'
+    );
+    expect(screen.getByRole('link', { name: /Accessibility/i })).toHaveAttribute(
+      'href',
+      'https://es.medicare.gov/about-us/accessibility-nondiscrimination-notice'
+    );
+    expect(screen.getByRole('link', { name: /Privacy Policy/i })).toHaveAttribute(
+      'href',
+      'https://es.medicare.gov/privacy-policy'
+    );
+    expect(screen.getByRole('link', { name: /Using This Site/i })).toHaveAttribute(
+      'href',
+      'https://es.medicare.gov/about-us/using-this-site'
+    );
+    expect(screen.getByRole('link', { name: /Plain Writing/i })).toHaveAttribute(
+      'href',
+      'https://es.medicare.gov/about-us/plain-writing'
+    );
+  });
+
+  it('uses English Medicare URLs when language="en" (default)', () => {
+    render(<SimpleFooter language="en" aboutMedicareLabel="About Medicare" />);
+
+    expect(screen.getByText('About Medicare')).toHaveAttribute(
+      'href',
+      'https://www.medicare.gov/about-us'
+    );
+    expect(screen.getByRole('link', { name: /Accessibility/i })).toHaveAttribute(
+      'href',
+      'https://www.medicare.gov/about-us/accessibility-nondiscrimination-notice'
+    );
+    expect(screen.getByRole('link', { name: /Privacy Policy/i })).toHaveAttribute(
+      'href',
+      'https://www.medicare.gov/privacy-policy'
+    );
+    expect(screen.getByRole('link', { name: /Using This Site/i })).toHaveAttribute(
+      'href',
+      'https://www.medicare.gov/about-us/using-this-site'
+    );
+    expect(screen.getByRole('link', { name: /Plain Writing/i })).toHaveAttribute(
+      'href',
+      'https://www.medicare.gov/about-us/plain-writing'
+    );
+  });
 });

--- a/packages/ds-medicare-gov/src/components/SimpleFooter/SimpleFooter.tsx
+++ b/packages/ds-medicare-gov/src/components/SimpleFooter/SimpleFooter.tsx
@@ -33,6 +33,7 @@ export const SimpleFooter: FunctionComponent<SimpleFooterProps> = ({
   onClickLinkAnalytics,
 }: SimpleFooterProps) => {
   const footerRef = useRef<HTMLElement>();
+  const baseUrl = language === 'es' ? 'https://es.medicare.gov' : 'https://www.medicare.gov';
 
   useEffect(() => {
     if (onClickLinkAnalytics) {
@@ -45,13 +46,13 @@ export const SimpleFooter: FunctionComponent<SimpleFooterProps> = ({
   return (
     <footer className="m-c-footer" ref={footerRef}>
       <div className="m-c-footer__linkRow">
-        <a href="https://www.medicare.gov/about-us">{aboutMedicareLabel}</a>
+        <a href={`${baseUrl}/about-us`}>{aboutMedicareLabel}</a>
         <span aria-hidden="true" className="m-c-footer__delimiter" />
-        <a href="https://www.medicare.gov/about-us/accessibility-nondiscrimination-notice">
+        <a href={`${baseUrl}/about-us/accessibility-nondiscrimination-notice`}>
           {nondiscriminationLabel}
         </a>
         <span aria-hidden="true" className="m-c-footer__delimiter" />
-        <a href="https://www.medicare.gov/privacy-policy">{privacyPolicyLabel}</a>
+        <a href={`${baseUrl}/privacy-policy`}>{privacyPolicyLabel}</a>
         <span aria-hidden="true" className="m-c-footer__delimiter" />
         <Button
           className="SimpleFooter__linkButton"
@@ -79,9 +80,9 @@ export const SimpleFooter: FunctionComponent<SimpleFooterProps> = ({
           {linkingPolicyLabel}
         </a>
         <span aria-hidden="true" className="m-c-footer__delimiter" />
-        <a href="https://www.medicare.gov/about-us/using-this-site">{usingThisSiteLabel}</a>
+        <a href={`${baseUrl}/about-us/using-this-site`}>{usingThisSiteLabel}</a>
         <span aria-hidden="true" className="m-c-footer__delimiter" />
-        <a href="https://www.medicare.gov/about-us/plain-writing">{plainWritingLabel}</a>
+        <a href={`${baseUrl}/about-us/plain-writing`}>{plainWritingLabel}</a>
       </div>
       <div className="m-c-footer__identityRow">
         <MedicaregovLogo className="m-c-footer__medicare-logo" />


### PR DESCRIPTION
## Summary

- Updated the `SimpleFooter `component to dynamically set the `baseUrl` based on the `language` prop, ensuring Medicare URLs use `es.medicare.gov` when `language="es"` and `www.medicare.gov` otherwise.
- [Jira Ticket](https://jira.cms.gov/browse/WNMGDS-3138)

## How to test

`npm run test:unit -t SimpleFooter`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone