### PR TITLE
[NO-TICKET] Fix broken link to support policies on Accessibility page.

### DIFF
--- a/packages/docs/content/guidelines/accessibility.mdx
+++ b/packages/docs/content/guidelines/accessibility.mdx
@@ -36,7 +36,7 @@ More information on Section 508 can be found at:
 
 ## Current browser/technology support
 
-The current browser support for the design system [can be viewed here](/guidelines/browser-support/). 
+The current browser support for the design system [can be viewed here](/guidelines/support-policies/). 
 
 
 ## How to provide feedback


### PR DESCRIPTION
## Summary

- Fixes a broken link on the Accessibility page under the "Current browser/technology support" heading.
- Updates the link target from `/guidelines/browser-support/` to `/guidelines/support-policies/`.
- Although [a redirect exists for the old URL](https://github.com/CMSgov/design-system/blob/main/packages/docs/redirects.json#L11-L12), the link does not consistently resolve correctly in prod.

## How to test

1. Start the development server.
2. Navigate to `http://localhost:8000/guidelines/accessibility/?theme=core`.
3. In the "Current browser/technology support" section, click the hyperlink.
4. Verify that it navigates to `http://localhost:8000/guidelines/support-policies/?theme=core`.


## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone