### PR TITLE
[WNMGDS-3416] Fix broken link to Typography page

### DIFF
--- a/packages/docs/content/foundation/layout-grid/responsive-design.mdx
+++ b/packages/docs/content/foundation/layout-grid/responsive-design.mdx
@@ -9,13 +9,13 @@ The design system's layout, utility, and typography classes are built with respo
 
 Use the breakpoint prefixes `sm`, `md`, `lg`, and `xl` to apply styles at different viewport sizes. For example: `.ds-u-lg-display--none` sets an element's `display` property to `none` when the viewport is `1024px` or wider.
 
-| Prefix | Breakpoint          | Sass variable       | Description                  |
-| ------ | ------------------- | ------------------- | ---------------------------- |
-|        | `min-width(0px)`    | `$media-width-xs`   | Viewports `0px` and wider    |
-| `sm`   | `min-width(544px)`  | `$media-width-sm`   | Viewports `544px` and wider  |
-| `md`   | `min-width(768px)`  | `$media-width-md`   | Viewports `768px` and wider  |
-| `lg`   | `min-width(1024px)` | `$media-width-lg`   | Viewports `1024px` and wider |
-| `xl`   | `min-width(1280px)` | `$media-width-xl`   | Viewports `1280px` and wider |
+| Prefix | Breakpoint          | Sass variable     | Description                  |
+| ------ | ------------------- | ----------------- | ---------------------------- |
+|        | `min-width(0px)`    | `$media-width-xs` | Viewports `0px` and wider    |
+| `sm`   | `min-width(544px)`  | `$media-width-sm` | Viewports `544px` and wider  |
+| `md`   | `min-width(768px)`  | `$media-width-md` | Viewports `768px` and wider  |
+| `lg`   | `min-width(1024px)` | `$media-width-lg` | Viewports `1024px` and wider |
+| `xl`   | `min-width(1280px)` | `$media-width-xl` | Viewports `1280px` and wider |
 
 ### What supports a breakpoint prefix
 
@@ -29,7 +29,7 @@ In order to reduce code bloat, not everything supports a breakpoint prefix. Only
 - [Margin](/utilities/margin#responsive-margins)
 - [Padding](/utilities/padding#responsive-padding)
 - [Text align](/utilities/text/text-align#responsive-text-alignment)
-- [Typography](/foundation/typography#responsive-typography)
+- [Typography](/foundation/typography/overview#responsive-typography)
 - [Visibility](/utilities/visibility#responsive-visibility)
 
 Additional usage examples are available on the pages listed above.


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/WNMGDS-3416)
- Fixes broken link

## How to test

1. Navigate to /foundation/layout-grid/responsive-design/ 
2. Click the 'Typography' link near the bottom of the page
3. Make sure it goes to /foundation/typography/overview (in theory it should go to #responsive-typography but the theme query breaks it :( )

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone