### PR TITLE
[NO-TICKET] Wait for fonts before snapshots and increase expect timeout on CI

### DIFF
--- a/tests/browser/playwright.config.ts
+++ b/tests/browser/playwright.config.ts
@@ -90,7 +90,7 @@ export const config: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000,
+    timeout: isCI ? 15000 : 5000,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/tests/browser/stories.test.ts
+++ b/tests/browser/stories.test.ts
@@ -78,6 +78,9 @@ stories.forEach((story) => {
           browserContext = await browser.newContext();
           page = await browserContext.newPage();
           await page.goto(`${storyUrl}&globals=theme:${theme}`);
+          await page.waitForLoadState('domcontentloaded');
+          // Ensure fonts are fully resolved before snapshot
+          await page.evaluate(() => document.fonts?.ready);
         });
 
         test.afterAll(async () => {


### PR DESCRIPTION
## Summary

Recent nightly runs show snapshot tests failing on the first attempt when switching to a new theme, but passing on retry. This flakiness hasn’t been reproducible locally.  

Example logs from **Build 1157**:  
```
[chromium] > stories.test.ts > Reset/Lists/Lists > with core theme > passes a11y checks: passed
[chromium] > stories.test.ts > Reset/Lists/Lists > with cmsgov theme > matches snapshot: failed
[chromium] > stories.test.ts > Reset/Lists/Lists > with cmsgov theme > matches snapshot: passed
[chromium] > stories.test.ts > Reset/Lists/Lists > with healthcare theme > matches snapshot: failed
[chromium] > stories.test.ts > Reset/Lists/Lists > with healthcare theme > matches snapshot: passed
```
Other builds showing a similar pattern pattern (switching theme → fail on first run → pass on retry):: [1157](https://ci.backends.cms.gov/wds/job/design-system/job/test-nightly/1157/), [1158](https://ci.backends.cms.gov/wds/job/design-system/job/test-nightly/1158/), [1159](https://ci.backends.cms.gov/wds/job/design-system/job/test-nightly/1159/), [1160](https://ci.backends.cms.gov/wds/job/design-system/job/test-nightly/1160/)

Wondering if font loading between themes (combined with slower processing on jenkins) might be contributing to the flakiness. So trying out a bit more flexibility around timeouts and font resolution to hopefully help stabilize things.

- Add a line to the `beforeEach` hook to ensure fonts are resolved before taking a snapshot.  
- Increase `expect` timeout in CI.  

## How to test

1. `CI=true npm run test:browser`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone