### PR TITLE
[NO-TICKET] Include changes made to `package-lock.json` in the release script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
     },
     "examples/angular": {
       "name": "angular-example",
-      "version": "12.0.0",
+      "version": "12.1.0-beta.0",
       "dependencies": {
         "@angular/animations": "^19.0.0",
         "@angular/common": "^19.0.0",
@@ -111,7 +111,7 @@
         "@angular/platform-browser": "^19.0.0",
         "@angular/platform-browser-dynamic": "^19.0.0",
         "@angular/router": "^19.0.0",
-        "@cmsgov/design-system": "^12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -7566,24 +7566,24 @@
     },
     "examples/astro": {
       "name": "astro-example",
-      "version": "12.0.0",
+      "version": "12.1.0-beta.0",
       "dependencies": {
         "@astrojs/check": "0.9.4",
         "@astrojs/preact": "4.0.1",
         "@astrojs/react": "4.1.2",
-        "@cmsgov/design-system": "12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "astro": "5.1.2",
         "typescript": "^5.4.3"
       }
     },
     "examples/astro-react-17": {
       "name": "astro-react-17-example",
-      "version": "12.0.0",
+      "version": "12.1.0-beta.0",
       "dependencies": {
         "@astrojs/check": "0.9.4",
         "@astrojs/preact": "4.0.1",
         "@astrojs/react": "4.1.2",
-        "@cmsgov/design-system": "12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "astro": "5.1.2",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -7592,12 +7592,12 @@
     },
     "examples/astro-react-18": {
       "name": "astro-react-18-example",
-      "version": "12.0.0",
+      "version": "12.1.0-beta.0",
       "dependencies": {
         "@astrojs/check": "0.9.4",
         "@astrojs/preact": "4.0.1",
         "@astrojs/react": "4.2.0",
-        "@cmsgov/design-system": "12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "astro": "5.1.2",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -8539,21 +8539,21 @@
     },
     "examples/astro-themes": {
       "name": "astro-themes-example",
-      "version": "12.0.0",
+      "version": "12.1.0-beta.0",
       "dependencies": {
         "@astrojs/check": "0.9.4",
         "@astrojs/preact": "4.0.1",
         "@astrojs/react": "4.1.2",
-        "@cmsgov/design-system": "12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "astro": "5.1.2",
         "typescript": "^5.4.3"
       }
     },
     "examples/preact-app": {
       "name": "preact-app-example",
-      "version": "12.0.0",
+      "version": "12.1.0-beta.0",
       "dependencies": {
-        "@cmsgov/design-system": "12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "preact": "10.11.3"
       },
       "devDependencies": {
@@ -8601,9 +8601,9 @@
     },
     "examples/preact-react-app": {
       "name": "preact-react-app-example",
-      "version": "12.0.0",
+      "version": "12.1.0-beta.0",
       "dependencies": {
-        "@cmsgov/design-system": "12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "preact": "10.11.3"
       },
       "devDependencies": {
@@ -8651,9 +8651,9 @@
     },
     "examples/react-app": {
       "name": "react-app-example",
-      "version": "12.0.0",
+      "version": "12.1.0-beta.0",
       "dependencies": {
-        "@cmsgov/design-system": "12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
@@ -61780,7 +61780,7 @@
     },
     "packages/design-system": {
       "name": "@cmsgov/design-system",
-      "version": "12.0.0",
+      "version": "12.1.0-beta.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@popperjs/core": "^2.4.4",
@@ -61966,9 +61966,9 @@
     },
     "packages/docs": {
       "name": "@cmsgov/cms-design-system-docs",
-      "version": "12.0.0",
+      "version": "12.1.0-beta.0",
       "dependencies": {
-        "@cmsgov/design-system": "12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "@mdx-js/mdx": "^1.6.22",
         "@mdx-js/react": "^1.6.22",
         "classnames": "^2.3.1",
@@ -62012,10 +62012,10 @@
     },
     "packages/ds-cms-gov": {
       "name": "@cmsgov/ds-cms-gov",
-      "version": "12.0.0",
+      "version": "12.1.0-beta.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@cmsgov/design-system": "12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "@types/react": "^18.2.6",
         "@types/react-dom": "^18.3.0"
       },
@@ -62025,9 +62025,9 @@
     },
     "packages/ds-healthcare-gov": {
       "name": "@cmsgov/ds-healthcare-gov",
-      "version": "16.0.0",
+      "version": "16.1.0-beta.0",
       "dependencies": {
-        "@cmsgov/design-system": "12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.0",
         "classnames": "^2.2.5"
@@ -62035,10 +62035,10 @@
     },
     "packages/ds-medicare-gov": {
       "name": "@cmsgov/ds-medicare-gov",
-      "version": "14.0.0",
+      "version": "14.1.0-beta.0",
       "license": "CC0-1.0",
       "dependencies": {
-        "@cmsgov/design-system": "12.0.0",
+        "@cmsgov/design-system": "12.1.0-beta.0",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.0"
       }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -80,8 +80,10 @@ async function bumpVersions() {
   );
   // Unstage the design-system-tokens package.json
   sh('git checkout ./packages/design-system-tokens/package.json');
-  // Only stage changes to package files
+  // Stage changes to package files
   sh('git add -u **/package.json');
+  // Stage changes to package-lock.json
+  sh('git add -u package-lock.json');
   // And discard all other changes
   sh('git checkout -- .');
   // Verify that there are actually changes staged


### PR DESCRIPTION
## Summary

Prior to migrating to `npm` (https://github.com/CMSgov/design-system/pull/3397), the `yarn.lock` [file](https://github.com/CMSgov/design-system/blob/0ba0518c6fac28f4ff8434e66921369188a6f0b6/yarn.lock) did not include the latest DS version used in each of this repository's examples and packages.

With the migration to npm, the `package-lock.json` [file](https://raw.githubusercontent.com/CMSgov/design-system/refs/heads/main/package-lock.json) does include that information. This PR specifically looks to include that change as part of the release script to ensure that running `npm install` after a version bump (https://github.com/CMSgov/design-system/pull/3473) does not change the `package-lock.json`

## How to test

1. On `main`, run `npm install` and verify that changes to the `package-lock.json` exist
2. On this branch, comment out line 88 (starting with `sh('git checkout -- .');`) of the `release.ts` [script](https://github.com/CMSgov/design-system/compare/kcn/no-ticket/bump-package?expand=1#diff-21f9896491d70e481e031a1c66e9ffed07592f08455bdcd4a3cecc9c63814768R88) to line 131.
3. Run the release script `npm run release` and choose a version (it does not matter since the lines above should be commented out)
4. Verify that running `git status` results in changes to all of the `package.json` files and the `package-lock.json` file are staged

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
