### PR TITLE
[NO-TICKET] Remove useRef and useEffect from Layout.tsx to correct analytics functioning

### DIFF
--- a/packages/docs/src/components/layout/Layout.tsx
+++ b/packages/docs/src/components/layout/Layout.tsx
@@ -1,5 +1,4 @@
 import type * as React from 'react';
-import { useEffect, useRef } from 'react';
 import Footer from './DocSiteFooter';
 import SideNav from './SideNav/SideNav';
 import PageHeader from './PageHeader';
@@ -69,44 +68,41 @@ const Layout = ({
   theme,
   tableOfContentsData,
 }: LayoutProps) => {
-  // Using a ref here because this value shouldn't change after the initial render.
-  const env = useRef('' as 'dev' | 'github-demo' | 'prod');
+  let env: 'dev' | 'github-demo' | 'prod';
   const baseTitle = theme === 'core' ? 'CMS Design System' : getThemeData(theme).longName;
   const tabTitle = frontmatter?.title ? `${frontmatter.title} - ${baseTitle}` : baseTitle;
 
   const pageId = slug ? `page--${slug.replace('/', '_')}` : null;
 
-  useEffect(() => {
-    if (window && (window as UtagContainer)?.utag) {
-      // We can define environment names as we wish
-      // github-demo is a demo deployment off of a specific branch.
-      switch (location.hostname) {
-        case 'localhost':
-          env.current = 'dev';
-          break;
-        case 'cmsgov.github.io':
-          env.current = 'github-demo';
-          break;
-        case 'design.cms.gov':
-          env.current = 'prod';
-          break;
-        default:
-          env.current = 'prod';
-      }
-
-      const analyticsPayload = {
-        content_language: 'en',
-        content_type: 'html',
-        logged_in: 'false',
-        page_name: tabTitle,
-        page_type: tabTitle.includes('Page not found') ? 'true' : 'false', //If page is a 404 (error page) this is set to true, otherwise it is false
-        site_environment: env.current, //Used to include or exclude traffic from different testing environments. Ex: test, test0, imp, production
-        site_section: location.pathname == '/' ? 'index' : location.pathname, // Set the section to the pathname, except in the case of the index.
-      } as any;
-
-      sendViewEvent(analyticsPayload);
+  if (window && (window as UtagContainer)?.utag) {
+    // We can define environment names as we wish
+    // github-demo is a demo deployment off of a specific branch.
+    switch (location.hostname) {
+      case 'localhost':
+        env = 'dev';
+        break;
+      case 'cmsgov.github.io':
+        env = 'github-demo';
+        break;
+      case 'design.cms.gov':
+        env = 'prod';
+        break;
+      default:
+        env = 'prod';
     }
-  }, []);
+
+    const analyticsPayload = {
+      content_language: 'en',
+      content_type: 'html',
+      logged_in: 'false',
+      page_name: tabTitle,
+      page_type: tabTitle.includes('Page not found') ? 'true' : 'false', //If page is a 404 (error page) this is set to true, otherwise it is false
+      site_environment: env, //Used to include or exclude traffic from different testing environments. Ex: test, test0, imp, production
+      site_section: location.pathname == '/' ? 'index' : location.pathname, // Set the section to the pathname, except in the case of the index.
+    } as any;
+
+    sendViewEvent(analyticsPayload);
+  }
 
   return (
     <div data-theme={theme} id={pageId}>
@@ -135,10 +131,8 @@ const Layout = ({
               : 'The CMS Design System is a set of open source design and front-end development resources for creating Section 508 compliant, responsive, and consistent websites.'
           }
         />
-        <script>{`window.tealiumEnvironment = "${env.current}";`}</script>
-        <script
-          src={`https://tealium-tags.cms.gov/cms-design/${env.current}/utag.sync.js`}
-        ></script>
+        <script>{`window.tealiumEnvironment = "${env}";`}</script>
+        <script src={`https://tealium-tags.cms.gov/cms-design/${env}/utag.sync.js`}></script>
         <script type="text/javascript">
           {'window.utag_cfg_ovrd = window.utag_cfg_ovrd || {}; window.utag_cfg_ovrd.noview = true;'}
         </script>

--- a/packages/docs/src/components/layout/Layout.tsx
+++ b/packages/docs/src/components/layout/Layout.tsx
@@ -74,7 +74,7 @@ const Layout = ({
 
   const pageId = slug ? `page--${slug.replace('/', '_')}` : null;
 
-  if (window && (window as UtagContainer)?.utag) {
+  if (typeof window !== 'undefined' && (window as UtagContainer)?.utag) {
     // We can define environment names as we wish
     // github-demo is a demo deployment off of a specific branch.
     switch (location.hostname) {


### PR DESCRIPTION
## Summary

The env variable is not being set properly on page load which is preventing our analytics script from working properly.

What I wanted to happen:
useEffect runs once on page load and updates the ref to the current environment, which then makes it’s way into the <head> element.

What is actually happening:
useEffect runs after page load and sets the ref value, but the page has already been rendered with null env variable from the initialized ref. Since it’s a ref, no rerender is scheduled and the updated value never makes it to the DOM.

I should've known this is what would happen. Anyway this change should fix it and will be released to the Doc site upon approval.

## How to test

1. Same as in https://github.com/CMSgov/design-system/pull/3559
2. Confirm that there is a line in the <head> element that reads: <script data-react-helmet="true">window.tealiumEnvironment = "dev";</script> when testing locally.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone
