### PR TITLE
[WNMGDS-3277] Added in default analytics value for empty string searches

### DIFF
--- a/packages/docs/src/components/content/SearchForm.tsx
+++ b/packages/docs/src/components/content/SearchForm.tsx
@@ -9,7 +9,9 @@ const SearchForm = ({ className }) => {
       method="GET"
       onSubmit={(event: React.FormEvent<HTMLFormElement>) => {
         const formData = new FormData(event.target as HTMLFormElement);
-        sendSearchInitiatedEvent(formData.get('query').toString());
+        sendSearchInitiatedEvent(
+          formData.get('query').toString() === '' ? 'no value' : formData.get('query').toString()
+        );
       }}
     >
       <TextInput

--- a/packages/docs/src/components/content/SearchForm.tsx
+++ b/packages/docs/src/components/content/SearchForm.tsx
@@ -9,9 +9,8 @@ const SearchForm = ({ className }) => {
       method="GET"
       onSubmit={(event: React.FormEvent<HTMLFormElement>) => {
         const formData = new FormData(event.target as HTMLFormElement);
-        sendSearchInitiatedEvent(
-          formData.get('query').toString() === '' ? 'no value' : formData.get('query').toString()
-        );
+        const query = formData.get('query').toString();
+        sendSearchInitiatedEvent(query === '' ? 'no value' : query);
       }}
     >
       <TextInput


### PR DESCRIPTION
## Summary

- When someone searches for nothing, make sure we submit a default value of "no value" to our analytics handler

## How to test

1. The best way to test is using the debugger built into your Browser of choice, for Firefox:
2. Open the page locally
3. Open dev tools and go to the Debugger tab
4. Press "Command + P" and search for "utag.js"
5. When that file is opened, search "Command + F" for track:
6. Place a break point at the line following the definition of the track function
7. Search for nothing. Just click the search button, do not enter any string content
8. In the Browser console, type "a"
9. Look at the associated object, and expand it to see the data property on that object
10. Confirm that search term is "no value"

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone