### PR TITLE
[WNMGDS-3356] Add redirect for text field page

### DIFF
--- a/packages/docs/redirects.json
+++ b/packages/docs/redirects.json
@@ -10,5 +10,9 @@
   {
     "fromPath": "/guidelines/browser-support/",
     "toPath": "/guidelines/support-policies/"
+  },
+  {
+    "fromPath": "/components/text-field/",
+    "toPath": "/components/text-field/text-field/"
   }
 ]


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/WNMGDS-3356)

## How to test

1. Locally, run `npm run build` within the /packages/docs directory
2. Run `npm run serve`
3. Try to navigate to `http://localhost:9000/components/text-field` - you should be redirected to `http://localhost:9000/components/text-field/text-field`
4. Our dev server isn't setup to handle redirects, so you need to imitate a production build

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone