### PR TITLE
[NO-TICKET] Update MonthPicker Code Connect Snippet

### DIFF
--- a/packages/design-system/src/components/MonthPicker/MonthPicker.figma.tsx
+++ b/packages/design-system/src/components/MonthPicker/MonthPicker.figma.tsx
@@ -3,23 +3,39 @@ import figma from '@figma/code-connect';
 
 figma.connect(
   MonthPicker,
-  'https://www.figma.com/design/OYkYP4pC9jwS7j2qafwmiv/Design-System-Library?m=dev&node-id=227-59865',
+  'https://www.figma.com/design/OYkYP4pC9jwS7j2qafwmiv/Design-System-Library?m=auto&node-id=27698-10200',
   {
     props: {
-      //`Inversed` (VARIANT on nested label/hint/error): needs to be added to top level component. Ticket: CMSDS-4091
-      // buttonVariation needs to be added to design. Ticket: CMSDS-4091
-      labelProps: figma.nestedProps('.LabelHeading', { label: figma.string('Heading text') }),
-      hintProps: figma.nestedProps('.HintText', { hint: figma.string('Hint text') }),
-      errorProps: figma.nestedProps('.ErrorText', {
-        errorMessage: figma.string('Error text'),
+      buttonVariation: figma.enum('Button', {
+        Default: undefined,
+        Ghost: 'ghost',
+        Solid: 'solid',
+        Outline: undefined,
+      }),
+      inversed: figma.enum('Inversed', {
+        Yes: true,
+        No: false,
+      }),
+      labelProps: figma.nestedProps('Form Label', {
+        label: figma.string('Heading text'),
+        hint: figma.boolean('Has hint', {
+          true: figma.string('Hint text'),
+          false: undefined,
+        }),
+        errorMessage: figma.boolean('Has error', {
+          true: figma.string('Error text'),
+          false: undefined,
+        }),
       }),
     },
-    example: ({ labelProps, hintProps, errorProps }) => (
+    example: ({ buttonVariation, labelProps, inversed }) => (
       <MonthPicker
         name="month_picker"
+        buttonVariation={buttonVariation}
         label={labelProps.label}
-        hint={hintProps.hint}
-        errorMessage={errorProps.errorMessage}
+        hint={labelProps.hint}
+        inversed={inversed}
+        errorMessage={labelProps.errorMessage}
       />
     ),
   }


### PR DESCRIPTION
## Summary

- Updated the MonthPicker code connect snippet to reflect changes to Figma by @carolyn-crabbycrab 

## How to test

1. Open the Explore Component behavior tab for the [dev branch component](https://www.figma.com/design/OYkYP4pC9jwS7j2qafwmiv/branch/m5vQUe1j796fuQ64nLwEei/Design-System-Library?m=dev&node-id=27698-10200)
2. Inversed: Edit the Inversed field in the Figma component, should change the inversed prop in the code snippet
3. Button - Default and Outline are the default options so they map onto `undefined`, which is a little wonky but how it is. Choosing Ghost or Solid should update the `buttonVariation` prop accordingly.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone
