### PR TITLE
[wnmgds 3339] Fix `onChange` not firing for grouped items in `Autocomplete`

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
@@ -367,6 +367,39 @@ describe('Autocomplete', () => {
     expect(onChange).toHaveBeenLastCalledWith(null);
   });
 
+  it('calls onChange when a grouped item is selected', async () => {
+    const onChange = jest.fn();
+    const items = [
+      {
+        label: 'Fruits',
+        id: 'group-fruits',
+        items: [
+          { id: 'apple', name: 'Apple' },
+          { id: 'banana', name: 'Banana' },
+        ],
+      },
+      {
+        label: 'Vegetables',
+        id: 'group-vegetables',
+        items: [
+          { id: 'carrot', name: 'Carrot' },
+          { id: 'lettuce', name: 'Lettuce' },
+        ],
+      },
+    ];
+
+    renderAutocomplete({ items, onChange });
+
+    const input = screen.getByRole('combobox');
+    userEvent.click(input);
+    userEvent.type(input, 'ban');
+
+    const bananaOption = await screen.findByRole('option', { name: 'Banana' });
+    userEvent.click(bananaOption);
+
+    expect(onChange).toHaveBeenCalledWith({ id: 'banana', name: 'Banana' });
+  });
+
   it('should select list items by keyboard', () => {
     const onChange = jest.fn();
     renderAutocomplete({ onChange });

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -12,6 +12,7 @@ import {
   getTextFieldChild,
   getActiveDescendant,
   removeUndefined,
+  findItemById,
 } from './utils';
 import { t } from '../i18n';
 import { useComboBox } from '../react-aria'; // from react-aria
@@ -232,7 +233,8 @@ export const Autocomplete = (props: AutocompleteProps) => {
       : undefined,
     onSelectionChange: onChange
       ? (selectedKey) => {
-          const selectedItem = items ? items.find((item) => selectedKey === item.id) : undefined;
+          const selectedItem =
+            items && selectedKey != null && findItemById(String(selectedKey), items);
           // We don't call onChange when the user deletes text, even though react-aria will call
           // this function with `null` if the input is cleared out. This is to maintain backwards
           // compatability, but we could consider changing this behavior in the future. If we

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -233,8 +233,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
       : undefined,
     onSelectionChange: onChange
       ? (selectedKey) => {
-          const selectedItem =
-            items && selectedKey != null && findItemById(String(selectedKey), items);
+          const selectedItem = items ? findItemById(String(selectedKey), items) : undefined;
           // We don't call onChange when the user deletes text, even though react-aria will call
           // this function with `null` if the input is cleared out. This is to maintain backwards
           // compatability, but we could consider changing this behavior in the future. If we

--- a/packages/design-system/src/components/Autocomplete/utils.tsx
+++ b/packages/design-system/src/components/Autocomplete/utils.tsx
@@ -90,27 +90,16 @@ export function removeUndefined<T>(obj: T): T {
   return obj;
 }
 
-export const isGroup = (
-  item: AutocompleteItem | AutocompleteItemGroup
-): item is AutocompleteItemGroup => {
-  return (
-    typeof (item as AutocompleteItemGroup).label === 'string' &&
-    Array.isArray((item as AutocompleteItemGroup).items)
-  );
-};
-
 export const findItemById = (
   id: string,
   items: AutocompleteItems
 ): AutocompleteItem | undefined => {
   for (const item of items) {
-    if (isGroup(item)) {
+    if ('items' in item) {
       const match = item.items.find((child) => child.id === id);
       if (match) return match;
     } else {
       if (item.id === id) return item;
     }
   }
-
-  return undefined;
 };

--- a/packages/design-system/src/components/Autocomplete/utils.tsx
+++ b/packages/design-system/src/components/Autocomplete/utils.tsx
@@ -89,3 +89,28 @@ export function removeUndefined<T>(obj: T): T {
   Object.keys(obj).forEach((key) => obj[key] === undefined && delete obj[key]);
   return obj;
 }
+
+export const isGroup = (
+  item: AutocompleteItem | AutocompleteItemGroup
+): item is AutocompleteItemGroup => {
+  return (
+    typeof (item as AutocompleteItemGroup).label === 'string' &&
+    Array.isArray((item as AutocompleteItemGroup).items)
+  );
+};
+
+export const findItemById = (
+  id: string,
+  items: AutocompleteItems
+): AutocompleteItem | undefined => {
+  for (const item of items) {
+    if (isGroup(item)) {
+      const match = item.items.find((child) => child.id === id);
+      if (match) return match;
+    } else {
+      if (item.id === id) return item;
+    }
+  }
+
+  return undefined;
+};

--- a/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.test.tsx
@@ -364,6 +364,52 @@ describe('Autocomplete', () => {
     expect(autocompleteField.value).toBe('');
   });
 
+  it('should dispatch ds-change when a grouped item is selected', () => {
+    const groupedItems = JSON.stringify([
+      {
+        label: 'Fruits',
+        id: 'group-fruits',
+        items: [
+          { id: 'apple', name: 'Apple' },
+          { id: 'banana', name: 'Banana' },
+        ],
+      },
+      {
+        label: 'Vegetables',
+        id: 'group-vegetables',
+        items: [
+          { id: 'carrot', name: 'Carrot' },
+          { id: 'lettuce', name: 'Lettuce' },
+        ],
+      },
+    ]);
+    renderAutocomplete({ items: groupedItems });
+
+    const autocompleteRoot = document.querySelector('ds-autocomplete');
+    const mockHandler = jest.fn();
+    autocompleteRoot.addEventListener('ds-change', mockHandler);
+
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    userEvent.click(input);
+    userEvent.type(input, 'ban');
+
+    const matchingItem = screen.getByRole('option', { name: 'Banana' });
+    userEvent.click(matchingItem);
+
+    expect(input.value).toBe('Banana');
+    expect(mockHandler).toHaveBeenCalledTimes(1);
+    expect(mockHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          selectedItem: { id: 'banana', name: 'Banana' },
+        },
+      })
+    );
+
+    expectMenuToBeClosed();
+    autocompleteRoot.removeEventListener('ds-change', mockHandler);
+  });
+
   it('should call onChange with null item when "Clear search" is clicked', () => {
     renderAutocomplete();
 


### PR DESCRIPTION
## Summary

Previously, when selecting a grouped item in the Autocomplete component, the `onChange` callback wasn't triggered. This was because the component only searched top-level items when resolving the selected ID and did not account for items nested within groups.

- This pull request updates the selection logic to correctly handle both standalone and grouped items.
- Adds unit tests to verify that:
  - `onChange` is triggered when selecting a grouped item (`Autocomplete`)
  - `ds-change` is dispatched when a grouped item is selected (`ds-autocomplete`)

[Jira ticket](https://jira.cms.gov/browse/WNMGDS-3339)

## How to test

- Run the unit tests: `npm run test:unit && npm run test:unit:wc`
- Open the `Autocomplete` story in Storybook. Select a grouped item and verify the `Actions` tab shows the appropriate `onChange` event.

## Checklist
- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone