### PR TITLE
[NO-TICKET] Upgrade `preact` to v10.19.5

### DIFF
--- a/examples/preact-app/package.json
+++ b/examples/preact-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@cmsgov/design-system": "13.1.1",
-    "preact": "10.11.3"
+    "preact": "10.19.5"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",

--- a/examples/preact-react-app/package.json
+++ b/examples/preact-react-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@cmsgov/design-system": "13.1.1",
-    "preact": "10.11.3"
+    "preact": "10.19.5"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "mini-css-extract-plugin": "^1",
         "postcss": "^8",
         "postcss-import": "^15.0.0",
-        "preact": "10.11.3",
+        "preact": "10.19.5",
         "prettier": "^2.6.1",
         "react": "18.3.1",
         "react-app-polyfill": "^3.0.0",
@@ -6158,7 +6158,7 @@
       "version": "13.1.1",
       "dependencies": {
         "@cmsgov/design-system": "13.1.1",
-        "preact": "10.11.3"
+        "preact": "10.19.5"
       },
       "devDependencies": {
         "@babel/core": "^7.21.4",
@@ -6208,7 +6208,7 @@
       "version": "13.1.1",
       "dependencies": {
         "@cmsgov/design-system": "13.1.1",
-        "preact": "10.11.3"
+        "preact": "10.19.5"
       },
       "devDependencies": {
         "@babel/core": "^7.21.4",
@@ -44756,9 +44756,10 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/preact": {
-      "version": "10.11.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
-      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "version": "10.19.5",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.5.tgz",
+      "integrity": "sha512-OPELkDmSVbKjbFqF9tgvOowiiQ9TmsJljIzXRyNE8nGiis94pwv1siF78rQkAP1Q1738Ce6pellRg/Ns/CtHqQ==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -54681,7 +54682,7 @@
         "inquirer": "^13.0.1",
         "lodash": "^4.17.21",
         "ora": "^6.1.2",
-        "preact": "10.11.3",
+        "preact": "10.19.5",
         "prop-types": "^15.8.1",
         "react-aria": "^3.27.0",
         "react-day-picker": "8.10.1",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "mini-css-extract-plugin": "^1",
     "postcss": "^8",
     "postcss-import": "^15.0.0",
-    "preact": "10.11.3",
+    "preact": "10.19.5",
     "prettier": "^2.6.1",
     "react": "18.3.1",
     "react-app-polyfill": "^3.0.0",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -71,7 +71,7 @@
     "inquirer": "^13.0.1",
     "lodash": "^4.17.21",
     "ora": "^6.1.2",
-    "preact": "10.11.3",
+    "preact": "10.19.5",
     "prop-types": "^15.8.1",
     "react-aria": "^3.27.0",
     "react-day-picker": "8.10.1",

--- a/packages/design-system/src/components/Icons/icons.stories.tsx
+++ b/packages/design-system/src/components/Icons/icons.stories.tsx
@@ -264,7 +264,7 @@ export const AvailableIcons = () => (
       </tr>
     </thead>
     <tbody>
-      {iconData.map(({ defaultTitle, component, name, notes }) => (
+      {iconData.map(({ defaultTitle, component, name, notes = '' }) => (
         <tr key={name}>
           <td>
             <code>{name}</code>

--- a/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.test.tsx
@@ -108,6 +108,7 @@ describe('Dropdown', () => {
   });
 
   it('fires a custom ds-change event', async () => {
+    jest.useFakeTimers();
     const { user } = renderDropdown();
 
     const dropdownRoot = document.querySelector('ds-dropdown');
@@ -136,7 +137,6 @@ describe('Dropdown', () => {
     const button = screen.getByRole('button');
     await user.click(button);
     await user.tab();
-    jest.runAllTimers();
 
     expect(onBlur).toHaveBeenCalledTimes(1);
     expect(onChange).not.toHaveBeenCalled();

--- a/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-dropdown/ds-dropdown.test.tsx
@@ -108,7 +108,6 @@ describe('Dropdown', () => {
   });
 
   it('fires a custom ds-change event', async () => {
-    jest.useFakeTimers();
     const { user } = renderDropdown();
 
     const dropdownRoot = document.querySelector('ds-dropdown');
@@ -126,7 +125,6 @@ describe('Dropdown', () => {
   });
 
   it('fires a custom ds-blur event', async () => {
-    jest.useFakeTimers();
     const { user } = renderDropdown();
 
     const dropdownRoot = document.querySelector('ds-dropdown');

--- a/packages/design-system/src/components/web-components/ds-icons/ds-icons.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-icons/ds-icons.stories.tsx
@@ -265,7 +265,7 @@ const iconsTable = () => (
       </tr>
     </thead>
     <tbody>
-      {iconData.map(({ defaultTitle, component, name, notes }) => (
+      {iconData.map(({ defaultTitle, component, name, notes = '' }) => (
         <tr key={name}>
           <td>
             <code>{name}</code>

--- a/packages/ds-medicare-gov/src/components/Icons/icons.stories.tsx
+++ b/packages/ds-medicare-gov/src/components/Icons/icons.stories.tsx
@@ -67,7 +67,7 @@ export const AvailableIcons = () => (
       </tr>
     </thead>
     <tbody>
-      {iconData.map(({ defaultTitle, component, name, notes }) => (
+      {iconData.map(({ defaultTitle, component, name, notes = '' }) => (
         <tr key={name}>
           <td>
             <code>{name}</code>


### PR DESCRIPTION
## Summary

- Upgrades Preact to v10.19.5 to pick up DOM vnode normalization for translate (mapping `translate="no"` to `false`). See [pr-3800](https://github.com/preactjs/preact/pull/3800)

## How to test
```
npm run freshen
npm run test 
npm run test:unit:wc
npm run start
npm run test:browser:all
```
## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone