### PR TITLE
[NO-TICKET] Add in UTAG page view analytics

### DIFF
--- a/packages/docs/src/components/layout/Layout.tsx
+++ b/packages/docs/src/components/layout/Layout.tsx
@@ -14,7 +14,6 @@ import {
   TableOfContentsItem,
 } from '../../helpers/graphQLTypes';
 import { withPrefix } from 'gatsby';
-import { UtagContainer } from '@cmsgov/design-system';
 import { sendViewEvent } from '@cmsgov/design-system';
 
 import '../../styles/index.scss';
@@ -76,7 +75,7 @@ const Layout = ({
   const pageId = slug ? `page--${slug.replace('/', '_')}` : null;
 
   useEffect(() => {
-    if (env !== undefined) {
+    if (env) {
       const analyticsPayload = {
         content_language: 'en',
         content_type: 'html',
@@ -89,7 +88,7 @@ const Layout = ({
 
       sendViewEvent(analyticsPayload);
     }
-  }, [env, location.pathname, location.hostname, tabTitle]);
+  }, [env, location.pathname, tabTitle]);
 
   useEffect(() => {
     // We can define environment names as we wish
@@ -107,7 +106,7 @@ const Layout = ({
       default:
         setEnv('prod');
     }
-  }, [env, location.hostname]);
+  }, [location.hostname]);
 
   useEffect(() => {
     if (typeof window != 'undefined' && 'tealiumEnvironment' in window) {

--- a/packages/docs/src/components/layout/Layout.tsx
+++ b/packages/docs/src/components/layout/Layout.tsx
@@ -1,5 +1,4 @@
 import type * as React from 'react';
-import { useEffect, useRef } from 'react';
 import Footer from './DocSiteFooter';
 import SideNav from './SideNav/SideNav';
 import PageHeader from './PageHeader';
@@ -69,44 +68,41 @@ const Layout = ({
   theme,
   tableOfContentsData,
 }: LayoutProps) => {
-  // Using a ref here because this value shouldn't change after the initial render.
-  const env = useRef('' as 'dev' | 'github-demo' | 'prod');
+  let env: 'dev' | 'github-demo' | 'prod';
   const baseTitle = theme === 'core' ? 'CMS Design System' : getThemeData(theme).longName;
   const tabTitle = frontmatter?.title ? `${frontmatter.title} - ${baseTitle}` : baseTitle;
 
   const pageId = slug ? `page--${slug.replace('/', '_')}` : null;
 
-  useEffect(() => {
-    if (window && (window as UtagContainer)?.utag) {
-      // We can define environment names as we wish
-      // github-demo is a demo deployment off of a specific branch.
-      switch (location.hostname) {
-        case 'localhost':
-          env.current = 'dev';
-          break;
-        case 'cmsgov.github.io':
-          env.current = 'github-demo';
-          break;
-        case 'design.cms.gov':
-          env.current = 'prod';
-          break;
-        default:
-          env.current = 'prod';
-      }
-
-      const analyticsPayload = {
-        content_language: 'en',
-        content_type: 'html',
-        logged_in: 'false',
-        page_name: tabTitle,
-        page_type: tabTitle.includes('Page not found') ? 'true' : 'false', //If page is a 404 (error page) this is set to true, otherwise it is false
-        site_environment: env.current, //Used to include or exclude traffic from different testing environments. Ex: test, test0, imp, production
-        site_section: location.pathname == '/' ? 'index' : location.pathname, // Set the section to the pathname, except in the case of the index.
-      } as any;
-
-      sendViewEvent(analyticsPayload);
+  if (window && (window as UtagContainer)?.utag) {
+    // We can define environment names as we wish
+    // github-demo is a demo deployment off of a specific branch.
+    switch (location.hostname) {
+      case 'localhost':
+        env = 'dev';
+        break;
+      case 'cmsgov.github.io':
+        env = 'github-demo';
+        break;
+      case 'design.cms.gov':
+        env = 'prod';
+        break;
+      default:
+        env = 'prod';
     }
-  }, []);
+
+    const analyticsPayload = {
+      content_language: 'en',
+      content_type: 'html',
+      logged_in: 'false',
+      page_name: tabTitle,
+      page_type: tabTitle.includes('Page not found') ? 'true' : 'false', //If page is a 404 (error page) this is set to true, otherwise it is false
+      site_environment: env, //Used to include or exclude traffic from different testing environments. Ex: test, test0, imp, production
+      site_section: location.pathname == '/' ? 'index' : location.pathname, // Set the section to the pathname, except in the case of the index.
+    } as any;
+
+    sendViewEvent(analyticsPayload);
+  }
 
   return (
     <div data-theme={theme} id={pageId}>
@@ -135,10 +131,8 @@ const Layout = ({
               : 'The CMS Design System is a set of open source design and front-end development resources for creating Section 508 compliant, responsive, and consistent websites.'
           }
         />
-        <script>{`window.tealiumEnvironment = "${env.current}";`}</script>
-        <script
-          src={`https://tealium-tags.cms.gov/cms-design/${env.current}/utag.sync.js`}
-        ></script>
+        <script>{`window.tealiumEnvironment = "${env}";`}</script>
+        <script src={`https://tealium-tags.cms.gov/cms-design/${env}/utag.sync.js`}></script>
         <script type="text/javascript">
           {'window.utag_cfg_ovrd = window.utag_cfg_ovrd || {}; window.utag_cfg_ovrd.noview = true;'}
         </script>

--- a/packages/docs/src/components/layout/Layout.tsx
+++ b/packages/docs/src/components/layout/Layout.tsx
@@ -74,7 +74,7 @@ const Layout = ({
 
   const pageId = slug ? `page--${slug.replace('/', '_')}` : null;
 
-  if (window && (window as UtagContainer)?.utag) {
+  if (typeof window !== 'undefined' && (window as UtagContainer)?.utag) {
     // We can define environment names as we wish
     // github-demo is a demo deployment off of a specific branch.
     switch (location.hostname) {


### PR DESCRIPTION
## Summary

So this has been a little bit of a saga.

In #3559 I attempted to add some new analytics functionality for page views. This didn't really work because of my use of a ref to store the env variable.
In #3591 I tried to simplify things and get all the work done outside of a useEffect, just in the script. But since I didn't understand the fineries of how Gatsby does server rendering (and some of the distinctions between Gatsby's development and production build processes) we end up with an undefined variable on production (thank you @tamara-corbalt for catching).
Rolled #3591 back in #3592 and so now here we are going back to the original client side implementation with some more sophistication (thank you @kim-cmsds). 

Anyway, here we are.

## How to test

1. The best way to test is using the debugger built into your Browser of choice, for Firefox:
2. Open the doc site locally
3. Open dev tools and go to the Debugger tab
4. Press "Command + P" and search for "utag.js"
5. When that file is opened, search "Command + F" for track:
6. Place a break point at the line following the definition of the track function
7. Click on a component, and then click on the Storybook link at the top of the page
8. In the Browser console, type "a"
9. Look at the associated object, and expand it to see the data property on that object
10. Note that for any link you click you will trigger a link event, to see this fire on page load you need to step past that break using the debugger
10. Confirm that the object contains a field that says "view", along with a "page_name" equal to the name of the page plus the theme name. 
11. Confirm that the environment is correct in both development (should be 'dev') and when running `gatsby server` (should be 'prod')

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
