### PR TITLE
[WNMGDS-3337] Fixed release script

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -76,14 +76,14 @@ async function bumpVersions() {
     ),
   });
   sh(
-    `npm version ${changeLevel} --workspaces=true --preid="beta" --git-tag-version=false --legacy-peer-deps=true`
+    `npm version ${changeLevel} --workspaces=true --preid="beta" --git-tag-version=false --legacy-peer-deps=true --update-workspaces=false`
   );
   // Unstage the design-system-tokens package.json
   sh('git checkout ./packages/design-system-tokens/package.json');
+  // Run npm install
+  sh('npm install');
   // Stage changes to package files
   sh('git add -u **/package.json');
-  // Stage changes to package-lock.json
-  sh('git add -u package-lock.json');
   // And discard all other changes
   sh('git checkout -- .');
   // Verify that there are actually changes staged
@@ -100,6 +100,13 @@ async function bumpVersions() {
   const currentVersionsByPackage = updateVersions();
   sh('git add -u');
   console.log(c.green('Updated versions.json.'));
+
+  // Clean the workspace's modules and reinstall dependencies
+  console.log(c.green('Cleaning workspace node modules.'));
+  sh('npm run clean:modules');
+  console.log(c.green('Installing packages.'));
+  sh('npm install');
+  sh('git add -u');
 
   // Determine our tag names and create the publish commit
   const tags = Object.keys(currentVersionsByPackage).map(


### PR DESCRIPTION
## Summary

This PR adds a new flag for the `npm version` command that is used in the [release.ts](https://github.com/CMSgov/design-system/blob/a0e0d1ff2e06119d4db85f4e2d8eca978bf8f2c5/scripts/release.ts) script. According to the [npm cli documentation](https://docs.npmjs.com/cli/v11/commands/npm-version#workspaces-update), the `workspaces-update` flag is automatically set to true, which means that after bumping the workspace's packages npm is trying to update all of the packages within the monorepo. That had been causing the 5k+ lines of difference in the `package-lock.json` diffs that were noticeable in prior "bump version" PRs (https://github.com/CMSgov/design-system/pull/3535).

We still need to add changes to the `package-lock.json` as part of the release script, but this PR changes the order of operations. After updating the [versions.json](https://github.com/CMSgov/design-system/blob/a0e0d1ff2e06119d4db85f4e2d8eca978bf8f2c5/versions.json) file, the goal is to clean node modules and then run `npm install` again and add those changes in before making the "publish" commit.

## How to test

1. Pull down this branch
2. Comment out lines 223-225 in the [release.ts](https://github.com/CMSgov/design-system/blob/a0e0d1ff2e06119d4db85f4e2d8eca978bf8f2c5/scripts/release.ts#L223-L225) script
3. Comment out lines 111-138 in the [release.ts](https://github.com/CMSgov/design-system/blob/a0e0d1ff2e06119d4db85f4e2d8eca978bf8f2c5/scripts/release.ts#L111-L138)
4. Run `npm run release` and select "Y" to the first prompt
5. Verify that running `npm run test` works without any failing tests
6. Verify that running `git status` results in changes to all of the `package.json` files, `the package-lock.json` file, and `versions.json` file have been staged

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
