### PR TITLE
[NO-TICKET] Fix ds-modal-dialog stories where the modals don't open

### DIFF
--- a/packages/design-system/src/components/web-components/ds-modal-dialog/ds-modal-dialog.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-modal-dialog/ds-modal-dialog.stories.tsx
@@ -27,9 +27,9 @@ const meta: Meta = {
             <ds-button value="rstBtn" class-name="ds-u-margin-right--1">
               Reset
             </ds-button>
-            <ds-button type="submit" value="sbmBtn">
+            <button className="ds-c-button" type="submit" value="sbmBtn">
               Confirm
-            </ds-button>
+            </button>
           </form>
         </span>
       </>
@@ -120,32 +120,54 @@ export default meta;
 
 const Template = (args) => {
   useEffect(() => {
-    const modal = document.querySelector('ds-modal-dialog');
-    const toggleButton = document.getElementById('modal-toggle');
-    const form = modal.querySelector('form[method="dialog"]');
+    const modals = Array.from(document.querySelectorAll('ds-modal-dialog'));
+    const toggleButtons = Array.from(document.querySelectorAll('ds-button'));
+    const forms = Array.from(document.querySelectorAll('form[method="dialog"]'));
 
-    const openModal = () => modal?.setAttribute('is-open', 'true');
-    const closeModal = () => modal?.setAttribute('is-open', 'false');
-
-    const handleExit = (event) => {
-      action('ds-exit')(event);
-      closeModal();
+    const openModal = (event) => {
+      const modal = document.getElementById(event.target.dataset.id);
+      modal?.setAttribute('is-open', 'true');
     };
 
-    modal?.addEventListener('ds-exit', handleExit);
-    toggleButton?.addEventListener('click', openModal);
-    form?.addEventListener('submit', closeModal);
+    const closeModal = (event) => {
+      action('ds-exit')(event);
+      let modal: Element;
+      if (event.target.tagName == 'FORM') {
+        modal = event.target.closest('ds-modal-dialog');
+      } else {
+        modal = document.getElementById(event.target.id);
+      }
+      modal?.setAttribute('is-open', 'false');
+    };
+
+    modals?.forEach((modal) => {
+      modal.addEventListener('ds-exit', closeModal);
+    });
+    toggleButtons?.forEach((button) => {
+      button.addEventListener('click', openModal);
+    });
+    forms?.forEach((form) => {
+      form.addEventListener('submit', closeModal);
+    });
 
     return () => {
-      modal?.removeEventListener('ds-exit', handleExit);
-      toggleButton?.removeEventListener('click', openModal);
-      form?.removeEventListener('submit', closeModal);
+      modals?.forEach((modal) => {
+        modal.removeEventListener('ds-exit', closeModal);
+      });
+      toggleButtons?.forEach((button) => {
+        button.removeEventListener('click', openModal);
+      });
+      forms?.forEach((form) => {
+        form.removeEventListener('submit', closeModal);
+      });
     };
   });
 
   return (
     <>
-      <ds-button id="modal-toggle">Open Modal</ds-button>
+      <ds-button id={`modal_toggle__${args.id}`} data-id={args.id}>
+        Open Modal
+      </ds-button>
       <ds-modal-dialog {...args}></ds-modal-dialog>
     </>
   );
@@ -155,6 +177,7 @@ export const Default = {
   render: Template,
   args: {
     alert: 'false',
+    id: '100',
   },
 };
 
@@ -164,6 +187,7 @@ export const BackdropClickExits = {
     alert: 'false',
     'backdrop-click-exits': 'true',
     heading: 'Dialog Heading',
+    id: '200',
   },
 };
 
@@ -233,5 +257,6 @@ export const PreventScrollExample = {
       </div>
     ),
     heading: 'Dialog Heading',
+    id: '300',
   },
 };


### PR DESCRIPTION
## Summary

- Modal dialogs don't open on the main documentation page for the modal dialog! Ack!
- This is due to how we're initially querying the DOM in our useEffect, we're only grabbing the first modal, button and form when really we ought to be grabbing all of them and then tying the opening and closing of the modal to the supplied id. There's a bit of checking for whether we're using a Form element or the dialog to close things, but that's a pretty minor check.

## How to test

1. Pull this down locally
2. Build & run storybook
3. Go to the ds-modal-dialog story and open and close all of the modals. Only one modal should open at a time and all should be closable.
4. Confirm that the modals open and close as expected in the specific story pages as well.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone