### PR TITLE
[CMSDS-3605] Update new relic browser app

### DIFF
--- a/packages/design-system/src/components/ChoiceList/ChoiceList.stories.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof ChoiceList> = {
           console.log('I am a ref callback being called!');
         },
       },
-      { label: 'Choice 2', requirementLabel: 'Choice hint text', value: 'B' },
+      { label: 'Choice 2', hint: 'Choice hint text', value: 'B' },
     ],
     // https://github.com/CMSgov/design-system/pull/3003#discussion_r1545916584
     onBlur: action('onBlur'),
@@ -140,7 +140,7 @@ export const ChoiceChildren: Story = {
       },
       {
         label: 'Choice 2',
-        requirementLabel: 'Choice hint text',
+        hint: 'Choice hint text',
         value: 'B',
         checkedChildren: (
           <div className="ds-c-choice__checkedChild">

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
@@ -68,13 +68,19 @@ describe('ChoiceList', () => {
 
     it('renders all choices', () => {
       const numChoices = 3;
-      renderChoiceList({}, numChoices);
+      renderChoiceList({
+        choices: generateChoices(3, {
+          hint: 'Choice hint text',
+        }),
+      });
       const choiceEls = screen.getAllByRole('radio');
       const choice = choiceEls[0] as HTMLInputElement;
+      const hintTexts = screen.getAllByText('Choice hint text');
 
       expect(choiceEls.length).toBe(numChoices);
       expect(choice.name).toBe('spec-field');
       expect(choice.value).toBe('1');
+      expect(hintTexts[0].tagName).toBe('P');
     });
 
     it('is enclosed by a fieldset', () => {


### PR DESCRIPTION
## Summary

- Updated `gatsby-plugin-newrelic` to version 2.9.0
- [Ticket](https://jira.cms.gov/browse/CMSDS-3605)

## How to test

1. Pull down this branch
2. Run `npm run clean && npm install && npm run start`
3. In the browser, inspect the doc site
4. Open the console
5. Type `newrelic`, press enter
6. Open the returned object
7. Open the `initializedAgents ` key
8. Open the first key available
9. View the `runtime` object
10. Confirm the version is `1.290` 

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone
