### PR TITLE
[CMSDS-3587] Removed Medicare-specific references from `Card` Guidance

### DIFF
--- a/packages/docs/content/components/card.mdx
+++ b/packages/docs/content/components/card.mdx
@@ -1,34 +1,26 @@
 ---
-title: Card (M.gov)
+title: Card
 status:
   level: avoid
   note: Lacks documented guidance on usage and accessibility.
 core:
+  # TODO: update figma node ID once the Figma file is updated with Core Card.
+  # This one goes directly to the Medicare-specific design.
   figmaNodeId: 4334-23875
+  githubLink: design-system/src/components/Card
+  storybookLink: components-card--docs
 medicare:
   githubLink: ds-medicare-gov/src/components/Card
   storybookLink: medicare-card--docs
 ---
 
-import { Alert } from '@cmsgov/design-system';
-
-<ThemeContent neverThemes={['medicare']}>
-  <Alert variation="error">
-    <p class="ds-c-alert__text">
-      {
-        'This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.'
-      }
-    </p>
-  </Alert>
-</ThemeContent>
-
 ## Examples
 
-<StorybookExample componentName="card" storyId="medicare-card--default" />
+<StorybookExample componentName="card" storyId="components-card--default" />
 
 ## Accessibility
 
-The [Medicare.gov](https://www.medicare.gov/) Card component is primarily a wrapper for other content. As such, while the component itself passes the relevant WCAG 2.0 accessibility tests, teams should take care to test the card implementation thoroughly, including any elements or components that are nested within it.
+The Card component is primarily a wrapper for other content. As such, while the component itself passes the relevant WCAG 2.0 accessibility tests, teams should take care to test the card implementation thoroughly, including any elements or components that are nested within it.
 
 ### Accessibility testing
 
@@ -42,7 +34,7 @@ Card components often contain text, buttons, and icons. The accessibility of tho
 
 ### React
 
-<SeeStorybookForGuidance storyId={'medicare-card--docs'} />
+<SeeStorybookForGuidance storyId={'components-card--docs'} />
 
 ## Component maturity
 


### PR DESCRIPTION
## Summary

- Generalized `Card` guidance by removing Medicare-specific references.
- Updated Storybook links to point to the Core component.
[Jira ticket](https://jira.cms.gov/browse/CMSDS-3587)

## How to test
1. Run `npm start`.
2. Navigate to the [Card page](http://localhost:8000/components/card/?theme=core).
3. Verify the guidance and storybook references are no longer medicare-specific.

## Checklist

- [ ] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [ ] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [ ] Selected appropriate `Impacts`, multiple can be selected.
- [ ] Selected appropriate release milestone