### PR TITLE
[WNMGDS-3279] Link URL should point to link destination

### DIFF
--- a/packages/docs/src/helpers/analytics.ts
+++ b/packages/docs/src/helpers/analytics.ts
@@ -36,7 +36,7 @@ export function sendNavigationOpenedAnalytics(id: string) {
 export function composeLinkAnalyticsEvent(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
   return {
     event_name: `internal_link_clicked`,
-    link_url: (event.target as HTMLAnchorElement).baseURI,
+    link_url: (event.target as HTMLAnchorElement).href,
     link_type: 'link_other',
     parent_component_heading:
       (event.target as HTMLAnchorElement).parentElement.innerText ?? noValue,


### PR DESCRIPTION
## Summary

- Links were pointing to the base url, but instead need to point to the href

## How to test

1. The best way to test is using the debugger built into your Browser of choice, for Firefox:
2. Open the page locally
3. Open dev tools and go to the Debugger tab
4. Press "Command + P" and search for "utag.js"
5. When that file is opened, search "Command + F" for track:
6. Place a break point at the line following the definition of the track function
7. Click a link in the main navigation of the page, the left hand navigation
8. In the Browser console, type "a"
9. Look at the associated object, and expand it to see the data property on that object
10. Confirm that the url listed in the data object indeed points to the destination url of the link

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone