### PR TITLE
[NO-TICKET] Silence missing key warnings during build

### DIFF
--- a/packages/docs/gatsby-ssr.tsx
+++ b/packages/docs/gatsby-ssr.tsx
@@ -1,7 +1,7 @@
 const proc = require('process');
 
 const HeadComponentsJs = (content) => (
-  <script type="text/javascript" dangerouslySetInnerHTML={content}></script>
+  <script key={'tealium-tags'} type="text/javascript" dangerouslySetInnerHTML={content}></script>
 );
 
 exports.onRenderBody = ({ setPreBodyComponents }) => {


### PR DESCRIPTION
## Summary

- I'm sick of seeing an error at build time for a missing key on an element. 
- So I added a key that I should've added a while ago.

## How to test

1.`npm run start`
2. You shouldn't see any missing key warnings during build

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone
