### PR TITLE
[WNMGDS-3412] Add Analytics Support to Tooltip

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -147,6 +147,7 @@ const analyticsSettingsDecorator = (Story, context) => {
     headerSendsAnalytics: on,
     footerSendsAnalytics: on,
     thirdPartyExternalLinkSendsAnalytics: on,
+    tooltipSendsAnalytics: on,
   });
 
   return <Story {...context} />;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15233,6 +15233,14 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
+      "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@inquirer/input": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-1.2.8.tgz",
@@ -41644,104 +41652,6 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
-    "node_modules/inquirer": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.2.tgz",
-      "integrity": "sha512-VV2ZOZe4ilLlOgEo7drIdzbi+EYJcNty0leF2vJq49zOW8+IoK1miJ+V5FjZY/X21Io29j66T/AiqHvS4tPIrw==",
-      "dependencies": {
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^5.2.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^4.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^5.0.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "1.0.0",
-        "ora": "^5.4.1",
-        "run-async": "^2.4.0",
-        "rxjs": "^7.8.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^7.0.1",
-        "through": "^2.3.6",
-        "wrap-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/inquirer/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/inquirer/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/inquirer/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/inquirer/node_modules/figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
-      "dependencies": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/inquirer/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/inquirer/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/internal-slot": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
@@ -42225,6 +42135,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -42579,6 +42490,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -45037,6 +44949,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -47356,6 +47269,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
       "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -48295,6 +48209,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
       "dependencies": {
         "bl": "^4.1.0",
         "chalk": "^4.1.0",
@@ -58402,6 +58317,13 @@
       "integrity": "sha512-Ia0sQNrMPXXkqVFt6w6M1n1oKo3NfKs+mvaV811Jwir7vAk9a6PVV9VPYf6X3BU97QiLEmuW3uXH9u87zDFfdw==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/unenv": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.10.0.tgz",
@@ -61549,7 +61471,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
       "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -61844,7 +61765,7 @@
         "ev-emitter": "^1.1.1",
         "focus-trap-react": "^10.0.0",
         "globby": "^13.1.2",
-        "inquirer": "^9.0.2",
+        "inquirer": "^12.6.3",
         "lodash": "^4.17.21",
         "ora": "^6.1.2",
         "preact": "10.11.3",
@@ -61871,6 +61792,299 @@
         "@types/node": "^17.0.22",
         "tsx": "^4.19.2",
         "typescript": "^5.4.3"
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/checkbox": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.8.tgz",
+      "integrity": "sha512-d/QAsnwuHX2OPolxvYcgSj7A9DO9H6gVOy2DvBTx+P2LH2iRTo/RSGV3iwCzW024nP9hw98KIuDmdyhZQj1UQg==",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/confirm": {
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.12.tgz",
+      "integrity": "sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/core": {
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
+      "integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/editor": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.13.tgz",
+      "integrity": "sha512-WbicD9SUQt/K8O5Vyk9iC2ojq5RHoCLK6itpp2fHsWe44VxxcA9z3GTWlvjSTGmMQpZr+lbVmrxdHcumJoLbMA==",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/expand": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.15.tgz",
+      "integrity": "sha512-4Y+pbr/U9Qcvf+N/goHzPEXiHH8680lM3Dr3Y9h9FFw4gHS+zVpbj8LfbKWIb/jayIB4aSO4pWiBTrBYWkvi5A==",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/input": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.12.tgz",
+      "integrity": "sha512-xJ6PFZpDjC+tC1P8ImGprgcsrzQRsUh9aH3IZixm1lAZFK49UGHxM3ltFfuInN2kPYNfyoPRh+tU4ftsjPLKqQ==",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/number": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.15.tgz",
+      "integrity": "sha512-xWg+iYfqdhRiM55MvqiTCleHzszpoigUpN5+t1OMcRkJrUrw7va3AzXaxvS+Ak7Gny0j2mFSTv2JJj8sMtbV2g==",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/password": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.15.tgz",
+      "integrity": "sha512-75CT2p43DGEnfGTaqFpbDC2p2EEMrq0S+IRrf9iJvYreMy5mAWj087+mdKyLHapUEPLjN10mNvABpGbk8Wdraw==",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/prompts": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.3.tgz",
+      "integrity": "sha512-8YL0WiV7J86hVAxrh3fE5mDCzcTDe1670unmJRz6ArDgN+DBK1a0+rbnNWp4DUB5rPMwqD5ZP6YHl9KK1mbZRg==",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.1.8",
+        "@inquirer/confirm": "^5.1.12",
+        "@inquirer/editor": "^4.2.13",
+        "@inquirer/expand": "^4.0.15",
+        "@inquirer/input": "^4.1.12",
+        "@inquirer/number": "^3.0.15",
+        "@inquirer/password": "^4.0.15",
+        "@inquirer/rawlist": "^4.1.3",
+        "@inquirer/search": "^3.0.15",
+        "@inquirer/select": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/rawlist": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.3.tgz",
+      "integrity": "sha512-7XrV//6kwYumNDSsvJIPeAqa8+p7GJh7H5kRuxirct2cgOcSWwwNGoXDRgpNFbY/MG2vQ4ccIWCi8+IXXyFMZA==",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/search": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.15.tgz",
+      "integrity": "sha512-YBMwPxYBrADqyvP4nNItpwkBnGGglAvCLVW8u4pRmmvOsHUtCAUIMbUrLX5B3tFL1/WsLGdQ2HNzkqswMs5Uaw==",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/select": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.3.tgz",
+      "integrity": "sha512-OAGhXU0Cvh0PhLz9xTF/kx6g6x+sP+PcyTiLvCrewI99P3BBeexD+VbuwkNDvqGkk3y2h5ZiWLeRP7BFlhkUDg==",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/design-system/node_modules/@inquirer/type": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
+      "integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "packages/design-system/node_modules/@internationalized/date": {
@@ -62353,6 +62567,16 @@
         "tslib": "^2.8.0"
       }
     },
+    "packages/design-system/node_modules/@types/node": {
+      "version": "22.15.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
+      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "packages/design-system/node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -62376,6 +62600,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/design-system/node_modules/inquirer": {
+      "version": "12.6.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.6.3.tgz",
+      "integrity": "sha512-eX9beYAjr1MqYsIjx1vAheXsRk1jbZRvHLcBu5nA9wX0rXR1IfCZLnVLp4Ym4mrhqmh7AuANwcdtgQ291fZDfQ==",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/prompts": "^7.5.3",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "mute-stream": "^2.0.0",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "packages/design-system/node_modules/is-interactive": {
@@ -62424,6 +62673,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/design-system/node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "packages/design-system/node_modules/ora": {
@@ -62508,6 +62765,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/design-system/node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "packages/design-system/node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "packages/design-system/node_modules/signal-exit": {

--- a/packages/design-system/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.test.tsx
@@ -164,22 +164,26 @@ describe('Tooltip', function () {
       jest.resetAllMocks();
     });
 
-    it('sends inline trigger tooltip analytics event', () => {
+    it('sends icon trigger tooltip analytics event on hover', () => {
       renderTooltip();
       const triggerEl = screen.queryByLabelText(triggerAriaLabelText);
       userEvent.hover(triggerEl);
       expect(tealiumMock.mock.calls[0]).toMatchSnapshot();
     });
 
-    it('sends icon and inversed trigger tooltip analytics event', () => {
-      renderTooltip();
-      userEvent.hover(screen.getByRole('button'));
+    it('sends inline tooltip analytics event', () => {
+      renderTooltip({ component: 'a', children: 'inline trigger' });
+      const triggerEl = screen.queryByLabelText(triggerAriaLabelText);
+      userEvent.hover(triggerEl);
       expect(tealiumMock.mock.calls[0]).toMatchSnapshot();
     });
 
-    it('sends interactive content and tooltip with close button analytics event', () => {
-      renderTooltip();
-      userEvent.click(screen.getByRole('button'));
+    it('sends dialog tooltip analytics event on open', () => {
+      renderTooltip({
+        dialog: true,
+      });
+      const tooltipTrigger = screen.getByLabelText(triggerAriaLabelText);
+      userEvent.click(tooltipTrigger);
       expect(tealiumMock.mock.calls[0]).toMatchSnapshot();
     });
 

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -9,8 +9,13 @@ import useId from '../utilities/useId';
 import { Button } from '../Button';
 import { CloseIconThin } from '../Icons';
 import usePrevious from '../utilities/usePrevious';
+import { AnalyticsOverrideProps, AnalyticsParentDataProps } from '../analytics';
+import useTooltipAnalytics from './useTooltipAnalytics';
+import mergeRefs from '../utilities/mergeRefs';
 
-export interface BaseTooltipProps {
+export interface BaseTooltipProps
+  extends Omit<AnalyticsOverrideProps, 'analyticsEventTypeOverride'>,
+    AnalyticsParentDataProps {
   /**
    * Classes applied to the tooltip trigger when the tooltip is active
    */
@@ -146,6 +151,7 @@ export const Tooltip = (props: TooltipProps) => {
   const contentId = useId('tooltip-trigger--', props.id);
   const triggerElement = useRef(null);
   const tooltipElement = useRef(null);
+  const { contentRef, sendTooltipEvent } = useTooltipAnalytics(props);
 
   const setTriggerElement = (elem) => {
     triggerElement.current = elem;
@@ -221,6 +227,7 @@ export const Tooltip = (props: TooltipProps) => {
   useEffect(() => {
     if (active) {
       props.onOpen && props.onOpen();
+      sendTooltipEvent();
     } else {
       props.onClose && props.onClose();
 
@@ -243,6 +250,9 @@ export const Tooltip = (props: TooltipProps) => {
   const renderTrigger = (props: TooltipProps): React.ReactElement => {
     const {
       activeClassName,
+      analytics,
+      analyticsLabelOverride,
+      onAnalyticsEvent,
       ariaLabel,
       children,
       className,
@@ -300,7 +310,7 @@ export const Tooltip = (props: TooltipProps) => {
         aria-label={ariaLabel || triggerAriaLabel || undefined}
         aria-describedby={dialog ? undefined : contentId}
         className={triggerClasses}
-        ref={setTriggerElement}
+        ref={mergeRefs([contentRef, setTriggerElement])}
         {...others}
         {...linkTriggerOverrides}
         {...eventHandlers}

--- a/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Tooltip Analytics event tracking sends dialog tooltip analytics event on open 1`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "tooltip_viewed",
+    "parent_component_heading": " ",
+    "parent_component_type": " ",
+    "text": "tooltip trigger",
+  },
+]
+`;
+
+exports[`Tooltip Analytics event tracking sends icon trigger tooltip analytics event on hover 1`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "tooltip_viewed",
+    "parent_component_heading": " ",
+    "parent_component_type": " ",
+    "text": "tooltip trigger",
+  },
+]
+`;
+
+exports[`Tooltip Analytics event tracking sends inline tooltip analytics event 1`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "tooltip_viewed",
+    "parent_component_heading": " ",
+    "parent_component_type": " ",
+    "text": "inline trigger",
+  },
+]
+`;
+
 exports[`Tooltip renders custom trigger component 1`] = `
 <a
   aria-describedby="static-id"

--- a/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -5,8 +5,6 @@ Array [
   Object {
     "event_extension": "Design system integration",
     "event_name": "tooltip_viewed",
-    "parent_component_heading": " ",
-    "parent_component_type": " ",
     "text": "tooltip trigger",
   },
 ]
@@ -17,8 +15,6 @@ Array [
   Object {
     "event_extension": "Design system integration",
     "event_name": "tooltip_viewed",
-    "parent_component_heading": " ",
-    "parent_component_type": " ",
     "text": "tooltip trigger",
   },
 ]
@@ -29,8 +25,6 @@ Array [
   Object {
     "event_extension": "Design system integration",
     "event_name": "tooltip_viewed",
-    "parent_component_heading": " ",
-    "parent_component_type": " ",
     "text": "inline trigger",
   },
 ]

--- a/packages/design-system/src/components/Tooltip/useTooltipAnalytics.ts
+++ b/packages/design-system/src/components/Tooltip/useTooltipAnalytics.ts
@@ -1,0 +1,43 @@
+import { TooltipProps } from './Tooltip';
+import { config } from '../config';
+import { getAnalyticsContentFromRefs, eventExtensionText } from '../analytics';
+import { useRef } from 'react';
+
+export default function useTooltipAnalytics({
+  analytics,
+  analyticsLabelOverride,
+  analyticsParentHeading,
+  analyticsParentType,
+  onAnalyticsEvent = config().defaultAnalyticsFunction,
+  ariaLabel,
+  triggerAriaLabel,
+}: TooltipProps) {
+  const contentRef = useRef();
+
+  function sendTooltipEvent() {
+    if (analytics !== true && (!config().tooltipSendsAnalytics || analytics === false)) {
+      return;
+    }
+
+    // In the case where an icon is supplied there won't be any internal text of the tooltip trigger.
+    // So, getAnalyticsContentFromRefs will return undefined. In that case, grab the aria label for the trigger.
+    // In the case of webcomponents, we need to grab the triggerAriaLabel.
+    const tooltipText =
+      analyticsLabelOverride ??
+      getAnalyticsContentFromRefs([contentRef]) ??
+      ariaLabel ??
+      triggerAriaLabel;
+    const tooltipParentHeading = analyticsParentHeading ?? ' ';
+    const tooltipParentType = analyticsParentType ?? ' ';
+
+    return onAnalyticsEvent({
+      event_name: 'tooltip_viewed',
+      event_extension: eventExtensionText,
+      text: tooltipText,
+      parent_component_heading: tooltipParentHeading,
+      parent_component_type: tooltipParentType,
+    });
+  }
+
+  return { contentRef, sendTooltipEvent };
+}

--- a/packages/design-system/src/components/Tooltip/useTooltipAnalytics.ts
+++ b/packages/design-system/src/components/Tooltip/useTooltipAnalytics.ts
@@ -12,7 +12,7 @@ export default function useTooltipAnalytics({
   ariaLabel,
   triggerAriaLabel,
 }: TooltipProps) {
-  const contentRef = useRef();
+  const contentRef = useRef<HTMLElement>();
 
   function sendTooltipEvent() {
     if (analytics !== true && (!config().tooltipSendsAnalytics || analytics === false)) {

--- a/packages/design-system/src/components/Tooltip/useTooltipAnalytics.ts
+++ b/packages/design-system/src/components/Tooltip/useTooltipAnalytics.ts
@@ -6,8 +6,6 @@ import { useRef } from 'react';
 export default function useTooltipAnalytics({
   analytics,
   analyticsLabelOverride,
-  analyticsParentHeading,
-  analyticsParentType,
   onAnalyticsEvent = config().defaultAnalyticsFunction,
   ariaLabel,
   triggerAriaLabel,
@@ -27,15 +25,11 @@ export default function useTooltipAnalytics({
       getAnalyticsContentFromRefs([contentRef]) ??
       ariaLabel ??
       triggerAriaLabel;
-    const tooltipParentHeading = analyticsParentHeading ?? ' ';
-    const tooltipParentType = analyticsParentType ?? ' ';
 
     return onAnalyticsEvent({
       event_name: 'tooltip_viewed',
       event_extension: eventExtensionText,
       text: tooltipText,
-      parent_component_heading: tooltipParentHeading,
-      parent_component_type: tooltipParentType,
     });
   }
 

--- a/packages/design-system/src/components/config.ts
+++ b/packages/design-system/src/components/config.ts
@@ -47,6 +47,11 @@ export interface Config {
    * To override this setting for an individual alert instance, use the `analytics` prop.
    */
   thirdPartyExternalLinkSendsAnalytics: boolean;
+  /**
+   * Controls whether tooltip components send analytics data by default.
+   * To override this setting for an individual alert instance, use the `analytics` prop.
+   */
+  tooltipSendsAnalytics: boolean;
 }
 
 export type PartialConfig = Partial<Config>;
@@ -61,6 +66,7 @@ export const DEFAULTS: Config = Object.freeze({
   headerSendsAnalytics: false,
   footerSendsAnalytics: false,
   thirdPartyExternalLinkSendsAnalytics: false,
+  tooltipSendsAnalytics: false,
 });
 
 export const HEALTHCARE_DEFAULTS: Config = {

--- a/packages/docs/content/components/analytics.mdx
+++ b/packages/docs/content/components/analytics.mdx
@@ -14,6 +14,7 @@ Some of the design system components come with built-in analytics functionality 
 - [Header](/components/header/healthcare-header/) (HealthCare.gov)
 - [Footer](/components/footer/healthcare-footer/) (HealthCare.gov)
 - [Third Party External Link](/components/third-party-external-link/)
+- [Tooltip](/components/tooltip/)
 
 ## Turning it on and off
 
@@ -46,6 +47,7 @@ Here is the list of each component config property for analytics:
 - `headerSendsAnalytics` (HealthCare.gov)
 - `footerSendsAnalytics` (HealthCare.gov)
 - `thirdPartyExternalLinkSendsAnalytics`
+- `tooltipSendsAnalytics`
 
 ## Handling the events
 
@@ -58,7 +60,7 @@ For the global default handler, the design system will currently attempt to pass
 
 <Alert heading="Overriding events in web components">
 
-  If you wish to override the analytics event handling for a particular web component instance by listening to the `ds-analytics-event`, simply listening to the event will not override the default behavior. If you want to keep the component from calling the `defaultAnalyticsFunction` with its events, you must call the `event.preventDefault()` function within your event handler.
+If you wish to override the analytics event handling for a particular web component instance by listening to the `ds-analytics-event`, simply listening to the event will not override the default behavior. If you want to keep the component from calling the `defaultAnalyticsFunction` with its events, you must call the `event.preventDefault()` function within your event handler.
 
 </Alert>
 

--- a/tests/browser/snapshots/storybook-docs/Docs-Components-Tooltip-Docs-prop-table-matches-snapshot-1.txt
+++ b/tests/browser/snapshots/storybook-docs/Docs-Components-Tooltip-Docs-prop-table-matches-snapshot-1.txt
@@ -5,6 +5,26 @@
     "-"
   ],
   [
+    "analytics",
+    "Analytics events tracking is enabled by default. Set this value to false to disable tracking for this component instance.\n\nRead more about analytics.\n\nboolean",
+    "-"
+  ],
+  [
+    "analyticsLabelOverride",
+    "An override for the dynamic content sent to analytics services. By default this content comes from the heading.\n\nIn cases where this component’s heading may contain sensitive information, use this prop to override what is sent to analytics.\n\nRead more about analytics.\n\nstring",
+    "-"
+  ],
+  [
+    "analyticsParentHeading",
+    "If needed for analytics, pass heading text of parent component of button.\n\nRead more about analytics.\n\nstring",
+    "-"
+  ],
+  [
+    "analyticsParentType",
+    "If needed for analytics, pass type of parent component of button.\n\nRead more about analytics.\n\nstring",
+    "-"
+  ],
+  [
     "ariaLabel",
     "Helpful description of the tooltip for screenreaders\nstring",
     "-"
@@ -63,6 +83,11 @@
     "offset",
     "Applies skidding and distance offsets to the tooltip relative to the trigger. See the popperjs docs for more info.\n[number, number]",
     "[0, 5]"
+  ],
+  [
+    "onAnalyticsEvent",
+    "Optional callback that will intercept analytics events for this component. If none is specified, the design system will use the default analytics function, which can be overwritten globally with the defaultAnalyticsFunction config property.\n\nRead more about analytics.\n\n(event: AnalyticsEvent) => void",
+    "-"
   ],
   [
     "onClose",


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/CMSDS-3412)
- Added analytics support to Tooltip 
- Based on [this contribution](https://github.com/CMSgov/design-system/pull/3618)
- Address the React portion of [this ticket](https://github.com/CMSgov/design-system/issues/3616)
- Web component work will be forthcoming

## How to test

1. Run unit tests locally, confirm they work
2. Follow this procedure for examining analytics events:
3. The best way to test is using the debugger built into your Browser of choice, for Firefox:
4. Open the storybook site locally
5. Open dev tools and go to the Debugger tab
6. Press "Command + P" and search for "utag.js"
7. When that file is opened, search "Command + F" for track:
8. Place a break point at the line following the definition of the track function
9. Hover over the Tooltip
10. In the Browser console, type "a"
11. Look at the associated object, and expand it to see the data property on that object
12. Confirm that the object contains a field that says "link", along with the following object structure (or something similar) in the data field:

{
    "event_extension": "Design system integration",
    "event_name": "tooltip_viewed",
    "parent_component_heading": " ",
    "parent_component_type": " ",
    "text": "tooltip trigger",
  }

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone
