### PR TITLE
[NO-TICKET] Clean up ds-drawer story

### DIFF
--- a/.storybook/docs/NoStoryWebComponentDocTemplate.mdx
+++ b/.storybook/docs/NoStoryWebComponentDocTemplate.mdx
@@ -1,0 +1,21 @@
+import { Meta, Title, Subtitle, Description, Primary, Stories } from '@storybook/blocks';
+import { WebComponentAttrs } from './WebComponentAttrs';
+import { WebComponentArgsTable } from './WebComponentArgsTable';
+import { WebComponentEventsTable } from './WebComponentEventsTable';
+import { WebComponentSlotsTable } from './WebComponentSlotsTable';
+
+<Meta isTemplate />
+
+<Title />
+<Subtitle />
+
+<Description />
+
+## Attributes
+
+<WebComponentArgsTable />
+<WebComponentAttrs />
+
+<WebComponentSlotsTable />
+
+<WebComponentEventsTable />

--- a/packages/design-system/src/components/web-components/ds-drawer/ds-drawer.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-drawer/ds-drawer.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta } from '@storybook/react';
 import { useEffect, useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import WebComponentDocTemplate from '../../../../../../.storybook/docs/WebComponentDocTemplate.mdx';
 import { webComponentDecorator } from '../storybook';
+import NoStoryWebComponentDocTemplate from '../../../../../../.storybook/docs/NoStoryWebComponentDocTemplate.mdx';
 import './ds-drawer';
 import '../ds-button';
 
@@ -11,7 +11,7 @@ const meta: Meta = {
   decorators: [webComponentDecorator],
   parameters: {
     docs: {
-      page: WebComponentDocTemplate,
+      page: NoStoryWebComponentDocTemplate,
       description: {
         component:
           'For information about how and when to use this component, [refer to its full documentation page](https://design.cms.gov/components/drawer/).',
@@ -129,12 +129,6 @@ const drawerContent = (
 
 const Template = (args) => {
   const [drawerOpen, setDrawerOpen] = useState(args['is-open'] ?? false);
-
-  useEffect(() => {
-    if (args['is-open'] !== drawerOpen) {
-      setDrawerOpen(args['is-open'] ?? false);
-    }
-  }, []);
 
   useEffect(() => {
     const drawerElement = document.querySelector('ds-drawer');


### PR DESCRIPTION
## Summary

Our Drawer story hides the demonstrations on the landing page via a `NoStoryDocTemplate.mdx` file. I initially tried to follow the procedure I did for the ds-modal stories, but realized that
a. The solution I had was more brittle as it relied on a particular DOM structure
b. The ds-drawer elements looked weird rendering in tine iFrames
c. The Drawer component stories are hidden on the doc page for similar display issues

So I followed that route and created a new template for this one. Open to suggestions!

## How to test

1. ds-drawer stories should not display on the doc page but should display and function normally on the subsequent stories

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone