### PR TITLE
[CMSDS-3444] Remove aria-invalid attribute if ChoiceList is a checkbox group.

### DIFF
--- a/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
@@ -217,4 +217,27 @@ describe('ChoiceList', () => {
       expect(inputRefCallback).toHaveBeenCalled();
     });
   });
+
+  describe('aria-invalid', () => {
+    describe('when type is radio', () => {
+      it('renders the aria-invalid attribute', () => {
+        renderChoiceList({
+          type: 'radio',
+        });
+        const fieldsetEl = screen.getByRole('radiogroup');
+
+        expect(fieldsetEl).toHaveAttribute('aria-invalid');
+      });
+    });
+    describe('when type is checkbox', () => {
+      it('does not render the aria-invalid attribute', () => {
+        renderChoiceList({
+          type: 'checkbox',
+        });
+        const fieldsetEl = screen.getByRole('group');
+
+        expect(fieldsetEl).not.toHaveAttribute('aria-invalid');
+      });
+    });
+  });
 });

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
@@ -82,11 +82,11 @@ export type ChoiceListProps = BaseChoiceListProps &
  * [HTML input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
  */
 export const ChoiceList = (props: ChoiceListProps) => {
-  const { onBlur, onComponentBlur, choices } = props;
+  const { onBlur, onComponentBlur, choices, type } = props;
   const id = useId('choice-list--', props.id);
 
   if (process.env.NODE_ENV !== 'production') {
-    if (props.type !== 'checkbox' && props.choices.length === 1) {
+    if (type !== 'checkbox' && choices.length === 1) {
       console.warn(
         `[Warning]: Use type="checkbox" for components with only one choice. A single radio button is disallowed because it prevents users from deselecting the field.`
       );
@@ -126,7 +126,7 @@ export const ChoiceList = (props: ChoiceListProps) => {
       onBlur: handleBlur,
       onChange: props.onChange,
       size: props.size,
-      type: props.type,
+      type,
       inputClassName: classNames(choiceProps.inputClassName, {
         'ds-c-choice--error': props.errorMessage,
       }),
@@ -149,12 +149,22 @@ export const ChoiceList = (props: ChoiceListProps) => {
     return <Choice key={choiceProps.value} {...completeChoiceProps} />;
   });
 
+  const addDynamicAttrs = () => {
+    const attrs: React.ComponentPropsWithRef<'fieldset'> = {};
+
+    if (type === 'radio') {
+      attrs['aria-invalid'] = invalid;
+      attrs.role = 'radiogroup';
+    }
+
+    return attrs;
+  };
+
   return (
     <fieldset
-      aria-invalid={invalid}
       aria-describedby={describeField({ ...props, hintId, errorId })}
       className={classNames('ds-c-fieldset', props.className)}
-      role={props.type === 'radio' ? 'radiogroup' : null}
+      {...addDynamicAttrs()}
     >
       <Label component="legend" {...labelProps} />
       {hintElement}

--- a/packages/design-system/src/components/InlineError/useInlineError.tsx
+++ b/packages/design-system/src/components/InlineError/useInlineError.tsx
@@ -76,7 +76,7 @@ export function useInlineError<T extends UseInlineErrorProps>(props: T) {
 
   // If the user has provided an `aria-invalid` attribute, use that as the source
   // of truth; otherwise, it's invalid if there's an error message.
-  const invalid = props['aria-invalid'] ?? !!errorMessage;
+  const invalid: React.AriaAttributes['aria-invalid'] = props['aria-invalid'] ?? !!errorMessage;
 
   return {
     errorId: errorMessage ? errorId : undefined,

--- a/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice-list.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice-list.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`ChoiceList accepts HTML as children 1`] = `
     type="checkbox"
   >
     <fieldset
-      aria-invalid="false"
       class="ds-c-fieldset"
     >
       <legend


### PR DESCRIPTION
## Summary

- The `aria-invalid` attribute is currently applied directly to the <fieldset> element on `ChoiceList` components. According to WAI-ARIA specifications, aria-invalid is a supported and valid attribute for elements with the "radiogroup" role, but not for fieldset elements that do not possess that role.
- This PR updates `ChoiceList` to only show the `aria-invalid` attribute when the `type` prop is set to 'radio'.
- [CMSDS-3444](https://jira.cms.gov/browse/CMSDS-3444)

## How to test

1. Instructions on how to test the changes in this PR.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] Verified that running both `npm run test:unit` and `npm run test:browser:all` were each successful
