### PR TITLE
[WNMGDS-3189] Fix `ds-autocomplete` storybook controls

### DIFF
--- a/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.stories.tsx
@@ -146,10 +146,6 @@ Please see examples for usage and [read the autocomplete docs](https://design.cm
     textFieldLabel: {
       table: { disable: true },
     },
-    value: {
-      description: 'Input value',
-      control: 'text',
-    },
   },
 };
 export default meta;
@@ -214,7 +210,6 @@ const Template = (args: DSAutocompleteProps) => {
       items={JSON.stringify(filteredItems)}
       label={label}
       hint={hint}
-      value={input}
     />
   );
 };

--- a/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.stories.tsx
@@ -75,6 +75,11 @@ const meta: Meta = {
       description: 'Enable the error state by providing an error message',
       control: 'text',
     },
+    'error-id': {
+      description:
+        'The ID of the error message applied to this field. If none is provided, the id will be derived from the `root-id` attribute.',
+      control: 'text',
+    },
     'error-placement': {
       description: 'Location of the error message relative to the field input',
       options: [undefined, 'top', 'bottom'],
@@ -87,6 +92,10 @@ const meta: Meta = {
     },
     hint: {
       description: 'An optional hint for the label',
+      control: 'text',
+    },
+    'hint-id': {
+      description: 'The ID of the hint element',
       control: 'text',
     },
     'hint-class-name': {
@@ -106,6 +115,20 @@ Please see examples for usage and [read the autocomplete docs](https://design.cm
     },
     label: {
       description: 'A label for the input',
+      control: 'text',
+    },
+    'label-class-name': {
+      description: 'Additional classes to be added to the field label',
+      control: 'text',
+    },
+    'label-id': {
+      description:
+        "A unique `id` to be used on the field label. If one isn't provided, a unique ID will be generated.",
+      control: 'text',
+    },
+    'requirement-label': {
+      description:
+        'Text showing the requirement (e.g., "Optional", or "Required"). In most cases, this should be used to indicate which fields are optional. See the [form guidelines](https://design.cms.gov/patterns/Forms/forms/) for more info.',
       control: 'text',
     },
     loading: {

--- a/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.tsx
+++ b/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.tsx
@@ -26,7 +26,6 @@ const attributes = [
   'name',
   'no-results-message',
   'root-id',
-  'value',
   ...formAttrs,
 ] as const;
 
@@ -51,7 +50,6 @@ interface WrapperProps
   errorMessage?: string;
   errorPlacement?: string;
   errorMessageClassName?: string;
-  value: string;
   items?: string;
   loading?: string;
   menuHeading?: string;
@@ -71,7 +69,6 @@ const Wrapper = ({
   menuHeadingId,
   name,
   rootId,
-  value,
   ...otherProps
 }: WrapperProps) => {
   return (
@@ -97,7 +94,6 @@ const Wrapper = ({
         label={label}
         hint={hint}
         name={name ?? 'autocomplete'}
-        value={value}
       />
     </Autocomplete>
   );

--- a/tests/browser/snapshots/storybook-docs/Docs-Web-Components-ds-autocomplete-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Web-Components-ds-autocomplete-Docs-prop-table-matches-snapshot-1.txt
@@ -35,6 +35,11 @@
     "\"true\"\"false\""
   ],
   [
+    "error-id",
+    "The ID of the error message applied to this field. If none is provided, the id will be derived from the root-id attribute.",
+    "string"
+  ],
+  [
     "error-message",
     "Enable the error state by providing an error message",
     "string"
@@ -60,6 +65,11 @@
     "string"
   ],
   [
+    "hint-id",
+    "The ID of the hint element",
+    "string"
+  ],
+  [
     "items",
     "An array of objects used to populate the suggestion list that appears below the input as users type. Passing an empty array will show a \"No results\" message. If you do not yet want to show results, this props should be undefined.\n\nWhen setting this attribute directly in HTML, it must be wrapped in single quotes, with double quotes inside the JSON. Example: <ds-autocomplete items='[{ \"id\": \"1\", \"name\": \"Advil\" }]' />\n\nIf you're setting this attribute in JavaScript, use JSON.stringify() to convert the array into a valid string value.\n\nPlease see examples for usage and read the autocomplete docs.",
     "string"
@@ -67,6 +77,16 @@
   [
     "label",
     "A label for the input",
+    "string"
+  ],
+  [
+    "label-class-name",
+    "Additional classes to be added to the field label",
+    "string"
+  ],
+  [
+    "label-id",
+    "A unique id to be used on the field label. If one isn't provided, a unique ID will be generated.",
     "string"
   ],
   [
@@ -100,13 +120,13 @@
     "string"
   ],
   [
-    "root-id",
-    "A unique ID for this element. A unique ID will be generated if one isn't provided.",
+    "requirement-label",
+    "Text showing the requirement (e.g., \"Optional\", or \"Required\"). In most cases, this should be used to indicate which fields are optional. See the form guidelines for more info.",
     "string"
   ],
   [
-    "value",
-    "Input value",
+    "root-id",
+    "A unique ID for this element. A unique ID will be generated if one isn't provided.",
     "string"
   ]
 ]


### PR DESCRIPTION
## Summary

- Removed `value` attribute from the public `ds-autocomplete` interface. There doesn't seem to be a clear use case for allowing external control of the input value. The previous storybook implementation appears to have masked the fact that forcibly passing a value breaks the expected behavior of the component. 

- Added missing [formAttrs](https://github.com/CMSgov/design-system/blob/main/packages/design-system/src/components/web-components/shared-attributes/form.ts#L1-L8) to `ds-autocomplete` storybook controls.

[Jira ticket](https://jira.cms.gov/browse/WNMGDS-3189)

## How to test

- Run storybook, open the ds-autocomplete stories, and verify that the missing [formAttrs](https://github.com/CMSgov/design-system/blob/main/packages/design-system/src/components/web-components/shared-attributes/form.ts#L1-L8) are now available in the controls panel.
- Run `npm test:unit:wc`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone