### PR TITLE
[CMSDS03971] Wire theme-specific `Alerts` for Logos into the frontmatter

### DIFF
--- a/packages/docs/content/components/logos/healthcare-logo.mdx
+++ b/packages/docs/content/components/logos/healthcare-logo.mdx
@@ -3,6 +3,8 @@ title: Healthcare.gov Logo
 intro: Renders the HealthCare.gov logo in English (default) or Spanish.
 status:
   level: use
+  targetTheme: healthcare
+  targetThemeNote: This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.
 core:
   figmaNodeId: 346-18284
 healthcare:
@@ -11,7 +13,6 @@ healthcare:
   storybookLink: healthcare-logo--docs
 ---
 
-import { Alert } from '@cmsgov/design-system';
 import { CloseIconThin, SvgIcon } from '@cmsgov/design-system';
 import colorBackground from '../../../src/images/HCgov-logo/4_ColorBackground.png';
 import photoBackground from '../../../src/images/HCgov-logo/5_PhotoBackground.png';
@@ -23,16 +24,6 @@ import squeezed from '../../../src/images/HCgov-logo/10_Squeezed.png';
 import hcgovFavicon from '../../../src/images/HCgov-logo/favicon.ico';
 import blackLogoTag from '../../../src/images/HCgov-logo/BlackLogoTag.png';
 import greyLogoTag from '../../../src/images/HCgov-logo/GreyLogoTag.png';
-
-<ThemeContent neverThemes={['healthcare']}>
-  <Alert variation="error">
-    <p class="ds-c-alert__text">
-      {
-        'This component is only used for HealthCare. Please use the theme switcher to view the component with HealthCare styles.'
-      }
-    </p>
-  </Alert>
-</ThemeContent>
 
 In keeping with our theme of trust, the HealthCare.gov identity marker establishes a universal signature across all HealthCare.gov communications. We treat the marker the same across all media. See the rules to follow when using the HealthCare.gov identity marker below.
 

--- a/packages/docs/content/components/logos/medicare-logo.mdx
+++ b/packages/docs/content/components/logos/medicare-logo.mdx
@@ -3,6 +3,8 @@ title: Medicare.gov Logo
 intro: Renders the Medicare.gov logo.
 status:
   level: use
+  targetTheme: medicare
+  targetThemeNote: This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.
 core:
   figmaNodeId: 346-18284
 medicare:
@@ -10,18 +12,6 @@ medicare:
   githubLink: ds-medicare-gov/src/components/MedicaregovLogo
   storybookLink: medicare-logo--docs
 ---
-
-import { Alert } from '@cmsgov/design-system';
-
-<ThemeContent neverThemes={['medicare']}>
-  <Alert variation="error">
-    <p class="ds-c-alert__text">
-      {
-        'This component is only used for Medicare. Please use the theme switcher to view the component with Medicare styles.'
-      }
-    </p>
-  </Alert>
-</ThemeContent>
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- When we first wired theme-specific alerts into frontmatter, the pages for Medicare and Healthcare logos were accidentally missed.
[Jira ticket](https://jira.cms.gov/browse/CMSDS-3971)

## How to test

Run `npm run start`, then navigate to:
- http://localhost:8000/components/logos/medicare-logo/
- http://localhost:8000/components/logos/healthcare-logo/

Verify that the theme-specific alert appears at the top of the page whenever the current theme does not match the themed component.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone