### PR TITLE
[CMSDS-3467] Coerce field values to string and add `coerceToString` utility

### DIFF
--- a/packages/design-system/src/components/TextField/LabelMask.tsx
+++ b/packages/design-system/src/components/TextField/LabelMask.tsx
@@ -1,6 +1,7 @@
 import { Children, cloneElement } from 'react';
 import type * as React from 'react';
 import { useLabelMask, MaskFunction } from './useLabelMask';
+import { TextInputProps } from './TextInput';
 
 export interface LabelMaskProps {
   /**
@@ -21,7 +22,7 @@ export interface LabelMaskProps {
 }
 
 const LabelMask = (props: LabelMaskProps) => {
-  const field = Children.only(props.children as React.ReactElement);
+  const field = Children.only(props.children) as React.ReactElement<TextInputProps>;
   const { labelMask, inputProps } = useLabelMask(props.labelMask, field.props);
   const input = cloneElement(field, inputProps);
 

--- a/packages/design-system/src/components/TextField/maskHelpers.test.ts
+++ b/packages/design-system/src/components/TextField/maskHelpers.test.ts
@@ -1,4 +1,4 @@
-import { toCurrency, unmaskValue } from './maskHelpers';
+import { toCurrency, unmaskValue, coerceToString } from './maskHelpers';
 
 describe('maskHelpers', function () {
   describe('Currency', () => {
@@ -111,6 +111,25 @@ describe('maskHelpers', function () {
 
       expect(unmaskValue('', name)).toBe('');
       expect(unmaskValue(' 123-456-7890 ', name)).toBe('1234567890');
+    });
+  });
+
+  describe('coerceToString', () => {
+    it('returns the same string when given a string', () => {
+      expect(coerceToString('hello')).toBe('hello');
+    });
+
+    it('converts a number to a string', () => {
+      expect(coerceToString(123)).toBe('123');
+      expect(coerceToString(0)).toBe('0');
+    });
+
+    it('returns empty string when given null', () => {
+      expect(coerceToString(null)).toBe('');
+    });
+
+    it('returns empty string when given undefined', () => {
+      expect(coerceToString(undefined)).toBe('');
     });
   });
 });

--- a/packages/design-system/src/components/TextField/maskHelpers.ts
+++ b/packages/design-system/src/components/TextField/maskHelpers.ts
@@ -126,3 +126,16 @@ export function unmaskValue(value?: string, mask?: string): string {
 
   return value;
 }
+
+/**
+ * Coerce a string | number | undefined into a safe string.
+ * - string -> returned as-is
+ * - number -> converted with String()
+ * - undefined/null -> ''
+ */
+export function coerceToString(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value);
+}


### PR DESCRIPTION
## Summary
- Updates the `Mask` component to ensure field values are always treated as strings, in line with stricter React 19 type definitions.
- Adds a utility to coerce field values to a string type.
- Adds test coverage for the new utility

[Jira ticket](https://jira.cms.gov/browse/CMSDS-3467)

## How to test
- Run `npm run build`
- Run `npm run test`

## Notes
This is **PR 3 of 5** in the broader effort to upgrade React types to v19.  
Please review after [PR 3782](https://github.com/CMSgov/design-system/pull/3782) has been merged.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone