### PR TITLE
[CMSDS-3605] Update new relic browser app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33005,6 +33005,22 @@
         "gatsby": ">= 2.20.0"
       }
     },
+    "node_modules/gatsby-plugin-newrelic": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-newrelic/-/gatsby-plugin-newrelic-2.9.0.tgz",
+      "integrity": "sha512-8cSq2I5eXm9U9TPUIzWgowobB4DgRJPCRmQEqL+AnBNG9o2aC5phHDJPIJ6/rN/sKDAQ0/PtLVgKh0iMWIokUQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=16.3.1"
+      },
+      "peerDependencies": {
+        "gatsby": "3.x - 5.x",
+        "react": "17 - 18",
+        "react-dom": "17 - 18"
+      }
+    },
     "node_modules/gatsby-plugin-page-creator": {
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-5.14.0.tgz",
@@ -58789,7 +58805,7 @@
         "gatsby-plugin-local-search": "^2.0.1",
         "gatsby-plugin-manifest": "^5.14.0",
         "gatsby-plugin-mdx": "^5.14.0",
-        "gatsby-plugin-newrelic": "^2.6.0",
+        "gatsby-plugin-newrelic": "^2.9.0",
         "gatsby-plugin-sass": "^6.14.0",
         "gatsby-plugin-sitemap": "^6.14.0",
         "gatsby-remark-autolink-headers": "^6.14.0",
@@ -59872,22 +59888,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "packages/docs/node_modules/gatsby-plugin-newrelic": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-newrelic/-/gatsby-plugin-newrelic-2.6.0.tgz",
-      "integrity": "sha512-5ToEx5ojxVj4Z3n3tXGsmwygx+Cf3B0keZ3bmYLLi8zF1K1m5r2OIjRbgZvGqikkhFNP+hyYATqPZRFaLumOxQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=16.3.1"
-      },
-      "peerDependencies": {
-        "gatsby": "3.x - 5.x",
-        "react": "17 - 18",
-        "react-dom": "17 - 18"
       }
     },
     "packages/docs/node_modules/gatsby-plugin-sass": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -33,7 +33,7 @@
     "gatsby-plugin-local-search": "^2.0.1",
     "gatsby-plugin-manifest": "^5.14.0",
     "gatsby-plugin-mdx": "^5.14.0",
-    "gatsby-plugin-newrelic": "^2.6.0",
+    "gatsby-plugin-newrelic": "^2.9.0",
     "gatsby-plugin-sass": "^6.14.0",
     "gatsby-plugin-sitemap": "^6.14.0",
     "gatsby-remark-autolink-headers": "^6.14.0",


### PR DESCRIPTION
## Summary

- Updated `gatsby-plugin-newrelic` to version 2.9.0
- [Ticket](https://jira.cms.gov/browse/CMSDS-3605)

## How to test

1. Pull down this branch
2. Run `npm run clean && npm install && npm run start`
3. In the browser, inspect the doc site
4. Open the console
5. Type `newrelic`, press enter
6. Open the returned object
7. Open the `initializedAgents ` key
8. Open the first key available
9. View the `runtime` object
10. Confirm the version is `1.290` 

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone
