### PR TITLE
[WNMGDS-3331] Fixes `href-template` attribute casing in `ds-pagination` Storybook docs

### DIFF
--- a/packages/design-system/src/components/web-components/ds-pagination/ds-pagination.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-pagination/ds-pagination.stories.tsx
@@ -35,7 +35,7 @@ export default {
       description: 'Set to "true" to hide instead of disable navigation buttons. Optional.',
       control: 'boolean',
     },
-    hrefTemplate: {
+    'href-template': {
       description:
         "A string used to generate URLs for each page link. The component will find any instance of `{page}` and replace it with the page number. Defaults to `'#page={page}'`.",
       control: 'text',


### PR DESCRIPTION
## Summary

This PR updates the Storybook documentation for the ds-pagination web component. The href-template attribute was previously documented using camelCase (hrefTemplate), which caused confusion for developers. This update corrects the attribute casing to kebab-case (href-template), which aligns with web component conventions.

[Jira Ticket](https://jira.cms.gov/browse/WNMGDS-3331)

## How to test

1. Run Storybook.
2. In the `ds-pagination` default story, set the href-template attribute to a test value.
3. Open DevTools and verify that the test value appears correctly in the href attribute of each anchor (`<a>`) tag.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone