### PR TITLE
[WNMGDS-3286] Resolves eslint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,9 @@ module.exports = {
       },
     ],
     'no-use-before-define': 'off',
-    'no-unused-vars': ['warn', { ignoreRestSiblings: true }],
+    // Disabling the base rule as it can report incorrect errors
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { ignoreRestSiblings: true }],
     'no-undef': 'warn',
     'no-useless-escape': 'warn',
     'standard/computed-property-even-spacing': 'off',

--- a/packages/design-system-tokens/src/css/translate.ts
+++ b/packages/design-system-tokens/src/css/translate.ts
@@ -139,7 +139,7 @@ export function tokensToCssProperties(
   ];
 
   const vars = tokenEntries
-    .filter(([_key, token]) => !(token.$type === 'boolean' && !token.$value))
+    .filter(([, token]) => !(token.$type === 'boolean' && !token.$value))
     .map(([key, token]) => {
       const varName = tokenNameToVarName(key);
       const varValue = tokenToCssValue(token, valueRenderConfig);
@@ -235,7 +235,7 @@ export function tokensToSassVars(
   const defaultFlag = useDefaultFlag ? ' !default' : '';
 
   const vars = tokenEntries
-    .filter(([_key, token]) => !(token.$type === 'boolean' && !token.$value))
+    .filter(([, token]) => !(token.$type === 'boolean' && !token.$value))
     .map(([key, token]) => {
       const varName = tokenNameToVarName(key);
       const varValue = tokenToCssValue(token, valueRenderConfig);

--- a/packages/design-system-tokens/src/figma/translateFigmaToTokens.test.ts
+++ b/packages/design-system-tokens/src/figma/translateFigmaToTokens.test.ts
@@ -12,7 +12,7 @@ describe('tokenFilesFromLocalVariables', () => {
   it('matches snapshot', async () => {
     const resolvers = {
       number: (variableName: string) => Promise.resolve(guessNumberType(variableName) ?? 'number'),
-      string: (variableName: string) => Promise.resolve('string' as StringType),
+      string: () => Promise.resolve('string' as StringType),
     };
     const tokenFiles = await tokenFilesFromLocalVariables(testResponse, {}, resolvers);
     const expected = {

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
@@ -1,7 +1,6 @@
 import Choice, { ChoiceProps as ChoiceComponentProps } from './Choice';
 import { Label } from '../Label';
 import type * as React from 'react';
-import { createRef } from 'react';
 import classNames from 'classnames';
 import describeField from '../utilities/describeField';
 import useId from '../utilities/useId';

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -78,10 +78,6 @@ function expectDropdownToBeClosed() {
   expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
 }
 
-async function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 describe('Dropdown', () => {
   afterEach(() => {
     jest.clearAllTimers();

--- a/packages/design-system/src/components/HelpDrawer/useHelpDrawerAnalytics.ts
+++ b/packages/design-system/src/components/HelpDrawer/useHelpDrawerAnalytics.ts
@@ -1,4 +1,4 @@
-import { useAnalyticsContent, eventExtensionText } from '../analytics';
+import { eventExtensionText } from '../analytics';
 import { HelpDrawerProps } from './HelpDrawer';
 import { config } from '../config';
 import { useNativeDialogAnalytics } from '../NativeDialog/useNativeDialogAnalytics';

--- a/packages/design-system/src/components/web-components/ds-button/ds-button.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-button/ds-button.test.tsx
@@ -1,4 +1,3 @@
-import { UtagContainer } from '../../analytics/index';
 import { config } from '../../config';
 import { getByRole, fireEvent } from '@testing-library/react';
 import './ds-button';

--- a/packages/design-system/src/components/web-components/ds-choice/ds-choice-list.tsx
+++ b/packages/design-system/src/components/web-components/ds-choice/ds-choice-list.tsx
@@ -1,7 +1,7 @@
 import type * as React from 'react';
 import { ReactNode } from 'react';
 import { define } from '../preactement/define';
-import { ChoiceList, ChoiceListProps, ChoiceListType } from '../../ChoiceList/ChoiceList';
+import { ChoiceList, ChoiceListProps } from '../../ChoiceList/ChoiceList';
 import { parseBooleanAttr } from '../wrapperUtils';
 import { ChoiceProps } from '../../ChoiceList/Choice';
 import { findElementsOfType } from '../../utilities/findElementsOfType';

--- a/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import './ds-dropdown';
 

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tab-panel.types.d.ts
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tab-panel.types.d.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 
 declare global {

--- a/packages/ds-medicare-gov/src/components/SimpleFooter/SimpleFooter.spec.tsx
+++ b/packages/ds-medicare-gov/src/components/SimpleFooter/SimpleFooter.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import SimpleFooter from './SimpleFooter';
 
 describe('SimpleFooter', () => {


### PR DESCRIPTION
## Summary

- Adjusts the "no-unsed-vars" rule to prioritize the typescript-specific one (https://typescript-eslint.io/rules/no-unused-vars/) so that the eslint rules match what is on `main`
- Previously, this feature branch's linting strategy removed this option that allows for destructing objects and removing unwanted params (more details: https://eslint.org/docs/latest/rules/no-unused-vars#ignorerestsiblings)
- This PR also addressed minor eslint errors
- [Jira Ticket](https://jira.cms.gov/browse/WNMGDS-3286)

## How to test

1. Run `npm run lint` and verify that linting passed with 0 errors

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
