### PR TITLE
[NO-TICKET] Updated the inline error language to be consistent

### DIFF
--- a/packages/docs/content/components/inline-error.mdx
+++ b/packages/docs/content/components/inline-error.mdx
@@ -19,7 +19,9 @@ core:
 ## Guidance
 
 - Inline errors are built in to all design-system form fields but can be used on their own to create custom fields.
-- Inline errors should sit either directly above or below the input, depending on the theme defaults.
+- Inline errors should sit either directly above or below the input, depending on the current theme defaults:
+  - In the CMS.gov, Medicare, and Core themes, errors appear above the input.
+  - In the Healthcare theme, errors appear below the input.
 - Visually align inline validation messages with the input fields, so people using screen magnifiers can read them quickly.
 - The form field should have an `aria-describedby` attribute that references the `id` of the error message.
 


### PR DESCRIPTION
## Summary

- Updated the language on the "Inline Error" documentation page to be consistent with what is found on the "Error Validation" page.

## How to test

1. Run the docs site and verify that the bullet point that starts with "Inline errors should" on the [Inline Error page](http://localhost:8000/components/inline-error/#guidance) matches the the bullet point that starts with "Inline errors should" found on the [Error Validation page](http://localhost:8000/patterns/Forms/error-validation/#do)

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/WNMGDS/) as `[WNMGDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone