### PR TITLE
[NO TICKET] Add nodeRef attribute to tooltip

### DIFF
--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -396,7 +396,12 @@ export const Tooltip = (props: TooltipProps) => {
     );
 
     return (
-      <CSSTransition in={active} classNames="ds-c-tooltip" timeout={transitionDuration}>
+      <CSSTransition
+        in={active}
+        classNames="ds-c-tooltip"
+        timeout={transitionDuration}
+        nodeRef={tooltipElement}
+      >
         {dialog ? (
           <FocusTrap
             active={active}


### PR DESCRIPTION
## Summary

- Added `nodeRef` attribute to tooltip to get CSS Transition library to work with React 19
- Closes #3786 

## How to test

1. Build locally, run tests, confirm they pass
2. Run storybook, confirm React and Web Component versions of the Tooltip work as expected

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone