### PR TITLE
CMSDS-4103 Update accessibility bug reporting links

### DIFF
--- a/packages/docs/content/components/alert.mdx
+++ b/packages/docs/content/components/alert.mdx
@@ -243,7 +243,9 @@ When using a screen reader (NVDA, JAWS, VoiceOver, TalkBack):
 
 ### Report an accessibility bug
 
-If you encounter a bug with the accessibility of the alert component, [refer to our refer to our bug reporting confluence page](https://confluence.cms.gov/pages/viewpage.action?pageId=1138979323) and use CMSDS bug reporting workflow in our #cms-design-system-team slack channel.
+If you have access to CMS internal tools, report accessibility issues through the [CMSDS bug reporting workflow in Confluence](https://confluence.cms.gov/pages/viewpage.action?pageId=1138979323).
+
+If you do not have access to CMS internal tools, report accessibility issues using the [public GitHub issue template](https://github.com/CMSgov/design-system/issues/new?template=propose-a-new-item-for-the-cms-design-system.md).
 
 ## Code
 


### PR DESCRIPTION
## Summary

Updates accessibility bug reporting guidance across the docsite to support both internal CMS users and external users.

Replaced references to internal-only reporting guidance with separate reporting paths for:

* CMS users (Confluence workflow)
* External users (public GitHub issue template)

Jira: [CMSDS-4103](https://jira.cms.gov/browse/CMSDS-4102)
---

## How to test

1. Run the docsite locally.
2. Navigate to the updated pages:
   * Alert
3. Verify the accessibility bug reporting language matches the approved content.
4. Verify the Confluence link is present for CMS users.
5. Verify the public GitHub issue template link is present and opens correctly.
6. Confirm the content is readable and free of formatting issues.

---

## Checklist

* [x] Prefixed the PR title with the Jira ticket number.
* [x] Selected appropriate Type label.
* [ ] Selected appropriate Impact label(s).
* [ ] Selected appropriate release milestone.

### Documentation/Content

* [x] Checked for spelling and grammatical errors.
* [x] Communicated the assigned milestone/release date with Design so they can communicate appropriately.