### PR TITLE
[WNMGDS-3349] Add `status` to frontmatter for `.mdx` files.

### DIFF
--- a/packages/docs/content/components/accordion.mdx
+++ b/packages/docs/content/components/accordion.mdx
@@ -1,6 +1,8 @@
 ---
 title: Accordion
 intro: An accordion is a list of headers that hide or reveal additional content when selected.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-79
 core:

--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -1,6 +1,8 @@
 ---
 title: Alert
 intro: Alerts give feedback to users, provide critical information, and/or offer key supplementary details about a task.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-80
 core:

--- a/packages/docs/content/components/autocomplete.mdx
+++ b/packages/docs/content/components/autocomplete.mdx
@@ -1,6 +1,8 @@
 ---
 title: Autocomplete
 intro: Autocompletes allow users to enter any combination of letters, numbers, or symbols of their choosing (unless otherwise restricted), and receive one or more suggested matches in a list below the input.
+status: 
+  level: use
 cmsgov:
   figmaNodeId: 6-81
 core:

--- a/packages/docs/content/components/badge.mdx
+++ b/packages/docs/content/components/badge.mdx
@@ -1,6 +1,8 @@
 ---
 title: Badge
 intro: Badges hold small amounts of information and draw attention to new or important content.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-82
 core:

--- a/packages/docs/content/components/button.mdx
+++ b/packages/docs/content/components/button.mdx
@@ -1,6 +1,8 @@
 ---
 title: Button
 intro: Buttons allow users to take actions from a current state to a future state.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-83
 core:

--- a/packages/docs/content/components/card.mdx
+++ b/packages/docs/content/components/card.mdx
@@ -1,5 +1,8 @@
 ---
 title: Card (M.gov)
+status:
+  level: avoid
+  note: Lacks documented guidance on usage and accessibility.
 core:
   figmaNodeId: 4334-23875
 medicare:

--- a/packages/docs/content/components/checkbox.mdx
+++ b/packages/docs/content/components/checkbox.mdx
@@ -1,6 +1,8 @@
 ---
 title: Checkbox
 intro: Checkboxes allow users to select one or more options from a list.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-84
 core:

--- a/packages/docs/content/components/date-field/date-picker.mdx
+++ b/packages/docs/content/components/date-field/date-picker.mdx
@@ -1,6 +1,8 @@
 ---
 title: Calendar Picker
 intro: Date field (with calendar picker), also known as "date picker", provides single date entry with a text field or selection through a visual calendar element tied to the input.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-85
 core:

--- a/packages/docs/content/components/date-field/multi-input-date-field.mdx
+++ b/packages/docs/content/components/date-field/multi-input-date-field.mdx
@@ -1,6 +1,8 @@
 ---
 title: Multi-Input Date Field
 intro: Date field (multi-input) provides date entry, spaced over three separate inputs for month, day, and year.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-85
 core:

--- a/packages/docs/content/components/date-field/single-input-date-field.mdx
+++ b/packages/docs/content/components/date-field/single-input-date-field.mdx
@@ -1,6 +1,8 @@
 ---
 title: Single-Input Date Field
 intro: Date field (single-input) provides date entry, using a text field, in a single input.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-85
 core:

--- a/packages/docs/content/components/drawer.mdx
+++ b/packages/docs/content/components/drawer.mdx
@@ -1,6 +1,8 @@
 ---
 title: Drawer & Help Drawer
 intro: A drawer provides a space for medium to long-form help content — content that's too long or not common enough to warrant being on the page by default.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-91
 core:

--- a/packages/docs/content/components/dropdown.mdx
+++ b/packages/docs/content/components/dropdown.mdx
@@ -1,6 +1,8 @@
 ---
 title: Dropdown
 intro: Dropdowns allow users to select one option from a temporary modal menu.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-88
 core:

--- a/packages/docs/content/components/filter-chip.mdx
+++ b/packages/docs/content/components/filter-chip.mdx
@@ -1,6 +1,8 @@
 ---
 title: Filter Chip
 intro: Filter Chips are used to display dismissible filter chips.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-89
 core:

--- a/packages/docs/content/components/footer/healthcare-footer.mdx
+++ b/packages/docs/content/components/footer/healthcare-footer.mdx
@@ -1,5 +1,7 @@
 ---
 title: Healthcare.gov Footer
+status:
+  level: use
 core:
   figmaNodeId: 346-13315
 healthcare:

--- a/packages/docs/content/components/footer/medicare-footer.mdx
+++ b/packages/docs/content/components/footer/medicare-footer.mdx
@@ -1,5 +1,7 @@
 ---
 title: Medicare.gov Footer
+status:
+  level: use
 core:
   figmaNodeId: 346-13315
 medicare:

--- a/packages/docs/content/components/header/healthcare-header.mdx
+++ b/packages/docs/content/components/header/healthcare-header.mdx
@@ -1,5 +1,7 @@
 ---
 title: Healthcare.gov Header
+status:
+  level: use
 core:
   figmaNodeId: 346-13316
 healthcare:

--- a/packages/docs/content/components/header/medicare-header.mdx
+++ b/packages/docs/content/components/header/medicare-header.mdx
@@ -1,6 +1,8 @@
 ---
 title: Medicare.gov Header
 intro: The Consistent Header is a shared component available for all of medicare.gov.
+status:
+  level: use
 core:
   figmaNodeId: 346-13316
 medicare:

--- a/packages/docs/content/components/hint.mdx
+++ b/packages/docs/content/components/hint.mdx
@@ -1,6 +1,8 @@
 ---
 title: Hint
 intro: Hint text is used in combination with a Label to provide extra instructions or context for form fields.
+status:
+  level: use
 core:
   githubLink: design-system/src/components/Hint
   storybookLink: components-hint--docs

--- a/packages/docs/content/components/icon.mdx
+++ b/packages/docs/content/components/icon.mdx
@@ -1,6 +1,8 @@
 ---
 title: Icon
 intro: Icons help communicate meaning, actions, status, or feedback.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-92
 core:

--- a/packages/docs/content/components/idle-timeout.mdx
+++ b/packages/docs/content/components/idle-timeout.mdx
@@ -1,6 +1,8 @@
 ---
 title: Idle Timeout
 intro: A component that counts down to the end of a session (behind the scenes) and shows a warning message after a set amount of time of inactivity.
+status:
+  level: use
 core:
   githubLink: design-system/src/components/IdleTimeout
   storybookLink: components-idletimeout--docs

--- a/packages/docs/content/components/inline-error.mdx
+++ b/packages/docs/content/components/inline-error.mdx
@@ -1,6 +1,8 @@
 ---
 title: Inline Error
 intro: Inline errors give validation feedback for specific form fields.
+status:
+  level: use
 core:
   githubLink: design-system/src/components/InlineError
   storybookLink: components-inlineerror--docs

--- a/packages/docs/content/components/inset.mdx
+++ b/packages/docs/content/components/inset.mdx
@@ -1,6 +1,9 @@
 ---
 title: Inset (HC.gov)
 intro: The Inset component is meant to draw attention to important content, or to associate a block of content with another element.
+status:
+  level: avoid
+  note: Usage and accessibility guidance is incomplete. Maturity checklist is not documented. Accessibility testing has not been performed.
 healthcare:
   githubLink: ds-healthcare-gov/src/styles/components/_Inset.scss
 ---

--- a/packages/docs/content/components/label.mdx
+++ b/packages/docs/content/components/label.mdx
@@ -1,6 +1,8 @@
 ---
 title: Label & Legend
 intro: Labels & legends describe individual form fields or fieldsets.
+status:
+  level: use
 core:
   githubLink: design-system/src/components/Label
   storybookLink: components-label--docs

--- a/packages/docs/content/components/logos/healthcare-logo.mdx
+++ b/packages/docs/content/components/logos/healthcare-logo.mdx
@@ -1,6 +1,8 @@
 ---
 title: Healthcare.gov Logo
 intro: Renders the HealthCare.gov logo in English (default) or Spanish.
+status:
+  level: use
 core:
   figmaNodeId: 346-18284
 healthcare:

--- a/packages/docs/content/components/logos/hhs-logo.mdx
+++ b/packages/docs/content/components/logos/hhs-logo.mdx
@@ -1,6 +1,8 @@
 ---
 title: HHS Logo
 intro: Renders the HHS logo.
+status:
+  level: use
 core:
   figmaNodeId: 346-18284
   githubLink: design-system/src/components/Icons/HhsLogo.tsx

--- a/packages/docs/content/components/logos/medicare-logo.mdx
+++ b/packages/docs/content/components/logos/medicare-logo.mdx
@@ -1,6 +1,8 @@
 ---
 title: Medicare.gov Logo
 intro: Renders the Medicare.gov logo.
+status:
+  level: use
 core:
   figmaNodeId: 346-18284
 medicare:

--- a/packages/docs/content/components/modal-dialog.mdx
+++ b/packages/docs/content/components/modal-dialog.mdx
@@ -1,6 +1,8 @@
 ---
 title: Modal Dialog
 intro: The dialog component can be used to focus a user's attention on a single piece of content, without taking them to a new screen. Please use with caution; view our guidance for more details.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-93
 core:

--- a/packages/docs/content/components/month-picker.mdx
+++ b/packages/docs/content/components/month-picker.mdx
@@ -1,5 +1,8 @@
 ---
 title: Month Picker
+status:
+  level: avoid
+  note: Lacks documented guidance on usage and accessibility. Accessibility testing has not been performed.
 cmsgov:
   figmaNodeId: 6-94
 core:

--- a/packages/docs/content/components/note-box.mdx
+++ b/packages/docs/content/components/note-box.mdx
@@ -1,6 +1,8 @@
 ---
 title: Note Box
 intro: The note box highlights information with a medium visual priority using existing typography styles with a box outline.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 10107:1379
 core:

--- a/packages/docs/content/components/pagination.mdx
+++ b/packages/docs/content/components/pagination.mdx
@@ -1,6 +1,8 @@
 ---
 title: Pagination
 intro: Pagination is navigation for paginated content.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-95
 core:

--- a/packages/docs/content/components/radio.mdx
+++ b/packages/docs/content/components/radio.mdx
@@ -1,6 +1,9 @@
 ---
 title: Radio Button
 intro: Radio buttons allow users to select exactly one choice from a group.
+status:
+  level: use
+  note: Fully tested and actively supported
 cmsgov:
   figmaNodeId: 6-84
 core:

--- a/packages/docs/content/components/review.mdx
+++ b/packages/docs/content/components/review.mdx
@@ -1,6 +1,9 @@
 ---
 title: Review
 intro: The review pattern is used for listing a summary of information entered by a user. Its content includes a heading, value, and edit link.
+status:
+  level: avoid
+  note: Accessibility testing has not been performed.
 cmsgov:
   figmaNodeId: 6-97
 core:

--- a/packages/docs/content/components/skip-nav.mdx
+++ b/packages/docs/content/components/skip-nav.mdx
@@ -1,6 +1,8 @@
 ---
 title: Skip Nav
 intro: Skip navigation links allow users with screen readers to bypass long navigation lists.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-98
 core:

--- a/packages/docs/content/components/spinner.mdx
+++ b/packages/docs/content/components/spinner.mdx
@@ -1,6 +1,8 @@
 ---
 title: Spinner
 intro: Spinners signify that the application is waiting for an asynchronous operation to complete.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 6-99
 core:

--- a/packages/docs/content/components/stars.mdx
+++ b/packages/docs/content/components/stars.mdx
@@ -1,5 +1,8 @@
 ---
 title: Stars (M.gov)
+status:
+  level: caution
+  note: Component maturity checklist is incomplete.
 core:
   figmaNodeId: 346-21580
 medicare:

--- a/packages/docs/content/components/step-list.mdx
+++ b/packages/docs/content/components/step-list.mdx
@@ -1,6 +1,9 @@
 ---
 title: Step List
 intro: A step list represents a user's progression through an application or multi-page form. It serves as a table of contents and a way to quickly see where they are and what they should be working on next.
+status:
+  level: avoid
+  note: Accessibility testing has not been performed.
 cmsgov:
   figmaNodeId: 7-100
 core:

--- a/packages/docs/content/components/table.mdx
+++ b/packages/docs/content/components/table.mdx
@@ -1,6 +1,8 @@
 ---
 title: Table
 intro: Tables show tabular data in columns and rows.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 7-101
 core:

--- a/packages/docs/content/components/tabs.mdx
+++ b/packages/docs/content/components/tabs.mdx
@@ -1,6 +1,8 @@
 ---
 title: Tabs
 intro: Tabs are a secondary navigation pattern, allowing a user to view only the content they're interested in. They build upon a real world metaphor, and the selected state simulates a folder being physically in front of others in the group.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 7-102
 core:

--- a/packages/docs/content/components/text-field/label-masked-field.mdx
+++ b/packages/docs/content/components/text-field/label-masked-field.mdx
@@ -1,6 +1,8 @@
 ---
 title: Label-Masked Field
 intro: A label-masked field is a text-field pattern that provides instant, visual feedback about how inputed data is being interpreted without creating a noisy aural experience.
+status:
+  level: use
 core:
   githubLink: design-system/src/components/LabelMask
   storybookLink: components-textfield--docs

--- a/packages/docs/content/components/text-field/masked-field.mdx
+++ b/packages/docs/content/components/text-field/masked-field.mdx
@@ -1,6 +1,9 @@
 ---
 title: Masked Field
 intro: A masked field is an enhanced input field that improves readability by providing visual and non-visual cues to a user about the expected value.
+status:
+  level: avoid
+  note: Preliminary accessibility testing has been done, but coverage is incomplete.
 core:
   githubLink: design-system/src/components/TextField
   storybookLink: components-textfield--docs

--- a/packages/docs/content/components/text-field/text-field.mdx
+++ b/packages/docs/content/components/text-field/text-field.mdx
@@ -1,6 +1,8 @@
 ---
 title: Text Field
 intro: Text fields allow users to enter any combination of letters, numbers, or symbols of their choosing (unless otherwise restricted). Text fields can span single or multiple lines.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 7-104
 core:

--- a/packages/docs/content/components/third-party-external-link.mdx
+++ b/packages/docs/content/components/third-party-external-link.mdx
@@ -1,6 +1,8 @@
 ---
 title: Third Party External Link
 intro: The third party external link component is used to notify a user that the action they are taking will take them to a new external website.
+status:
+  level: use
 core:
   githubLink: design-system/src/components/ThirdPartyExternalLink
   storybookLink: components-thirdpartyexternallink--docs

--- a/packages/docs/content/components/tooltip.mdx
+++ b/packages/docs/content/components/tooltip.mdx
@@ -1,6 +1,8 @@
 ---
 title: Tooltip
 intro: Tooltips provide additional information upon hover, focus or click. The information should be contextual, useful, and nonessential information.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 7-105
 core:

--- a/packages/docs/content/components/usa-banner.mdx
+++ b/packages/docs/content/components/usa-banner.mdx
@@ -1,6 +1,8 @@
 ---
 title: USA Banner
 intro: The USA banner identifies official websites of government organizations in the United States. It also helps visitors understand how to tell that a website is both official and secure.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 7-106
 core:

--- a/packages/docs/content/components/vertical-navigation.mdx
+++ b/packages/docs/content/components/vertical-navigation.mdx
@@ -1,6 +1,8 @@
 ---
 title: Vertical Navigation
 intro: Hierarchical, vertical navigation.
+status:
+  level: use
 cmsgov:
   figmaNodeId: 7-107
 core:

--- a/packages/docs/gatsby-node.js
+++ b/packages/docs/gatsby-node.js
@@ -19,6 +19,26 @@ exports.onCreateWebpackConfig = ({ actions }) => {
   });
 };
 
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions;
+  createTypes(`
+    type MdxFrontmatter {
+      status: ComponentStatus
+    }
+
+    type ComponentStatus {
+      level: ComponentStatusLevel!
+      note: String
+    }
+
+    enum ComponentStatusLevel {
+      use
+      caution
+      avoid
+    }
+  `);
+};
+
 exports.onCreateDevServer = ({ app }) => {
   app.use(express.static('static'));
 };

--- a/packages/docs/src/components/page-templates/InfoPage.tsx
+++ b/packages/docs/src/components/page-templates/InfoPage.tsx
@@ -11,6 +11,12 @@ import { graphql } from 'gatsby';
 const InfoPage = ({ data, location }: MdxQuery) => {
   const { frontmatter, body, tableOfContents, slug } = data.mdx;
   const theme = useTheme();
+  if (frontmatter.title === 'Alert') {
+    console.log('Front matter', frontmatter);
+  }
+  if (frontmatter.title === 'Autocomplete') {
+    console.log('Front matter', frontmatter);
+  }
 
   return (
     <Layout
@@ -32,6 +38,10 @@ export const query = graphql`
       frontmatter {
         title
         intro
+        status {
+          level
+          note
+        }
         cmsgov {
           figmaNodeId
         }


### PR DESCRIPTION
## Summary

- Introduces a `status` field in component `.mdx` frontmatter:
```
---
title: Table
// ... other fields ...
status:
  level: use | caution | avoid
  note: // Optional context for "caution" and "avoid" cases. 
---
```
- Adds `status` to the frontmatter of each component `.mdx` file.
- Adds a type validation  for `status.level` using gatsby schema customization.

[Jira ticket](https://jira.cms.gov/browse/WNMGDS-3349)

## How to test
- Run `npm run start`. The site should build without errors.
- Open `http://localhost:8000/___graphql` and run the following query.
```
query mdxStatusQuery {
  allMdx(
    filter: { frontmatter: { title: { ne: null }, status: { level: { ne: null } } } }
    sort: { fields: frontmatter___title, order: ASC }
  ) {
    nodes {
      frontmatter {
        title
        status {
          level
          note
        }
      }
    }
  }
}
```
Verify that:
- Every component has a `status.level` (use, caution, or avoid)
  _Note:  When `status.level` is "caution" or "avoid", the `note` field is populated. For the `use` case, the `note` field is `null`._
To verify the `status.level` type validation:
- Open any component `.mdx` file.
- Change the `status.level` value to something invalid (e.g., "banana").
 - Run `npm run start` again — the build should fail with a graphQL schema error.
```
ERROR #85901  GRAPHQL

There was an error in your GraphQL query:

Enum "ComponentStatusLevel" cannot represent value: "banana"
```
## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone