### PR TITLE
[NO-TICKET] Ensure `Card` is exported from Core

### DIFF
--- a/examples/_shared/react/CardComponentExample.tsx
+++ b/examples/_shared/react/CardComponentExample.tsx
@@ -1,0 +1,17 @@
+import { Card } from '@cmsgov/design-system';
+
+export function CardComponentExample() {
+  return (
+    <>
+      <h2>Core Card Component Example</h2>
+      <Card className="ds-u-padding--2">
+        It was the best of times, it was the worst of times, it was the age of wisdom, it was the
+        age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the
+        season of Light, it was the season of Darkness, it was the spring of hope, it was the winter
+        of despair...
+      </Card>
+    </>
+  );
+}
+
+export default CardComponentExample;

--- a/examples/astro-react-18/src/pages/index.astro
+++ b/examples/astro-react-18/src/pages/index.astro
@@ -6,6 +6,7 @@ import AutocompleteExample from '../../../_shared/react/AutocompleteExample';
 import BadgeExample from '../../../_shared/react/BadgeExample';
 import ButtonExample from '../../../_shared/react/ButtonExample';
 import ChoiceListExample from '../../../_shared/react/ChoiceListExample';
+import CardComponentExample from '../../../_shared/react/CardComponentExample';
 import SingleInputDateFieldExample from '../../../_shared/react/SingleInputDateFieldExample';
 import MultiInputDateFieldExample from '../../../_shared/react/MultiInputDateFieldExample';
 import DropdownExample from '../../../_shared/react/DropdownExample';
@@ -40,6 +41,7 @@ import { SkipNav, UsaBanner } from '@cmsgov/design-system';
     <BadgeExample client:visible />
     <ButtonExample client:visible />
     <ChoiceListExample client:visible />
+    <CardComponentExample client:visible />
     <SingleInputDateFieldExample client:visible />
     <MultiInputDateFieldExample client:visible />
     <DropdownExample client:visible />

--- a/packages/design-system/src/components/Card/index.ts
+++ b/packages/design-system/src/components/Card/index.ts
@@ -1,0 +1,1 @@
+export * from './Card';

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -4,6 +4,7 @@ export * from './Autocomplete';
 export * from './Badge';
 export * from './NoteBox';
 export * from './Button';
+export * from './Card';
 export * from './ChoiceList';
 export * from './DateField';
 export * from './Dialog';

--- a/packages/ds-medicare-gov/src/components/index.ts
+++ b/packages/ds-medicare-gov/src/components/index.ts
@@ -12,6 +12,6 @@ export * from './MedicaregovHelpDrawer';
 export * from './MedicaregovLogo';
 export * from './MedicaregovThirdPartyExternalLink';
 export * from './SimpleFooter';
-export * from './Card';
+export { Card } from './Card';
 export * from './Stars';
 export * from './Icons';


### PR DESCRIPTION
## Summary
- Adds missing entry points for the new Core `Card` component.  
- Adds `ComponentCardExample` – tests that the Core `Card` component can be imported and used in an application.  

## How to test
1. `cd examples/astro-react-18` 
2. `npm run start`
3. Inspect Core Card component example.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone