### PR TITLE
[CMSDS-3407] Updated `error-validation` documentation to specify inline error placement (top or bottom) based on theme.

### DIFF
--- a/packages/docs/content/patterns/Forms/error-validation.mdx
+++ b/packages/docs/content/patterns/Forms/error-validation.mdx
@@ -56,7 +56,9 @@ Use the [Validation on Submit](#validation-on-submit-default) pattern for most u
 
 - Use the [Validation on Submit](#validation-on-submit-default) for most use cases. Use [Instant Validation](#instant-validation) when the answers aren't obvious or when input fields are difficult to complete.
 - Inline errors are built into all design system form fields but can be used on their own to create custom fields. See [Inline Error](/components/inline-error/) for more information.
-- Inline errors should sit either directly above or below the input, depending on the theme defaults.
+- Inline errors should sit either directly above or below the input, depending on the current theme defaults:
+  - In the CMS.gov, Medicare, and Core themes, errors appear above the input.
+  - In the Healthcare theme, errors appear below the input.
 - Visually align inline validation messages with the input fields so people using screen magnifiers can read them quickly.
 - The form field should have an `aria-describedby` attribute that references the `id` of the error message.
 - Use color as a secondary way to draw attention to an error. Do not rely on color alone to indicate an error.


### PR DESCRIPTION
## Summary

- Updates `error-validation` documentation to specify inline error placement (top or bottom) based on theme.
[Jira ticket](https://jira.cms.gov/browse/CMSDS-3407)

## How to test

1. Run doc site locally and navigate to `patterns/Forms/error-validation/`.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone