### PR TITLE
[CMSDS-4151] Remove "bin" field from ds-cms-gov package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56596,9 +56596,6 @@
         "@cmsgov/design-system": "18.0.1",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.9"
-      },
-      "bin": {
-        "cmsds-migrate": "scripts/cmsds-migrate/src/main.mjs"
       }
     },
     "packages/ds-healthcare-gov": {

--- a/packages/ds-cms-gov/package.json
+++ b/packages/ds-cms-gov/package.json
@@ -5,9 +5,6 @@
     "access": "public",
     "tag": "latest"
   },
-  "bin": {
-    "cmsds-migrate": "./scripts/cmsds-migrate/src/main.mjs"
-  },
   "description": "A design system for CMS.gov products",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- There's a "bin" field in the package.json file for the ds-cms-gov package that should not be there. We do not copy over this npx command from the design-system package, and there's no need to, as every child system depends on the design-system package anyways and this command would be installed by that dependency. The presence of this line is preventing a successful npm install on Node v19. This PR removes it.
- [CMSDS-4151](https://jira.cms.gov/browse/CMSDS-4151)

## How to test

1. Verify `npm run freshen` completes successfully.
2. Run `npm start` and verify the CMS.gov child theme runs on the doc site.
3. Verify `npx cmsds-migrate` works as a command. (The command itself may fail, but it should be at least recognized as a valid command.)

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [x] Verified that running both `npm run test:unit` and `npm run test:browser:all` were each successful
