### PR TITLE
[CMSDS-3467] Migrate `JSX.IntrinsicElements` to `React.JSX.IntrinsicElements` and add custom element support

### DIFF
--- a/packages/design-system/src/components/Review/Review.tsx
+++ b/packages/design-system/src/components/Review/Review.tsx
@@ -37,7 +37,7 @@ export interface ReviewProps {
 }
 
 const getHeading = (heading, headingLevel) => {
-  const Heading = (`h${headingLevel}` || `h3`) as keyof JSX.IntrinsicElements;
+  const Heading = (`h${headingLevel}` || `h3`) as keyof React.JSX.IntrinsicElements;
   if (heading) {
     return <Heading className="ds-c-review__heading">{heading}</Heading>;
   }

--- a/packages/design-system/src/components/utilities/findElementsOfType.ts
+++ b/packages/design-system/src/components/utilities/findElementsOfType.ts
@@ -1,30 +1,31 @@
 import { isValidElement, ReactNode, ReactElement } from 'react';
 
-export function findElementsOfType<T extends keyof JSX.IntrinsicElements>(
-  types: T[],
-  node: ReactNode
-): ReactElement<any, T>[] {
+type CustomElements =
+  | 'ds-choice'
+  | 'ds-accordion'
+  | 'ds-tooltip-icon'
+  | 'ds-third-party-external-link';
+
+type AllowedElements = keyof React.JSX.IntrinsicElements | CustomElements;
+
+export function findElementsOfType(types: AllowedElements[], node: ReactNode): ReactElement<any>[] {
   if (!node || !(isValidElement(node) || Array.isArray(node))) {
     // There's nothing to recurse on, and this is not the droid we're looking for
     return [];
   }
 
-  if (isValidElement(node) && types.includes(node.type as T)) {
+  if (isValidElement(node) && types.includes(node.type as AllowedElements)) {
     // We found it! Return an array because it will be flattened
-    return [node as ReactElement<any, T>];
+    return [node];
   }
 
   if (Array.isArray(node)) {
     // Recurse on each member of the array and flatten the result
     return node.reduce(
-      (acc: ReactElement<any, T>[], child: ReactNode) => [
-        ...acc,
-        ...findElementsOfType(types, child),
-      ],
+      (acc: ReactElement<any>[], child: ReactNode) => [...acc, ...findElementsOfType(types, child)],
       []
-    ) as ReactElement<any, T>[];
+    );
   }
-
   // It's a React element, so recurse on its children (a ReactNode)
-  return findElementsOfType(types, (node as ReactElement).props?.children);
+  return findElementsOfType(types, (node as ReactElement<any>).props?.children);
 }

--- a/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.tsx
+++ b/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.tsx
@@ -103,7 +103,7 @@ const Wrapper = ({
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      'ds-autocomplete': JSX.IntrinsicElements['div'] & {
+      'ds-autocomplete': React.JSX.IntrinsicElements['div'] & {
         [K in (typeof attributes)[number]]?: string;
       };
     }

--- a/packages/design-system/src/components/web-components/ds-choice/ds-choice-list.tsx
+++ b/packages/design-system/src/components/web-components/ds-choice/ds-choice-list.tsx
@@ -57,7 +57,7 @@ const Wrapper = ({ children, choices, rootId, ...otherProps }: WrapperProps) => 
         if (element.props.children.length > 0) {
           element.props.children.map((child: string | React.ReactElement) => {
             if (typeof child !== 'string') {
-              const { children, slot } = child.props;
+              const { children, slot } = (child as React.ReactElement<any>).props;
 
               if (slot === 'checked-children') {
                 checkedChild = children;

--- a/packages/design-system/src/components/web-components/ds-date-field/ds-date-field.tsx
+++ b/packages/design-system/src/components/web-components/ds-date-field/ds-date-field.tsx
@@ -76,7 +76,7 @@ const Wrapper = ({
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      'ds-date-field': JSX.IntrinsicElements['div'] & {
+      'ds-date-field': React.JSX.IntrinsicElements['div'] & {
         [K in (typeof attributes)[number]]?: string;
       };
     }

--- a/packages/design-system/src/components/web-components/ds-drawer/ds-drawer.tsx
+++ b/packages/design-system/src/components/web-components/ds-drawer/ds-drawer.tsx
@@ -69,7 +69,7 @@ const Wrapper = ({
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      'ds-drawer': JSX.IntrinsicElements['div'] & {
+      'ds-drawer': React.JSX.IntrinsicElements['div'] & {
         [K in (typeof attributes)[number]]?: string;
       };
     }

--- a/packages/design-system/src/components/web-components/ds-review/ds-review.tsx
+++ b/packages/design-system/src/components/web-components/ds-review/ds-review.tsx
@@ -18,7 +18,7 @@ const Wrapper = ({ children, ...otherProps }) => {
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      'ds-review': JSX.IntrinsicElements['div'] & {
+      'ds-review': React.JSX.IntrinsicElements['div'] & {
         [K in (typeof attributes)[number]]?: string;
       };
     }

--- a/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
+++ b/packages/design-system/src/components/web-components/ds-tabs/ds-tabs.tsx
@@ -57,7 +57,7 @@ const Wrapper = ({ tabsAriaLabel, ...props }) => {
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      'ds-tabs': JSX.IntrinsicElements['div'] & {
+      'ds-tabs': React.JSX.IntrinsicElements['div'] & {
         [K in (typeof attributes)[number]]?: string;
       };
     }

--- a/packages/design-system/src/components/web-components/ds-third-party-external-link/ds-third-party-external-link.tsx
+++ b/packages/design-system/src/components/web-components/ds-third-party-external-link/ds-third-party-external-link.tsx
@@ -30,7 +30,7 @@ const Wrapper = ({ analytics, ...otherProps }: WrapperProps) => (
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      'ds-third-party-external-link': JSX.IntrinsicElements['div'] & {
+      'ds-third-party-external-link': React.JSX.IntrinsicElements['div'] & {
         [K in (typeof attributes)[number]]?: string;
       };
     }

--- a/packages/ds-medicare-gov/src/components/web-components/ds-simple-footer/ds-simple-footer.tsx
+++ b/packages/ds-medicare-gov/src/components/web-components/ds-simple-footer/ds-simple-footer.tsx
@@ -21,7 +21,7 @@ const Wrapper = ({ ...otherProps }) => {
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      'ds-simple-footer': JSX.IntrinsicElements['div'] & {
+      'ds-simple-footer': React.JSX.IntrinsicElements['div'] & {
         [K in (typeof attributes)[number]]?: string;
       };
     }


### PR DESCRIPTION
## Summary
- Migrates all `JSX.IntrinsicElements` references to `React.JSX.IntrinsicElements`, which is required by React 19 type definitions.
- Adds custom element type support in `findElementsOfType` 

[Jira ticket](https://jira.cms.gov/browse/CMSDS-3467)

## How to test
- Run `npm run build` 
- Run `npm run test`
- Run `npm run test:unit:wc` to validate web component typings and usage.

## Notes
This is **PR 2 of 5** in the broader effort to upgrade React types to v19.
Please review after [pr-3781](https://github.com/CMSgov/design-system/pull/3781) (useRef fixes) has been merged.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone