### PR TITLE
[CMSDS-3635] Remove push tokens to figma npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "start": "npm run build:storybook:docs && npm --prefix ./packages/docs run develop",
     "storybook": "storybook dev -p 6006",
     "storybook:react": "PREACT=false storybook dev -p 6006",
-    "sync:tokens-to-figma": "npm --prefix ./packages/design-system-tokens run sync:to-figma",
     "sync:tokens-from-figma": "npm --prefix ./packages/design-system-tokens run sync:from-figma",
     "test": "npm run test:unit",
     "posttest": "npm run lint",

--- a/packages/design-system-tokens/package.json
+++ b/packages/design-system-tokens/package.json
@@ -13,7 +13,6 @@
   "scripts": {
     "build": "tsx ./src/css/index.ts",
     "clean": "rm -rf dist/*",
-    "sync:to-figma": "tsx ./src/figma/syncTokensToFigma.ts",
     "sync:from-figma": "tsx ./src/figma/syncFigmaToTokens.ts"
   }
 }


### PR DESCRIPTION
## Summary

- What it says on the tin

## How to test

1. Um, you shouldn't be able to call these scripts via `npm run` anymore? Is there another entry way to the `syncFigmaToTokens.ts` file?

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone
