### PR TITLE
[WNMGDS-3443] Add analytics for default/informational Alerts

### DIFF
--- a/packages/design-system/src/components/Alert/Alert.test.tsx
+++ b/packages/design-system/src/components/Alert/Alert.test.tsx
@@ -160,9 +160,10 @@ describe('Alert', function () {
       expect(tealiumMock).toHaveBeenCalledTimes(1);
     });
 
-    it('does not send analytics event for default variation', () => {
+    it('sends analytics event for default/informational variation', () => {
       renderAlert();
-      expect(tealiumMock).not.toBeCalled();
+      expect(tealiumMock.mock.lastCall).toMatchSnapshot();
+      expect(tealiumMock).toBeCalled();
     });
 
     it('disables analytics tracking', () => {

--- a/packages/design-system/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/packages/design-system/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -11,6 +11,17 @@ Array [
 ]
 `;
 
+exports[`Alert Analytics event tracking sends analytics event for default/informational variation 1`] = `
+Array [
+  Object {
+    "event_extension": "Design system integration",
+    "event_name": "alert_impression",
+    "heading": "Notice: Ruhroh",
+    "type": "informational",
+  },
+]
+`;
+
 exports[`Alert Analytics event tracking sends analytics event with body-content fallback 1`] = `
 Array [
   Object {

--- a/packages/design-system/src/components/Alert/useAlertAnalytics.ts
+++ b/packages/design-system/src/components/Alert/useAlertAnalytics.ts
@@ -15,11 +15,6 @@ export default function useAlertAnalytics({
         return;
       }
 
-      // Do not send analytics event for default alerts
-      if (!variation) {
-        return;
-      }
-
       const eventHeadingText = analyticsLabelOverride ?? content;
       if (!eventHeadingText) {
         console.error('No content found for Alert analytics event');
@@ -30,7 +25,7 @@ export default function useAlertAnalytics({
         event_name: 'alert_impression',
         event_extension: eventExtensionText,
         heading: eventHeadingText,
-        type: variation,
+        type: variation ?? 'informational',
       });
     },
   });


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/CMSDS-3443)

## How to test

1. Enable analytics events in the Alert Story
2. Confirm that the analytics event fires and that the object in the event looks like this:
{
event_extension: "Design system integration"
event_name: "alert_impression"
heading: "Notice: Confidentiality and medical data sharing"
type: "informational"
}

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone