### PR TITLE
[CMSDS-3467] Pass null into useRef initializers to align with react 19 types 

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -246,9 +246,9 @@ export const Autocomplete = (props: AutocompleteProps) => {
       : undefined,
   });
 
-  const inputRef = useRef<HTMLInputElement>();
-  const listBoxRef = useRef<HTMLElement>();
-  const wrapperRef = useRef<HTMLDivElement>();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listBoxRef = useRef<HTMLElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const useComboboxProps = useComboBox(
     {
       ...autocompleteProps,

--- a/packages/design-system/src/components/Button/useButtonAnalytics.ts
+++ b/packages/design-system/src/components/Button/useButtonAnalytics.ts
@@ -13,7 +13,7 @@ export default function useButtonAnalytics({
   type,
   variation,
 }: ButtonProps) {
-  const contentRef = useRef();
+  const contentRef = useRef(null);
 
   function sendButtonEvent() {
     if (analytics !== true && (!config().buttonSendsAnalytics || analytics === false)) {

--- a/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.tsx
@@ -133,7 +133,9 @@ export const ChoiceList = (props: ChoiceListProps) => {
       disabled: choiceProps.disabled || props.disabled, // Individual choices can be disabled as well as the entire field
       inputRef: mergeRefs([
         choiceProps.inputRef,
-        (inputElement) => inputElements.push(inputElement),
+        (inputElement) => {
+          inputElements.push(inputElement);
+        },
       ]),
       _choiceChild: true,
     };

--- a/packages/design-system/src/components/DateField/SingleInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.tsx
@@ -159,7 +159,7 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
   const { errorId, topError, bottomError, invalid } = useInlineError({ ...props, id });
   const { hintId, hintElement } = useHint({ ...props, id });
   const labelProps = useLabelProps({ ...props, id });
-  const inputRef = useRef<HTMLInputElement>();
+  const inputRef = useRef<HTMLInputElement>(null);
   const { labelMask, inputProps } = useLabelMask(DATE_MASK, {
     ...cleanFieldProps(remainingProps),
     value,
@@ -172,8 +172,8 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
   });
 
   // Handle alternate ways of closing the day picker
-  const dayPickerRef = useRef();
-  const calendarButtonRef = useRef();
+  const dayPickerRef = useRef(null);
+  const calendarButtonRef = useRef(null);
   useClickOutsideHandler([dayPickerRef, calendarButtonRef], () => setPickerVisible(false));
   usePressEscapeHandler(dayPickerRef, () => {
     setPickerVisible(false);

--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -107,7 +107,7 @@ export const Dialog = (props: DialogProps) => {
   const headerClassNames = classNames('ds-c-dialog__header', headerClassName);
   const actionsClassNames = classNames('ds-c-dialog__actions', actionsClassName);
 
-  const containerRef = useRef<HTMLDivElement>();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Set initial focus
   useEffect(() => {

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -235,7 +235,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     [userOnBlur, state]
   );
 
-  const triggerRef = useRef<HTMLButtonElement>();
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const useSelectProps = useSelect(
     { ...props, onBlur, isDisabled: props.disabled },
     state,
@@ -290,7 +290,7 @@ export const Dropdown: React.FC<DropdownProps> = (props: DropdownProps) => {
     // role: 'combobox',
   };
 
-  const wrapperRef = useRef<HTMLDivElement>();
+  const wrapperRef = useRef<HTMLDivElement>(null);
   useClickOutsideHandler([wrapperRef], () => state.setOpen(false));
 
   return (

--- a/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
@@ -43,7 +43,7 @@ export function DropdownMenu<T>({
     `${componentClass}__menu-container`,
     size && `ds-c-field--${size}`
   );
-  const containerRef = useRef<HTMLDivElement>();
+  const containerRef = useRef<HTMLDivElement>(null);
   usePressEscapeHandler(containerRef, () => {
     state.setOpen(false);
     (props.triggerRef.current as HTMLButtonElement)?.focus?.();

--- a/packages/design-system/src/components/NativeDialog/useNativeDialogAnalytics.ts
+++ b/packages/design-system/src/components/NativeDialog/useNativeDialogAnalytics.ts
@@ -35,7 +35,7 @@ export function useNativeDialogAnalytics({
   onOpen,
   onClose,
 }: UseNativeDialogAnalyticsProps) {
-  const headingRef = useRef();
+  const headingRef = useRef<HTMLHeadingElement>(null);
   const prevIsOpen = usePrevious(isOpen);
   useEffect(() => {
     const headingContent = getAnalyticsContentFromRefs([headingRef]);

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -122,7 +122,7 @@ export const Table = ({
     }
   }
 
-  const containerRef = useRef();
+  const containerRef = useRef(null);
   useEffect(() => {
     if (!window || !scrollable) {
       return;
@@ -169,7 +169,7 @@ export const Table = ({
     if (isTableCaption(child)) {
       // Extend props on TableCaption before rendering.
       if (scrollable) {
-        return cloneElement(child, {
+        return cloneElement(child as React.ReactElement<any>, {
           _id: captionId,
           _scrollActive: scrollActive,
           _scrollableNotice: scrollableNotice,

--- a/packages/design-system/src/components/ThirdPartyExternalLink/useThirdPartyExternalLinkAnalytics.ts
+++ b/packages/design-system/src/components/ThirdPartyExternalLink/useThirdPartyExternalLinkAnalytics.ts
@@ -11,7 +11,7 @@ export function useThirdPartyExternalLinkAnalytics({
   onAnalyticsEvent = config().defaultAnalyticsFunction,
   href,
 }: ThirdPartyExternalLinkProps) {
-  const contentRef = useRef<HTMLAnchorElement>();
+  const contentRef = useRef<HTMLAnchorElement>(null);
 
   function buttonAnalyticsHandler() {
     if (

--- a/packages/design-system/src/components/Tooltip/useTooltipAnalytics.ts
+++ b/packages/design-system/src/components/Tooltip/useTooltipAnalytics.ts
@@ -10,7 +10,7 @@ export default function useTooltipAnalytics({
   ariaLabel,
   triggerAriaLabel,
 }: TooltipProps) {
-  const contentRef = useRef<HTMLElement>();
+  const contentRef = useRef<HTMLElement>(null);
 
   function sendTooltipEvent() {
     if (analytics !== true && (!config().tooltipSendsAnalytics || analytics === false)) {

--- a/packages/design-system/src/components/analytics/useAnalyticsContent.ts
+++ b/packages/design-system/src/components/analytics/useAnalyticsContent.ts
@@ -39,7 +39,11 @@ export interface UseAnalyticsContentProps {
  */
 export function useAnalyticsContent({ onMount, onUnmount }: UseAnalyticsContentProps) {
   // Three refs should be enough to support fallback content. Add more in the future if needed
-  const refs: RefObject<any>[] = [useRef(), useRef(), useRef()];
+  const refs: RefObject<HTMLDivElement>[] = [
+    useRef<HTMLDivElement>(null),
+    useRef<HTMLDivElement>(null),
+    useRef<HTMLDivElement>(null),
+  ];
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   // According to this lint rule, we need to include all the dependencies of this function in the

--- a/packages/design-system/src/components/utilities/useAutoFocus.ts
+++ b/packages/design-system/src/components/utilities/useAutoFocus.ts
@@ -5,7 +5,7 @@ import { useEffect, useRef } from 'react';
  * if the `autoFocus` boolean parameter is truthy.
  */
 export const useAutofocus = <T extends HTMLElement>(autoFocus?: boolean) => {
-  const ref = useRef<T>();
+  const ref = useRef<T>(null);
 
   useEffect(() => {
     if (autoFocus && ref.current?.focus) {

--- a/packages/design-system/src/components/utilities/usePrevious.ts
+++ b/packages/design-system/src/components/utilities/usePrevious.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react';
 // storing a previous version of a prop for comparison
 // similar to the old previousProps param from `componentDidUpdate`
 const usePrevious = <T>(value: T): T | undefined => {
-  const ref = useRef<T>();
+  const ref = useRef<T>(null);
   useEffect(() => {
     ref.current = value;
   });

--- a/packages/ds-medicare-gov/src/components/SimpleFooter/SimpleFooter.tsx
+++ b/packages/ds-medicare-gov/src/components/SimpleFooter/SimpleFooter.tsx
@@ -32,7 +32,7 @@ export const SimpleFooter: FunctionComponent<SimpleFooterProps> = ({
   websiteInfo = 'A federal government website managed and paid for by the U.S. Centers for Medicare and Medicaid Services.',
   onClickLinkAnalytics,
 }: SimpleFooterProps) => {
-  const footerRef = useRef<HTMLElement>();
+  const footerRef = useRef<HTMLElement>(null);
   const baseUrl = language === 'es' ? 'https://es.medicare.gov' : 'https://www.medicare.gov';
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Updates all `useRef` initializers to pass in `null` as the default value, which is required by React 19 type definitions.
- This is **PR 1 of 5** in the broader effort to upgrade React types to v19.
[Jira ticket](https://jira.cms.gov/browse/CMSDS-3467)

## How to test
- `npm run build`
- `npm run test`

## Notes
This pr is the first in a stacked series. Please review and merge before [pr-3782](https://github.com/CMSgov/design-system/pull/3782) (JSX namespace migration).

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
