### PR TITLE
[WNMGDS-3284] Fixes typo in `ds-dropdown` storybook docs

### DIFF
--- a/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.stories.tsx
@@ -117,7 +117,7 @@ export default {
         'ds-change': {
           description: 'Dispatched whenever the selected value changes.',
           eventObjectDescription:
-            '`event.details.target.value` - The `value` of the selected option',
+            '`event.detail.target.value` - The `value` of the selected option',
         },
         'ds-blur': {
           description: 'Dispatched whenever the dropdown loses focus.',


### PR DESCRIPTION
## Summary

Fixes a typo in the `ds-dropdown` Storybook documentation. The event object for `ds-change` was incorrectly documented as `event.details.target.value` instead of `event.detail.target.value`. 

## How to test

Review the updated Storybook documentation for `ds-dropdown` and verify that the event object reference is correct.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone. 

**Note:** Wasn't sure which milestone to select, so went with 12.1.1 (doc site changes).