### PR TITLE
[WNGDS-3283] Hide abbreviated month labels from screen readers in `MonthPicker`.

### DIFF
--- a/packages/design-system/src/components/Label/Label.test.tsx
+++ b/packages/design-system/src/components/Label/Label.test.tsx
@@ -14,6 +14,27 @@ describe('Label', () => {
     expect(label).toMatchSnapshot();
   });
 
+  it('hides label from screen readers when labelHidden is true', () => {
+    render(<Label labelHidden={true}>{labelText}</Label>);
+
+    const label = screen.getByText(labelText);
+    expect(label).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('does not hide label when labelHidden is false', () => {
+    render(<Label labelHidden={false}>{labelText}</Label>);
+
+    const label = screen.getByText(labelText);
+    expect(label).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('does not hide label when labelHidden is not provided', () => {
+    render(<Label>{labelText}</Label>);
+
+    const label = screen.getByText(labelText);
+    expect(label).not.toHaveAttribute('aria-hidden');
+  });
+
   describe('Deprecated hint and error functionality', () => {
     let warn;
 

--- a/packages/design-system/src/components/Label/Label.tsx
+++ b/packages/design-system/src/components/Label/Label.tsx
@@ -61,6 +61,13 @@ export interface LabelProps {
    * Text showing the requirement ("Required", "Optional", etc.). See [Required and Optional Fields](https://design.cms.gov/patterns/Forms/forms/#required-and-optional-fields).
    */
   requirementLabel?: React.ReactNode;
+  /**
+   * Determines whether the label should be hidden from screen readers.
+   * Set to `true` to apply `aria-hidden="true"` to the label.
+   * This is useful in cases where the label does not provide valuable context for screen reader users,
+   * such as when the associated input already has an accessible name.
+   */
+  labelHidden?: boolean;
 }
 
 type LabelComponentProps = React.ComponentPropsWithRef<'label'> &
@@ -90,6 +97,8 @@ export const Label = (props: LabelComponentProps) => {
     requirementLabel,
     ...labelProps
   } = props;
+
+  const { labelHidden } = labelProps;
 
   if (process.env.NODE_ENV !== 'production' && (hint || hintId)) {
     console.warn(
@@ -130,7 +139,13 @@ export const Label = (props: LabelComponentProps) => {
 
   return (
     <>
-      <ComponentType className={classes} htmlFor={htmlFor} id={id} {...labelProps}>
+      <ComponentType
+        className={classes}
+        htmlFor={htmlFor}
+        id={id}
+        aria-hidden={labelHidden ? true : undefined}
+        {...labelProps}
+      >
         {children}
       </ComponentType>
       {hintElement}

--- a/packages/design-system/src/components/Label/useLabelProps.ts
+++ b/packages/design-system/src/components/Label/useLabelProps.ts
@@ -24,6 +24,13 @@ export interface UseLabelPropsProps {
    * Set to `true` to apply the "inverse" color scheme
    */
   inversed?: boolean;
+  /**
+   * Determines whether the label should be hidden from screen readers.
+   * Set to `true` to apply `aria-hidden="true"` to the label.
+   * This is useful in cases where the label does not provide valuable context for screen reader users,
+   * such as when the associated input already has an accessible name.
+   */
+  labelHidden?: boolean;
 }
 
 /**
@@ -36,13 +43,14 @@ export interface UseLabelPropsProps {
 export function useLabelProps<T extends UseLabelPropsProps>(props: T): Omit<LabelProps, 'fieldId'> {
   const labelId = props.labelId ?? `${props.id}__label`;
 
-  const { label, labelClassName, inversed } = props;
+  const { label, labelClassName, inversed, labelHidden } = props;
 
   return {
     children: label,
     className: labelClassName,
     id: labelId,
     inversed,
+    labelHidden,
   };
 }
 

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.test.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.test.tsx
@@ -98,6 +98,18 @@ describe('MonthPicker', () => {
     });
   });
 
+  it('hides labels from screen readers with aria-hidden', () => {
+    renderMonthPicker();
+
+    const labels = screen.getAllByText((content, element) => {
+      return element?.tagName.toLowerCase() === 'label';
+    });
+
+    labels.forEach((label) => {
+      expect(label).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
   it('calls `onChange` and maintains state when checking/unchecking checkboxes', () => {
     const onChange = jest.fn();
     renderMonthPicker({ onChange });

--- a/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.tsx
@@ -203,6 +203,7 @@ export const MonthPicker = (props: MonthPickerProps) => {
                 type="checkbox"
                 value={i + 1}
                 label={month}
+                labelHidden={true}
                 id={`${id}__choice--${i + 1}`}
                 _choiceChild={true}
               />

--- a/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.tsx.snap
+++ b/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.tsx.snap
@@ -83,6 +83,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="1"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--1"
                 id="month-picker--1__choice--1__label"
@@ -108,6 +109,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="2"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--2"
                 id="month-picker--1__choice--2__label"
@@ -133,6 +135,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="3"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--3"
                 id="month-picker--1__choice--3__label"
@@ -158,6 +161,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="4"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--4"
                 id="month-picker--1__choice--4__label"
@@ -183,6 +187,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="5"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--5"
                 id="month-picker--1__choice--5__label"
@@ -208,6 +213,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="6"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--6"
                 id="month-picker--1__choice--6__label"
@@ -233,6 +239,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="7"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--7"
                 id="month-picker--1__choice--7__label"
@@ -258,6 +265,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="8"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--8"
                 id="month-picker--1__choice--8__label"
@@ -283,6 +291,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="9"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--9"
                 id="month-picker--1__choice--9__label"
@@ -308,6 +317,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="10"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--10"
                 id="month-picker--1__choice--10__label"
@@ -333,6 +343,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="11"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--11"
                 id="month-picker--1__choice--11__label"
@@ -358,6 +369,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 value="12"
               />
               <label
+                aria-hidden="true"
                 class="ds-c-label"
                 for="month-picker--1__choice--12"
                 id="month-picker--1__choice--12__label"

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Choice-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Choice-Docs-prop-table-matches-snapshot-1.txt
@@ -90,6 +90,11 @@
     "-"
   ],
   [
+    "labelHidden",
+    "Determines whether the label should be hidden from screen readers. Set to true to apply aria-hidden=\"true\" to the label. This is useful in cases where the label does not provide valuable context for screen reader users, such as when the associated input already has an accessible name.\n\nboolean",
+    "-"
+  ],
+  [
     "labelId",
     "A unique id to be used on the field label. If one isn't provided, a unique ID will be generated.\n\nstring",
     "-"

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-ChoiceList-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-ChoiceList-Docs-prop-table-matches-snapshot-1.txt
@@ -70,6 +70,11 @@
     "-"
   ],
   [
+    "labelHidden",
+    "Determines whether the label should be hidden from screen readers. Set to true to apply aria-hidden=\"true\" to the label. This is useful in cases where the label does not provide valuable context for screen reader users, such as when the associated input already has an accessible name.\n\nboolean",
+    "-"
+  ],
+  [
     "labelId",
     "A unique id to be used on the field label. If one isn't provided, a unique ID will be generated.\n\nstring",
     "-"

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Dropdown-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Dropdown-Docs-prop-table-matches-snapshot-1.txt
@@ -106,6 +106,11 @@
     "-"
   ],
   [
+    "labelHidden",
+    "Determines whether the label should be hidden from screen readers. Set to true to apply aria-hidden=\"true\" to the label. This is useful in cases where the label does not provide valuable context for screen reader users, such as when the associated input already has an accessible name.\n\nboolean",
+    "-"
+  ],
+  [
     "labelId",
     "A unique id to be used on the field label. If one isn't provided, a unique ID will be generated.\n\nstring",
     "-"

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Label-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Label-Docs-prop-table-matches-snapshot-1.txt
@@ -18,5 +18,10 @@
     "inversed",
     "Set to true to apply the \"inverse\" theme\nboolean",
     "-"
+  ],
+  [
+    "labelHidden",
+    "Determines whether the label should be hidden from screen readers. Set to true to apply aria-hidden=\"true\" to the label. This is useful in cases where the label does not provide valuable context for screen reader users, such as when the associated input already has an accessible name.\n\nboolean",
+    "-"
   ]
 ]

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-MonthPicker-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-MonthPicker-Docs-prop-table-matches-snapshot-1.txt
@@ -80,6 +80,11 @@
     "-"
   ],
   [
+    "labelHidden",
+    "Determines whether the label should be hidden from screen readers. Set to true to apply aria-hidden=\"true\" to the label. This is useful in cases where the label does not provide valuable context for screen reader users, such as when the associated input already has an accessible name.\n\nboolean",
+    "-"
+  ],
+  [
     "labelId",
     "A unique id to be used on the field label. If one isn't provided, a unique ID will be generated.\n\nstring",
     "-"

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-MultiInputDateField-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-MultiInputDateField-Docs-prop-table-matches-snapshot-1.txt
@@ -100,6 +100,11 @@
     "-"
   ],
   [
+    "labelHidden",
+    "Determines whether the label should be hidden from screen readers. Set to true to apply aria-hidden=\"true\" to the label. This is useful in cases where the label does not provide valuable context for screen reader users, such as when the associated input already has an accessible name.\n\nboolean",
+    "-"
+  ],
+  [
     "labelId",
     "A unique id to be used on the field label. If one isn't provided, a unique ID will be generated.\n\nstring",
     "-"

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-SingleInputDateField-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-SingleInputDateField-Docs-prop-table-matches-snapshot-1.txt
@@ -99,6 +99,11 @@
     "-"
   ],
   [
+    "labelHidden",
+    "Determines whether the label should be hidden from screen readers. Set to true to apply aria-hidden=\"true\" to the label. This is useful in cases where the label does not provide valuable context for screen reader users, such as when the associated input already has an accessible name.\n\nboolean",
+    "-"
+  ],
+  [
     "labelId",
     "A unique id to be used on the field label. If one isn't provided, a unique ID will be generated.\n\nstring",
     "-"

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-TextField-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-TextField-Docs-prop-table-matches-snapshot-1.txt
@@ -90,6 +90,11 @@
     "-"
   ],
   [
+    "labelHidden",
+    "Determines whether the label should be hidden from screen readers. Set to true to apply aria-hidden=\"true\" to the label. This is useful in cases where the label does not provide valuable context for screen reader users, such as when the associated input already has an accessible name.\n\nboolean",
+    "-"
+  ],
+  [
     "labelId",
     "A unique id to be used on the field label. If one isn't provided, a unique ID will be generated.\n\nstring",
     "-"


### PR DESCRIPTION
## Summary

- Adds functionality to hide abbreviated month labels from screen readers, ensuring that only the full month name is announced for each checkbox in the `MonthPicker` component.

[Jira ticket](https://jira.cms.gov/browse/WNMGDS-3283)

## How to test

1. Run Storybook: 
  - Inspect the `MonthPicker` while `VoiceOver` is enabled.
  - Each checkbox should announce only the full month name, not the abbreviated label.
2. Run unit tests - `npm run test:unit`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
