### PR TITLE
[CMSDS-3547] Replace requiredLabel with hint on ChoiceList Story

### DIFF
--- a/packages/design-system/src/components/ChoiceList/ChoiceList.stories.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.stories.tsx
@@ -26,6 +26,7 @@ const meta: Meta<typeof ChoiceList> = {
     errorMessage: { control: 'text' },
     hint: { control: 'text' },
     ref: { table: { disable: true } },
+    requirementLabel: { control: 'text' },
     size: {
       options: [undefined, 'small'],
       control: { type: 'radio' },

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.stories.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof ChoiceList> = {
           console.log('I am a ref callback being called!');
         },
       },
-      { label: 'Choice 2', requirementLabel: 'Choice hint text', value: 'B' },
+      { label: 'Choice 2', hint: 'Choice hint text', value: 'B' },
     ],
     // https://github.com/CMSgov/design-system/pull/3003#discussion_r1545916584
     onBlur: action('onBlur'),
@@ -26,7 +26,6 @@ const meta: Meta<typeof ChoiceList> = {
     errorMessage: { control: 'text' },
     hint: { control: 'text' },
     ref: { table: { disable: true } },
-    requirementLabel: { control: 'text' },
     size: {
       options: [undefined, 'small'],
       control: { type: 'radio' },
@@ -140,7 +139,7 @@ export const ChoiceChildren: Story = {
       },
       {
         label: 'Choice 2',
-        requirementLabel: 'Choice hint text',
+        hint: 'Choice hint text',
         value: 'B',
         checkedChildren: (
           <div className="ds-c-choice__checkedChild">

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
@@ -68,13 +68,19 @@ describe('ChoiceList', () => {
 
     it('renders all choices', () => {
       const numChoices = 3;
-      renderChoiceList({}, numChoices);
+      renderChoiceList({
+        choices: generateChoices(3, {
+          hint: 'Choice hint text',
+        }),
+      });
       const choiceEls = screen.getAllByRole('radio');
       const choice = choiceEls[0] as HTMLInputElement;
+      const hintTexts = screen.getAllByText('Choice hint text');
 
       expect(choiceEls.length).toBe(numChoices);
       expect(choice.name).toBe('spec-field');
       expect(choice.value).toBe('1');
+      expect(hintTexts[0].tagName).toBe('P');
     });
 
     it('is enclosed by a fieldset', () => {


### PR DESCRIPTION
## Summary

- Updated the ChoiceList example to use the `hint` prop instead of the `requirementLabel` prop to render the hint text. `requirementLabel` is meant for that text that says "Required" or "Optional" before the hint text.
- CMSDS-3547
- Closes #3726 

## How to test

1. Run `npm run storybook`
2. Navigate to the `ChoiceList` docs
3. Under the example, click "Show code"
4. Verify the second choice has a `hint` prop with the value "Choice hint text"

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] Verified that running both `npm run test:unit` and `npm run test:browser:all` were each successful

### If this is a change to documentation/content:

- [x] Checked for spelling and grammatical errors
