### PR TITLE
[CMDS-3467] Bump `@types/react` packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,8 @@
         "@tsconfig/node18": "^18.2.4",
         "@types/jest": "^27.5.1",
         "@types/node": "^18.11.9",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.9",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "autoprefixer": "^10.4.19",
@@ -2409,15 +2411,6 @@
       },
       "peerDependencies": {
         "@types/node": ">=18"
-      }
-    },
-    "examples/angular/node_modules/@inquirer/figures": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.9.tgz",
-      "integrity": "sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "examples/angular/node_modules/@inquirer/input": {
@@ -6279,11 +6272,6 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="
     },
-    "examples/astro-react-17/node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
-    },
     "examples/astro-react-17/node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -7786,11 +7774,6 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="
     },
-    "examples/astro-react-18/node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
-    },
     "examples/astro-react-18/node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -9266,11 +9249,6 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="
     },
-    "examples/astro-themes/node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
-    },
     "examples/astro-themes/node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -10733,11 +10711,6 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="
-    },
-    "examples/astro/node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
     },
     "examples/astro/node_modules/@types/hast": {
       "version": "3.0.4",
@@ -22923,11 +22896,6 @@
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
-    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -22949,20 +22917,21 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
+      "version": "19.1.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.15.tgz",
+      "integrity": "sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==",
+      "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "dependencies": {
-        "@types/react": "*"
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
+      "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -57756,8 +57725,8 @@
       "dependencies": {
         "@popperjs/core": "^2.4.4",
         "@preact/signals": "1.3.0",
-        "@types/react": "^18.3.1",
-        "@types/react-dom": "^18.3.0",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.9",
         "@types/react-transition-group": "^4.4.5",
         "case-it": "^1.0.1",
         "chalk": "^5.5.0",
@@ -58820,8 +58789,8 @@
       },
       "devDependencies": {
         "@types/node": "^18.11.9",
-        "@types/react": "^18.3.1",
-        "@types/react-dom": "^18.3.0",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.9",
         "copyfiles": "^2.4.1"
       }
     },
@@ -59004,11 +58973,6 @@
       "dependencies": {
         "@types/ms": "*"
       }
-    },
-    "packages/docs/node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "packages/docs/node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
@@ -61714,8 +61678,8 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@cmsgov/design-system": "13.0.0",
-        "@types/react": "^18.2.6",
-        "@types/react-dom": "^18.3.0"
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.9"
       },
       "bin": {
         "cmsds-migrate": "scripts/cmsds-migrate/src/main.mjs"
@@ -61726,8 +61690,8 @@
       "version": "17.0.0",
       "dependencies": {
         "@cmsgov/design-system": "13.0.0",
-        "@types/react": "^18.3.1",
-        "@types/react-dom": "^18.3.0",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.9",
         "classnames": "^2.2.5"
       }
     },
@@ -61737,8 +61701,8 @@
       "license": "CC0-1.0",
       "dependencies": {
         "@cmsgov/design-system": "13.0.0",
-        "@types/react": "^18.3.1",
-        "@types/react-dom": "^18.3.0"
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.9"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -118,6 +118,8 @@
     "@tsconfig/node18": "^18.2.4",
     "@types/jest": "^27.5.1",
     "@types/node": "^18.11.9",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.9",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "autoprefixer": "^10.4.19",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -58,8 +58,8 @@
   "dependencies": {
     "@popperjs/core": "^2.4.4",
     "@preact/signals": "1.3.0",
-    "@types/react": "^18.3.1",
-    "@types/react-dom": "^18.3.0",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.9",
     "@types/react-transition-group": "^4.4.5",
     "case-it": "^1.0.1",
     "chalk": "^5.5.0",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -48,8 +48,8 @@
   },
   "devDependencies": {
     "@types/node": "^18.11.9",
-    "@types/react": "^18.3.1",
-    "@types/react-dom": "^18.3.0",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.9",
     "copyfiles": "^2.4.1"
   }
 }

--- a/packages/ds-cms-gov/package.json
+++ b/packages/ds-cms-gov/package.json
@@ -59,7 +59,7 @@
   ],
   "dependencies": {
     "@cmsgov/design-system": "13.0.0",
-    "@types/react": "^18.2.6",
-    "@types/react-dom": "^18.3.0"
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.9"
   }
 }

--- a/packages/ds-healthcare-gov/package.json
+++ b/packages/ds-healthcare-gov/package.json
@@ -58,8 +58,8 @@
   ],
   "dependencies": {
     "@cmsgov/design-system": "13.0.0",
-    "@types/react": "^18.3.1",
-    "@types/react-dom": "^18.3.0",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.9",
     "classnames": "^2.2.5"
   }
 }

--- a/packages/ds-medicare-gov/package.json
+++ b/packages/ds-medicare-gov/package.json
@@ -58,7 +58,7 @@
   ],
   "dependencies": {
     "@cmsgov/design-system": "13.0.0",
-    "@types/react": "^18.3.1",
-    "@types/react-dom": "^18.3.0"
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.9"
   }
 }


### PR DESCRIPTION
## Summary
- Bump @types/react packages

[Jira ticket](https://jira.cms.gov/browse/CMSDS-3467)

## How to test
- `npm run clean && npm install && npm run build`
- `npm run test`
- `npm run test:unit:wc`
- `npm run test:browser:all`
- `npm run start`

## Notes
This is **PR 5 of 5** in the broader effort to upgrade React types to v19.  
Please review after [PR 3784](https://github.com/CMSgov/design-system/pull/3784) has been merged.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone