### PR TITLE
[NO-TICKET] The viewport does not need to be listed as an addon

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,7 +8,6 @@ const config: StorybookConfig = {
   addons: [
     getAbsolutePath('@storybook/addon-links'),
     getAbsolutePath('@storybook/addon-essentials'),
-    getAbsolutePath('@storybook/addon-viewport'),
     'storybook-addon-fetch-mock',
     '@storybook/addon-webpack5-compiler-babel',
   ],


### PR DESCRIPTION
## Summary

- We get this notice in the console on Storybook: `storybook/viewport was loaded twice, this could have bad side-effects`
- Turns out this is because we're loading the viewport addon twice. [It's included in the `@storybook/addon-essentials` package](https://storybook.js.org/docs/8/essentials/index), so we don't need it listed in the addons array in our main.ts file.

## How to test

1. Run storybook locally
2. Make sure there is no warning in the console.
3. Make sure the viewport feature works

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone