### PR TITLE
Update to use React's `useId` hook

### DIFF
--- a/packages/design-system/src/components/Alert/Alert.test.tsx
+++ b/packages/design-system/src/components/Alert/Alert.test.tsx
@@ -118,16 +118,20 @@ describe('Alert', function () {
     it('points aria-labelledby to heading', () => {
       const heading = 'Elvis has left the building';
       renderAlert({ heading, variation: 'error' });
+
       const alert = screen.getByRole('alert');
       const id = alert.getAttribute('aria-labelledby');
-      expect(alert.querySelector(`#${id}`).textContent).toContain(`Alert: ${heading}`);
+      const labelEl = document.getElementById(id!);
+
+      expect(labelEl?.textContent).toContain(`Alert: ${heading}`);
     });
 
     it('falls back aria-labelledby to a11y label when no heading is provided', () => {
       renderAlert();
       const alert = screen.getByRole('region');
       const id = alert.getAttribute('aria-labelledby');
-      expect(alert.querySelector(`#${id}`).textContent).toContain('Notice');
+      const labelEl = document.getElementById(id!);
+      expect(labelEl.textContent).toContain('Notice');
     });
   });
 

--- a/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.test.tsx
@@ -123,7 +123,7 @@ describe('Autocomplete', () => {
   it('generates ids when no id is provided', async () => {
     const { user } = renderAutocomplete({ id: undefined });
     await open({ user });
-    const idRegex = /autocomplete--\d+/;
+    const idRegex = /^autocomplete--[\w:.-]+$/;
     expect(screen.getByRole('listbox').id).toMatch(idRegex);
     expect(screen.getByRole('combobox').id).toMatch(idRegex);
   });

--- a/packages/design-system/src/components/ChoiceList/Choice.test.tsx
+++ b/packages/design-system/src/components/ChoiceList/Choice.test.tsx
@@ -180,7 +180,7 @@ describe('Choice', () => {
       </div>
     );
 
-    const idRegex = /choice--\d+/;
+    const idRegex = /^choice--[\w:.-]+$/;
     const labels = container.querySelectorAll('label');
     const labelA = labels[0];
     const labelB = labels[1];

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
@@ -86,7 +86,7 @@ describe('ChoiceList', () => {
 
     it('generates ids when no id is provided', () => {
       const { container } = renderChoiceList({ id: undefined });
-      expect(container.querySelector('legend').id).toMatch(/choice-list--\d+/);
+      expect(container.querySelector('legend')?.id).toMatch(/^choice-list--[\w:.-]+$/);
 
       const choices = screen.getAllByRole('radio');
       const choiceIdRegex = /choice--\d+/;

--- a/packages/design-system/src/components/DateField/SingleInputDateField.test.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.test.tsx
@@ -113,8 +113,8 @@ describe('SingleInputDateField', function () {
 
     it('generates ids when no id is provided', () => {
       renderPicker({ id: undefined });
-      expect(screen.getByRole('textbox').id).toMatch(/date-field--\d+/);
-      expect(screen.getByRole('img').id).toMatch(/date-field--\d+__icon/);
+      expect(screen.getByRole('textbox').id).toMatch(/^date-field--[\w:.-]+$/);
+      expect(screen.getByRole('img').id).toMatch(/^date-field--[\w:.-]+__icon$/);
     });
 
     it('selecting a day calls onChange', async () => {

--- a/packages/design-system/src/components/Dialog/Dialog.test.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.test.tsx
@@ -25,7 +25,7 @@ function renderDialog(props = {}) {
 describe('Dialog', function () {
   it('generates ids when no id is provided', () => {
     renderDialog({ id: undefined });
-    const idRegex = /dialog--\d+/;
+    const idRegex = /^dialog--[\w:.-]+$/;
     expect(screen.getByRole('dialog').id).toMatch(idRegex);
     expect(screen.getByRole('heading').id).toMatch(idRegex);
   });

--- a/packages/design-system/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/design-system/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Drawer renders a dialog 1`] = `
 <dialog
-  aria-labelledby="drawer--1"
+  aria-labelledby="drawer--:r0:"
   class="ds-c-drawer"
   open=""
   role="dialog"
@@ -16,7 +16,7 @@ exports[`Drawer renders a dialog 1`] = `
     >
       <h3
         class="ds-c-drawer__header-heading"
-        id="drawer--1"
+        id="drawer--:r0:"
       >
         Drawer title
       </h3>

--- a/packages/design-system/src/components/FilterChip/FilterChip.test.tsx
+++ b/packages/design-system/src/components/FilterChip/FilterChip.test.tsx
@@ -33,7 +33,7 @@ describe('FilterChip', () => {
 
   it('generates an id when no id is provided', () => {
     renderFilterChip({ id: undefined });
-    const idRegex = /filter-chip--\d+/;
+    const idRegex = /^filter-chip--[\w:.-]+$/;
     expect(screen.getByRole('button').id).toMatch(idRegex);
   });
 

--- a/packages/design-system/src/components/HelpDrawer/__snapshots__/HelpDrawer.test.tsx.snap
+++ b/packages/design-system/src/components/HelpDrawer/__snapshots__/HelpDrawer.test.tsx.snap
@@ -53,7 +53,7 @@ Array [
 exports[`HelpDrawer renders a snapshot 1`] = `
 <DocumentFragment>
   <dialog
-    aria-labelledby="drawer--2"
+    aria-labelledby="drawer--:r1:"
     class="ds-c-help-drawer ds-c-drawer"
     open=""
     role="dialog"
@@ -67,7 +67,7 @@ exports[`HelpDrawer renders a snapshot 1`] = `
       >
         <h3
           class="ds-c-drawer__header-heading"
-          id="drawer--2"
+          id="drawer--:r1:"
         >
           HelpDrawer title
         </h3>

--- a/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.tsx.snap
+++ b/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`MonthPicker renders a snapshot 1`] = `
 <DocumentFragment>
   <fieldset
-    aria-describedby="month-picker--1__error month-picker--1__hint"
+    aria-describedby="month-picker--:r0:__error month-picker--:r0:__hint"
     aria-invalid="true"
     class="ds-c-fieldset ds-c-month-picker"
   >
     <legend
       class="ds-c-label"
-      id="month-picker--1__label"
+      id="month-picker--:r0:__label"
     >
       Months
     </legend>
     <p
       class="ds-c-hint"
-      id="month-picker--1__hint"
+      id="month-picker--:r0:__hint"
     >
       Guess and test
     </p>
@@ -23,7 +23,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
       aria-atomic="true"
       aria-live="assertive"
       class="ds-c-inline-error"
-      id="month-picker--1__error"
+      id="month-picker--:r0:__error"
     >
       <svg
         aria-hidden="true"
@@ -77,7 +77,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="January"
                 class="ds-c-choice"
-                id="month-picker--1__choice--1"
+                id="month-picker--:r0:__choice--1"
                 name="months"
                 type="checkbox"
                 value="1"
@@ -85,8 +85,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--1"
-                id="month-picker--1__choice--1__label"
+                for="month-picker--:r0:__choice--1"
+                id="month-picker--:r0:__choice--1__label"
               >
                 Jan
               </label>
@@ -103,7 +103,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="February"
                 class="ds-c-choice"
-                id="month-picker--1__choice--2"
+                id="month-picker--:r0:__choice--2"
                 name="months"
                 type="checkbox"
                 value="2"
@@ -111,8 +111,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--2"
-                id="month-picker--1__choice--2__label"
+                for="month-picker--:r0:__choice--2"
+                id="month-picker--:r0:__choice--2__label"
               >
                 Feb
               </label>
@@ -129,7 +129,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="March"
                 class="ds-c-choice"
-                id="month-picker--1__choice--3"
+                id="month-picker--:r0:__choice--3"
                 name="months"
                 type="checkbox"
                 value="3"
@@ -137,8 +137,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--3"
-                id="month-picker--1__choice--3__label"
+                for="month-picker--:r0:__choice--3"
+                id="month-picker--:r0:__choice--3__label"
               >
                 Mar
               </label>
@@ -155,7 +155,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="April"
                 class="ds-c-choice"
-                id="month-picker--1__choice--4"
+                id="month-picker--:r0:__choice--4"
                 name="months"
                 type="checkbox"
                 value="4"
@@ -163,8 +163,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--4"
-                id="month-picker--1__choice--4__label"
+                for="month-picker--:r0:__choice--4"
+                id="month-picker--:r0:__choice--4__label"
               >
                 Apr
               </label>
@@ -181,7 +181,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="May"
                 class="ds-c-choice"
-                id="month-picker--1__choice--5"
+                id="month-picker--:r0:__choice--5"
                 name="months"
                 type="checkbox"
                 value="5"
@@ -189,8 +189,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--5"
-                id="month-picker--1__choice--5__label"
+                for="month-picker--:r0:__choice--5"
+                id="month-picker--:r0:__choice--5__label"
               >
                 May
               </label>
@@ -207,7 +207,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="June"
                 class="ds-c-choice"
-                id="month-picker--1__choice--6"
+                id="month-picker--:r0:__choice--6"
                 name="months"
                 type="checkbox"
                 value="6"
@@ -215,8 +215,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--6"
-                id="month-picker--1__choice--6__label"
+                for="month-picker--:r0:__choice--6"
+                id="month-picker--:r0:__choice--6__label"
               >
                 Jun
               </label>
@@ -233,7 +233,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="July"
                 class="ds-c-choice"
-                id="month-picker--1__choice--7"
+                id="month-picker--:r0:__choice--7"
                 name="months"
                 type="checkbox"
                 value="7"
@@ -241,8 +241,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--7"
-                id="month-picker--1__choice--7__label"
+                for="month-picker--:r0:__choice--7"
+                id="month-picker--:r0:__choice--7__label"
               >
                 Jul
               </label>
@@ -259,7 +259,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="August"
                 class="ds-c-choice"
-                id="month-picker--1__choice--8"
+                id="month-picker--:r0:__choice--8"
                 name="months"
                 type="checkbox"
                 value="8"
@@ -267,8 +267,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--8"
-                id="month-picker--1__choice--8__label"
+                for="month-picker--:r0:__choice--8"
+                id="month-picker--:r0:__choice--8__label"
               >
                 Aug
               </label>
@@ -285,7 +285,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="September"
                 class="ds-c-choice"
-                id="month-picker--1__choice--9"
+                id="month-picker--:r0:__choice--9"
                 name="months"
                 type="checkbox"
                 value="9"
@@ -293,8 +293,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--9"
-                id="month-picker--1__choice--9__label"
+                for="month-picker--:r0:__choice--9"
+                id="month-picker--:r0:__choice--9__label"
               >
                 Sep
               </label>
@@ -311,7 +311,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="October"
                 class="ds-c-choice"
-                id="month-picker--1__choice--10"
+                id="month-picker--:r0:__choice--10"
                 name="months"
                 type="checkbox"
                 value="10"
@@ -319,8 +319,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--10"
-                id="month-picker--1__choice--10__label"
+                for="month-picker--:r0:__choice--10"
+                id="month-picker--:r0:__choice--10__label"
               >
                 Oct
               </label>
@@ -337,7 +337,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="November"
                 class="ds-c-choice"
-                id="month-picker--1__choice--11"
+                id="month-picker--:r0:__choice--11"
                 name="months"
                 type="checkbox"
                 value="11"
@@ -345,8 +345,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--11"
-                id="month-picker--1__choice--11__label"
+                for="month-picker--:r0:__choice--11"
+                id="month-picker--:r0:__choice--11__label"
               >
                 Nov
               </label>
@@ -363,7 +363,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <input
                 aria-label="December"
                 class="ds-c-choice"
-                id="month-picker--1__choice--12"
+                id="month-picker--:r0:__choice--12"
                 name="months"
                 type="checkbox"
                 value="12"
@@ -371,8 +371,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
               <label
                 aria-hidden="true"
                 class="ds-c-label"
-                for="month-picker--1__choice--12"
-                id="month-picker--1__choice--12__label"
+                for="month-picker--:r0:__choice--12"
+                id="month-picker--:r0:__choice--12__label"
               >
                 Dec
               </label>

--- a/packages/design-system/src/components/Table/Table.test.tsx
+++ b/packages/design-system/src/components/Table/Table.test.tsx
@@ -55,7 +55,7 @@ describe('Table', function () {
     makeTable({ scrollable: true, id: undefined });
     const table = screen.getByRole('table');
     const caption = table.querySelector('caption');
-    expect(caption.id).toMatch(/table-caption--\d+/);
+    expect(caption.id).toMatch(/^table-caption--[\w:.-]+$/);
   });
 
   it('applies responsive stacked table', () => {

--- a/packages/design-system/src/components/TextField/TextField.test.tsx
+++ b/packages/design-system/src/components/TextField/TextField.test.tsx
@@ -86,7 +86,7 @@ describe('TextField', function () {
 
   it('generates ids when no id is provided', () => {
     const { container } = renderTextField({ id: undefined });
-    const idRegex = /text-field--\d+/;
+    const idRegex = /^text-field--[\w:.-]+$/;
     expect(container.querySelector('input').id).toMatch(idRegex);
     expect(container.querySelector('label').id).toMatch(idRegex);
   });

--- a/packages/design-system/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
+++ b/packages/design-system/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
@@ -30,9 +30,9 @@ Array [
 
 exports[`ThirdPartyExternalLink ThirdPartyExternalLink dialog renders external link dialog 1`] = `
 <dialog
-  aria-labelledby="dialog--8__heading"
+  aria-labelledby="dialog--:rd:__heading"
   class="ds-c-dialog"
-  id="dialog--8"
+  id="dialog--:rd:"
   open=""
   role="dialog"
   tabindex="-1"
@@ -45,20 +45,20 @@ exports[`ThirdPartyExternalLink ThirdPartyExternalLink dialog renders external l
     >
       <h2
         class="ds-c-dialog__heading"
-        id="dialog--8__heading"
+        id="dialog--:rd:__heading"
       >
         You are leaving bar.
       </h2>
       <button
         aria-label="Close modal dialog"
         class="ds-c-close-button ds-c-dialog__close"
-        id="dialog--8__close"
+        id="dialog--:rd:__close"
         type="button"
       >
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
-          id="dialog--8__close__icon"
+          id="dialog--:rd:__close__icon"
           viewBox="-2 -2 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -76,7 +76,7 @@ exports[`ThirdPartyExternalLink ThirdPartyExternalLink dialog renders external l
       class="ds-c-dialog__body"
     >
       <div
-        id="dialog--8__content"
+        id="dialog--:rd:__content"
       >
         <p>
           You're about to connect to a third-party site. Select CONTINUE to proceed or CANCEL to stay on this site.
@@ -117,15 +117,15 @@ exports[`ThirdPartyExternalLink renders external link 1`] = `
   External site link
   <svg
     aria-hidden="false"
-    aria-labelledby="icon--1__title"
+    aria-labelledby="icon--:r0:__title"
     class="ds-c-icon ds-c-icon--external-link ds-c-external-link__icon"
-    id="icon--1"
+    id="icon--:r0:"
     role="img"
     viewBox="0 0 512 512"
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="icon--1__title"
+      id="icon--:r0:__title"
     >
       This link goes to an external site
     </title>

--- a/packages/design-system/src/components/utilities/useId.ts
+++ b/packages/design-system/src/components/utilities/useId.ts
@@ -1,12 +1,6 @@
-import uniqueId from 'lodash/uniqueId';
-import { useRef } from 'react';
+import { useId as useReactId } from 'react';
 
-/**
- * Generates a unique id.
- *
- * TODO: Once we're on React 18, we can use the `useId` hook instead of rolling
- * our own with `useRef` and lodash.
- */
 export default function useId(prefix?: string, providedId?: string) {
-  return useRef(providedId ?? uniqueId(prefix)).current;
+  const reactId = useReactId();
+  return providedId ?? `${prefix ?? ''}${reactId}`;
 }

--- a/packages/design-system/src/components/web-components/ds-accordion/ds-accordion-item.tsx
+++ b/packages/design-system/src/components/web-components/ds-accordion/ds-accordion-item.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { define } from '../preactement/define';
 import { AccordionItem, AccordionItemProps } from '../../Accordion';
 import { parseBooleanAttr } from '../wrapperUtils';
+import { useUniqueId } from '../utils';
 
 const attributes = [
   'button-class-name',
@@ -56,6 +57,8 @@ const Wrapper = ({
   customElement,
   ...otherProps
 }: WrapperProps) => {
+  const autoId = useUniqueId('accordion-item--');
+  const id = contentId && contentId.trim() !== '' ? contentId : autoId;
   const parentAccordion = findAccordionAncestor(customElement);
   const bordered = parseBooleanAttr(parentAccordion?.getAttribute('bordered'));
 
@@ -63,7 +66,7 @@ const Wrapper = ({
     <AccordionItem
       {...otherProps}
       defaultOpen={parseBooleanAttr(defaultOpen)}
-      id={contentId}
+      id={id}
       contentClassName={classNames(
         contentClassName,
         bordered && 'ds-c-accordion__content--bordered'

--- a/packages/design-system/src/components/web-components/ds-alert/__snapshots__/ds-alert.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-alert/__snapshots__/ds-alert.test.tsx.snap
@@ -46,7 +46,7 @@ Array [
 
 exports[`Alert renders alert 1`] = `
 <div
-  aria-labelledby="alert--1__a11y-label"
+  aria-labelledby="alert--P0-0__a11y-label"
   class="ds-c-alert"
   role="region"
 >
@@ -65,7 +65,7 @@ exports[`Alert renders alert 1`] = `
   >
     <span
       class="ds-c-alert__a11y-label ds-u-visibility--screen-reader"
-      id="alert--1__a11y-label"
+      id="alert--P0-0__a11y-label"
     >
       Notice: 
     </span>

--- a/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.test.tsx
@@ -217,7 +217,7 @@ describe('Autocomplete', () => {
   it('generates ids when no root id is provided', async () => {
     const { user } = renderAutocomplete({ 'root-id': undefined, items: defaultItems });
     await open({ user });
-    const idRegex = /autocomplete--\d+/;
+    const idRegex = /^autocomplete--[\w:.-]+$/;
     expect(screen.getByRole('listbox').id).toMatch(idRegex);
     expect(screen.getByRole('combobox').id).toMatch(idRegex);
   });

--- a/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice-list.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice-list.test.tsx.snap
@@ -11,13 +11,13 @@ exports[`ChoiceList accepts HTML as children 1`] = `
     >
       <legend
         class="ds-c-label"
-        id="choice-list--11__label"
+        id="choice-list--P0-0__label"
       />
       <p
         aria-atomic="true"
         aria-live="assertive"
         class="ds-c-inline-error"
-        id="choice-list--11__error"
+        id="choice-list--P0-0__error"
       />
       <div>
         <div
@@ -25,14 +25,14 @@ exports[`ChoiceList accepts HTML as children 1`] = `
         >
           <input
             class="ds-c-choice"
-            id="choice-list--11__choice--0"
+            id="choice-list--P0-0__choice--0"
             type="checkbox"
             value="foo"
           />
           <label
             class="ds-c-label"
-            for="choice-list--11__choice--0"
-            id="choice-list--11__choice--0__label"
+            for="choice-list--P0-0__choice--0"
+            id="choice-list--P0-0__choice--0__label"
           >
             Foo
           </label>
@@ -44,14 +44,14 @@ exports[`ChoiceList accepts HTML as children 1`] = `
         >
           <input
             class="ds-c-choice"
-            id="choice-list--11__choice--1"
+            id="choice-list--P0-0__choice--1"
             type="checkbox"
             value="bar"
           />
           <label
             class="ds-c-label"
-            for="choice-list--11__choice--1"
-            id="choice-list--11__choice--1__label"
+            for="choice-list--P0-0__choice--1"
+            id="choice-list--P0-0__choice--1__label"
           >
             Bar
           </label>
@@ -75,20 +75,20 @@ exports[`ChoiceList is a radio button group 1`] = `
     type="radio"
   >
     <fieldset
-      aria-describedby="choice-list--1__error choice-list--1__hint"
+      aria-describedby="choice-list--P0-0__error choice-list--P0-0__hint"
       aria-invalid="true"
       class="ds-c-fieldset"
       role="radiogroup"
     >
       <legend
         class="ds-c-label"
-        id="choice-list--1__label"
+        id="choice-list--P0-0__label"
       >
         Foo
       </legend>
       <p
         class="ds-c-hint"
-        id="choice-list--1__hint"
+        id="choice-list--P0-0__hint"
       >
         Psst! I know the answer
       </p>
@@ -96,7 +96,7 @@ exports[`ChoiceList is a radio button group 1`] = `
         aria-atomic="true"
         aria-live="assertive"
         class="ds-c-inline-error"
-        id="choice-list--1__error"
+        id="choice-list--P0-0__error"
       >
         <svg
           aria-hidden="true"
@@ -121,15 +121,15 @@ exports[`ChoiceList is a radio button group 1`] = `
         >
           <input
             class="ds-c-choice--error ds-c-choice"
-            id="choice-list--1__choice--0"
+            id="choice-list--P0-0__choice--0"
             name="spec-field"
             type="radio"
             value="1"
           />
           <label
             class="ds-c-label"
-            for="choice-list--1__choice--0"
-            id="choice-list--1__choice--0__label"
+            for="choice-list--P0-0__choice--0"
+            id="choice-list--P0-0__choice--0__label"
           >
             Choice 1
           </label>
@@ -141,15 +141,15 @@ exports[`ChoiceList is a radio button group 1`] = `
         >
           <input
             class="ds-c-choice--error ds-c-choice"
-            id="choice-list--1__choice--1"
+            id="choice-list--P0-0__choice--1"
             name="spec-field"
             type="radio"
             value="2"
           />
           <label
             class="ds-c-label"
-            for="choice-list--1__choice--1"
-            id="choice-list--1__choice--1__label"
+            for="choice-list--P0-0__choice--1"
+            id="choice-list--P0-0__choice--1__label"
           >
             Choice 2
           </label>

--- a/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice.test.tsx.snap
@@ -15,17 +15,17 @@ exports[`Choice applies errorMessage to label 1`] = `
         class="ds-c-choice-wrapper"
       >
         <input
-          aria-describedby="choice--11__error"
+          aria-describedby="choice--10__error"
           class="ds-c-choice"
-          id="choice--11"
+          id="choice--10"
           name="foo"
           type="checkbox"
           value="boo"
         />
         <label
           class="ds-c-label"
-          for="choice--11"
-          id="choice--11__label"
+          for="choice--10"
+          id="choice--10__label"
         >
           George Washington
         </label>
@@ -33,7 +33,7 @@ exports[`Choice applies errorMessage to label 1`] = `
           aria-atomic="true"
           aria-live="assertive"
           class="ds-c-inline-error"
-          id="choice--11__error"
+          id="choice--10__error"
         >
           <svg
             aria-hidden="true"
@@ -75,23 +75,23 @@ exports[`Choice has a hint and requirementLabel 1`] = `
         class="ds-c-choice-wrapper"
       >
         <input
-          aria-describedby="choice--8__error choice--8__hint"
+          aria-describedby="choice--7__error choice--7__hint"
           class="ds-c-choice"
-          id="choice--8"
+          id="choice--7"
           name="foo"
           type="checkbox"
           value="boo"
         />
         <label
           class="ds-c-label"
-          for="choice--8"
-          id="choice--8__label"
+          for="choice--7"
+          id="choice--7__label"
         >
           George Washington
         </label>
         <p
           class="ds-c-hint"
-          id="choice--8__hint"
+          id="choice--7__hint"
         >
           Optional. Hello world
         </p>
@@ -99,7 +99,7 @@ exports[`Choice has a hint and requirementLabel 1`] = `
           aria-atomic="true"
           aria-live="assertive"
           class="ds-c-inline-error"
-          id="choice--8__error"
+          id="choice--7__error"
         />
       </div>
     </div>
@@ -208,17 +208,17 @@ exports[`Choice nested content renders checked and unchecked children appropriat
         class="ds-c-choice-wrapper"
       >
         <input
-          aria-describedby="choice--23__error"
+          aria-describedby="choice--21__error"
           class="ds-c-choice"
-          id="choice--23"
+          id="choice--21"
           name="foo"
           type="checkbox"
           value="boo"
         />
         <label
           class="ds-c-label"
-          for="choice--23"
-          id="choice--23__label"
+          for="choice--21"
+          id="choice--21__label"
         >
           George Washington
         </label>
@@ -226,7 +226,7 @@ exports[`Choice nested content renders checked and unchecked children appropriat
           aria-atomic="true"
           aria-live="assertive"
           class="ds-c-inline-error"
-          id="choice--23__error"
+          id="choice--21__error"
         />
       </div>
       <strong

--- a/packages/design-system/src/components/web-components/ds-choice/ds-choice-list.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-choice/ds-choice-list.test.tsx
@@ -96,7 +96,7 @@ describe('ChoiceList', () => {
 
   it('generates ids when no id is provided', () => {
     const { container } = renderChoiceList({ id: undefined });
-    expect(container.querySelector('legend').id).toMatch(/choice-list--\d+/);
+    expect(container.querySelector('legend').id).toMatch(/^choice-list--[\w:.-]+$/);
 
     const choices = screen.getAllByRole('radio');
     const choiceIdRegex = /choice--\d+/;

--- a/packages/design-system/src/components/web-components/ds-choice/ds-choice.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-choice/ds-choice.test.tsx
@@ -147,7 +147,7 @@ describe('Choice', () => {
       </div>
     );
 
-    const idRegex = /choice--\d+/;
+    const idRegex = /^choice--[\w:.-]+$/;
     const labels = container.querySelectorAll('label');
     const labelA = labels[0];
     const labelB = labels[1];

--- a/packages/design-system/src/components/web-components/ds-choice/ds-choice.tsx
+++ b/packages/design-system/src/components/web-components/ds-choice/ds-choice.tsx
@@ -1,11 +1,9 @@
 import type * as React from 'react';
-// import { useId as useReactId } from 'react';
 import { useRef } from 'react';
 import { define } from '../preactement/define';
 import { Choice, ChoiceProps } from '../../ChoiceList/Choice';
 import { parseBooleanAttr } from '../wrapperUtils';
 import { formAttrs } from '../shared-attributes/form';
-// import uniqueId from 'lodash/uniqueId';
 
 let globalIdCounter = 0;
 

--- a/packages/design-system/src/components/web-components/ds-choice/ds-choice.tsx
+++ b/packages/design-system/src/components/web-components/ds-choice/ds-choice.tsx
@@ -1,19 +1,9 @@
 import type * as React from 'react';
-import { useRef } from 'react';
 import { define } from '../preactement/define';
 import { Choice, ChoiceProps } from '../../ChoiceList/Choice';
 import { parseBooleanAttr } from '../wrapperUtils';
 import { formAttrs } from '../shared-attributes/form';
-
-let globalIdCounter = 0;
-
-export function useUniqueId(prefix = '') {
-  const idRef = useRef<string | null>(null);
-  if (idRef.current === null) {
-    idRef.current = `${prefix}${++globalIdCounter}`;
-  }
-  return idRef.current;
-}
+import { useUniqueId } from '../utils';
 
 const attributes = [
   'checked-children',

--- a/packages/design-system/src/components/web-components/ds-choice/ds-choice.tsx
+++ b/packages/design-system/src/components/web-components/ds-choice/ds-choice.tsx
@@ -1,8 +1,21 @@
 import type * as React from 'react';
+// import { useId as useReactId } from 'react';
+import { useRef } from 'react';
 import { define } from '../preactement/define';
 import { Choice, ChoiceProps } from '../../ChoiceList/Choice';
 import { parseBooleanAttr } from '../wrapperUtils';
 import { formAttrs } from '../shared-attributes/form';
+// import uniqueId from 'lodash/uniqueId';
+
+let globalIdCounter = 0;
+
+export function useUniqueId(prefix = '') {
+  const idRef = useRef<string | null>(null);
+  if (idRef.current === null) {
+    idRef.current = `${prefix}${++globalIdCounter}`;
+  }
+  return idRef.current;
+}
 
 const attributes = [
   'checked-children',
@@ -45,15 +58,20 @@ interface WrapperProps
   rootId?: string;
 }
 
-const Wrapper = ({ checked, defaultChecked, rootId, ...otherProps }: WrapperProps) => (
-  <Choice
-    {...otherProps}
-    checked={checked && Boolean(JSON.parse(checked))}
-    defaultChecked={defaultChecked && Boolean(JSON.parse(defaultChecked))}
-    disabled={parseBooleanAttr(otherProps.disabled)}
-    id={rootId}
-    inversed={parseBooleanAttr(otherProps.inversed)}
-  ></Choice>
-);
+const Wrapper = ({ checked, defaultChecked, rootId, ...otherProps }: WrapperProps) => {
+  const autoId = useUniqueId('choice--');
+  const id = rootId && rootId.trim() !== '' ? rootId : autoId;
+
+  return (
+    <Choice
+      {...otherProps}
+      checked={checked && Boolean(JSON.parse(checked))}
+      defaultChecked={defaultChecked && Boolean(JSON.parse(defaultChecked))}
+      disabled={parseBooleanAttr(otherProps.disabled)}
+      id={id}
+      inversed={parseBooleanAttr(otherProps.inversed)}
+    />
+  );
+};
 
 define('ds-choice', () => Wrapper, { attributes, events: ['onChange', 'onBlur'] });

--- a/packages/design-system/src/components/web-components/ds-date-field/__snapshots__/ds-date-field.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-date-field/__snapshots__/ds-date-field.test.tsx.snap
@@ -67,10 +67,10 @@ exports[`DateField DateField with picker renders with picker 1`] = `
 
 exports[`DateField generates ids when no id is provided 1`] = `
 <input
-  aria-describedby="date-field--6__hint date-field--6__label-mask"
+  aria-describedby="date-field--P0-0__hint date-field--P0-0__label-mask"
   aria-invalid="false"
   class="ds-c-field"
-  id="date-field--6"
+  id="date-field--P0-0"
   inputmode="numeric"
   name="ds-date-field"
   type="text"

--- a/packages/design-system/src/components/web-components/ds-date-field/ds-date-field.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-date-field/ds-date-field.test.tsx
@@ -79,7 +79,7 @@ describe('DateField', () => {
     });
     const inputElement = getInput();
     expect(inputElement).toMatchSnapshot();
-    expect(inputElement.id).toMatch(/date-field--\d+/);
+    expect(inputElement.id).toMatch(/^date-field--[\w:.-]+$/);
   });
 
   it('calls ds-change (onChange) when input changes', async () => {

--- a/packages/design-system/src/components/web-components/ds-drawer/__snapshots__/ds-drawer.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-drawer/__snapshots__/ds-drawer.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Drawer should render a dialog 1`] = `
 <dialog
-  aria-labelledby="drawer--1"
+  aria-labelledby="drawer--P0-0"
   class="ds-c-drawer"
   open=""
   role="dialog"
@@ -16,7 +16,7 @@ exports[`Drawer should render a dialog 1`] = `
     >
       <h3
         class="ds-c-drawer__header-heading"
-        id="drawer--1"
+        id="drawer--P0-0"
       >
         Test Drawer Heading
       </h3>

--- a/packages/design-system/src/components/web-components/ds-dropdown/__snapshots__/ds-dropdown.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-dropdown/__snapshots__/ds-dropdown.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Dropdown renders a dropdown 1`] = `
     >
       <div
         class="ds-c-label ds-c-dropdown__label"
-        id="dropdown--1__label"
+        id="dropdown--P0-0__label"
       >
         Dropdown label
       </div>
@@ -19,7 +19,7 @@ exports[`Dropdown renders a dropdown 1`] = `
         aria-atomic="true"
         aria-live="assertive"
         class="ds-c-inline-error"
-        id="dropdown--1__error"
+        id="dropdown--P0-0__error"
       />
       <div
         aria-hidden="true"
@@ -53,18 +53,18 @@ exports[`Dropdown renders a dropdown 1`] = `
         </label>
       </div>
       <button
-        aria-controls="dropdown--1__menu"
+        aria-controls="dropdown--P0-0__menu"
         aria-disabled="false"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="dropdown--1__button-content dropdown--1__label"
+        aria-labelledby="dropdown--P0-0__button-content dropdown--P0-0__label"
         class="ds-c-dropdown__button ds-c-field"
-        id="dropdown--1"
+        id="dropdown--P0-0"
         type="button"
       >
         <span
           class="ds-c-dropdown__label-text"
-          id="dropdown--1__button-content"
+          id="dropdown--P0-0__button-content"
         >
           Option 1
         </span>
@@ -99,7 +99,7 @@ exports[`Dropdown renders a dropdown using html options 1`] = `
     >
       <div
         class="ds-c-label ds-c-dropdown__label"
-        id="dropdown--5__label"
+        id="dropdown--P0-0__label"
       >
         Dropdown label
       </div>
@@ -107,7 +107,7 @@ exports[`Dropdown renders a dropdown using html options 1`] = `
         aria-atomic="true"
         aria-live="assertive"
         class="ds-c-inline-error"
-        id="dropdown--5__error"
+        id="dropdown--P0-0__error"
       />
       <div
         aria-hidden="true"
@@ -146,18 +146,18 @@ exports[`Dropdown renders a dropdown using html options 1`] = `
         </label>
       </div>
       <button
-        aria-controls="dropdown--5__menu"
+        aria-controls="dropdown--P0-0__menu"
         aria-disabled="false"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="dropdown--5__button-content dropdown--5__label"
+        aria-labelledby="dropdown--P0-0__button-content dropdown--P0-0__label"
         class="ds-c-dropdown__button ds-c-field"
-        id="dropdown--5"
+        id="dropdown--P0-0"
         type="button"
       >
         <span
           class="ds-c-dropdown__label-text"
-          id="dropdown--5__button-content"
+          id="dropdown--P0-0__button-content"
         >
           Option A-1
         </span>

--- a/packages/design-system/src/components/web-components/ds-filter-chip/__snapshots__/ds-filter-chip.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-filter-chip/__snapshots__/ds-filter-chip.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`ds-filter-chip should include children as label 1`] = `
 <button
   class="ds-c-filter-chip__button ds-not-a-real-class"
-  id="filter-chip--1"
+  id="filter-chip--P0-0"
   type="button"
 >
   <span
-    aria-describedby="filter-chip--1-instructions"
+    aria-describedby="filter-chip--P0-0-instructions"
     aria-hidden="true"
     class="ds-c-filter-chip__label"
   >
@@ -15,7 +15,7 @@ exports[`ds-filter-chip should include children as label 1`] = `
   </span>
   <span
     class="ds-u-visibility--screen-reader"
-    id="filter-chip--1-instructions"
+    id="filter-chip--P0-0-instructions"
   >
     
      

--- a/packages/design-system/src/components/web-components/ds-filter-chip/ds-filter-chip.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-filter-chip/ds-filter-chip.test.tsx
@@ -33,13 +33,13 @@ describe('ds-filter-chip', () => {
 
   it('generates an id when an empty string is provided', () => {
     renderFilterChip({ 'root-id': '' });
-    const idRegex = /filter-chip--\d+/;
+    const idRegex = /^filter-chip--[\w:.-]+$/;
     expect(screen.getByRole('button').id).toMatch(idRegex);
   });
 
   it('generates an id when undefined is provided', () => {
     renderFilterChip({ 'root-id': undefined });
-    const idRegex = /filter-chip--\d+/;
+    const idRegex = /^filter-chip--[\w:.-]+$/;
     expect(screen.getByRole('button').id).toMatch(idRegex);
   });
 

--- a/packages/design-system/src/components/web-components/ds-inline-error/__snapshots__/ds-inline-error.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-inline-error/__snapshots__/ds-inline-error.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`InlineError should render a default inline-error 1`] = `
   aria-atomic="true"
   aria-live="assertive"
   class="ds-c-inline-error"
-  id="inline-error--1"
+  id="inline-error--P0-0"
 >
   <svg
     aria-hidden="true"

--- a/packages/design-system/src/components/web-components/ds-modal-dialog/ds-modal-dialog.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-modal-dialog/ds-modal-dialog.test.tsx
@@ -36,7 +36,7 @@ function getDialog(shadowRoot: ShadowRoot): HTMLDialogElement {
 describe('DS Modal Dialog', function () {
   it('generates ids when no id is provided', () => {
     const { shadowRoot } = renderDialog({ 'root-id': undefined });
-    const idRegex = /dialog--\d+/;
+    const idRegex = /^dialog--[\w:.-]+$/;
     expect(getDialog(shadowRoot).id).toMatch(idRegex);
     expect(getByRole(shadowRoot as any as HTMLElement, 'heading').id).toMatch(idRegex);
   });

--- a/packages/design-system/src/components/web-components/ds-month-picker/__snapshots__/ds-month-picker.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-month-picker/__snapshots__/ds-month-picker.test.tsx.snap
@@ -9,19 +9,19 @@ exports[`MonthPicker renders a snapshot 1`] = `
     name="months"
   >
     <fieldset
-      aria-describedby="month-picker--1__error month-picker--1__hint"
+      aria-describedby="month-picker--P0-0__error month-picker--P0-0__hint"
       aria-invalid="true"
       class="ds-c-fieldset ds-c-month-picker"
     >
       <legend
         class="ds-c-label"
-        id="month-picker--1__label"
+        id="month-picker--P0-0__label"
       >
         Months
       </legend>
       <p
         class="ds-c-hint"
-        id="month-picker--1__hint"
+        id="month-picker--P0-0__hint"
       >
         Guess and test
       </p>
@@ -29,7 +29,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
         aria-atomic="true"
         aria-live="assertive"
         class="ds-c-inline-error"
-        id="month-picker--1__error"
+        id="month-picker--P0-0__error"
       >
         <svg
           aria-hidden="true"
@@ -83,7 +83,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="January"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--1"
+                  id="month-picker--P0-0__choice--1"
                   name="months"
                   type="checkbox"
                   value="1"
@@ -91,8 +91,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--1"
-                  id="month-picker--1__choice--1__label"
+                  for="month-picker--P0-0__choice--1"
+                  id="month-picker--P0-0__choice--1__label"
                 >
                   Jan
                 </label>
@@ -109,7 +109,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="February"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--2"
+                  id="month-picker--P0-0__choice--2"
                   name="months"
                   type="checkbox"
                   value="2"
@@ -117,8 +117,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--2"
-                  id="month-picker--1__choice--2__label"
+                  for="month-picker--P0-0__choice--2"
+                  id="month-picker--P0-0__choice--2__label"
                 >
                   Feb
                 </label>
@@ -135,7 +135,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="March"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--3"
+                  id="month-picker--P0-0__choice--3"
                   name="months"
                   type="checkbox"
                   value="3"
@@ -143,8 +143,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--3"
-                  id="month-picker--1__choice--3__label"
+                  for="month-picker--P0-0__choice--3"
+                  id="month-picker--P0-0__choice--3__label"
                 >
                   Mar
                 </label>
@@ -161,7 +161,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="April"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--4"
+                  id="month-picker--P0-0__choice--4"
                   name="months"
                   type="checkbox"
                   value="4"
@@ -169,8 +169,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--4"
-                  id="month-picker--1__choice--4__label"
+                  for="month-picker--P0-0__choice--4"
+                  id="month-picker--P0-0__choice--4__label"
                 >
                   Apr
                 </label>
@@ -187,7 +187,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="May"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--5"
+                  id="month-picker--P0-0__choice--5"
                   name="months"
                   type="checkbox"
                   value="5"
@@ -195,8 +195,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--5"
-                  id="month-picker--1__choice--5__label"
+                  for="month-picker--P0-0__choice--5"
+                  id="month-picker--P0-0__choice--5__label"
                 >
                   May
                 </label>
@@ -213,7 +213,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="June"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--6"
+                  id="month-picker--P0-0__choice--6"
                   name="months"
                   type="checkbox"
                   value="6"
@@ -221,8 +221,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--6"
-                  id="month-picker--1__choice--6__label"
+                  for="month-picker--P0-0__choice--6"
+                  id="month-picker--P0-0__choice--6__label"
                 >
                   Jun
                 </label>
@@ -239,7 +239,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="July"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--7"
+                  id="month-picker--P0-0__choice--7"
                   name="months"
                   type="checkbox"
                   value="7"
@@ -247,8 +247,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--7"
-                  id="month-picker--1__choice--7__label"
+                  for="month-picker--P0-0__choice--7"
+                  id="month-picker--P0-0__choice--7__label"
                 >
                   Jul
                 </label>
@@ -265,7 +265,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="August"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--8"
+                  id="month-picker--P0-0__choice--8"
                   name="months"
                   type="checkbox"
                   value="8"
@@ -273,8 +273,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--8"
-                  id="month-picker--1__choice--8__label"
+                  for="month-picker--P0-0__choice--8"
+                  id="month-picker--P0-0__choice--8__label"
                 >
                   Aug
                 </label>
@@ -291,7 +291,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="September"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--9"
+                  id="month-picker--P0-0__choice--9"
                   name="months"
                   type="checkbox"
                   value="9"
@@ -299,8 +299,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--9"
-                  id="month-picker--1__choice--9__label"
+                  for="month-picker--P0-0__choice--9"
+                  id="month-picker--P0-0__choice--9__label"
                 >
                   Sep
                 </label>
@@ -317,7 +317,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="October"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--10"
+                  id="month-picker--P0-0__choice--10"
                   name="months"
                   type="checkbox"
                   value="10"
@@ -325,8 +325,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--10"
-                  id="month-picker--1__choice--10__label"
+                  for="month-picker--P0-0__choice--10"
+                  id="month-picker--P0-0__choice--10__label"
                 >
                   Oct
                 </label>
@@ -343,7 +343,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="November"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--11"
+                  id="month-picker--P0-0__choice--11"
                   name="months"
                   type="checkbox"
                   value="11"
@@ -351,8 +351,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--11"
-                  id="month-picker--1__choice--11__label"
+                  for="month-picker--P0-0__choice--11"
+                  id="month-picker--P0-0__choice--11__label"
                 >
                   Nov
                 </label>
@@ -369,7 +369,7 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <input
                   aria-label="December"
                   class="ds-c-choice"
-                  id="month-picker--1__choice--12"
+                  id="month-picker--P0-0__choice--12"
                   name="months"
                   type="checkbox"
                   value="12"
@@ -377,8 +377,8 @@ exports[`MonthPicker renders a snapshot 1`] = `
                 <label
                   aria-hidden="true"
                   class="ds-c-label"
-                  for="month-picker--1__choice--12"
-                  id="month-picker--1__choice--12__label"
+                  for="month-picker--P0-0__choice--12"
+                  id="month-picker--P0-0__choice--12__label"
                 >
                   Dec
                 </label>

--- a/packages/design-system/src/components/web-components/ds-text-field/__snapshots__/ds-text-field.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-text-field/__snapshots__/ds-text-field.test.tsx.snap
@@ -10,20 +10,20 @@ exports[`ds-text-field renders text-field 1`] = `
     >
       <label
         class="ds-c-label"
-        for="text-field--1"
-        id="text-field--1__label"
+        for="text-field--P0-0"
+        id="text-field--P0-0__label"
       />
       <p
         aria-atomic="true"
         aria-live="assertive"
         class="ds-c-inline-error"
-        id="text-field--1__error"
+        id="text-field--P0-0__error"
       />
       <input
         aria-disabled="false"
         aria-invalid="false"
         class="ds-c-field"
-        id="text-field--1"
+        id="text-field--P0-0"
         type="text"
       />
     </div>

--- a/packages/design-system/src/components/web-components/ds-usa-banner/ds-usa-banner.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-usa-banner/ds-usa-banner.test.tsx
@@ -24,7 +24,7 @@ describe('UsaBanner', function () {
 
   it('generates ids when no id is provided', () => {
     const { container } = renderBanner();
-    const idRegex = /usa-banner--\d+/;
+    const idRegex = /^usa-banner[\w:.-]+$/;
     const button = screen.getByRole('button');
     const panelId = button.getAttribute('aria-controls');
     const panel = container.querySelector(`#${panelId}`);

--- a/packages/design-system/src/components/web-components/utils.ts
+++ b/packages/design-system/src/components/web-components/utils.ts
@@ -1,3 +1,15 @@
+import { useRef } from 'react';
+
+let globalIdCounter = 0;
+
+export function useUniqueId(prefix = '') {
+  const idRef = useRef<string | null>(null);
+  if (idRef.current === null) {
+    idRef.current = `${prefix}${++globalIdCounter}`;
+  }
+  return idRef.current;
+}
+
 export const isPossibleValue = <T extends string>(
   value: string,
   possibleValues: readonly T[]

--- a/packages/design-system/src/components/web-components/utils.ts
+++ b/packages/design-system/src/components/web-components/utils.ts
@@ -1,11 +1,10 @@
 import { useRef } from 'react';
-
-let globalIdCounter = 0;
+import uniqueId from 'lodash/uniqueId';
 
 export function useUniqueId(prefix = '') {
   const idRef = useRef<string | null>(null);
   if (idRef.current === null) {
-    idRef.current = `${prefix}${++globalIdCounter}`;
+    idRef.current = uniqueId(prefix);
   }
   return idRef.current;
 }

--- a/packages/docs/src/components/layout/FilterDialog/__snapshots__/FilterDialog.test.tsx.snap
+++ b/packages/docs/src/components/layout/FilterDialog/__snapshots__/FilterDialog.test.tsx.snap
@@ -28,15 +28,15 @@ exports[`FilterDialog renders a dialog 1`] = `
       >
         <svg
           aria-hidden="false"
-          aria-labelledby="icon--2__title"
+          aria-labelledby="icon--:r0:__title"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
-          id="icon--2"
+          id="icon--:r0:"
           role="img"
           viewBox="-2 -2 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
           <title
-            id="icon--2__title"
+            id="icon--:r0:__title"
           >
             Close
           </title>

--- a/packages/ds-healthcare-gov/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`ThirdPartyExternalLink ThirdPartyExternalLink dialog renders external link dialog 1`] = `
 <dialog
-  aria-labelledby="dialog--4__heading"
+  aria-labelledby="dialog--:r5:__heading"
   class="ds-c-dialog"
-  id="dialog--4"
+  id="dialog--:r5:"
   open=""
   role="dialog"
   tabindex="-1"
@@ -17,20 +17,20 @@ exports[`ThirdPartyExternalLink ThirdPartyExternalLink dialog renders external l
     >
       <h2
         class="ds-c-dialog__heading"
-        id="dialog--4__heading"
+        id="dialog--:r5:__heading"
       >
         You are leaving bar.
       </h2>
       <button
         aria-label="Close modal dialog"
         class="ds-c-close-button ds-c-dialog__close"
-        id="dialog--4__close"
+        id="dialog--:r5:__close"
         type="button"
       >
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
-          id="dialog--4__close__icon"
+          id="dialog--:r5:__close__icon"
           viewBox="-2 -2 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -48,7 +48,7 @@ exports[`ThirdPartyExternalLink ThirdPartyExternalLink dialog renders external l
       class="ds-c-dialog__body"
     >
       <div
-        id="dialog--4__content"
+        id="dialog--:r5:__content"
       >
         <p>
           You're about to connect to a third-party site. Select CONTINUE to proceed or CANCEL to stay on this site.
@@ -91,15 +91,15 @@ exports[`ThirdPartyExternalLink renders external link 1`] = `
   External site link
   <svg
     aria-hidden="false"
-    aria-labelledby="icon--1__title"
+    aria-labelledby="icon--:r0:__title"
     class="ds-c-icon ds-c-icon--external-link ds-c-external-link__icon"
-    id="icon--1"
+    id="icon--:r0:"
     role="img"
     viewBox="0 0 512 512"
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="icon--1__title"
+      id="icon--:r0:__title"
     >
       This link goes to an external site
     </title>

--- a/packages/ds-medicare-gov/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
+++ b/packages/ds-medicare-gov/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`ThirdPartyExternalLink ThirdPartyExternalLink dialog renders external link dialog 1`] = `
 <dialog
-  aria-labelledby="dialog--4__heading"
+  aria-labelledby="dialog--:r5:__heading"
   class="ds-c-dialog"
-  id="dialog--4"
+  id="dialog--:r5:"
   open=""
   role="dialog"
   tabindex="-1"
@@ -17,20 +17,20 @@ exports[`ThirdPartyExternalLink ThirdPartyExternalLink dialog renders external l
     >
       <h2
         class="ds-c-dialog__heading"
-        id="dialog--4__heading"
+        id="dialog--:r5:__heading"
       >
         You are leaving bar.
       </h2>
       <button
         aria-label="Close modal dialog"
         class="ds-c-close-button ds-c-dialog__close"
-        id="dialog--4__close"
+        id="dialog--:r5:__close"
         type="button"
       >
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
-          id="dialog--4__close__icon"
+          id="dialog--:r5:__close__icon"
           viewBox="-2 -2 18 18"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -48,7 +48,7 @@ exports[`ThirdPartyExternalLink ThirdPartyExternalLink dialog renders external l
       class="ds-c-dialog__body"
     >
       <div
-        id="dialog--4__content"
+        id="dialog--:r5:__content"
       >
         <p>
           You're about to connect to a third-party site. Select CONTINUE to proceed or CANCEL to stay on this site.
@@ -91,15 +91,15 @@ exports[`ThirdPartyExternalLink renders external link 1`] = `
   External site link
   <svg
     aria-hidden="false"
-    aria-labelledby="icon--1__title"
+    aria-labelledby="icon--:r0:__title"
     class="ds-c-icon ds-c-icon--external-link ds-c-external-link__icon"
-    id="icon--1"
+    id="icon--:r0:"
     role="img"
     viewBox="0 0 512 512"
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="icon--1__title"
+      id="icon--:r0:__title"
     >
       This link goes to an external site
     </title>

--- a/packages/ds-medicare-gov/src/components/web-components/ds-simple-footer/__snapshots__/ds-simple-footer.test.tsx.snap
+++ b/packages/ds-medicare-gov/src/components/web-components/ds-simple-footer/__snapshots__/ds-simple-footer.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`SimpleFooter renders without crashing 1`] = `
         class="m-c-footer__identityRow"
       >
         <svg
-          aria-labelledby="medicare-gov-logo--1"
+          aria-labelledby="medicare-gov-logo--P0-0"
           class="m-c-footer__medicare-logo"
           height="39"
           preserveAspectRatio="xMidYMid meet"
@@ -89,7 +89,7 @@ exports[`SimpleFooter renders without crashing 1`] = `
           xmlspace="preserve"
         >
           <title
-            id="medicare-gov-logo--1"
+            id="medicare-gov-logo--P0-0"
           >
             Medicare.gov
           </title>
@@ -121,15 +121,15 @@ exports[`SimpleFooter renders without crashing 1`] = `
         </svg>
         <svg
           aria-hidden="false"
-          aria-labelledby="icon--2__title"
+          aria-labelledby="icon--P0-1__title"
           class="ds-c-icon ds-c-icon--hhs-logo m-c-footer__hhs-logo"
-          id="icon--2"
+          id="icon--P0-1"
           role="img"
           viewBox="0 0 252 252"
           xmlns="http://www.w3.org/2000/svg"
         >
           <title
-            id="icon--2__title"
+            id="icon--P0-1__title"
           >
             Department of Health and Human Services
           </title>


### PR DESCRIPTION
## Summary

- Replaced our custom `useId`-like utility function that leverages `lodash/uniqueId` to use React's built in `useId`.
- Updated regex patterns in unit tests to reflect the new ID format generated by `useId`.
[Jira ticket](https://jira.cms.gov/browse/CMSDS-3403)

### Issues with removing `lodash/uniqueId`

In addition to replacing our existing `useId` utility with React’s built-in `useId` hook, another potential acceptance criterion in [this ticket](https://jira.cms.gov/browse/CMSDS-3403) was to remove our dependency on `lodash/uniqueId` entirely, if feasible. As a first step, I updated the utility to leverage React's `useId` (replacing the previous use of `uniqueId` and `useRef`)) while preserving the existing logic for ID prefixes (e.g., `autocomplete--`) in a centralized place. From there, I began debugging test failures. Most were straightforward and only required updates to the regex used in validating generated Ids.

However, as I debugged various failing web component tests, I found that in our web components—which are essentially our React components rendered via Preact—React’s `useId` did not generate reliably unique IDs across multiple instances of the same component, as seen in [this test case](https://github.com/CMSgov/design-system/blob/main/packages/design-system/src/components/web-components/ds-choice/ds-choice.test.tsx#L127-L157). My working hypothesis is that each web component is rendered in an isolated context—such as a `DocumentFragment` or shadow root—which prevents `useId` from coordinating unique IDs across these render contexts. In contrast, `lodash/uniqueId` relies on a global counter, which *does* appear to work across these boundaries.

For now, I’ve retained `lodash/uniqueId` in specific web components likely to have multiple instances like `ds-choice` and `ds-accordion-item`. 

**Additionally**, we can’t fully remove the `lodash/uniqueId` module yet, as it’s still used in our `DateInput` class component. Refactoring it to a functional component would be required before it could use hooks like `useId`.


## How to test

- `npm run test`
- `npm run test:unit:wc`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone