### PR TITLE
[NO-TICKET] Wrap hint props in <div> tag instead of <p> tag to avoid DOM nesting errors

### DIFF
--- a/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
+++ b/packages/design-system/src/components/ChoiceList/ChoiceList.test.tsx
@@ -80,7 +80,7 @@ describe('ChoiceList', () => {
       expect(choiceEls.length).toBe(numChoices);
       expect(choice.name).toBe('spec-field');
       expect(choice.value).toBe('1');
-      expect(hintTexts[0].tagName).toBe('P');
+      expect(hintTexts[0].tagName).toBe('DIV');
     });
 
     it('is enclosed by a fieldset', () => {

--- a/packages/design-system/src/components/ChoiceList/__snapshots__/Choice.test.tsx.snap
+++ b/packages/design-system/src/components/ChoiceList/__snapshots__/Choice.test.tsx.snap
@@ -107,12 +107,12 @@ exports[`Choice has a hint and requirementLabel 1`] = `
       >
         George Washington
       </label>
-      <p
+      <div
         class="ds-c-hint"
         id="static-id__hint"
       >
         Optional. Hello world
-      </p>
+      </div>
       <p
         aria-atomic="true"
         aria-live="assertive"

--- a/packages/design-system/src/components/ChoiceList/__snapshots__/ChoiceList.test.tsx.snap
+++ b/packages/design-system/src/components/ChoiceList/__snapshots__/ChoiceList.test.tsx.snap
@@ -14,12 +14,12 @@ exports[`ChoiceList Radio buttons and Checkboxes is a radio button group 1`] = `
     >
       Foo
     </legend>
-    <p
+    <div
       class="ds-c-hint"
       id="static-id__hint"
     >
       Psst! I know the answer
-    </p>
+    </div>
     <p
       aria-atomic="true"
       aria-live="assertive"

--- a/packages/design-system/src/components/Hint/Hint.tsx
+++ b/packages/design-system/src/components/Hint/Hint.tsx
@@ -59,10 +59,10 @@ export const Hint = ({
   }
 
   return (
-    <p {...otherProps} id={id} className={hintClasses}>
+    <div {...otherProps} id={id} className={hintClasses}>
       {requirementLabel}
       {hintPadding}
       {children}
-    </p>
+    </div>
   );
 };

--- a/packages/design-system/src/components/Label/__snapshots__/Label.test.tsx.snap
+++ b/packages/design-system/src/components/Label/__snapshots__/Label.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`Label Deprecated hint and error functionality adds punctuation to requi
 `;
 
 exports[`Label is inversed 1`] = `
-<p
+<div
   class="ds-c-hint ds-c-hint--inverse"
 >
   Foo
-</p>
+</div>
 `;
 
 exports[`Label renders as a legend element 1`] = `

--- a/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.tsx.snap
+++ b/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.tsx.snap
@@ -13,12 +13,12 @@ exports[`MonthPicker renders a snapshot 1`] = `
     >
       Months
     </legend>
-    <p
+    <div
       class="ds-c-hint"
       id="month-picker--1__hint"
     >
       Guess and test
-    </p>
+    </div>
     <p
       aria-atomic="true"
       aria-live="assertive"


### PR DESCRIPTION
## Summary

This PR addresses an issue with passing block-level DOM elements to the `<Hint>` component or the `hint` props of form components. While I haven't seen this cause issues in practice, the result is invalid HTML and may cause issues in certain browsers/environments, and React will throw a warning in the developer console.

<img width="812" height="504" alt="Screenshot 2025-10-09 at 2 43 18 PM" src="https://github.com/user-attachments/assets/87eccbc6-eee3-4a0d-acdb-8194abf48cc8" />

The proposed solution is to change the element that wraps the passed in content from a `<p>` tag to a `<div>` tag, which can validly wrap other block level elements.

## How to test

1. Instructions on how to test the changes in this PR.

## Checklist

- [ ] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [ ] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [ ] Selected appropriate `Impacts`, multiple can be selected.
- [ ] Selected appropriate release milestone

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] Verified that running both `npm run test:unit` and `npm run test:browser:all` were each successful
- [x] If necessary, updated unit-test snapshots (`npm run test:unit:update`) and browser-test snapshots (`npm run test:browser:all:update`)
