### PR TITLE
[WNMGDS-3280] Make figma use the external link event

### DIFF
--- a/packages/docs/src/components/content/ContentRenderer.tsx
+++ b/packages/docs/src/components/content/ContentRenderer.tsx
@@ -95,7 +95,7 @@ const customComponents = (theme) => ({
     if (href.startsWith('http') && !RE_INTERNAL_URL.test(href)) {
       return <ThirdPartyExternalLink analytics={true} origin="design.cms.gov" {...props} />;
     }
-    if (href.includes('github.com/CMSgov/design-system') || href.includes('https:')) {
+    if (href.includes('github.com/CMSgov/design-system') || href.startsWith('https:')) {
       return <a href={href} {...restProps} />;
     } else {
       return <Link onClick={linkAnalytics} to={href} {...restProps} />;

--- a/packages/docs/src/components/content/ContentRenderer.tsx
+++ b/packages/docs/src/components/content/ContentRenderer.tsx
@@ -95,8 +95,8 @@ const customComponents = (theme) => ({
     if (href.startsWith('http') && !RE_INTERNAL_URL.test(href)) {
       return <ThirdPartyExternalLink analytics={true} origin="design.cms.gov" {...props} />;
     }
-    if (href.includes('github.com/CMSgov/design-system') || href.startsWith('https:')) {
-      return <a onClick={linkAnalytics} href={href} {...restProps} />;
+    if (href.includes('github.com/CMSgov/design-system') || href.includes('https:')) {
+      return <a href={href} {...restProps} />;
     } else {
       return <Link onClick={linkAnalytics} to={href} {...restProps} />;
     }

--- a/packages/docs/src/components/layout/PageHeader.tsx
+++ b/packages/docs/src/components/layout/PageHeader.tsx
@@ -49,11 +49,7 @@ const PageHeader = ({ frontmatter = { title: '' }, theme }: PageHeaderProps) => 
       {showLinkBar && (
         <div className="ds-u-margin-top--1 ds-u-margin-bottom--0">
           {figmaNodeId && (
-            <a
-              onClick={linkAnalytics}
-              href={makeFigmaUrl(figmaNodeId, figmaTheme)}
-              className="c-page-header__link"
-            >
+            <a href={makeFigmaUrl(figmaNodeId, figmaTheme)} className="c-page-header__link">
               <img
                 alt="Figma logo"
                 src={withPrefix('/images/figma-icon.png')}
@@ -63,21 +59,13 @@ const PageHeader = ({ frontmatter = { title: '' }, theme }: PageHeaderProps) => 
             </a>
           )}
           {ghPath && (
-            <a
-              onClick={linkAnalytics}
-              href={makeGithubUrl(`tree/main/packages/${ghPath}`)}
-              className="c-page-header__link"
-            >
+            <a href={makeGithubUrl(`tree/main/packages/${ghPath}`)} className="c-page-header__link">
               <GithubIcon />
               Github
             </a>
           )}
           {storyId && (
-            <a
-              onClick={linkAnalytics}
-              href={makeStorybookUrl(storyId, theme, 'docs')}
-              className="c-page-header__link"
-            >
+            <a href={makeStorybookUrl(storyId, theme, 'docs')} className="c-page-header__link">
               <img
                 alt="Storybook logo"
                 src={withPrefix('/images/storybook-icon.png')}


### PR DESCRIPTION
## Summary

- Make sure the Figma link present on all pages uses an'external-link' event rather than an 'internal-link' event

## How to test

1. The best way to test is using the debugger built into your Browser of choice, for Firefox:
2. Open the page locally
3. Open dev tools and go to the Debugger tab
4. Press "Command + P" and search for "utag.js"
5. When that file is opened, search "Command + F" for `track:`
6. Place a break point at the line following the definition of the track function
7. Click on the Figma link
8. In the Browser console, type "a"
9. Look at the associated object, and expand it to see the data property on that object
10. Confirm that the "event_name" field sis "external_linl"

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone