### PR TITLE
[CMSDS-3417] Wire up `StatusIndicator` Badges & Theme-specific Alerts

### DIFF
--- a/packages/docs/content/components/card.mdx
+++ b/packages/docs/content/components/card.mdx
@@ -1,8 +1,7 @@
 ---
 title: Card
 status:
-  level: avoid
-  note: Lacks documented guidance on usage and accessibility.
+  level: use
 core:
   figmaNodeId: 4334-23875
   githubLink: design-system/src/components/Card

--- a/packages/docs/content/components/footer/healthcare-footer.mdx
+++ b/packages/docs/content/components/footer/healthcare-footer.mdx
@@ -2,6 +2,8 @@
 title: Healthcare.gov Footer
 status:
   level: use
+  targetTheme: healthcare
+  targetThemeNote: This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.
 core:
   figmaNodeId: 346-13315
 healthcare:
@@ -9,18 +11,6 @@ healthcare:
   githubLink: ds-healthcare-gov/src/components/Footer
   storybookLink: healthcare-footer--docs
 ---
-
-import { Alert } from '@cmsgov/design-system';
-
-<ThemeContent neverThemes={['healthcare']}>
-  <Alert variation="error">
-    <p class="ds-c-alert__text">
-      {
-        'This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.'
-      }
-    </p>
-  </Alert>
-</ThemeContent>
 
 ## Examples
 

--- a/packages/docs/content/components/footer/medicare-footer.mdx
+++ b/packages/docs/content/components/footer/medicare-footer.mdx
@@ -2,6 +2,8 @@
 title: Medicare.gov Footer
 status:
   level: use
+  targetTheme: medicare
+  targetThemeNote: This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.
 core:
   figmaNodeId: 346-13315
 medicare:
@@ -9,18 +11,6 @@ medicare:
   githubLink: ds-medicare-gov/src/components/SimpleFooter
   storybookLink: medicare-simplefooter--docs
 ---
-
-import { Alert } from '@cmsgov/design-system';
-
-<ThemeContent neverThemes={['medicare']}>
-  <Alert variation="error">
-    <p class="ds-c-alert__text">
-      {
-        'This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.'
-      }
-    </p>
-  </Alert>
-</ThemeContent>
 
 ## Examples
 

--- a/packages/docs/content/components/header/healthcare-header.mdx
+++ b/packages/docs/content/components/header/healthcare-header.mdx
@@ -2,6 +2,8 @@
 title: Healthcare.gov Header
 status:
   level: use
+  targetTheme: healthcare
+  targetThemeNote: This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.
 core:
   figmaNodeId: 346-13316
 healthcare:
@@ -9,18 +11,6 @@ healthcare:
   githubLink: ds-healthcare-gov/src/components/Header
   storybookLink: healthcare-header--docs
 ---
-
-import { Alert } from '@cmsgov/design-system';
-
-<ThemeContent neverThemes={['healthcare']}>
-  <Alert variation="error">
-    <p class="ds-c-alert__text">
-      {
-        'This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.'
-      }
-    </p>
-  </Alert>
-</ThemeContent>
 
 ## Examples
 

--- a/packages/docs/content/components/header/medicare-header.mdx
+++ b/packages/docs/content/components/header/medicare-header.mdx
@@ -3,13 +3,14 @@ title: Medicare.gov Header
 intro: The Consistent Header is a shared component available for all of medicare.gov.
 status:
   level: use
+  targetTheme: medicare
+  targetThemeNote: This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.
 core:
   figmaNodeId: 346-13316
 medicare:
   figmaNodeId: 346-13316
 ---
 
-import { Alert } from '@cmsgov/design-system';
 import consistentHeaderBreakpointsImg from '../../../src/images/consistent-header/consistent-header-breakpoints.png';
 import consistentHeaderCurrentSectionImg from '../../../src/images/consistent-header/consistent-header-current-section.png';
 import consistentHeaderDropdownImg from '../../../src/images/consistent-header/consistent-header-dropdown-menus.png';
@@ -20,18 +21,6 @@ import consistentHeaderSubNavImg from '../../../src/images/consistent-header/con
 import consistentHeaderPageLevelImg from '../../../src/images/consistent-header/consistent-header-page-level-messages.png';
 import consistentHeaderSlideOutDrawerImg from '../../../src/images/consistent-header/consistent-header-slide-out-drawers.png';
 import consistentHeaderToastImg from '../../../src/images/consistent-header/consistent-header-toast.png';
-
-<ThemeContent neverThemes={['medicare']}>
-  <Alert variation="error">
-    <p class="ds-c-alert__text">
-      {
-        'This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.'
-      }
-    </p>
-  </Alert>
-</ThemeContent>
-
-
 
 ## Guidance
 

--- a/packages/docs/content/components/inset.mdx
+++ b/packages/docs/content/components/inset.mdx
@@ -3,23 +3,14 @@ title: Inset (HC.gov)
 intro: The Inset component is meant to draw attention to important content, or to associate a block of content with another element.
 status:
   level: avoid
-  note: Usage and accessibility guidance is incomplete. Maturity checklist is not documented. Accessibility testing has not been performed.
+  note: This component hasn't been tested solely with a keyboard and may be inaccessible to people using keyboard navigation. This component hasn't been fully validated against the WCAG standard and may have other accessibility issues.
+  targetTheme: healthcare
+  targetThemeNote: This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.
 healthcare:
   githubLink: ds-healthcare-gov/src/styles/components/_Inset.scss
 ---
 
 import loremIpsumGenerator from '../../src/helpers/loremIpsumGenerator';
-import { Alert } from '@cmsgov/design-system';
-
-<ThemeContent neverThemes={['healthcare']}>
-  <Alert variation="error">
-    <p class="ds-c-alert__text">
-      {
-        'This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.'
-      }
-    </p>
-  </Alert>
-</ThemeContent>
 
 ## Examples
 

--- a/packages/docs/content/components/inset.mdx
+++ b/packages/docs/content/components/inset.mdx
@@ -3,7 +3,6 @@ title: Inset (HC.gov)
 intro: The Inset component is meant to draw attention to important content, or to associate a block of content with another element.
 status:
   level: avoid
-  note: This component hasn't been tested solely with a keyboard and may be inaccessible to people using keyboard navigation. This component hasn't been fully validated against the WCAG standard and may have other accessibility issues.
   targetTheme: healthcare
   targetThemeNote: This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.
 healthcare:

--- a/packages/docs/content/components/month-picker.mdx
+++ b/packages/docs/content/components/month-picker.mdx
@@ -1,8 +1,7 @@
 ---
 title: Month Picker
 status:
-  level: avoid
-  note: Lacks documented guidance on usage and accessibility. Accessibility testing has not been performed.
+  level: use
 cmsgov:
   figmaNodeId: 6-94
 core:

--- a/packages/docs/content/components/review.mdx
+++ b/packages/docs/content/components/review.mdx
@@ -2,8 +2,7 @@
 title: Review
 intro: The review pattern is used for listing a summary of information entered by a user. Its content includes a heading, value, and edit link.
 status:
-  level: avoid
-  note: Accessibility testing has not been performed.
+  level: use
 cmsgov:
   figmaNodeId: 6-97
 core:

--- a/packages/docs/content/components/stars.mdx
+++ b/packages/docs/content/components/stars.mdx
@@ -2,7 +2,9 @@
 title: Stars (M.gov)
 status:
   level: caution
-  note: Component maturity checklist is incomplete.
+  note: Use caution when implementing Stars. This component hasn't been tested with screen readers, and may be inaccessible to people using screen readers.
+  targetTheme: medicare
+  targetThemeNote: This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.
 core:
   figmaNodeId: 346-21580
 medicare:
@@ -10,18 +12,6 @@ medicare:
   githubLink: ds-medicare-gov/src/components/Stars
   storybookLink: medicare-stars--docs
 ---
-
-import { Alert } from '@cmsgov/design-system';
-
-<ThemeContent neverThemes={['medicare']}>
-  <Alert variation="error">
-    <p class="ds-c-alert__text">
-      {
-        'This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.'
-      }
-    </p>
-  </Alert>
-</ThemeContent>
 
 ## Examples
 

--- a/packages/docs/content/components/step-list.mdx
+++ b/packages/docs/content/components/step-list.mdx
@@ -2,8 +2,8 @@
 title: Step List
 intro: A step list represents a user's progression through an application or multi-page form. It serves as a table of contents and a way to quickly see where they are and what they should be working on next.
 status:
-  level: avoid
-  note: Accessibility testing has not been performed.
+  level: caution
+  note: Use caution when implementing the Step List. This component hasn't been tested solely with a keyboard and may be inaccessible to people using keyboard navigation.
 cmsgov:
   figmaNodeId: 7-100
 core:

--- a/packages/docs/content/components/text-field/masked-field.mdx
+++ b/packages/docs/content/components/text-field/masked-field.mdx
@@ -2,8 +2,8 @@
 title: Masked Field
 intro: A masked field is an enhanced input field that improves readability by providing visual and non-visual cues to a user about the expected value.
 status:
-  level: avoid
-  note: Preliminary accessibility testing has been done, but coverage is incomplete.
+  level: caution
+  note: Use caution when implementing masked text fields. This component hasn't been tested with screen readers, and may be inaccessible to people using screen readers.
 core:
   githubLink: design-system/src/components/TextField
   storybookLink: components-textfield--docs

--- a/packages/docs/src/components/layout/PageHeader.tsx
+++ b/packages/docs/src/components/layout/PageHeader.tsx
@@ -1,5 +1,8 @@
 import { FrontmatterInterface } from '../../helpers/graphQLTypes';
 import { linkAnalytics } from '../../helpers/analytics';
+import StatusIndicator from './StatusIndicator';
+import ThemeContent from '../content/ThemeContent';
+import { Alert } from '@cmsgov/design-system';
 import { withPrefix } from 'gatsby';
 import { makeFigmaUrl, makeGithubUrl, makeStorybookUrl } from '../../helpers/urlUtils';
 import GithubIcon from '../icons/GithubIcon';
@@ -16,7 +19,11 @@ type PageHeaderProps = {
  */
 const PageHeader = ({ frontmatter = { title: '' }, theme }: PageHeaderProps) => {
   const [themeLinks, setThemeLinks] = useState(undefined);
-  const { title, core, intro } = frontmatter;
+  const { title, core, intro, status } = frontmatter;
+  const level = status?.level;
+  const note = status?.note;
+  const targetTheme = status?.targetTheme;
+  const targetThemeNote = status?.targetThemeNote;
 
   const figmaNodeId = themeLinks?.figmaNodeId || core?.figmaNodeId || null;
   const figmaTheme = themeLinks?.figmaNodeId ? theme : 'core';
@@ -40,7 +47,17 @@ const PageHeader = ({ frontmatter = { title: '' }, theme }: PageHeaderProps) => 
 
   return (
     <header className={headerClassNames}>
-      <h1 className="ds-text-heading--4xl">{title}</h1>
+      <div className="ds-u-display--flex ds-u-align-items--baseline ds-u-flex-direction--row">
+        <h1 className="ds-text-heading--4xl">{title}</h1>
+        {status?.level && (
+          <div
+            className="ds-u-margin-left--2"
+            style={level === 'use' ? { position: 'relative', top: '-2px' } : undefined}
+          >
+            <StatusIndicator level={level} />
+          </div>
+        )}
+      </div>
       {intro && (
         <p className="ds-u-font-size--lg ds-u-measure--base ds-u-margin-top--1 ds-u-margin-bottom--1">
           {intro}
@@ -78,6 +95,22 @@ const PageHeader = ({ frontmatter = { title: '' }, theme }: PageHeaderProps) => 
               Storybook
             </a>
           )}
+        </div>
+      )}
+      {note && level && (
+        <div className="ds-u-measure--wide ds-u-margin-top--2">
+          <Alert variation={level === 'caution' ? 'warn' : 'error'}>
+            <p className="ds-c-alert__text">{note}</p>
+          </Alert>
+        </div>
+      )}
+      {targetThemeNote && targetTheme && (
+        <div className="ds-u-measure--wide ds-u-margin-top--2 ds-u-margin-bottom--2">
+          <ThemeContent theme={theme} neverThemes={[targetTheme]}>
+            <Alert variation="error">
+              <p className="ds-c-alert__text">{targetThemeNote}</p>
+            </Alert>
+          </ThemeContent>
         </div>
       )}
     </header>

--- a/packages/docs/src/components/layout/SideNav/SideNav.tsx
+++ b/packages/docs/src/components/layout/SideNav/SideNav.tsx
@@ -97,6 +97,9 @@ const SideNav = ({ location }: SideNavProps) => {
                 frontmatter {
                   title
                   order
+                  status {
+                    level
+                  }
                 }
               }
             }

--- a/packages/docs/src/components/layout/StatusIndicator.tsx
+++ b/packages/docs/src/components/layout/StatusIndicator.tsx
@@ -27,12 +27,12 @@ const statusConfig: Record<
   },
   caution: {
     variation: 'warn',
-    label: 'Caution',
+    label: 'Use with caution',
     Icon: AlertIcon,
   },
   avoid: {
     variation: 'alert',
-    label: 'Avoid',
+    label: "Don't use",
     Icon: AlertIcon,
   },
 };

--- a/packages/docs/src/components/layout/StatusIndicator.tsx
+++ b/packages/docs/src/components/layout/StatusIndicator.tsx
@@ -41,7 +41,11 @@ export const StatusIndicator: React.FC<StatusIndicatorProps> = ({ level }) => {
   const { variation, label, Icon, iconClassName } = statusConfig[level];
 
   return (
-    <Badge variation={variation} className="ds-u-display--inline-flex ds-u-align-items--center">
+    <Badge
+      variation={variation}
+      hideScreenReaderText
+      className="ds-u-display--inline-flex ds-u-align-items--center"
+    >
       <Icon
         className={iconClassName}
         style={{ fontSize: '1em', height: '1em', width: '1em', verticalAlign: 'text-bottom' }}

--- a/packages/docs/src/components/page-templates/InfoPage.tsx
+++ b/packages/docs/src/components/page-templates/InfoPage.tsx
@@ -49,6 +49,8 @@ export const query = graphql`
         status {
           level
           note
+          targetTheme
+          targetThemeNote
         }
         cmsgov {
           figmaNodeId

--- a/packages/docs/src/helpers/graphQLTypes.ts
+++ b/packages/docs/src/helpers/graphQLTypes.ts
@@ -25,6 +25,8 @@ export interface LocationInterface {
 export interface StatusInterface {
   level: 'use' | 'caution' | 'avoid';
   note?: string;
+  targetTheme?: 'core' | 'cmsgov' | 'healthcare' | 'medicare';
+  targetThemeNote?: string;
 }
 
 export interface FrontmatterInterface {

--- a/packages/docs/src/helpers/graphQLTypes.ts
+++ b/packages/docs/src/helpers/graphQLTypes.ts
@@ -100,6 +100,7 @@ export interface NavItem {
     frontmatter?: {
       title: string;
       order?: number;
+      status?: StatusInterface;
     };
   };
 }

--- a/packages/docs/src/helpers/navDataFormatUtils.ts
+++ b/packages/docs/src/helpers/navDataFormatUtils.ts
@@ -7,6 +7,7 @@ import { sendNavigationOpenedAnalytics } from '../helpers/analytics';
 export interface DocsNavItem extends Omit<VerticalNavItemProps, 'label'> {
   label: string;
   order: number;
+  status?: 'use' | 'caution' | 'avoid';
 }
 
 // order of labels of level 1 items
@@ -54,6 +55,7 @@ const formatNavItemData = ({ childMdx, relativePath }: NavItem, location: Locati
     id: relativePath,
     selected: isItemSelected(relativePath, location),
     order: frontmatter?.order || 0,
+    ...(frontmatter?.status?.level && { _status: frontmatter.status.level }),
   };
 };
 


### PR DESCRIPTION
## Summary

- Wires up `StatusIndicator` badges and Alerts. Some Alerts explain why a component has a **caution** or **avoid** status; others flag product-specific components (e.g., Medicare Footer) and prompt users to switch to the appropriate theme on the doc site.
- Updates select status messages to align with approved copy.

[Jira ticket](https://jira.cms.gov/browse/CMSDS-3417)

> **Note**  
> This is the first of two PRs that will wire up all visual changes related to component status indication on the doc site.

## How to test

- Run `npm run start`.
- Verify that `StatusIndicator` Badges appear on all component pages.
- For components with **Caution** or **Avoid** status (e.g., Inset or Stars), verify that an Alert is displayed explaining the status.
- Verify that product-specific Alerts render correctly on the following pages (note: not all pages include these, only product-specific components):
  - [Healthcare Footer](http://localhost:8000/components/footer/healthcare-footer/?theme=core)
  - [Medicare Footer](http://localhost:8000/components/footer/medicare-footer/?theme=core)
  - [Healthcare Header](http://localhost:8000/components/header/healthcare-header/?theme=core)
  - [Medicare Header](http://localhost:8000/components/header/medicare-header/?theme=core)
  - [Inset (Healthcare)](http://localhost:8000/components/inset/?theme=core)
  - [Stars (Medicare)](http://localhost:8000/components/stars/?theme=core)
- Toggle between themes for each page. When the correct theme is selected for a product-specific component, the Alert should no longer appear.

## Checklist
- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
