### PR TITLE
[NO-TICKET] Doc Site Analytics - set environment at build time not on the client

### DIFF
--- a/packages/docs/src/components/layout/Layout.tsx
+++ b/packages/docs/src/components/layout/Layout.tsx
@@ -68,51 +68,29 @@ const Layout = ({
   theme,
   tableOfContentsData,
 }: LayoutProps) => {
-  const [env, setEnv] = useState<'dev' | 'github-demo' | 'prod' | undefined>(undefined);
+  const env = process.env.NODE_ENV === 'production' ? 'prod' : 'dev';
   const baseTitle = theme === 'core' ? 'CMS Design System' : getThemeData(theme).longName;
   const tabTitle = frontmatter?.title ? `${frontmatter.title} - ${baseTitle}` : baseTitle;
 
   const pageId = slug ? `page--${slug.replace('/', '_')}` : null;
 
-  useEffect(() => {
-    if (env) {
-      const analyticsPayload = {
-        content_language: 'en',
-        content_type: 'html',
-        logged_in: 'false',
-        page_name: tabTitle,
-        page_type: tabTitle.includes('Page not found') ? 'true' : 'false', //If page is a 404 (error page) this is set to true, otherwise it is false
-        site_environment: env, //Used to include or exclude traffic from different testing environments. Ex: test, test0, imp, production
-        site_section: location.pathname == '/' ? 'index' : location.pathname, // Set the section to the pathname, except in the case of the index.
-      } as any;
-
-      sendViewEvent(analyticsPayload);
-    }
-  }, [env, location.pathname, tabTitle]);
+  if (typeof window != 'undefined' && 'tealiumEnvironment' in window) {
+    window.tealiumEnvironment = env;
+  }
 
   useEffect(() => {
-    // We can define environment names as we wish
-    // github-demo is a demo deployment off of a specific branch.
-    switch (location.hostname) {
-      case 'localhost':
-        setEnv('dev');
-        break;
-      case 'cmsgov.github.io':
-        setEnv('github-demo');
-        break;
-      case 'design.cms.gov':
-        setEnv('prod');
-        break;
-      default:
-        setEnv('prod');
-    }
-  }, [location.hostname]);
+    const analyticsPayload = {
+      content_language: 'en',
+      content_type: 'html',
+      logged_in: 'false',
+      page_name: tabTitle,
+      page_type: tabTitle.includes('Page not found') ? 'true' : 'false', //If page is a 404 (error page) this is set to true, otherwise it is false
+      site_environment: env, //Used to include or exclude traffic from different testing environments. Ex: test, test0, imp, production
+      site_section: location.pathname == '/' ? 'index' : location.pathname, // Set the section to the pathname, except in the case of the index.
+    } as any;
 
-  useEffect(() => {
-    if (typeof window != 'undefined' && 'tealiumEnvironment' in window) {
-      window.tealiumEnvironment = env;
-    }
-  }, [env]);
+    sendViewEvent(analyticsPayload);
+  }, [location.pathname, tabTitle]);
 
   return (
     <div data-theme={theme} id={pageId}>


### PR DESCRIPTION
## Summary

- We now set the env variable once, at build time.
- It doesn't need to be in state, since it won't change.
- We no longer alter the env value in an effect, because it has been set already at build time. One small caveat of this is that we are not longer checking for other testing environments. We can handle that when we have a dev env set up.
- Another note: we will get `prod` as an env value if you run `gatsby serve` locally. 

## How to test

1. The best way to test is using the debugger built into your Browser of choice, for Firefox:
2. Open the doc site locally
3. Open dev tools and go to the Debugger tab
4. Press "Command + P" and search for "utag.js"
5. When that file is opened, search "Command + F" for track:
6. Place a break point at the line following the definition of the track function
7. Click on a component, and then click on the Storybook link at the top of the page
8. In the Browser console, type "a"
9. Look at the associated object, and expand it to see the data property on that object
10. Note that for any link you click you will trigger a link event, to see this fire on page load you need to step past that break using the debugger
11. Confirm that the object contains a field that says "view", along with a "page_name" equal to the name of the page plus the theme name.
12. Confirm that the environment is correct in both development (should be 'dev') and when running gatsby server (should be 'prod')

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone