### PR TITLE
[WNMGDS-3278] Add in search results position to search event

### DIFF
--- a/packages/docs/src/pages/search.tsx
+++ b/packages/docs/src/pages/search.tsx
@@ -71,7 +71,7 @@ const SearchPage = ({ location }: MdxQuery) => {
                 sendLinkEvent({
                   event_name: 'search_result_engaged',
                   search_result_count: results.length.toString(),
-                  search_result_position: result.title,
+                  search_result_position: String(resultIndex + 1),
                   search_term: query,
                   search_term_type: 'user_initiated',
                 } as any);


### PR DESCRIPTION
## Summary

- The search value was grabbing the title of the search result link, not it's position in the list. We now grab the position in the list.

## How to test

1. The best way to test is using the debugger built into your Browser of choice, for Firefox:
2. Open the page locally
3. Open dev tools and go to the Debugger tab
4. Press "Command + P" and search for "utag.js"
5. When that file is opened, search "Command + F" for track:
6. Place a break point at the line following the definition of the track function
7. Search for something that will return results, like "help drawer"
8. Click some of the search results links
8. In the Browser console, type "a"
9. Look at the associated object, and expand it to see the data property on that object
10. Confirm that search results position is indeed the number of the item in the results list that you clicked on

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone