### PR TITLE
[CMSDS-3544] Add tooltip to Angular example application

### DIFF
--- a/examples/angular/src/app/app.component.html
+++ b/examples/angular/src/app/app.component.html
@@ -216,7 +216,20 @@
       [drawerHeading]="drawerHeading"
       (ds-close-click)="closeDrawer()"
     >
-      <strong> An Explanation <ds-usa-flag-icon /></strong>
+      <strong>
+        An Explanation
+        <ds-tooltip
+          class-name="ds-c-tooltip__trigger-icon ds-u-display--inline"
+          component="button"
+          root-id="1"
+          trigger-aria-label="An icon of a flag of the United States of America."
+        >
+          <ds-usa-flag-icon />
+          <div slot="title">
+            <p>Testing a tooltip inside of a &lt;ds-drawer&gt; element.</p>
+          </div>
+        </ds-tooltip>
+      </strong>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
         labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco


### PR DESCRIPTION
## Summary

- Extends the Angular example project to include `ds-tooltip`. Also adds another `ds-tooltip` inside `ds-drawer` to verify whether it functions as expected. (It does not.)
- [CMSDS-3544](https://jira.cms.gov/browse/CMSDS-3544)

## How to test

1. Build the design system: `npm run build`
2. Start the Angular example app: `cd examples/angular && npm run start`
3. Load up the app: http://localhost:4200/
4. Scroll to the bottom of the screen and verify a section named "Tooltip" exists.
5. Verify the tooltip icon appears and tooltip functionality works as expected.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

<!-- Feel free to remove items or sections that are not applicable -->

### If this is a change to code:

- [x] Verified that running both `npm run test:unit` and `npm run test:browser:all` were each successful
