### PR TITLE
[NO-TICKET] Update check for production to work on the server or client

### DIFF
--- a/packages/docs/src/helpers/urlUtils.ts
+++ b/packages/docs/src/helpers/urlUtils.ts
@@ -73,5 +73,8 @@ export function setQueryParam(name: string, value: string, reloadPage: boolean =
  * @returns boolean - true if we are on prod, aka design.cms.gov, and false otherwise
  */
 export function isProduction(): boolean {
+  if (!window) {
+    return process.env.NODE_ENV === 'production';
+  }
   return location.hostname == 'design.cms.gov';
 }


### PR DESCRIPTION
## Summary

- So yeah Kim had a really good point [here](https://github.com/CMSgov/design-system/pull/3566#discussion_r2079888694) and it bugged me that I didn't properly address it. So in this teeny tiny pr I'm trying to ease my conscience by setting this check to work on both the server and client. Note: this function will be called twice in some cases, since some of our code is both rendered statically at build time and on the client. But that should be ok so long as you aren't doing something like calling 'gatsby serve' locally (gatsby serve passes in 'production' as the node env). 


## How to test

1. Add <ComponentThemeOptions componentname="form" /> to a random markdown page
2. Observe the warning in the console.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone