### PR TITLE
[NO-TICKET] Add analytics handler to storybook links

### DIFF
--- a/packages/docs/src/components/layout/PageHeader.tsx
+++ b/packages/docs/src/components/layout/PageHeader.tsx
@@ -65,7 +65,11 @@ const PageHeader = ({ frontmatter = { title: '' }, theme }: PageHeaderProps) => 
             </a>
           )}
           {storyId && (
-            <a href={makeStorybookUrl(storyId, theme, 'docs')} className="c-page-header__link">
+            <a
+              onClick={(event) => linkAnalytics(event)}
+              href={makeStorybookUrl(storyId, theme, 'docs')}
+              className="c-page-header__link"
+            >
               <img
                 alt="Storybook logo"
                 src={withPrefix('/images/storybook-icon.png')}


### PR DESCRIPTION
## Summary

- Storybook links are internal links, this request makes sure they are treated as such by our analytics 

## How to test

1. The best way to test is using the debugger built into your Browser of choice, for Firefox:
2. Open the page locally
3. Open dev tools and go to the Debugger tab
4. Press "Command + P" and search for "utag.js"
5. When that file is opened, search "Command + F" for track:
6. Place a break point at the line following the definition of the track function
7. Click on a component, and then click on the Storybook link at the top of the page
8. In the Browser console, type "a"
9. Look at the associated object, and expand it to see the data property on that object
10. Confirm that the object contains a field that says "event_name":"internal_link_clicked"

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone