### PR TITLE
Update tabs background and hover styling

### DIFF
--- a/packages/design-system-tokens/src/css/__snapshots__/css-snapshots.test.ts.snap
+++ b/packages/design-system-tokens/src/css/__snapshots__/css-snapshots.test.ts.snap
@@ -929,7 +929,7 @@ exports[`CSS snapshots variables in core-theme.css match snapshot 1`] = `
 --table__padding: var(--spacer-2);
 --tabs-panel__background-color: var(--color-background);
 --tabs__background-color--disabled: var(--color-gray-lighter);
---tabs__background-color--hover: var(--color-background);
+--tabs__background-color--hover: var(--color-primary-lightest);
 --tabs__background-color--selected: var(--color-background);
 --tabs__background-color: var(--color-background);
 --tabs__border-color--disabled: var(--color-gray-lighter);
@@ -937,7 +937,7 @@ exports[`CSS snapshots variables in core-theme.css match snapshot 1`] = `
 --tabs__border-color: var(--color-border);
 --tabs__color--active: var(--color-primary-darker);
 --tabs__color--disabled: var(--color-gray-darker);
---tabs__color--hover: var(--color-primary);
+--tabs__color--hover: var(--color-primary-darker);
 --tabs__color--selected: var(--color-primary);
 --tabs__color: var(--color-base);
 --text-input-currency-icon__line-height: var(--text-input__line-height);
@@ -1418,7 +1418,7 @@ exports[`CSS snapshots variables in healthcare-theme.css match snapshot 1`] = `
 --table__padding: var(--spacer-2);
 --tabs-panel__background-color: var(--color-background);
 --tabs__background-color--disabled: var(--color-gray-lighter);
---tabs__background-color--hover: var(--color-background);
+--tabs__background-color--hover: var(--color-primary-lightest);
 --tabs__background-color--selected: var(--color-background);
 --tabs__background-color: var(--color-background);
 --tabs__border-color--disabled: var(--color-gray-lighter);
@@ -1426,7 +1426,7 @@ exports[`CSS snapshots variables in healthcare-theme.css match snapshot 1`] = `
 --tabs__border-color: var(--color-border);
 --tabs__color--active: var(--color-primary-darker);
 --tabs__color--disabled: var(--color-gray-darker);
---tabs__color--hover: var(--color-primary);
+--tabs__color--hover: var(--color-primary-darker);
 --tabs__color--selected: var(--color-primary);
 --tabs__color: var(--color-base);
 --text-input-currency-icon__line-height: var(--text-input__line-height);
@@ -1906,7 +1906,7 @@ exports[`CSS snapshots variables in medicare-theme.css match snapshot 1`] = `
 --table__padding: var(--spacer-2);
 --tabs-panel__background-color: var(--color-background);
 --tabs__background-color--disabled: var(--color-gray-lighter);
---tabs__background-color--hover: var(--color-background);
+--tabs__background-color--hover: var(--color-primary-lightest);
 --tabs__background-color--selected: var(--color-background);
 --tabs__background-color: var(--color-background);
 --tabs__border-color--disabled: var(--color-gray-lighter);
@@ -1914,7 +1914,7 @@ exports[`CSS snapshots variables in medicare-theme.css match snapshot 1`] = `
 --tabs__border-color: var(--color-border);
 --tabs__color--active: var(--color-primary-darker);
 --tabs__color--disabled: var(--color-gray-darker);
---tabs__color--hover: var(--color-primary);
+--tabs__color--hover: var(--color-primary-darker);
 --tabs__color--selected: var(--color-primary);
 --tabs__color: var(--color-base);
 --text-input-currency-icon__line-height: var(--font-line-height-reset);

--- a/packages/design-system-tokens/src/tokens/Theme.core.json
+++ b/packages/design-system-tokens/src/tokens/Theme.core.json
@@ -4165,7 +4165,7 @@
         }
       },
       "background-color--hover": {
-        "$value": "{theme.color.background}",
+        "$value": "{theme.color.primary-lightest}",
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": false,
@@ -4215,7 +4215,7 @@
         }
       },
       "color--hover": {
-        "$value": "{theme.color.primary}",
+        "$value": "{theme.color.primary-darker}",
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": false,

--- a/packages/design-system-tokens/src/tokens/Theme.healthcare.json
+++ b/packages/design-system-tokens/src/tokens/Theme.healthcare.json
@@ -4155,7 +4155,7 @@
         }
       },
       "background-color--hover": {
-        "$value": "{theme.color.background}",
+        "$value": "{theme.color.primary-lightest}",
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": false,
@@ -4205,7 +4205,7 @@
         }
       },
       "color--hover": {
-        "$value": "{theme.color.primary}",
+        "$value": "{theme.color.primary-darker}",
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": false,

--- a/packages/design-system-tokens/src/tokens/Theme.medicare.json
+++ b/packages/design-system-tokens/src/tokens/Theme.medicare.json
@@ -4164,7 +4164,7 @@
         }
       },
       "background-color--hover": {
-        "$value": "{theme.color.background}",
+        "$value": "{theme.color.primary-lightest}",
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": false,
@@ -4214,7 +4214,7 @@
         }
       },
       "color--hover": {
-        "$value": "{theme.color.primary}",
+        "$value": "{theme.color.primary-darker}",
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": false,

--- a/packages/design-system/src/components/TextField/__snapshots__/useLabelMask.test.tsx.snap
+++ b/packages/design-system/src/components/TextField/__snapshots__/useLabelMask.test.tsx.snap
@@ -6,7 +6,9 @@ exports[`useLabelMask renders the appropriate dom for a CURRENCY_MASK 1`] = `
     class="ds-c-label-mask"
     id="static-id__label-mask"
   >
-    <span>
+    <span
+      class=""
+    >
       $
     </span>
     <span
@@ -25,7 +27,9 @@ exports[`useLabelMask renders the appropriate dom for a PHONE_MASK 1`] = `
     class="ds-c-label-mask"
     id="static-id__label-mask"
   >
-    <span>
+    <span
+      class=""
+    >
       ###-###-####
     </span>
     <span
@@ -44,7 +48,9 @@ exports[`useLabelMask renders the appropriate dom for a SSN_MASK 1`] = `
     class="ds-c-label-mask"
     id="static-id__label-mask"
   >
-    <span>
+    <span
+      class=""
+    >
       ###-##-####
     </span>
     <span
@@ -63,7 +69,9 @@ exports[`useLabelMask renders the appropriate dom for a ZIP_MASK 1`] = `
     class="ds-c-label-mask"
     id="static-id__label-mask"
   >
-    <span>
+    <span
+      class=""
+    >
       #####
     </span>
     <span
@@ -89,6 +97,7 @@ exports[`useLabelMask shows masked value when focused 1`] = `
     </span>
     <span
       aria-hidden="true"
+      class=""
     >
       12/DD/YYYY
     </span>
@@ -102,7 +111,9 @@ exports[`useLabelMask shows unfilled mask when not focused 1`] = `
     class="ds-c-label-mask"
     id="static-id__label-mask"
   >
-    <span>
+    <span
+      class=""
+    >
       MM/DD/YYYY
     </span>
     <span

--- a/packages/design-system/src/components/TextField/__snapshots__/useLabelMask.test.tsx.snap
+++ b/packages/design-system/src/components/TextField/__snapshots__/useLabelMask.test.tsx.snap
@@ -6,9 +6,7 @@ exports[`useLabelMask renders the appropriate dom for a CURRENCY_MASK 1`] = `
     class="ds-c-label-mask"
     id="static-id__label-mask"
   >
-    <span
-      class=""
-    >
+    <span>
       $
     </span>
     <span
@@ -27,9 +25,7 @@ exports[`useLabelMask renders the appropriate dom for a PHONE_MASK 1`] = `
     class="ds-c-label-mask"
     id="static-id__label-mask"
   >
-    <span
-      class=""
-    >
+    <span>
       ###-###-####
     </span>
     <span
@@ -48,9 +44,7 @@ exports[`useLabelMask renders the appropriate dom for a SSN_MASK 1`] = `
     class="ds-c-label-mask"
     id="static-id__label-mask"
   >
-    <span
-      class=""
-    >
+    <span>
       ###-##-####
     </span>
     <span
@@ -69,9 +63,7 @@ exports[`useLabelMask renders the appropriate dom for a ZIP_MASK 1`] = `
     class="ds-c-label-mask"
     id="static-id__label-mask"
   >
-    <span
-      class=""
-    >
+    <span>
       #####
     </span>
     <span
@@ -97,7 +89,6 @@ exports[`useLabelMask shows masked value when focused 1`] = `
     </span>
     <span
       aria-hidden="true"
-      class=""
     >
       12/DD/YYYY
     </span>
@@ -111,9 +102,7 @@ exports[`useLabelMask shows unfilled mask when not focused 1`] = `
     class="ds-c-label-mask"
     id="static-id__label-mask"
   >
-    <span
-      class=""
-    >
+    <span>
       MM/DD/YYYY
     </span>
     <span

--- a/packages/docs/static/themes/core-theme.css
+++ b/packages/docs/static/themes/core-theme.css
@@ -438,12 +438,12 @@
 --tabs__border-color: var(--color-border);
 --tabs__background-color: var(--color-background);
 --tabs__background-color--selected: var(--color-background);
---tabs__background-color--hover: var(--color-background);
+--tabs__background-color--hover: var(--color-primary-lightest);
 --tabs__background-color--disabled: var(--color-gray-lighter);
 --tabs__border-color--selected: var(--color-primary);
 --tabs__border-color--disabled: var(--color-gray-lighter);
 --tabs__color: var(--color-base);
---tabs__color--hover: var(--color-primary);
+--tabs__color--hover: var(--color-primary-darker);
 --tabs__color--selected: var(--color-primary);
 --tabs-panel__background-color: var(--color-background);
 --tabs__color--active: var(--color-primary-darker);

--- a/packages/docs/static/themes/healthcare-theme.css
+++ b/packages/docs/static/themes/healthcare-theme.css
@@ -437,12 +437,12 @@
 --tabs__border-color: var(--color-border);
 --tabs__background-color: var(--color-background);
 --tabs__background-color--selected: var(--color-background);
---tabs__background-color--hover: var(--color-background);
+--tabs__background-color--hover: var(--color-primary-lightest);
 --tabs__background-color--disabled: var(--color-gray-lighter);
 --tabs__border-color--selected: var(--color-primary);
 --tabs__border-color--disabled: var(--color-gray-lighter);
 --tabs__color: var(--color-base);
---tabs__color--hover: var(--color-primary);
+--tabs__color--hover: var(--color-primary-darker);
 --tabs__color--selected: var(--color-primary);
 --tabs-panel__background-color: var(--color-background);
 --tabs__color--active: var(--color-primary-darker);

--- a/packages/docs/static/themes/medicare-theme.css
+++ b/packages/docs/static/themes/medicare-theme.css
@@ -436,12 +436,12 @@
 --tabs__border-color: var(--color-border);
 --tabs__background-color: var(--color-background);
 --tabs__background-color--selected: var(--color-background);
---tabs__background-color--hover: var(--color-background);
+--tabs__background-color--hover: var(--color-primary-lightest);
 --tabs__background-color--disabled: var(--color-gray-lighter);
 --tabs__border-color--selected: var(--color-primary);
 --tabs__border-color--disabled: var(--color-gray-lighter);
 --tabs__color: var(--color-base);
---tabs__color--hover: var(--color-primary);
+--tabs__color--hover: var(--color-primary-darker);
 --tabs__color--selected: var(--color-primary);
 --tabs-panel__background-color: var(--color-background);
 --tabs__color--active: var(--color-primary-darker);


### PR DESCRIPTION
## Summary

- Token changes to support new Tabs hover state design
- Changes made for Core, Healthcare and Medicare. CMS excluded because the hover state already has sufficient contrast.
- [Ticket](https://jira.cms.gov/browse/CMSDS-3936)

## How to test

1. Run Storybook locally
2. Confirm the new hover state for the Tabs component matches the screen shots attached here

<img width="443" height="335" alt="cmsgov-tabs-a11y" src="https://github.com/user-attachments/assets/ee77e013-3112-447a-9a25-8707639583d7" />
<img width="1199" height="851" alt="cmsgov-tabs" src="https://github.com/user-attachments/assets/fa58049e-a619-4552-9dbc-74f788fc592b" />
<img width="517" height="349" alt="core-tabs-a11y" src="https://github.com/user-attachments/assets/ab5caae1-a313-4357-8f03-11b99df4e359" />
<img width="1212" height="900" alt="core-tabs" src="https://github.com/user-attachments/assets/1da8a05b-6dec-4480-be75-b2875ba9be0f" />
<img width="476" height="338" alt="healthcare-tabs-a11y" src="https://github.com/user-attachments/assets/d30b76fb-130a-4706-996f-70b651fbebf9" />
<img width="1185" height="845" alt="healthcare-tabs" src="https://github.com/user-attachments/assets/6ff931f2-7a58-4ac7-8476-e595fbec89cf" />
<img width="427" height="337" alt="medicare-tabs-a11y" src="https://github.com/user-attachments/assets/c8274e18-aece-4ff0-b89f-59f60a7b18a9" />
<img width="1167" height="818" alt="medicare-tabs" src="https://github.com/user-attachments/assets/4dfc39b9-3de2-456d-8089-f91e0beda8e9" />


## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone