### PR TITLE
[WNMGDS-3360] Add `StatusIndicator` component to docs. 

### DIFF
--- a/packages/docs/src/components/layout/StatusIndicator.tsx
+++ b/packages/docs/src/components/layout/StatusIndicator.tsx
@@ -1,0 +1,54 @@
+import { Badge, AlertIcon, CheckIcon } from '@cmsgov/design-system';
+import { StatusInterface } from '../../helpers/graphQLTypes';
+import React from 'react';
+
+type StatusLevel = StatusInterface['level'];
+
+interface StatusIndicatorProps {
+  level: StatusLevel;
+}
+
+const statusConfig: Record<
+  StatusLevel,
+  {
+    variation: 'success' | 'warn' | 'alert';
+    label: string;
+    Icon: React.ElementType;
+    className: string;
+  }
+> = {
+  use: {
+    variation: 'success',
+    label: 'Use',
+    Icon: CheckIcon,
+    className: 'ds-u-margin-right--1',
+  },
+  caution: {
+    variation: 'warn',
+    label: 'Caution',
+    Icon: AlertIcon,
+    className: '',
+  },
+  avoid: {
+    variation: 'alert',
+    label: 'Avoid',
+    Icon: AlertIcon,
+    className: '',
+  },
+};
+
+export const StatusIndicator: React.FC<StatusIndicatorProps> = ({ level }) => {
+  const { variation, label, Icon, className } = statusConfig[level];
+
+  return (
+    <Badge variation={variation} className="ds-u-display--inline-flex ds-u-align-items--center">
+      <Icon
+        className={className}
+        style={{ fontSize: '1em', height: '1em', width: '1em', verticalAlign: 'text-bottom' }}
+      />
+      {label}
+    </Badge>
+  );
+};
+
+export default StatusIndicator;

--- a/packages/docs/src/components/layout/StatusIndicator.tsx
+++ b/packages/docs/src/components/layout/StatusIndicator.tsx
@@ -1,5 +1,4 @@
 import { Badge, AlertIcon, CheckIcon } from '@cmsgov/design-system';
-import { BadgeVariation } from '@cmsgov/design-system/dist/react-components/types/Badge/Badge.js';
 import { StatusInterface } from '../../helpers/graphQLTypes';
 import React from 'react';
 
@@ -12,7 +11,9 @@ interface StatusIndicatorProps {
 const statusConfig: Record<
   StatusLevel,
   {
-    variation: BadgeVariation;
+    // Inlined from the `BadgeVariation` type to avoid deep import from @cmsgov/design-system.
+    // Update this if `BadgeVariation` changes.
+    variation: 'info' | 'success' | 'warn' | 'alert';
     label: string;
     Icon: React.ElementType;
     iconClassName?: string;

--- a/packages/docs/src/components/layout/StatusIndicator.tsx
+++ b/packages/docs/src/components/layout/StatusIndicator.tsx
@@ -1,4 +1,5 @@
 import { Badge, AlertIcon, CheckIcon } from '@cmsgov/design-system';
+import { BadgeVariation } from '@cmsgov/design-system/dist/react-components/types/Badge/Badge.js';
 import { StatusInterface } from '../../helpers/graphQLTypes';
 import React from 'react';
 
@@ -11,39 +12,37 @@ interface StatusIndicatorProps {
 const statusConfig: Record<
   StatusLevel,
   {
-    variation: 'success' | 'warn' | 'alert';
+    variation: BadgeVariation;
     label: string;
     Icon: React.ElementType;
-    className: string;
+    iconClassName?: string;
   }
 > = {
   use: {
     variation: 'success',
     label: 'Use',
     Icon: CheckIcon,
-    className: 'ds-u-margin-right--1',
+    iconClassName: 'ds-u-margin-right--1',
   },
   caution: {
     variation: 'warn',
     label: 'Caution',
     Icon: AlertIcon,
-    className: '',
   },
   avoid: {
     variation: 'alert',
     label: 'Avoid',
     Icon: AlertIcon,
-    className: '',
   },
 };
 
 export const StatusIndicator: React.FC<StatusIndicatorProps> = ({ level }) => {
-  const { variation, label, Icon, className } = statusConfig[level];
+  const { variation, label, Icon, iconClassName } = statusConfig[level];
 
   return (
     <Badge variation={variation} className="ds-u-display--inline-flex ds-u-align-items--center">
       <Icon
-        className={className}
+        className={iconClassName}
         style={{ fontSize: '1em', height: '1em', width: '1em', verticalAlign: 'text-bottom' }}
       />
       {label}

--- a/packages/docs/src/helpers/graphQLTypes.ts
+++ b/packages/docs/src/helpers/graphQLTypes.ts
@@ -22,6 +22,11 @@ export interface LocationInterface {
   origin?: string;
 }
 
+export interface StatusInterface {
+  level: 'use' | 'caution' | 'avoid';
+  note?: string;
+}
+
 export interface FrontmatterInterface {
   title: string;
   date?: string;
@@ -30,6 +35,7 @@ export interface FrontmatterInterface {
   healthcare?: ComponentLinksInterface;
   medicare?: ComponentLinksInterface;
   intro?: string;
+  status?: StatusInterface;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `StatusIndicator` components from [pr-3595](https://github.com/CMSgov/design-system/pull/3595), omitting any logic that wires it into the `PageHeader` while we wait for content approval on status badge text and contextual alerts.

[Jira ticket](https://jira.cms.gov/browse/WNMGDS-3360)

## Testing Steps
- Confirm the doc site builds locally without errors.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone