### PR TITLE
[CMSDS-3469] Override Doc Site ThirdPartyExternalLink analytics values

### DIFF
--- a/packages/docs/src/components/content/ContentRenderer.tsx
+++ b/packages/docs/src/components/content/ContentRenderer.tsx
@@ -94,7 +94,15 @@ const customComponents = (theme) => ({
   a: (props) => {
     const { href, ...restProps } = props;
     if (href.startsWith('http') && !RE_INTERNAL_URL.test(href)) {
-      return <ThirdPartyExternalLink analytics={true} origin="design.cms.gov" {...props} />;
+      return (
+        <ThirdPartyExternalLink
+          analyticsParentHeading="no value available"
+          analyticsParentType="no value available"
+          analytics={true}
+          origin="design.cms.gov"
+          {...props}
+        />
+      );
     }
     if (href.includes('github.com/CMSgov/design-system') || href.startsWith('https:')) {
       return <a href={href} {...restProps} />;


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/CMSDS-3469)
- Basically we're just passing in "no value available" to our ThirdPartyExternalLink component on the doc site since those values are not helpful in this context.

## How to test

This one is a little weird, I'm having trouble seeing the correct analytics object on click. But try the following approach to test:
1. Run unit tests locally, confirm they work
2. Follow this procedure for examining analytics events:
3. The best way to test is using the debugger built into your Browser of choice, for Chrome:
4. Open the Documentation Site locally
5. Open dev tools and go to the Sources tab
6. Press "Command + P" and search for "utag.js"
7. When that file is opened, search "Command + F" for track:
8. Place a break point at the line following the definition of the track function
9. Press tab to focus on an external link, like the one on /guidelines/accessibility, press enter and then click on the continue button on the modal.
10. In the Browser console, type "a"
11. Look at the associated object, and expand it to see the data property on that object
12. Confirm that the object contains a field that says "link", along with the following object structure (or something similar) in the data field:
{
"event_extension": "Design system integration",
"event_name": "external_link",
"parent_component_heading": "no value available",
"parent_component_type": "no value available",
...
}


## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone