### PR TITLE
[WNMGDS-3354] A11y guidance for radio and checkbox components

### DIFF
--- a/packages/docs/content/components/checkbox.mdx
+++ b/packages/docs/content/components/checkbox.mdx
@@ -73,6 +73,11 @@ Checkboxes can have optional checked or unchecked children that are conditionall
 - If you opt for smaller radio buttons or checkboxes, add className `.ds-c-choice__checkedChild--small` to your checked child container
 
 ## Accessibility
+The radio button component handles rendering labels, and if you’re using ChoiceList for a set of controls, will also wrap them in `<fieldset>` to maintain accessibility, and `<legend>` to provide context.
+
+### General accessibility guidance
+- For a single radio button, donʼt use `<fieldset>` and `<legend>`.
+- Use semantic tags. Each input should have a semantic tag for the id attribute, and its corresponding label should have the same value in its for attribute.
 - No other interactive elements (such as links or buttons) should be included inside the label or hint text.
 - A group of checkboxes should be wrapped in a `<fieldset>` that includes a `<legend>` element within.
   - The `<legend>` provides context for the grouping, much like a label.

--- a/packages/docs/content/components/radio.mdx
+++ b/packages/docs/content/components/radio.mdx
@@ -37,27 +37,6 @@ Radio buttons can have optional checked or unchecked children that are condition
   storyId="components-choicelist--choice-children"
 />
 
-## Code
-
-### React
-
-<StorybookDocLinks>
-  <StorybookDocLink storyId="components-choice--docs">Choice</StorybookDocLink>
-  <StorybookDocLink storyId="components-choicelist--docs">Choice List</StorybookDocLink>
-</StorybookDocLinks>
-
-### Style customization
-
-The following CSS variables can be overridden to customize choice fields:
-
-<ComponentThemeOptions componentname="choice" />
-
-#### Form components
-
-This component also makes use of form field styles, which can be customized by the following variables:
-
-<ComponentThemeOptions componentname="form" />
-
 ## Guidance
 
 ### When to use
@@ -89,6 +68,13 @@ This component also makes use of form field styles, which can be customized by t
 - Add the className `.ds-c-choice__checkedChild--inverse` to the `div` to show the inverse white border
 - You may need to add the className `.ds-u-margin--0` to your child element(s) to avoid extra top margin
 - If you opt for smaller radio buttons or checkboxes, add className `.ds-c-choice__checkedChild--small` to your checked child container
+
+## Accessibility 
+The radio button component handles rendering labels, and if you’re using ChoiceList for a set of controls, will also wrap them in `<fieldset>` to maintain accessibility, and `<legend>` to provide context.
+
+### General accessibility guidance
+- For a single radio button, donʼt use `<fieldset>` and `<legend>`.
+- Use semantic tags. Each input should have a semantic tag for the id attribute, and its corresponding label should have the same value in its for attribute.
 
 ### Accessibility testing
 
@@ -140,6 +126,27 @@ If there are `checkedChildren` being used and...
 - Click/tap target area is a minimum of 24x24px.
 
 Read our [Form Validations guidance](/patterns/Forms/validation/) for communicating to users about form errors and how to fix them.
+
+## Code
+
+### React
+
+<StorybookDocLinks>
+  <StorybookDocLink storyId="components-choice--docs">Choice</StorybookDocLink>
+  <StorybookDocLink storyId="components-choicelist--docs">Choice List</StorybookDocLink>
+</StorybookDocLinks>
+
+### Style customization
+
+The following CSS variables can be overridden to customize choice fields:
+
+<ComponentThemeOptions componentname="choice" />
+
+#### Form components
+
+This component also makes use of form field styles, which can be customized by the following variables:
+
+<ComponentThemeOptions componentname="form" />
 
 ## Related patterns
 


### PR DESCRIPTION
## Summary

- General a11y guidance is added to both the checkbox and radio component (see Jira ticket for content)
- The sections match the order of our [template](https://confluence.cms.gov/display/HCDSG/Doc+Site+Guidance%3A+Information+Architecture)

## How to test

1. Run locally and confirm that the above criteria are met.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone