### PR TITLE
[CMSDS-3466] Upgrade `react-docgen-typescript` to v2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "prettier": "^2.6.1",
         "react": "17.0.2",
         "react-app-polyfill": "^3.0.0",
-        "react-docgen-typescript": "2.3.0-beta.0",
+        "react-docgen-typescript": "2.4.0",
         "react-dom": "17.0.2",
         "react-test-renderer": "17.0.2",
         "sass": "^1.53.0",
@@ -50892,10 +50892,11 @@
       }
     },
     "node_modules/react-docgen-typescript": {
-      "version": "2.3.0-beta.0",
-      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.3.0-beta.0.tgz",
-      "integrity": "sha512-Uh2ZHWNDF4TJZRodJ2+yN13k4vlzPya+6VqDDS+9F4fEdZDBvQvCkowyHQQNZ1If8688hHbSJYHXYNiD3kml3A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
+      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">= 4.3.x"
       }

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "prettier": "^2.6.1",
     "react": "17.0.2",
     "react-app-polyfill": "^3.0.0",
-    "react-docgen-typescript": "2.3.0-beta.0",
+    "react-docgen-typescript": "2.4.0",
     "react-dom": "17.0.2",
     "react-test-renderer": "17.0.2",
     "sass": "^1.53.0",
@@ -176,8 +176,5 @@
   },
   "engines": {
     "node": ">=18.20.4"
-  },
-  "overrides": {
-    "react-docgen-typescript": "2.3.0-beta.0"
   }
 }


### PR DESCRIPTION
## Summary

- Storybook v9 continues to support `react-docgen-typescript`.
- The `react-docgen-typescript` package has released [v2.4.0](https://github.com/styleguidist/react-docgen-typescript/releases), which includes [this commit](https://github.com/styleguidist/react-docgen-typescript/pull/503) that ensures typeScript union types are consistently sorted.
- This version resolves the issue that previously required us to pin to a beta release and apply a package override. With the upgrade, this override is no longer necessary.

## How to test

1. Run `npm run clean && npm install && npm run build` and verify that the project builds without errors.
2. Run `npm ls react-docgen-typescript` to confirm that version 2.4.0 is installed and used by both the root project and Storybook’s internal plugin (`@storybook/react-docgen-typescript-plugin`).
3. Run Storybook

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone