### PR TITLE
[CMSDS-3575] Add a11y guidance for the Calendar Picker component

### DIFF
--- a/packages/docs/content/components/date-field/date-picker.mdx
+++ b/packages/docs/content/components/date-field/date-picker.mdx
@@ -31,7 +31,7 @@ medicare:
 
 Allow users to have flexibility in entering the date, such as allowing one-digit numbers with or without "0" prior to the number, or entering a date with or without slashes to separate month, day, and year.
 
-- Example: "1" as well as "01" for a month or day.
+- Example: "01" for a month or day. Leading zeros for single digits are necessary if you do not include separating characters between the month, day and year values.
 - Example: "05/18/2022" as well as "05182022".
 
 ### When to consider alternatives
@@ -45,7 +45,7 @@ Allow users to have flexibility in entering the date, such as allowing one-digit
 
 - Please see the [accessibility guidelines for all text inputs](/components/text-field/#guidance) for information specific to the input fields.
 - The calendar button uses `aria-describedby` to connect the required label text (supplied via the `label` prop) and the optional hint text (provided by the `hint` prop), to ensure screen readers announce contextual information when the open calendar button receives focus.
-- Users will be able to enter a variety of date formats that automatically format to the correct date format of MM/DD/YYYY. This change happens once the form field loses focus. For example, a user enters a date as "4122020" and it changes to "04/01/2020" once focus leaves the date input.
+- Users will be able to enter a variety of date formats that automatically format to the correct date format of MM/DD/YYYY. This change happens once the form field loses focus. For example, a user enters a date as "04122020" and it changes to "04/12/2020" once focus leaves the date input.
 - Focus automatically returns to the date input field after date selection.
 
 #### Accessibility Testing

--- a/packages/docs/content/components/date-field/date-picker.mdx
+++ b/packages/docs/content/components/date-field/date-picker.mdx
@@ -2,24 +2,69 @@
 title: Calendar Picker
 intro: Date field (with calendar picker), also known as "date picker", provides single date entry with a text field or selection through a visual calendar element tied to the input.
 status:
-  level: use
+ level: use
 cmsgov:
-  figmaNodeId: 6-85
+ figmaNodeId: 6-85
 core:
-  figmaNodeId: 6-85
-  githubLink: design-system/src/components/DateField
+ figmaNodeId: 6-85
+ githubLink: design-system/src/components/DateField
 healthcare:
-  figmaNodeId: 6-85
+ figmaNodeId: 6-85
 medicare:
-  figmaNodeId: 6-85
+ figmaNodeId: 6-85
 ---
 
 ## Examples
 
 <StorybookExample
-  componentName="singleInputDateField"
-  storyId="components-singleinputdatefield--with-picker"
+ componentName="singleInputDateField"
+ storyId="components-singleinputdatefield--with-picker"
 />
+
+## Guidance
+
+### When to use
+
+- Use the date picker for dates that have happened within the last year, in the future, or is relevant to selecting the day of the week.
+
+### Guidelines
+
+Allow users to have flexibility in entering the date, such as allowing one-digit numbers with or without "0" prior to the number, or entering a date with or without slashes to separate month, day, and year.
+
+- Example: "1" as well as "01" for a month or day.
+- Example: "05/18/2022" as well as "05182022".
+
+### When to consider alternatives
+
+- Don't use if users are entering a memorable date. Instead, use either [single-](/components/single-input-date-field/) or [multi-input](/components/multi-input-date-field/) date fields.
+- Don't use if the date occurred in the distant past (like date of birth).
+
+### Accessibility
+
+#### Accessibility
+
+- Please see the [accessibility guidelines for all text inputs](/components/text-field/#guidance) for information specific to the input fields.
+- The calendar button uses `aria-describedby` to connect the required label text (supplied via the `label` prop) and the optional hint text (provided by the `hint` prop), to ensure screen readers announce contextual information when the open calendar button receives focus.
+- Users will be able to enter a variety of date formats that automatically format to the correct date format of MM/DD/YYYY. This change happens once the form field loses focus. For example, a user enters a date as "4122020" and it changes to "04/01/2020" once focus leaves the date input.
+- Focus automatically returns to the date input field after date selection.
+
+#### Accessibility Testing
+
+**Keyboard**:
+- Keyboard interactions follow the guidelines put forth by the [ARIA Authoring Practices Guide for the Date Picker Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/#kbd_label).
+- A notable exception to the above pattern is that the CMSDS does not yet support usage of the ESC key to close the dialog.
+- Tab: Moves between the date input field and calendar button. When the calendar is initially opened, pressing tab will move focus first from a previous month selection button then to the month selection dropdown, next the year selection dropdown and finally the date entered in the text input or the first of the month if no date has been entered.
+- Enter/Space: Opens calendar when button is focused, selects date when calendar is open.
+- Arrow keys: Navigate between dates within the calendar grid.
+- Home/End: Navigate to beginning/end of week.
+- Page Up/Down: Navigate between months.
+
+**Screen reader**:
+- The date format and any helper text is announced when the input receives focus.
+- Calendar button is announced with its current state when focused ("Open calendar picker dialog" or "Close calendar picker dialog").
+- Selected dates in the calendar are announced with full date information.
+- Month/year navigation changes are announced to screen readers.
+- Date restrictions (from/to dates) are communicated when users encounter disabled dates (i.e. noted as “dimmed” in MacOS Voiceover).
 
 ## Code
 
@@ -35,30 +80,6 @@ The following CSS variables can be overridden to customize Input/Form components
 
 <ComponentThemeOptions componentname="text-input" />
 
-## Guidance
-
-### When to use
-
-- Use the date picker for dates that have happened within the last year, in the future, or is relevant to selecting the day of the week.
-
-### When to consider alternatives
-
-- Don't use if users are entering a memorable date. Instead, use either [single-](/components/single-input-date-field/) or [multi-input](/components/multi-input-date-field/) date fields.
-- Don't use if the date occurred in the distant past (like date of birth).
-
-### Usage
-
-Allow users to have flexibility in entering the date, such as allowing one-digit numbers with or without "0" prior to the number, or entering a date with or without slashes to separate month, day, and year.
-
-- Example: "1" as well as "01" for a month or day.
-- Example: "05/18/2022" as well as "05182022".
-
-### Accessibility
-
-- These text fields should follow the [accessibility guidelines for all text inputs](/components/text-field/#guidance).
-- Users will be able to enter a variety of date formats that automatically format to the correct date format of MM/DD/YYYY. This change happens once the form field loses focus. For example, a user enters a date as "4122020" and it changes to "04/01/2020" once focus leaves the date input.
-- Instructions are available make this more usable/accessible for assistive technology.
-
 ### Related patterns
 
 - [Date field (multi-input)](/components/date-field/multi-input-date-field/)
@@ -67,16 +88,16 @@ Allow users to have flexibility in entering the date, such as allowing one-digit
 ## Component maturity
 
 <MaturityChecklist
-  a11yStandards={true}
-  color={true}
-  forcedColors={true}
-  screenReaders={true}
-  keyboardNavigable={true}
-  storybook={true}
-  responsive={true}
-  spanish={true}
-  completeUiKit={false}
-  responsiveUiKit={false}
-  tokensInCode={true}
-  tokensInSketch={true}
+ a11yStandards={true}
+ color={true}
+ forcedColors={true}
+ screenReaders={true}
+ keyboardNavigable={true}
+ storybook={true}
+ responsive={true}
+ spanish={true}
+ completeUiKit={false}
+ responsiveUiKit={false}
+ tokensInCode={true}
+ tokensInSketch={true}
 />


### PR DESCRIPTION
## Summary

- Added a11y guidance for the calendar picker component
- [Ticket](https://jira.cms.gov/browse/CMSDS-3575)

## How to test

1. Run locally
2. Confirm that the text on /components/date-field/date-picker/ matches the text in the PDF in the ticket. Except for the small alteration on line 56:
Previous: Tab: Moves between the date input field and calendar button. When the calendar is initially opened, pressing tab will move focus first from a previous month selection button then to the month selection dropdown, next the year selection dropdown and finally **the initially selected date or the first of the month**
Revision: Tab: Moves between the date input field and calendar button. When the calendar is initially opened, pressing tab will move focus first from a previous month selection button then to the month selection dropdown, next the year selection dropdown and finally the **date entered in the text input or the first of the month if no date has been entered**.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone