### PR TITLE
[CMSDS-4051] Resolve item announcement issue on Autocomplete

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -17,6 +17,7 @@ import {
 import { t } from '../i18n';
 import { useComboBox } from '../react-aria'; // from react-aria
 import { useComboBoxState } from '../react-aria'; // from react-stately
+import type { CollectionChildren } from '@react-types/shared';
 
 export interface AutocompleteItem extends Omit<React.HTMLAttributes<'option'>, 'name'> {
   /**
@@ -117,7 +118,7 @@ export interface AutocompleteProps {
   /**
    * Called when the user selects an item and the selected item has changed. Called with the item that was selected.
    */
-  onChange?: (selectedItem: AutocompleteItem) => void;
+  onChange?: (selectedItem: AutocompleteItem | null) => void;
   /**
    * Called when the child `TextField` value changes. Is called with a string representing the input value.
    */
@@ -168,15 +169,23 @@ export const Autocomplete = (props: AutocompleteProps) => {
     ...autocompleteProps
   } = props;
 
-  const hasValidStandaloneItems = items?.some((item) => !('items' in item));
-  const hasValidGroupedItems = items?.some((item) => 'items' in item && item.items?.length > 0);
+  function hasRenderableItems(items: AutocompleteItems | undefined): items is AutocompleteItems {
+    if (!items?.length) return false;
+
+    const hasValidStandaloneItems = items?.some((item) => !('items' in item));
+    const hasValidGroupedItems = items?.some((item) => 'items' in item && item.items?.length > 0);
+
+    return hasValidStandaloneItems || hasValidGroupedItems;
+  }
 
   // Determine what we'll show based on state
-  let reactStatelyItems = [];
+  let reactStatelyItems: React.ReactElement[] = [];
   let statusMessage;
 
-  if (hasValidStandaloneItems || hasValidGroupedItems) {
-    reactStatelyItems = renderReactStatelyItems(items);
+  if (hasRenderableItems(items)) {
+    // items can be "undefined" but because of the .some checks above we know
+    // items is defined and has a length, hence including the ! here to assert so.
+    reactStatelyItems = renderReactStatelyItems(items!);
   } else if (loading) {
     // If we're waiting for results to load, show the non-selected message
     statusMessage = renderStatusMessage(loadingMessage ?? t('autocomplete.loadingMessage'));
@@ -193,7 +202,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
     ...autocompleteProps,
     allowsCustomValue: true,
     allowsEmptyCollection: true,
-    children: reactStatelyItems,
+    children: reactStatelyItems as CollectionChildren<object>,
     inputValue: textField.props.value,
     onInputChange: onInputValueChange
       ? (value) => {
@@ -217,6 +226,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
 
   const inputRef = useRef<HTMLInputElement>(null);
   const listBoxRef = useRef<HTMLElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const useComboboxProps = useComboBox(
     {
@@ -226,7 +236,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
       isDisabled: textField.props.disabled,
       inputRef,
       listBoxRef,
-      popoverRef: listBoxRef,
+      popoverRef,
     },
     state
   );
@@ -259,26 +269,26 @@ export const Autocomplete = (props: AutocompleteProps) => {
     // Restores previous functionality where if you had typed characters into the text
     // field to get results and then blur away and come back, it'll open the results
     // list again without having to press anything on the keyboard.
-    onFocus: (event) => {
+    onFocus: (event: React.FocusEvent<HTMLInputElement>) => {
       useComboboxProps.inputProps.onFocus?.(event);
       textField.props.onFocus?.(event);
       state.open();
     },
     // Allow the user to continue to attach their own event handlers to the TextField.
     // The following event handlers would normally be overwritten by useCombobox.
-    onChange: (event) => {
+    onChange: (event: React.FocusEvent<HTMLInputElement>) => {
       useComboboxProps.inputProps.onChange?.(event);
       textField.props.onChange?.(event);
     },
-    onBlur: (event) => {
+    onBlur: (event: React.FocusEvent<HTMLInputElement>) => {
       useComboboxProps.inputProps.onBlur?.(event);
       textField.props.onBlur?.(event);
     },
-    onTouchEnd: (event) => {
+    onTouchEnd: (event: React.TouchEvent<HTMLInputElement>) => {
       useComboboxProps.inputProps.onTouchEnd?.(event);
       textField.props.onTouchEnd?.(event);
     },
-    onKeyDown: (event) => {
+    onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {
       useComboboxProps.inputProps.onKeyDown?.(event);
       textField.props.onKeyDown?.(event);
     },
@@ -290,34 +300,31 @@ export const Autocomplete = (props: AutocompleteProps) => {
     <div className={rootClassName} ref={wrapperRef}>
       {cloneElement(textField, textFieldProps)}
 
-      {((state.isOpen && reactStatelyItems.length > 0) || (state.isFocused && statusMessage)) && (
-        <DropdownMenu
-          {...useComboboxProps.listBoxProps}
-          componentClass="ds-c-autocomplete"
-          heading={menuHeading}
-          labelId={menuHeadingId}
-          menuId={menuId}
-          rootId={id}
-          size={size}
-          state={state}
-          triggerRef={wrapperRef}
-          listBoxRef={listBoxRef}
-        >
-          {statusMessage}
-        </DropdownMenu>
-      )}
-
+      <div ref={popoverRef}>
+        {((state.isOpen && reactStatelyItems.length > 0) || (state.isFocused && statusMessage)) && (
+          <DropdownMenu
+            {...useComboboxProps.listBoxProps}
+            componentClass="ds-c-autocomplete"
+            heading={menuHeading}
+            labelId={menuHeadingId}
+            menuId={menuId}
+            rootId={id}
+            size={size}
+            state={state}
+            triggerRef={wrapperRef}
+            listBoxRef={listBoxRef}
+          >
+            {statusMessage}
+          </DropdownMenu>
+        )}
+      </div>
       {clearSearchButton && (
         <Button
           className="ds-u-padding-right--0 ds-c-autocomplete__clear-btn"
           onClick={() => {
-            state.setSelectedKey(null);
             state.setInputValue('');
             inputRef.current?.focus();
-
-            if (state.selectedKey) {
-              onChange?.(null);
-            }
+            onChange?.(null);
           }}
           size="small"
           variation="ghost"

--- a/packages/design-system/src/components/Autocomplete/utils.tsx
+++ b/packages/design-system/src/components/Autocomplete/utils.tsx
@@ -69,7 +69,7 @@ export function getTextFieldChild(children: ReactNode): ReactElement<any> | unde
 export function getActiveDescendant(
   rootId: string,
   state: ComboBoxState<object>,
-  items: AutocompleteItem[]
+  items: AutocompleteItem[] | undefined
 ): string {
   const index = (items ?? []).findIndex((item) => state.selectionManager.focusedKey === item.id);
   return getOptionId(rootId, index);

--- a/packages/design-system/src/components/react-aria/index.js
+++ b/packages/design-system/src/components/react-aria/index.js
@@ -6705,8 +6705,6 @@ function $c350ade66beef0af$export$8c18d1b4f7232bbf(props, state) {
     }
   };
   let onBlur = (e) => {
-    console.log('ON BLUR CALLED: LINE 6712');
-    console.log({ popoverRef: popoverRef.current });
     var _popoverRef_current;
     // Ignore blur if focused moved to the button or into the popover.
     if (

--- a/packages/design-system/src/components/react-aria/index.js
+++ b/packages/design-system/src/components/react-aria/index.js
@@ -6705,6 +6705,8 @@ function $c350ade66beef0af$export$8c18d1b4f7232bbf(props, state) {
     }
   };
   let onBlur = (e) => {
+    console.log('ON BLUR CALLED: LINE 6712');
+    console.log({ popoverRef: popoverRef.current });
     var _popoverRef_current;
     // Ignore blur if focused moved to the button or into the popover.
     if (

--- a/packages/design-system/src/components/utilities/mergeRefs.ts
+++ b/packages/design-system/src/components/utilities/mergeRefs.ts
@@ -4,7 +4,7 @@
  * Borrowed from https://github.com/gregberge/react-merge-refs/blob/main/src/index.tsx
  */
 export default function mergeRefs<T = any>(
-  refs: Array<React.RefObject<T | null> | React.Ref<T>>
+  refs: Array<React.RefObject<T | null> | React.Ref<T> | undefined>
 ): React.RefCallback<T> {
   return (value) => {
     refs.forEach((ref) => {

--- a/packages/design-system/src/components/web-components/ds-autocomplete/__snapshots__/ds-autocomplete.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-autocomplete/__snapshots__/ds-autocomplete.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`Autocomplete can add a custom class name to the error message 1`] = `
           </p>
         </div>
       </div>
+      <div />
       <button
         class="ds-c-button ds-c-button--small ds-c-button--ghost ds-u-padding-right--0 ds-c-autocomplete__clear-btn"
         type="button"
@@ -149,6 +150,7 @@ exports[`Autocomplete displays an error message in the default location for Heal
           </p>
         </div>
       </div>
+      <div />
       <button
         class="ds-c-button ds-c-button--small ds-c-button--ghost ds-u-padding-right--0 ds-c-autocomplete__clear-btn"
         type="button"
@@ -229,6 +231,7 @@ exports[`Autocomplete displays an error message in the default position for Core
           type="text"
         />
       </div>
+      <div />
       <button
         class="ds-c-button ds-c-button--small ds-c-button--ghost ds-u-padding-right--0 ds-c-autocomplete__clear-btn"
         type="button"
@@ -291,6 +294,7 @@ exports[`Autocomplete renders correctly 1`] = `
           type="text"
         />
       </div>
+      <div />
       <button
         class="ds-c-button ds-c-button--small ds-c-button--ghost ds-u-padding-right--0 ds-c-autocomplete__clear-btn"
         type="button"
@@ -399,6 +403,7 @@ exports[`Autocomplete sets the display location of the error message 1`] = `
           </p>
         </div>
       </div>
+      <div />
       <button
         class="ds-c-button ds-c-button--small ds-c-button--ghost ds-u-padding-right--0 ds-c-autocomplete__clear-btn"
         type="button"


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/CMSDS-4051)
- The individual items in the Autocomplete element were not being read out JAWS or NVDA
- Component worked ok in Safari & Chrome, however the text content of the list item was not being read out when JAWS or NVDA stepped through using the DownArrow key. 

## How to test

Really, the reporting team will need to test once we cut the beta release, but putting testing steps here for posterity

1. Run locally - `npm run storybook`
2. Repeat for Chrome and Safari - if you have access to NVDA (via Browserstack or Windows VM) open in Edge
3. Open in Chrome - navigate to Autocomplete story
4. Start Voiceover - CMD + FN + F5 - or enable NVDA in Browserstack
5. Tab so that focus is on the TextField of the Autocomplete
6. Type a few letters so that the list options displays
7. The number of options should be read out
8. Press the down arrow key
9. Options should be visually highlighted
10. Text content of each item should be announced

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone

## Videos confirming functionality:

### Chrome:
https://github.com/user-attachments/assets/cb5aa9e9-6253-40cc-9b4e-b253db916ded

### Safari:
https://github.com/user-attachments/assets/418ecdab-403e-47f3-9ed2-49fad2eba57b

### NVDA & Edge:
https://github.com/user-attachments/assets/fd0c77be-58f1-40bb-a00d-206290fcdc81

