### PR TITLE
[CMSDS-3979] New Relic dev env

### DIFF
--- a/packages/docs/gatsby-config.mjs
+++ b/packages/docs/gatsby-config.mjs
@@ -2,7 +2,6 @@
 import remarkGfm from 'remark-gfm';
 import generateNewRelicPlugin from './newRelicConfig.mjs'
 
-
 const newRelicPlugin = generateNewRelicPlugin();
 
 /**

--- a/packages/docs/gatsby-config.mjs
+++ b/packages/docs/gatsby-config.mjs
@@ -1,5 +1,9 @@
 // @ts-check
 import remarkGfm from 'remark-gfm';
+import generateNewRelicPlugin from './newRelicConfig.mjs'
+
+
+const newRelicPlugin = generateNewRelicPlugin();
 
 /**
  * @type {import('gatsby').GatsbyConfig}
@@ -74,21 +78,7 @@ const config = {
         extensions: [`.mdx`, `.md`],
       },
     },
-    {
-      resolve: 'gatsby-plugin-newrelic',
-      options: {
-        config: {
-          instrumentationType: 'proAndSPA',
-          accountId: '6704482',
-          trustKey: '39033',
-          agentID: '1134604697',
-          licenseKey: 'NRJS-d12a0b7909b564e0959',
-          applicationID: '1134604697',
-          beacon: 'gov-bam.nr-data.net',
-          errorBeacon: 'gov-bam.nr-data.net',
-        },
-      },
-    },
+    newRelicPlugin || '',
     {
       resolve: 'gatsby-plugin-local-search',
       options: {
@@ -131,7 +121,7 @@ const config = {
       },
     },
     'gatsby-plugin-client-side-redirect',
-  ],
+  ].filter(Boolean),
 };
 
 if (process.env.PATH_PREFIX) {

--- a/packages/docs/newRelicConfig.mjs
+++ b/packages/docs/newRelicConfig.mjs
@@ -1,0 +1,45 @@
+export default function generateNewRelicPlugin() {
+  const NEW_RELIC_MODE = process.env.NEW_RELIC_MODE || 'off';
+
+  const NEW_RELIC_BASE_CONFIG = {
+    instrumentationType: 'proAndSPA',
+    trustKey: '39033',
+    licenseKey: 'NRJS-d12a0b7909b564e0959',
+    beacon: 'gov-bam.nr-data.net',
+    errorBeacon: 'gov-bam.nr-data.net',
+  };
+
+  const NEW_RELIC_CONFIG_BY_MODE = {
+    dev: {
+      ...NEW_RELIC_BASE_CONFIG,
+      accountId: process.env.NEW_RELIC_ACCOUNT_ID_DEV,
+      agentID: process.env.NEW_RELIC_AGENT_ID_DEV,
+      applicationID: process.env.NEW_RELIC_AGENT_ID_DEV,
+    },
+    prod: {
+      ...NEW_RELIC_BASE_CONFIG,
+      accountId: process.env.NEW_RELIC_ACCOUNT_ID_PROD || '6704482',
+      agentID: process.env.NEW_RELIC_AGENT_ID_PROD || '1134604697',
+      applicationID: process.env.NEW_RELIC_AGENT_ID_PROD || '1134604697',
+    },
+  };
+
+  if (!['off', 'dev', 'prod'].includes(NEW_RELIC_MODE)) {
+    throw new Error(
+      `Invalid NEW_RELIC_MODE: "${NEW_RELIC_MODE}". Expected "off", "dev", or "prod".`
+    );
+  }
+
+  const newRelicPlugin =
+    NEW_RELIC_MODE === 'off'
+      ? null
+      : {
+          resolve: 'gatsby-plugin-newrelic',
+          options: {
+            // @ts-ignore
+            config: NEW_RELIC_CONFIG_BY_MODE[NEW_RELIC_MODE],
+          },
+        };
+
+  return newRelicPlugin;
+}

--- a/packages/docs/newRelicConfig.mjs
+++ b/packages/docs/newRelicConfig.mjs
@@ -1,27 +1,18 @@
 export default function generateNewRelicPlugin() {
+    // Default to 'off' so we don't initialize New Relic at all on localhost
   const NEW_RELIC_MODE = process.env.NEW_RELIC_MODE || 'off';
 
-  const NEW_RELIC_BASE_CONFIG = {
+  const NEW_RELIC_CONFIG = {
     instrumentationType: 'proAndSPA',
     trustKey: '39033',
-    licenseKey: 'NRJS-d12a0b7909b564e0959',
     beacon: 'gov-bam.nr-data.net',
     errorBeacon: 'gov-bam.nr-data.net',
-  };
-
-  const NEW_RELIC_CONFIG_BY_MODE = {
-    dev: {
-      ...NEW_RELIC_BASE_CONFIG,
-      accountId: process.env.NEW_RELIC_ACCOUNT_ID_DEV,
-      agentID: process.env.NEW_RELIC_AGENT_ID_DEV,
-      applicationID: process.env.NEW_RELIC_AGENT_ID_DEV,
-    },
-    prod: {
-      ...NEW_RELIC_BASE_CONFIG,
-      accountId: process.env.NEW_RELIC_ACCOUNT_ID_PROD || '6704482',
-      agentID: process.env.NEW_RELIC_AGENT_ID_PROD || '1134604697',
-      applicationID: process.env.NEW_RELIC_AGENT_ID_PROD || '1134604697',
-    },
+    // These values change between the Dev and Prod instances of New Relic.
+    licenseKey: process.env.NEW_RELIC_LICENSE_KEY,
+    accountId: process.env.NEW_RELIC_ACCOUNT_ID,
+    agentID: process.env.NEW_RELIC_AGENT_ID,
+    // Application ID and Agent ID appear to be the same on the New Relic side.
+    applicationID: process.env.NEW_RELIC_AGENT_ID,
   };
 
   if (!['off', 'dev', 'prod'].includes(NEW_RELIC_MODE)) {
@@ -36,8 +27,7 @@ export default function generateNewRelicPlugin() {
       : {
           resolve: 'gatsby-plugin-newrelic',
           options: {
-            // @ts-ignore
-            config: NEW_RELIC_CONFIG_BY_MODE[NEW_RELIC_MODE],
+            config: NEW_RELIC_CONFIG,
           },
         };
 

--- a/packages/docs/newRelicConfig.mjs
+++ b/packages/docs/newRelicConfig.mjs
@@ -1,6 +1,29 @@
 export default function generateNewRelicPlugin() {
-    // Default to 'off' so we don't initialize New Relic at all on localhost
+  // Default to 'off' so we don't initialize New Relic at all on localhost
   const NEW_RELIC_MODE = process.env.NEW_RELIC_MODE || 'off';
+
+  if (!['off', 'dev', 'prod'].includes(NEW_RELIC_MODE)) {
+    throw new Error(
+      `Invalid NEW_RELIC_MODE: "${NEW_RELIC_MODE}". Expected "off", "dev", or "prod".`
+    );
+  }
+
+  // Error on missing environment params:
+  if (NEW_RELIC_MODE !== 'off') {
+    const requiredVars = [
+      'NEW_RELIC_LICENSE_KEY',
+      'NEW_RELIC_ACCOUNT_ID',
+      'NEW_RELIC_AGENT_ID',
+    ];
+
+    const missing = requiredVars.filter((key) => !process.env[key]?.trim());
+
+    if (missing.length) {
+      throw new Error(
+        `Missing required environment variable${missing.length > 1 ? 's' : ''}: ${missing.join(', ')} for NEW_RELIC_MODE="${NEW_RELIC_MODE}"`
+      );
+    }
+  }
 
   const NEW_RELIC_CONFIG = {
     instrumentationType: 'proAndSPA',
@@ -14,12 +37,6 @@ export default function generateNewRelicPlugin() {
     // Application ID and Agent ID appear to be the same on the New Relic side.
     applicationID: process.env.NEW_RELIC_AGENT_ID,
   };
-
-  if (!['off', 'dev', 'prod'].includes(NEW_RELIC_MODE)) {
-    throw new Error(
-      `Invalid NEW_RELIC_MODE: "${NEW_RELIC_MODE}". Expected "off", "dev", or "prod".`
-    );
-  }
 
   const newRelicPlugin =
     NEW_RELIC_MODE === 'off'


### PR DESCRIPTION
## Summary

- We've got a non-prod New Relic instance, let's start using it. 
- This introduces a new CJS file that is referenced during start up to create a New Relic plugin that is sensitive to the environment we are working in
- By default New Relic will not be added to the doc site, so we won't collect data on localhost
- Passing in the correct env variable will enable it for dev and prod instances
- [Ticket](https://jira.cms.gov/browse/CMSDS-3979)
- See backend changes in the following [Pull Request](https://github.cms.gov/CMS-WDS/experience-toolkit/pull/107)

## How to test

1. Start the doc server locally: `NEW_RELIC_MODE=dev NEW_RELIC_LICENSE_KEY=test NEW_RELIC_ACCOUNT_ID=quark NEW_RELIC_AGENT_ID=lol  npm run start`
2. The `NEW_RELIC` vars are passed in as environment variables
3. Type `NREUM` into your browser console you're running the doc site in
4. See following snapshot and confirm all the variables are set properly:
<img width="455" height="208" alt="Screenshot 2026-04-27 at 10 16 23 AM" src="https://github.com/user-attachments/assets/612d8b2a-9f1c-48cc-93fe-96ce938bb5f9" />

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone