### PR TITLE
[NO-TICKET] Update `package-lock.json` after bumping `ev-emitter`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27157,9 +27157,10 @@
       }
     },
     "node_modules/ev-emitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.1.1.tgz",
-      "integrity": "sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-2.1.2.tgz",
+      "integrity": "sha512-jQ5Ql18hdCQ4qS+RCrbLfz1n+Pags27q5TwMKvZyhp5hh2UULUYZUy1keqj6k6SYsdqIYjnmz7xyyEY0V67B8Q==",
+      "license": "MIT"
     },
     "node_modules/event-emitter": {
       "version": "0.3.5",
@@ -55064,7 +55065,7 @@
         "chalk": "^5.6.2",
         "classnames": "^2.2.5",
         "date-fns": "^3.0.6",
-        "ev-emitter": "^1.1.1",
+        "ev-emitter": "^2.1.2",
         "globby": "^16.0.0",
         "inquirer": "^13.0.1",
         "lodash": "^4.17.21",


### PR DESCRIPTION
## Summary

- Updates `package-lock.json` to reconcile trailing changes introduced after merging the Dependabot `ev-emitter` bump [pr-4013](https://github.com/CMSgov/design-system/pull/4013).

## How to test
`npm run freshen` - everything builds correctly and tests pass.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone