### PR TITLE
[NO-TICKET] New form for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug Report
+description: Create a report to help us improve
+title: '[Bug:] '
+labels:
+  [
+    'dependencies',
+    'Impacts: CMSGov',
+    'Impacts: Core',
+    'Impacts: Documentation',
+    'Impacts: Healthcare',
+    'Impacts: Medicare',
+    'javascript',
+    'Status: In JIRA',
+    'Status: Work In Progress',
+  ]
+type: 'Bug'
+body:
+  - type: textarea
+    attributes:
+      label: Describe the Bug
+      description: A clear an concise description of what the bug is.
+  - type: textarea
+    attributes:
+      label: To reproduce
+      description: 'Steps to reproduce the behavior:'
+      placeholder: |
+        1. Go to '...'
+        2. Click on  '...'
+        3. Scroll down to '...'
+        4. See error
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+  - type: markdown
+    attributes:
+      value: 'Desktop (please complete the following information):'
+  - type: input
+    attributes:
+      label: Operating System
+  - type: input
+    attributes:
+      label: Browser
+  - type: input
+    attributes:
+      label: Browser Version
+  - type: markdown
+    attributes:
+      value: 'Smartphone (please complete the following information):'
+  - type: input
+    attributes:
+      label: Device
+      description: e.g. iPhone6
+  - type: input
+    attributes:
+      label: OS
+      description: e.g. iOS8.1
+  - type: input
+    attributes:
+      label: Browser
+      description: e.g. stock brower, Safari etc.
+  - type: input
+    attributes:
+      label: Version
+      description: e.g. 22
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+  - type: input
+    attributes:
+      label: Codebase/Repository URL
+      description: Please include the codebase or repository that you are working within
+  - type: input
+    attributes:
+      label: Design System Version
+  - type: input
+    attributes:
+      label: Existing branch or Pull request on Github
+      description: Please supply a branch name or URL if there is an existing branch on Github
+  - type: input
+    attributes:
+      label: Team Name


### PR DESCRIPTION
## Summary

The idea here is to bolster our bug reporting format to use a [Github form schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms). This might also allow us to hook into our slack bug reporting workflow.

## How to test

1. I'm not exactly sure? Try to  create a ticket and see if you can use a form?

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone