### PR TITLE
[CMSDS-4068] Add MonthPicker Figma Code Connection

### DIFF
--- a/packages/design-system/src/components/MonthPicker/MonthPicker.figma.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.figma.tsx
@@ -1,0 +1,26 @@
+import MonthPicker from './MonthPicker';
+import figma from '@figma/code-connect';
+
+figma.connect(
+  MonthPicker,
+  'https://www.figma.com/design/OYkYP4pC9jwS7j2qafwmiv/Design-System-Library?m=dev&node-id=227-59865',
+  {
+    props: {
+      //`Inversed` (VARIANT on nested label/hint/error): needs to be added to top level component. Ticket: CMSDS-4091
+      // buttonVariation needs to be added to design. Ticket: CMSDS-4091
+      labelProps: figma.nestedProps('.LabelHeading', { label: figma.string('Heading text') }),
+      hintProps: figma.nestedProps('.HintText', { hint: figma.string('Hint text') }),
+      errorProps: figma.nestedProps('.ErrorText', {
+        errorMessage: figma.string('Error text'),
+      }),
+    },
+    example: ({ labelProps, hintProps, errorProps }) => (
+      <MonthPicker
+        name="month_picker"
+        label={labelProps.label}
+        hint={hintProps.hint}
+        errorMessage={errorProps.errorMessage}
+      />
+    ),
+  }
+);


### PR DESCRIPTION
## Summary

- Added MonthPicker code connect snippet
- Pretty basic, two props are missing from the Figma Design, so I created design tickets to address that and have noted so in a comment within the code.

## How to test

1. Open the Explore Component behavior tab for the [dev branch component](https://www.figma.com/design/OYkYP4pC9jwS7j2qafwmiv/branch/m5vQUe1j796fuQ64nLwEei/Design-System-Library?m=dev&node-id=227-59865)
2. `label`: Edit the `Heading Text` field in the `.LabelHeading` Figma component, should change the label prop in the code snippet
3. `hint`: Edit the `Hint Text` field in the `.HintText` Figma Component, should change the hint prop in the code snippet 


## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone
