### PR TITLE
[WNMGDS-3414] Fix Textfield regex patterns

### DIFF
--- a/packages/design-system/src/components/TextField/Mask.test.tsx
+++ b/packages/design-system/src/components/TextField/Mask.test.tsx
@@ -48,7 +48,7 @@ describe('Mask', function () {
     const input = screen.getByRole('textbox');
     expect(input.classList).toContain('ds-c-field--ssn');
     expect(input).toHaveAttribute('type', 'text');
-    expect(input).toHaveAttribute('pattern', '[0-9-*]*');
+    expect(input).toHaveAttribute('pattern', '[0-9\\-*]*');
     expect(input).toHaveAttribute('inputmode', 'numeric');
   });
 
@@ -63,7 +63,7 @@ describe('Mask', function () {
     const input = screen.getByRole('textbox');
     expect(input.classList).toContain('ds-c-field--currency');
     expect(input).toHaveAttribute('type', 'text');
-    expect(input).toHaveAttribute('pattern', '[0-9.,-]*');
+    expect(input).toHaveAttribute('pattern', '[0-9.,\\-]*');
     expect(input).toHaveAttribute('inputmode', 'numeric');
   });
 

--- a/packages/design-system/src/components/TextField/Mask.tsx
+++ b/packages/design-system/src/components/TextField/Mask.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 import { Children, PureComponent, cloneElement, isValidElement } from 'react';
 import type * as React from 'react';
 import classNames from 'classnames';
@@ -6,11 +7,15 @@ import { maskValue, unmaskValue } from './maskHelpers';
 // TODO: Remove `maskValue` and `unmaskValue` exports with next major release (v3.x.x)
 export { maskValue, unmaskValue };
 
+/**
+ * Note: Chrome appends a /v modifier to regular expressions, which enables all unicode character set features. As a result,
+ * - and { } characters must be escaped.
+ */
 const maskPattern = {
-  phone: '[0-9-]*',
-  ssn: '[0-9-*]*',
-  zip: '[0-9-]*',
-  currency: '[0-9.,-]*',
+  phone: '[0-9\\-]*',
+  ssn: '[0-9\\-*]*',
+  zip: '[0-9\\-]*',
+  currency: '[0-9.,\\-]*',
 };
 
 const maskOverlayContent = {


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/CMSDS-3414)
- Problem: Chrome appends a `/v` modifier to pattern regexes. This means we need to escape certain characters. This modifier leads to the following console error:
Pattern attribute value [0-9-]* is not a valid regular expression: Uncaught SyntaxError: Invalid regular expression: /[0-9-]*/v: Invalid character class

By escaping the `-` and `{}` characters we prevent this error. Note there is a double escape character because the regexes are turned into strings, and the original escape character is removed.

## How to test

1. Run locally
2. Go to the `components-textfield--all-masked-fields` story under TextField in Storybook
3. Confirm there is no console error.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone