### PR TITLE
[WNMGDS-3262] Added missing custom event documentation on storybook for several web components.

### DIFF
--- a/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.stories.tsx
@@ -16,6 +16,18 @@ const meta: Meta = {
   parameters: {
     docs: {
       page: WebComponentDocTemplate,
+      componentEvents: {
+        'ds-input-value-change': {
+          description:
+            'Called when the child `TextField` value changes. Is called with a string representing the input value.',
+          eventObjectDescription: '`event.detail.value` - The `value` of the user input',
+        },
+        'ds-change': {
+          description:
+            'Called when the user selects an item and the selected item has changed. Called with the item that was selected.',
+          eventObjectDescription: '`event.detail.selectedItem` - The user-selected item',
+        },
+      },
     },
   },
   args: {

--- a/packages/design-system/src/components/web-components/ds-date-field/ds-date-field.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-date-field/ds-date-field.stories.tsx
@@ -18,6 +18,17 @@ const meta: Meta = {
   parameters: {
     docs: {
       page: WebComponentDocTemplate,
+      componentEvents: {
+        'ds-change': {
+          description:
+            "Called anytime any date input is changed. This function is called with two arguments. The first argument should be used to update whatever state your application uses to supply back to this component's `value` prop in a _controlled component_ pattern.",
+          eventObjectDescription:
+            "`event.detail.updatedValue` - The input's new value, `event.detail.formattedValue` - The input's new value with date formatting applied for convenience. Do not use this value as the component's `value` prop. An appropriate use for this value would be to run date-validation checks against it.",
+        },
+        'ds-blur': {
+          description: 'Dispatched whenever the date input loses focus.',
+        },
+      },
     },
   },
   args: {

--- a/packages/design-system/src/components/web-components/ds-skip-nav/ds-skip-nav.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-skip-nav/ds-skip-nav.stories.tsx
@@ -24,6 +24,11 @@ export default {
       description: {
         component: `For information about how and when to use this component, [refer to its full documentation page](https://design.cms.gov/components/skip-nav/).`,
       },
+      componentEvents: {
+        'ds-click': {
+          description: 'An onClick handler used for manually setting focus on the content.',
+        },
+      },
     },
   },
   decorators: [webComponentDecorator],

--- a/packages/design-system/src/components/web-components/ds-text-field/ds-text-field.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-text-field/ds-text-field.stories.tsx
@@ -99,6 +99,14 @@ export default {
       description: {
         component: `For information about how and when to use this component, [refer to its full documentation page](https://design.cms.gov/components/text-field/).`,
       },
+      componentEvents: {
+        'ds-change': {
+          description: 'Dispatched whenever the user input changes.',
+        },
+        'ds-blur': {
+          description: 'Dispatched whenever the text input loses focus.',
+        },
+      },
     },
   },
   decorators: [webComponentDecorator],


### PR DESCRIPTION
## Summary

- Adds custom event docs on Storybook for `ds-autocomplete`, `ds-date-field`, `skip-nav` & `ds-text-field`

## How to test

- Run storybook locally. 
- Inspect the custom event docs for: `ds-autocomplete`, `ds-date-field`, `skip-nav` & `ds-text-field`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone