### PR TITLE
[WNMGDS-3352] added a11y guidance idle timeout

### DIFF
--- a/packages/docs/content/components/idle-timeout.mdx
+++ b/packages/docs/content/components/idle-timeout.mdx
@@ -16,6 +16,19 @@ core:
   minHeight={350}
 />
 
+## Guidance
+
+### When to use
+
+- Use the IdleTimeout for authenticated sessions to force logout after a set amount of time on inactivity
+
+##Accessibility
+
+Idle timeout is a behind-the-scenes function that triggers a modal window using
+the design system’s modal component.
+
+Please refer to the modal component’s [accessibility documentation](https://design.cms.gov/components/modal-dialog/?theme=core#accessibility).
+
 ## Code
 
 ### React
@@ -27,12 +40,6 @@ core:
 The following CSS variables can be overridden to customize Dialog components:
 
 <ComponentThemeOptions componentname="dialog" />
-
-## Guidance
-
-### When to use
-
-- Use the IdleTimeout for authenticated sessions to force logout after a set amount of time on inactivity
 
 ### Related patterns
 

--- a/packages/docs/content/components/idle-timeout.mdx
+++ b/packages/docs/content/components/idle-timeout.mdx
@@ -22,7 +22,7 @@ core:
 
 - Use the IdleTimeout for authenticated sessions to force logout after a set amount of time on inactivity
 
-##Accessibility
+## Accessibility
 
 Idle timeout is a behind-the-scenes function that triggers a modal window using
 the design system’s modal component.

--- a/packages/docs/content/components/idle-timeout.mdx
+++ b/packages/docs/content/components/idle-timeout.mdx
@@ -20,14 +20,14 @@ core:
 
 ### When to use
 
-- Use the IdleTimeout for authenticated sessions to force logout after a set amount of time on inactivity
+- Use the `IdleTimeout` for authenticated sessions to force logout after a set amount of time on inactivity.
 
 ## Accessibility
 
 Idle timeout is a behind-the-scenes function that triggers a modal window using
-the design system’s modal component.
+the design system’s [modal component](/components/modal-dialog/).
 
-Please refer to the modal component’s [accessibility documentation](/components/modal-dialog/#accessibility).
+Please refer to the modal component’s [accessibility documentation](/components/modal-dialog/#accessibility/).
 
 ## Code
 

--- a/packages/docs/content/components/idle-timeout.mdx
+++ b/packages/docs/content/components/idle-timeout.mdx
@@ -27,7 +27,7 @@ core:
 Idle timeout is a behind-the-scenes function that triggers a modal window using
 the design system’s modal component.
 
-Please refer to the modal component’s [accessibility documentation](https://design.cms.gov/components/modal-dialog/?theme=core#accessibility).
+Please refer to the modal component’s [accessibility documentation](/components/modal-dialog/#accessibility).
 
 ## Code
 


### PR DESCRIPTION
## Summary

- Added new accessibility guidance to the idle timeout component page and reordered the sections of content to match our new template
- Jira ticket: [WNMGDS-3352](https://jira.cms.gov/browse/WNMGDS-3352)

## How to test

1. Navigate to idle timeout component page and confirm that the new accessibility guidance is formatted correctly.
2. Confirm that the content sections are ordered correctly on the page.
3. Test the "accessibility documentation" link text works in the new accessibility guidance.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
