### PR TITLE
[WNMGDS-2880] Add support for aria-describedby to ThirdPartyExernalLink

### DIFF
--- a/packages/design-system/src/components/ThirdPartyExternalLink/ThirdPartyExternalLink.tsx
+++ b/packages/design-system/src/components/ThirdPartyExternalLink/ThirdPartyExternalLink.tsx
@@ -11,6 +11,8 @@ import useThirdPartyExternalLinkAnalytics from './useThirdPartyExternalLinkAnaly
 export interface ThirdPartyExternalLinkProps
   extends AnalyticsOverrideProps,
     AnalyticsParentDataProps {
+  /** An id of an another element on the page that provides additional descriptive content for the anchor link */
+  ariaDescribedby?: string;
   /** External link url. The destination. */
   href: string;
   /** External link text. This text will appear in the button triggering the dialog. */
@@ -29,7 +31,7 @@ export interface ThirdPartyExternalLinkProps
  */
 const ThirdPartyExternalLink = (props: ThirdPartyExternalLinkProps) => {
   const { contentRef, buttonAnalyticsHandler } = useThirdPartyExternalLinkAnalytics(props);
-  const { href, children, className, learnMoreUrl, origin } = props;
+  const { href, children, className, learnMoreUrl, origin, ariaDescribedby } = props;
 
   const [showDialog, setShowDialog] = useState(false);
   function open(event: React.SyntheticEvent<any>) {
@@ -47,6 +49,7 @@ const ThirdPartyExternalLink = (props: ThirdPartyExternalLinkProps) => {
         onClick={open}
         href={href}
         ref={contentRef}
+        aria-describedby={ariaDescribedby}
       >
         {children}
         <ExternalLinkIcon className="ds-c-external-link__icon" />

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-ThirdPartyExternalLink-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-ThirdPartyExternalLink-Docs-prop-table-matches-snapshot-1.txt
@@ -20,6 +20,11 @@
     "-"
   ],
   [
+    "ariaDescribedby",
+    "An id of an another element on the page that provides additional descriptive content for the anchor link\nstring",
+    "-"
+  ],
+  [
     "children*",
     "External link text. This text will appear in the button triggering the dialog.\nstring",
     "-"


### PR DESCRIPTION
## Summary

[Ticket](https://jira.cms.gov/browse/WNMGDS-2880)

## How to test

1. Open storybook
2. Confirm that ariaDescribedby exists as a control in the ThirdPartyExternal link story
3. Confrim that setting it to a value adds the attribute `aria-describedby` to the underlying anchor link

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone