### PR TITLE
[NO-TICKET] Add GitHub Issue line to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,13 @@
 - Overview of changes
 - A link to the Jira ticket for quick reference
 
+<!--
+  If this PR resolves a GitHub Issue, add that number below.
+  Otherwise, feel free to remove this line.
+-->
+
+- Closes #XXXX
+
 ## How to test
 
 1. Instructions on how to test the changes in this PR.


### PR DESCRIPTION
## Summary

- Adds an optional line to the "Summary" section for closing relevant GitHub issues.

## How to test

1. Read the template and make sure it looks ok

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
