### PR TITLE
[WNMGDS-3350] Remove form components table

### DIFF
--- a/packages/docs/content/components/checkbox.mdx
+++ b/packages/docs/content/components/checkbox.mdx
@@ -47,22 +47,19 @@ Checkboxes can have optional checked or unchecked children that are conditionall
 ### Web Component
 
 <StorybookDocLinks tech="wc">
-  <StorybookDocLink tech="wc" storyId="web-components-ds-choice--docs">Choice</StorybookDocLink>
-  <StorybookDocLink tech="wc" storyId="web-components-ds-choice-list--docs">Choice List</StorybookDocLink>
+  <StorybookDocLink tech="wc" storyId="web-components-ds-choice--docs">
+    Choice
+  </StorybookDocLink>
+  <StorybookDocLink tech="wc" storyId="web-components-ds-choice-list--docs">
+    Choice List
+  </StorybookDocLink>
 </StorybookDocLinks>
-
 
 ### Style customization
 
 The following CSS variables can be overridden to customize choice fields:
 
 <ComponentThemeOptions componentname="choice" />
-
-#### Form components
-
-This component also makes use of form field styles, which can be customized by the following variables:
-
-<ComponentThemeOptions componentname="form" />
 
 ## Guidance
 

--- a/packages/docs/content/components/date-field/date-picker.mdx
+++ b/packages/docs/content/components/date-field/date-picker.mdx
@@ -33,12 +33,6 @@ The following CSS variables can be overridden to customize Input/Form components
 
 <ComponentThemeOptions componentname="text-input" />
 
-#### Form components
-
-This component also makes use of form field styles, which can be customized by the following variables:
-
-<ComponentThemeOptions componentname="form" />
-
 ## Guidance
 
 ### When to use

--- a/packages/docs/content/components/date-field/multi-input-date-field.mdx
+++ b/packages/docs/content/components/date-field/multi-input-date-field.mdx
@@ -32,12 +32,6 @@ The following CSS variables can be overridden to customize Input/Form components
 
 <ComponentThemeOptions componentname="text-input" />
 
-#### Form components
-
-This component also makes use of form field styles, which can be customized by the following variables:
-
-<ComponentThemeOptions componentname="form" />
-
 ## Guidance
 
 ### When to use

--- a/packages/docs/content/components/date-field/single-input-date-field.mdx
+++ b/packages/docs/content/components/date-field/single-input-date-field.mdx
@@ -36,12 +36,6 @@ The following CSS variables can be overridden to customize Input/Form components
 
 <ComponentThemeOptions componentname="text-input" />
 
-#### Form components
-
-This component also makes use of form field styles, which can be customized by the following variables:
-
-<ComponentThemeOptions componentname="form" />
-
 ## Guidance
 
 ### When to use

--- a/packages/docs/content/components/hint.mdx
+++ b/packages/docs/content/components/hint.mdx
@@ -24,12 +24,6 @@ core:
 
 <SeeStorybookForGuidance tech="wc" storyId={'web-components-hint--docs'} />
 
-### Style customization
-
-The following CSS variables can be overridden to customize Form components:
-
-<ComponentThemeOptions componentname="form" />
-
 ## Guidance
 
 - Hints are built in to all design-system form fields but can be used on their own to create custom fields.

--- a/packages/docs/content/components/inline-error.mdx
+++ b/packages/docs/content/components/inline-error.mdx
@@ -24,12 +24,6 @@ core:
 
 <SeeStorybookForGuidance tech="wc" storyId={'web-components-inlineerror--docs'} />
 
-### Style customization
-
-The following CSS variables can be overridden to customize Form components:
-
-<ComponentThemeOptions componentname="form" />
-
 ## Guidance
 
 - Inline errors are built in to all design-system form fields but can be used on their own to create custom fields.

--- a/packages/docs/content/components/label.mdx
+++ b/packages/docs/content/components/label.mdx
@@ -24,11 +24,6 @@ core:
 
 <SeeStorybookForGuidance tech="wc" storyId={'web-components-label--docs'} />
 
-### Style customization
-
-The following CSS variables can be overridden to customize Form components:
-
-<ComponentThemeOptions componentname="form" />
 
 ## Guidance
 
@@ -55,7 +50,7 @@ The following CSS variables can be overridden to customize Form components:
   - Form fields can use traditional labels for many items. (Examples: "First name," "Last name," "Address," etc.) Traditional labels don’t need punctuation.
   - Form labels and decision helpers can use completes sentences (imperatives or questions) for user understanding or conversational feel. (Examples: "Tell us why you need a faster decision." "Select a reason for your request." "Do you want to see costs when you compare X?" "Do you have another mailing address?") Include punctuation.
 - For imperative labels, start with an action verb and pair it with a noun to help it be clearer. Example: "Enter your age."
-- Use the fewest words possible. Don't use "please" or add unnecessary explanation/context in your label. Instead, use hint text or hint text with a help drawer link to provide information the user must have to correctly enter their answer. 
+- Use the fewest words possible. Don't use "please" or add unnecessary explanation/context in your label. Instead, use hint text or hint text with a help drawer link to provide information the user must have to correctly enter their answer.
 
 ### Accessibility testing
 

--- a/packages/docs/content/components/month-picker.mdx
+++ b/packages/docs/content/components/month-picker.mdx
@@ -21,7 +21,7 @@ The Month Picker component renders a grid of checkboxes with shortened month nam
 ### Accessibility
 
 #### Accessibility
-- Be mindful of color contrast ratios between the checkbox and its background color. For instance, a dark green or blue behind the component will most likely cause problems for users. When using a dark background, consider using the `inversed` prop. [Read our guidance on color for more information.](../../foundation/system-color-tokens/#accessibility-considerations) 
+- Be mindful of color contrast ratios between the checkbox and its background color. For instance, a dark green or blue behind the component will most likely cause problems for users. When using a dark background, consider using the `inversed` prop. [Read our guidance on color for more information.](../../foundation/system-color-tokens/#accessibility-considerations)
 
 ### Accessibility testing
 
@@ -64,12 +64,6 @@ The Month Picker component renders a grid of checkboxes with shortened month nam
 The following CSS variables can be overridden to customize MonthPicker fields:
 
 <ComponentThemeOptions componentname="choice" />
-
-### Form components
-
-This component also makes use of form field styles, which can be customized by the following variables:
-
-<ComponentThemeOptions componentname="form" />
 
 ## Component maturity
 

--- a/packages/docs/content/components/radio.mdx
+++ b/packages/docs/content/components/radio.mdx
@@ -50,12 +50,6 @@ The following CSS variables can be overridden to customize choice fields:
 
 <ComponentThemeOptions componentname="choice" />
 
-#### Form components
-
-This component also makes use of form field styles, which can be customized by the following variables:
-
-<ComponentThemeOptions componentname="form" />
-
 ## Guidance
 
 ### When to use

--- a/packages/docs/content/components/text-field/masked-field.mdx
+++ b/packages/docs/content/components/text-field/masked-field.mdx
@@ -30,12 +30,6 @@ The following CSS variables can be overridden to customize Input/Form components
 
 <ComponentThemeOptions componentname="text-input" />
 
-#### Form components
-
-This component uses a text field and its styles, which can be customized by the following variables:
-
-<ComponentThemeOptions componentname="form" />
-
 ## Accessibility
 Please note that USWDS and others recognize some [accessibility issues](https://designsystem.digital.gov/components/input-mask/#known-issues) with masked input fields:
 - It can be difficult to recover from errors without good form validation and feedback to users, particularly if special characters are disallowed and ignored, or replaced. [USWDS](https://github.com/uswds/uswds/issues/5481)

--- a/packages/docs/content/components/text-field/text-field.mdx
+++ b/packages/docs/content/components/text-field/text-field.mdx
@@ -32,11 +32,13 @@ medicare:
 ## Guidance
 
 ### When to use
+
 - If you can’t reasonably predict a user’s answer to a prompt and there might be wide variability in users’ answers.
 - When using another type of input will make answering more difficult. For example, birthdays and other known dates are easier to type in than they are to select from a calendar picker.
 - When users want to paste in a response.
 
 ### Guidelines
+
 - Don't use placeholder text in form fields. Use hint text instead, if you need to provide contextual information. Placeholder text disappears after a user types a value, therefore users will no longer have that text available when they need to review their entries. People who have cognitive or visual disabilities have additional problems with placeholder text.
 - The length of the text field provides a hint to users as to how much text to write. Do not require users to write paragraphs of text into a single-line input box; use a `<textarea>` instead.
 - Text fields are among the easiest type of input for desktop users but are more difficult for mobile users.
@@ -53,6 +55,7 @@ medicare:
 ## Accessibility
 
 ### Accessibility guidance
+
 - Group each set of thematically related controls in a `fieldset` element. Use the `legend` element to offer a label within each `fieldset`. The `fieldset` and `legend` elements make it easier for screen reader users to navigate the form.
 - Keep your form blocks in a vertical pattern. This approach is ideal, from an accessibility standpoint, because of limited vision that makes it hard to scan from left to right.
 
@@ -73,12 +76,6 @@ A `TextField` component renders an input field as well as supporting UI elements
 The following CSS variables can be overridden to customize Input/Form components:
 
 <ComponentThemeOptions componentname="text-input" />
-
-### Form components
-
-This component also makes use of form field styles, which can be customized by the following variables:
-
-<ComponentThemeOptions componentname="form" />
 
 ## Related patterns
 

--- a/packages/docs/src/components/content/ComponentThemeOptions.tsx
+++ b/packages/docs/src/components/content/ComponentThemeOptions.tsx
@@ -72,7 +72,7 @@ const ComponentThemeOptions = ({ theme, componentname }: ComponentThemeOptionsPr
     </Table>
   );
 
-  if ((!componentVariables || componentVariables.length == 0) && !isProduction()) {
+  if (componentVariables.length == 0 && !isProduction()) {
     console.error(
       'You are trying to render componentVariables inside of a call to ComponentThemeOptions. The componentVariables array is either undefined or empty. This will prevent the table from rendering.'
     );

--- a/packages/docs/src/components/content/ComponentThemeOptions.tsx
+++ b/packages/docs/src/components/content/ComponentThemeOptions.tsx
@@ -75,7 +75,7 @@ const ComponentThemeOptions = ({ theme, componentname }: ComponentThemeOptionsPr
     <section className="c-configuration-options ds-u-padding-bottom--3">
       {componentVariables.length > 0
         ? componentOptions
-        : `No variables available for ${componentname}.`}
+        : `No variables available for component: "${componentname}".`}
     </section>
   );
 };

--- a/packages/docs/src/components/content/ComponentThemeOptions.tsx
+++ b/packages/docs/src/components/content/ComponentThemeOptions.tsx
@@ -10,6 +10,7 @@ import {
 } from '@cmsgov/design-system';
 import ColorSwatch from './ColorSwatch';
 import { getComponentVariables, ThemeName } from '../../helpers/themeTokens';
+import { isProduction } from '../../helpers/urlUtils';
 
 interface ComponentThemeOptionsProps {
   /**
@@ -71,8 +72,8 @@ const ComponentThemeOptions = ({ theme, componentname }: ComponentThemeOptionsPr
     </Table>
   );
 
-  if (!componentVariables || componentVariables.length == 0) {
-    console.warn(
+  if ((!componentVariables || componentVariables.length == 0) && !isProduction()) {
+    console.error(
       'You are trying to render componentVariables inside of a call to ComponentThemeOptions. The componentVariables array is either undefined or empty. This will prevent the table from rendering.'
     );
   }

--- a/packages/docs/src/components/content/ComponentThemeOptions.tsx
+++ b/packages/docs/src/components/content/ComponentThemeOptions.tsx
@@ -72,7 +72,11 @@ const ComponentThemeOptions = ({ theme, componentname }: ComponentThemeOptionsPr
   );
 
   return (
-    <section className="c-configuration-options ds-u-padding-bottom--3">{componentOptions}</section>
+    <section className="c-configuration-options ds-u-padding-bottom--3">
+      {componentVariables.length > 0
+        ? componentOptions
+        : `No variables available for ${componentname}.`}
+    </section>
   );
 };
 

--- a/packages/docs/src/components/content/ComponentThemeOptions.tsx
+++ b/packages/docs/src/components/content/ComponentThemeOptions.tsx
@@ -71,12 +71,18 @@ const ComponentThemeOptions = ({ theme, componentname }: ComponentThemeOptionsPr
     </Table>
   );
 
+  if (!componentVariables || componentVariables.length == 0) {
+    console.warn(
+      'You are trying to render componentVariables inside of a call to ComponentThemeOptions. The componentVariables array is either undefined or empty. This will prevent the table from rendering.'
+    );
+  }
+
   return (
-    <section className="c-configuration-options ds-u-padding-bottom--3">
-      {componentVariables.length > 0
-        ? componentOptions
-        : `No variables available for component: "${componentname}".`}
-    </section>
+    componentVariables.length > 0 && (
+      <section className="c-configuration-options ds-u-padding-bottom--3">
+        {componentOptions}
+      </section>
+    )
   );
 };
 

--- a/packages/docs/src/helpers/urlUtils.ts
+++ b/packages/docs/src/helpers/urlUtils.ts
@@ -67,3 +67,11 @@ export function setQueryParam(name: string, value: string, reloadPage: boolean =
     }
   }
 }
+
+/**
+ * isProduction
+ * @returns boolean - true if we are on prod, aka design.cms.gov, and false otherwise
+ */
+export function isProduction(): boolean {
+  return location.hostname == 'design.cms.gov';
+}


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/WNMGDS-3350)
- We attempt to render an additional styling table for form components, however there is no component named "form" in the Tokens lists (or in the design system, it is a pattern) so we are unable to render any additional form styling tables. 
- This ticket removes all mentions of `<ComponentThemeOptions componentname="form" />` in our MDX files, and the associated text providing context for those tables.
- I also took the liberty to add a little message for when no additional styling variables exist for a given component.

## How to test

1. Search for `<ComponentThemeOptions componentname="form" />` in the codebase. There should be 0 results.
2. Fire up the doc site locally, and add `<ComponentThemeOptions componentname="form" />` to a random MDX page. You should see the message `No variables available for component: "form".` Happy to discuss whether this is needed or not.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone
