### PR TITLE
[CMSDS-3499] Adds a11y testing guidance to filter chip

### DIFF
--- a/packages/docs/content/components/filter-chip.mdx
+++ b/packages/docs/content/components/filter-chip.mdx
@@ -19,22 +19,6 @@ medicare:
 
 <StorybookExample componentName="filterChip" storyId="components-filterchip--multiple-chips" />
 
-## Code
-
-### React
-
-<SeeStorybookForGuidance storyId={'components-filterchip--docs'} />
-
-### Web Component
-
-<SeeStorybookForGuidance tech="wc" storyId={'web-components-ds-filter-chip--docs'} />
-
-### Style customization
-
-The following CSS variables can be overridden to customize FilterChip components:
-
-<ComponentThemeOptions componentname="filter-chip" />
-
 ## Guidance
 
 ### When to use
@@ -54,9 +38,43 @@ The following CSS variables can be overridden to customize FilterChip components
 - Allow adequate spacing (at least 8px) between each filter chip, as much as the design will allow.
 - The colors of the Filter Chip can be overriden using the CSS variables listed below, but should not be overriden with colors outside of the color palette.
 
-### Accessibility
+## Accessibility
 
+The filter chip component has been tested against, and meets, WCAG 2.0 standards for size, color contrast, and screen reader usage.
+
+- The label for the chip is its label text. Other actions, like remove, should be labeled separately
+- The chip should receive focus
 - `Enter`, `Backspace`, `Delete`, and `Spacebar` will remove the tag when it is in focus
+
+### Accessibility testing
+
+#### Screen reader testing
+
+- When navigating to a filter chip, screen readers should announce the label text and any actions, like remove, separately
+- Screen readers should identify filter chips as buttons
+
+#### Keyboard testing
+
+- Users should be able to navigate to the chip with their keyboard
+- Filter chips should receive focus
+- `Enter`, `Backspace`, `Delete`, and `Spacebar` should remove the tag when it is in focus
+
+
+## Code
+
+### React
+
+<SeeStorybookForGuidance storyId={'components-filterchip--docs'} />
+
+### Web Component
+
+<SeeStorybookForGuidance tech="wc" storyId={'web-components-ds-filter-chip--docs'} />
+
+### Style customization
+
+The following CSS variables can be overridden to customize FilterChip components:
+
+<ComponentThemeOptions componentname="filter-chip" />
 
 ## Component maturity
 


### PR DESCRIPTION
## Summary

- a11y guidance is added to the filter chip component
- The sections match the order of our [template](https://confluence.cms.gov/display/HCDSG/Doc+Site+Guidance%3A+Information+Architecture)

## How to test
Run locally and confirm that the above criteria are met.

## Checklist

- [ ] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [ ] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [ ] Selected appropriate `Impacts`, multiple can be selected.
- [ ] Selected appropriate release milestone

