### PR TITLE
[CMSDS-4053] Add `SvgIcon` dimension fallbacks

### DIFF
--- a/packages/design-system/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/design-system/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -19,8 +19,10 @@ exports[`Accordion renders accordion 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--add ds-c-accordion__button-icon"
+          height="1.5em"
           id="1__icon"
           viewBox="3 3 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -52,8 +54,10 @@ exports[`Accordion renders accordion 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--add ds-c-accordion__button-icon"
+          height="1.5em"
           id="2__icon"
           viewBox="3 3 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/design-system/src/components/Accordion/__snapshots__/AccordionItem.test.tsx.snap
+++ b/packages/design-system/src/components/Accordion/__snapshots__/AccordionItem.test.tsx.snap
@@ -16,8 +16,10 @@ exports[`AccordionItem renders an accordion item 1`] = `
       <svg
         aria-hidden="true"
         class="ds-c-icon ds-c-icon--add ds-c-accordion__button-icon"
+        height="1.5em"
         id="static-id__icon"
         viewBox="3 3 18 18"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/packages/design-system/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/packages/design-system/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -54,7 +54,9 @@ exports[`Alert renders alert 1`] = `
   <svg
     aria-hidden="true"
     class="ds-c-icon ds-c-icon--info-circle ds-c-alert__icon"
+    height="1.5em"
     viewBox="37 2 135 135"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path

--- a/packages/design-system/src/components/ChoiceList/__snapshots__/Choice.test.tsx.snap
+++ b/packages/design-system/src/components/ChoiceList/__snapshots__/Choice.test.tsx.snap
@@ -72,7 +72,9 @@ exports[`Choice applies errorMessage to label 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--alert-circle "
+            height="1.5em"
             viewBox="36 -12 186 186"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path

--- a/packages/design-system/src/components/ChoiceList/__snapshots__/ChoiceList.test.tsx.snap
+++ b/packages/design-system/src/components/ChoiceList/__snapshots__/ChoiceList.test.tsx.snap
@@ -31,7 +31,9 @@ exports[`ChoiceList Radio buttons and Checkboxes is a radio button group 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--alert-circle "
+          height="1.5em"
           viewBox="36 -12 186 186"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/design-system/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/design-system/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -30,8 +30,10 @@ exports[`Dialog renders with additional classNames and size 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           id="static-id__close__icon"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -39,7 +39,9 @@ exports[`Dropdown accepts optgroup children 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-u-font-size--sm"
+            height="1.5em"
             viewBox="0 0 448 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -211,7 +213,9 @@ exports[`Dropdown dropdown matches snapshot 1`] = `
       <svg
         aria-hidden="true"
         class="ds-c-icon ds-u-font-size--sm"
+        height="1.5em"
         viewBox="0 0 448 512"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -231,7 +235,9 @@ exports[`Dropdown shows error message 1`] = `
   <svg
     aria-hidden="true"
     class="ds-c-icon ds-c-icon--alert-circle "
+    height="1.5em"
     viewBox="36 -12 186 186"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path

--- a/packages/design-system/src/components/FilterChip/__snapshots__/FilterChip.test.tsx.snap
+++ b/packages/design-system/src/components/FilterChip/__snapshots__/FilterChip.test.tsx.snap
@@ -28,7 +28,9 @@ exports[`FilterChip should include children as label 1`] = `
     <svg
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--close "
+      height="1.5em"
       viewBox="0 0 16 16"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -47,7 +49,9 @@ exports[`FilterChip should use alternate icon 1`] = `
   <svg
     aria-hidden="true"
     class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+    height="1.5em"
     viewBox="-2 -2 18 18"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path

--- a/packages/design-system/src/components/Icons/SvgIcon.test.tsx
+++ b/packages/design-system/src/components/Icons/SvgIcon.test.tsx
@@ -27,6 +27,24 @@ describe('SvgIcon', () => {
     expect(iconEl).toMatchSnapshot();
   });
 
+  it('adds default width and height fallbacks', () => {
+    renderSvgIcon({ 'data-testid': 'iconTest' });
+
+    const iconEl = screen.getByTestId('iconTest');
+
+    expect(iconEl).toHaveAttribute('width', '1.5em');
+    expect(iconEl).toHaveAttribute('height', '1.5em');
+  });
+
+  it('wrapper icon allows width and height to be overridden', () => {
+    render(<AddIcon data-testid="addIconTest" width="2em" height="2em" />);
+
+    const iconEl = screen.getByTestId('addIconTest');
+
+    expect(iconEl).toHaveAttribute('width', '2em');
+    expect(iconEl).toHaveAttribute('height', '2em');
+  });
+
   describe('when ariaHidden is false', () => {
     it('shows accessibility attributes', () => {
       renderSvgIcon({ id: 'static-id' });

--- a/packages/design-system/src/components/Icons/SvgIcon.tsx
+++ b/packages/design-system/src/components/Icons/SvgIcon.tsx
@@ -77,6 +77,8 @@ export const SvgIcon = ({
       className={svgClasses}
       id={id ?? isSrVisible ? rootId : undefined}
       viewBox={viewBox}
+      width="1.5em"
+      height="1.5em"
       xmlns="http://www.w3.org/2000/svg"
       {...screenReaderProps}
       {...otherProps}

--- a/packages/design-system/src/components/Icons/__snapshots__/SvgIcon.test.tsx.snap
+++ b/packages/design-system/src/components/Icons/__snapshots__/SvgIcon.test.tsx.snap
@@ -6,8 +6,10 @@ exports[`SvgIcon passes through additional props 1`] = `
   aria-labelledby="static-id__title"
   class="ds-c-icon"
   data-testid="iconTest"
+  height="1.5em"
   id="static-id"
   role="img"
+  width="1.5em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <title
@@ -24,6 +26,8 @@ exports[`SvgIcon when ariaHidden is true renders without title or description" 1
   aria-hidden="true"
   class="ds-c-icon"
   data-testid="testId"
+  height="1.5em"
+  width="1.5em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path />
@@ -35,7 +39,9 @@ exports[`SvgIcon wrapper icon can pass through additional props 1`] = `
   aria-hidden="true"
   class="ds-c-icon ds-c-icon--add "
   data-testid="addIconTest"
+  height="1.5em"
   viewBox="3 3 18 18"
+  width="1.5em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path

--- a/packages/design-system/src/components/InlineError/__snapshots__/InlineError.test.tsx.snap
+++ b/packages/design-system/src/components/InlineError/__snapshots__/InlineError.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`InlineError renders inline error 1`] = `
   <svg
     aria-hidden="true"
     class="ds-c-icon ds-c-icon--alert-circle "
+    height="1.5em"
     viewBox="36 -12 186 186"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
@@ -32,7 +34,9 @@ exports[`InlineError renders inverse error 1`] = `
   <svg
     aria-hidden="true"
     class="ds-c-icon ds-c-icon--alert-circle "
+    height="1.5em"
     viewBox="36 -12 186 186"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path

--- a/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.tsx.snap
+++ b/packages/design-system/src/components/MonthPicker/__snapshots__/MonthPicker.test.tsx.snap
@@ -30,7 +30,9 @@ exports[`MonthPicker renders a snapshot 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--alert-circle "
+          height="1.5em"
           viewBox="36 -12 186 186"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/design-system/src/components/NoteBox/__snapshots__/NoteBox.test.tsx.snap
+++ b/packages/design-system/src/components/NoteBox/__snapshots__/NoteBox.test.tsx.snap
@@ -31,7 +31,9 @@ exports[`NoteBox renders quote option properly 1`] = `
     <svg
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--left-quote "
+      height="1.5em"
       viewBox="2 0 40 32"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/design-system/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/design-system/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -69,7 +69,9 @@ exports[`Pagination should render component 1`] = `
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-left ds-c-pagination__nav--image"
           direction="left"
+          height="1.5em"
           viewBox="0 0 320 512"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -131,7 +133,9 @@ exports[`Pagination should render component 1`] = `
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-right ds-c-pagination__nav--image"
           direction="right"
+          height="1.5em"
           viewBox="0 0 320 512"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -175,7 +179,9 @@ exports[`Pagination with compact prop enabled should render compact variant 1`] 
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-left ds-c-pagination__nav--image"
           direction="left"
+          height="1.5em"
           viewBox="0 0 320 512"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -216,7 +222,9 @@ exports[`Pagination with compact prop enabled should render compact variant 1`] 
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-right ds-c-pagination__nav--image"
           direction="right"
+          height="1.5em"
           viewBox="0 0 320 512"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/design-system/src/components/StepList/__snapshots__/Step.test.jsx.snap
+++ b/packages/design-system/src/components/StepList/__snapshots__/Step.test.jsx.snap
@@ -30,7 +30,9 @@ exports[`Step renders completed text and an edit link for completed steps 1`] = 
       <svg
         aria-hidden="true"
         class="ds-c-icon ds-c-icon--check ds-c-icon-color--success"
+        height="1.5em"
         viewBox="0 0 16 12"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/packages/design-system/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
+++ b/packages/design-system/src/components/ThirdPartyExternalLink/__snapshots__/ThirdPartyExternalLink.test.tsx.snap
@@ -58,8 +58,10 @@ exports[`ThirdPartyExternalLink ThirdPartyExternalLink dialog renders external l
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           id="dialog--8__close__icon"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -114,9 +116,11 @@ exports[`ThirdPartyExternalLink renders external link 1`] = `
     aria-hidden="false"
     aria-labelledby="icon--1__title"
     class="ds-c-icon ds-c-icon--external-link ds-c-external-link__icon"
+    height="1.5em"
     id="icon--1"
     role="img"
     viewBox="0 0 512 512"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <title

--- a/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/design-system/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -42,7 +42,9 @@ exports[`Tooltip renders a tooltip on hover 1`] = `
     <svg
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--info-circle-thin ds-c-tooltip-icon"
+      height="1.5em"
       viewBox="0 0 16 16"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -66,7 +68,9 @@ exports[`Tooltip renders custom trigger component 1`] = `
     <svg
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--info-circle-thin ds-c-tooltip-icon"
+      height="1.5em"
       viewBox="0 0 16 16"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -94,7 +98,9 @@ exports[`Tooltip renders inverse tooltip 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--info-circle-thin ds-c-tooltip-icon"
+          height="1.5em"
           viewBox="0 0 16 16"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/design-system/src/components/Tooltip/__snapshots__/TooltipIcon.test.jsx.snap
+++ b/packages/design-system/src/components/Tooltip/__snapshots__/TooltipIcon.test.jsx.snap
@@ -8,7 +8,9 @@ exports[`TooltipIcon renders inverse trigger icon 1`] = `
     <svg
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--info-circle-thin ds-c-tooltip-icon ds-c-tooltip-icon--inverse"
+      height="1.5em"
       viewBox="0 0 16 16"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -28,7 +30,9 @@ exports[`TooltipIcon renders normal trigger icon 1`] = `
     <svg
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--info-circle-thin ds-c-tooltip-icon"
+      height="1.5em"
       viewBox="0 0 16 16"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/design-system/src/components/UsaBanner/__snapshots__/UsaBanner.test.tsx.snap
+++ b/packages/design-system/src/components/UsaBanner/__snapshots__/UsaBanner.test.tsx.snap
@@ -7,7 +7,9 @@ exports[`UsaBanner renders correctly 1`] = `
   <svg
     aria-hidden="true"
     class="ds-c-icon ds-c-icon--usa-flag ds-c-usa-banner__header-icon"
+    height="1.5em"
     viewBox="0 0 16 11"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <g
@@ -49,7 +51,9 @@ exports[`UsaBanner renders correctly 1`] = `
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
       direction="down"
+      height="1.5em"
       viewBox="0 0 320 512"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -72,7 +76,9 @@ exports[`UsaBanner renders correctly 1`] = `
         aria-hidden="true"
         class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
         direction="down"
+        height="1.5em"
         viewBox="0 0 320 512"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -88,7 +94,9 @@ exports[`UsaBanner renders correctly 1`] = `
       <svg
         aria-hidden="true"
         class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin ds-c-usa-banner__button-icon"
+        height="1.5em"
         viewBox="-2 -2 18 18"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/packages/design-system/src/components/VerticalNav/__snapshots__/VerticalNavItem.test.tsx.snap
+++ b/packages/design-system/src/components/VerticalNav/__snapshots__/VerticalNavItem.test.tsx.snap
@@ -4,8 +4,10 @@ exports[`VerticalNavItem Status icon renders a success icon when status is "use"
 <svg
   aria-hidden="true"
   class="ds-c-icon ds-c-icon--check-circle ds-u-margin-right--1 ds-c-icon-color--success"
+  height="1.5em"
   style="height: 1em; width: 1em; vertical-align: text-bottom;"
   viewBox="38 7 135 135"
+  width="1.5em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path

--- a/packages/design-system/src/components/VerticalNav/__snapshots__/VerticalNavItemLabel.test.tsx.snap
+++ b/packages/design-system/src/components/VerticalNav/__snapshots__/VerticalNavItemLabel.test.tsx.snap
@@ -34,7 +34,9 @@ exports[`VerticalNavItemLabel with subnav shows a down arrow when collapsed 1`] 
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down"
       direction="down"
+      height="1.5em"
       viewBox="0 0 320 512"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -58,7 +60,9 @@ exports[`VerticalNavItemLabel with subnav shows an up arrow when not collapsed 1
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-up"
       direction="up"
+      height="1.5em"
       viewBox="0 0 320 512"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/design-system/src/components/web-components/ds-alert/__snapshots__/ds-alert.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-alert/__snapshots__/ds-alert.test.tsx.snap
@@ -53,7 +53,9 @@ exports[`Alert renders alert 1`] = `
   <svg
     aria-hidden="true"
     class="ds-c-icon ds-c-icon--info-circle ds-c-alert__icon"
+    height="1.5em"
     viewBox="37 2 135 135"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path

--- a/packages/design-system/src/components/web-components/ds-autocomplete/__snapshots__/ds-autocomplete.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-autocomplete/__snapshots__/ds-autocomplete.test.tsx.snap
@@ -53,7 +53,9 @@ exports[`Autocomplete can add a custom class name to the error message 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--alert-circle "
+              height="1.5em"
               viewBox="36 -12 186 186"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -134,7 +136,9 @@ exports[`Autocomplete displays an error message in the default location for Heal
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--alert-circle "
+              height="1.5em"
               viewBox="36 -12 186 186"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -199,7 +203,9 @@ exports[`Autocomplete displays an error message in the default position for Core
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--alert-circle "
+              height="1.5em"
               viewBox="36 -12 186 186"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -387,7 +393,9 @@ exports[`Autocomplete sets the display location of the error message 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--alert-circle "
+              height="1.5em"
               viewBox="36 -12 186 186"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice-list.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice-list.test.tsx.snap
@@ -105,7 +105,9 @@ exports[`ChoiceList is a radio button group 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--alert-circle "
+            height="1.5em"
             viewBox="36 -12 186 186"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path

--- a/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-choice/__snapshots__/ds-choice.test.tsx.snap
@@ -40,7 +40,9 @@ exports[`Choice applies errorMessage to label 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--alert-circle "
+              height="1.5em"
               viewBox="36 -12 186 186"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/packages/design-system/src/components/web-components/ds-date-field/__snapshots__/ds-date-field.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-date-field/__snapshots__/ds-date-field.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`DateField Date Field with Error renders with error message 1`] = `
   <svg
     aria-hidden="true"
     class="ds-c-icon ds-c-icon--alert-circle "
+    height="1.5em"
     viewBox="36 -12 186 186"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
@@ -46,9 +48,11 @@ exports[`DateField DateField with picker renders with picker 1`] = `
     aria-hidden="false"
     aria-labelledby="static-id__icon__title"
     class="ds-c-icon ds-c-icon--calendar "
+    height="1.5em"
     id="static-id__icon"
     role="img"
     viewBox="0 0 448 512"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <title

--- a/packages/design-system/src/components/web-components/ds-dropdown/__snapshots__/ds-dropdown.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-dropdown/__snapshots__/ds-dropdown.test.tsx.snap
@@ -77,7 +77,9 @@ exports[`Dropdown renders a dropdown 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-u-font-size--sm"
+            height="1.5em"
             viewBox="0 0 448 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -173,7 +175,9 @@ exports[`Dropdown renders a dropdown using html options 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-u-font-size--sm"
+            height="1.5em"
             viewBox="0 0 448 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path

--- a/packages/design-system/src/components/web-components/ds-filter-chip/__snapshots__/ds-filter-chip.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-filter-chip/__snapshots__/ds-filter-chip.test.tsx.snap
@@ -28,7 +28,9 @@ exports[`ds-filter-chip should include children as label 1`] = `
     <svg
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--close "
+      height="1.5em"
       viewBox="0 0 16 16"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -47,7 +49,9 @@ exports[`ds-filter-chip should use alternate icon 1`] = `
   <svg
     aria-hidden="true"
     class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+    height="1.5em"
     viewBox="-2 -2 18 18"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path

--- a/packages/design-system/src/components/web-components/ds-inline-error/__snapshots__/ds-inline-error.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-inline-error/__snapshots__/ds-inline-error.test.tsx.snap
@@ -12,7 +12,9 @@ exports[`InlineError should render a default inline-error 1`] = `
     <svg
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--alert-circle "
+      height="1.5em"
       viewBox="36 -12 186 186"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/design-system/src/components/web-components/ds-modal-dialog/__snapshots__/ds-modal-dialog.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-modal-dialog/__snapshots__/ds-modal-dialog.test.tsx.snap
@@ -58,8 +58,10 @@ exports[`DS Modal Dialog accepts an alert attribute 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           id="static-id__close__icon"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -115,8 +117,10 @@ exports[`DS Modal Dialog applies classes to the header 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           id="static-id__close__icon"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -172,8 +176,10 @@ exports[`DS Modal Dialog renders slot content to actions 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           id="static-id__close__icon"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -238,8 +244,10 @@ exports[`DS Modal Dialog renders slot content to heading 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           id="static-id__close__icon"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -295,8 +303,10 @@ exports[`DS Modal Dialog renders with additional classNames and size 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           id="static-id__close__icon"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/design-system/src/components/web-components/ds-month-picker/__snapshots__/ds-month-picker.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-month-picker/__snapshots__/ds-month-picker.test.tsx.snap
@@ -36,7 +36,9 @@ exports[`MonthPicker renders a snapshot 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--alert-circle "
+            height="1.5em"
             viewBox="36 -12 186 186"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path

--- a/packages/design-system/src/components/web-components/ds-pagination/__snapshots__/ds-pagination.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-pagination/__snapshots__/ds-pagination.test.tsx.snap
@@ -35,7 +35,9 @@ exports[`Pagination should render component 1`] = `
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-left ds-c-pagination__nav--image"
             direction="left"
+            height="1.5em"
             viewBox="0 0 320 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -97,7 +99,9 @@ exports[`Pagination should render component 1`] = `
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-right ds-c-pagination__nav--image"
             direction="right"
+            height="1.5em"
             viewBox="0 0 320 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -149,7 +153,9 @@ exports[`Pagination with compact prop enabled should render compact variant 1`] 
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-left ds-c-pagination__nav--image"
             direction="left"
+            height="1.5em"
             viewBox="0 0 320 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -190,7 +196,9 @@ exports[`Pagination with compact prop enabled should render compact variant 1`] 
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-right ds-c-pagination__nav--image"
             direction="right"
+            height="1.5em"
             viewBox="0 0 320 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path

--- a/packages/design-system/src/components/web-components/ds-third-party-external-link/__snapshots__/ds-third-party-external-link.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-third-party-external-link/__snapshots__/ds-third-party-external-link.test.tsx.snap
@@ -58,8 +58,10 @@ exports[`ThirdPartyExternalLink ThirdPartyExternalLink dialog renders external l
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           id="dialog--8__close__icon"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -114,9 +116,11 @@ exports[`ThirdPartyExternalLink should render ThirdPartyExternalLink 1`] = `
         aria-hidden="false"
         aria-labelledby="icon--1__title"
         class="ds-c-icon ds-c-icon--external-link ds-c-external-link__icon"
+        height="1.5em"
         id="icon--1"
         role="img"
         viewBox="0 0 512 512"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <title
@@ -157,8 +161,10 @@ exports[`ThirdPartyExternalLink should render ThirdPartyExternalLink 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+              height="1.5em"
               id="dialog--2__close__icon"
               viewBox="-2 -2 18 18"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/packages/design-system/src/components/web-components/ds-tooltip/__snapshots__/ds-tooltip.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-tooltip/__snapshots__/ds-tooltip.test.tsx.snap
@@ -23,7 +23,9 @@ exports[`ds-tooltip renders a tooltip 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--info-circle-thin ds-c-tooltip-icon"
+              height="1.5em"
               viewBox="0 0 16 16"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -64,7 +66,9 @@ exports[`ds-tooltip renders default trigger icon 1`] = `
       <svg
         aria-hidden="true"
         class="ds-c-icon ds-c-icon--info-circle-thin ds-c-tooltip-icon"
+        height="1.5em"
         viewBox="0 0 16 16"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -159,7 +163,9 @@ exports[`ds-tooltip renders heading element and close button 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -201,7 +207,9 @@ exports[`ds-tooltip renders inverse tooltip 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--info-circle-thin ds-c-tooltip-icon"
+              height="1.5em"
               viewBox="0 0 16 16"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/packages/design-system/src/components/web-components/ds-usa-banner/__snapshots__/ds-usa-banner.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-usa-banner/__snapshots__/ds-usa-banner.test.tsx.snap
@@ -15,7 +15,9 @@ exports[`UsaBanner renders correctly 1`] = `
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--usa-flag ds-c-usa-banner__header-icon"
+          height="1.5em"
           viewBox="0 0 16 11"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <g
@@ -57,7 +59,9 @@ exports[`UsaBanner renders correctly 1`] = `
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
             direction="down"
+            height="1.5em"
             viewBox="0 0 320 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -80,7 +84,9 @@ exports[`UsaBanner renders correctly 1`] = `
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
               direction="down"
+              height="1.5em"
               viewBox="0 0 320 512"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -96,7 +102,9 @@ exports[`UsaBanner renders correctly 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin ds-c-usa-banner__button-icon"
+              height="1.5em"
               viewBox="-2 -2 18 18"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -124,7 +132,9 @@ exports[`UsaBanner renders correctly 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--building-circle ds-c-usa-banner__guidance-icon"
+              height="1.5em"
               viewBox="0 0 54 54"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <g>
@@ -164,7 +174,9 @@ exports[`UsaBanner renders correctly 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--lock-circle ds-c-usa-banner__guidance-icon"
+              height="1.5em"
               viewBox="0 0 54 54"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -195,7 +207,9 @@ exports[`UsaBanner renders correctly 1`] = `
               <svg
                 aria-hidden="true"
                 class="ds-c-icon ds-c-icon--lock ds-c-usa-banner__inline-lock-icon"
+                height="1.5em"
                 viewBox="0 0 52 64"
+                width="1.5em"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path

--- a/packages/docs/src/components/layout/FilterDialog/__snapshots__/FilterDialog.test.tsx.snap
+++ b/packages/docs/src/components/layout/FilterDialog/__snapshots__/FilterDialog.test.tsx.snap
@@ -30,9 +30,11 @@ exports[`FilterDialog renders a dialog 1`] = `
           aria-hidden="false"
           aria-labelledby="icon--2__title"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           id="icon--2"
           role="img"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <title

--- a/packages/ds-healthcare-gov/src/components/Header/__snapshots__/ActionMenu.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Header/__snapshots__/ActionMenu.test.tsx.snap
@@ -63,7 +63,9 @@ exports[`ActionMenu logged-in version renders logged-in version 1`] = `
     <svg
       aria-hidden="true"
       class="ds-c-icon ds-u-margin-right--1 ds-c-icon--menu"
+      height="1.5em"
       viewBox="0 0 448 512"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -95,7 +97,9 @@ exports[`ActionMenu logged-in version set aria-expanded to true 1`] = `
     <svg
       aria-hidden="true"
       class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin ds-u-margin-right--1"
+      height="1.5em"
       viewBox="-2 -2 18 18"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -140,7 +144,9 @@ exports[`ActionMenu logged-out version renders logged-out version 1`] = `
     <svg
       aria-hidden="true"
       class="ds-c-icon ds-u-margin-right--1 ds-c-icon--menu"
+      height="1.5em"
       viewBox="0 0 448 512"
+      width="1.5em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/ds-healthcare-gov/src/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/Header/__snapshots__/Header.test.tsx.snap
@@ -18,7 +18,9 @@ exports[`Header renders Direct Enrollment banner 1`] = `
       <svg
         aria-hidden="true"
         class="ds-c-icon ds-c-icon--usa-flag ds-c-usa-banner__header-icon"
+        height="1.5em"
         viewBox="0 0 16 11"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <g
@@ -60,7 +62,9 @@ exports[`Header renders Direct Enrollment banner 1`] = `
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
           direction="down"
+          height="1.5em"
           viewBox="0 0 320 512"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -83,7 +87,9 @@ exports[`Header renders Direct Enrollment banner 1`] = `
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
             direction="down"
+            height="1.5em"
             viewBox="0 0 320 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -99,7 +105,9 @@ exports[`Header renders Direct Enrollment banner 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin ds-c-usa-banner__button-icon"
+            height="1.5em"
             viewBox="-2 -2 18 18"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -127,7 +135,9 @@ exports[`Header renders Direct Enrollment banner 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--building-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <g>
@@ -167,7 +177,9 @@ exports[`Header renders Direct Enrollment banner 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--lock-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -198,7 +210,9 @@ exports[`Header renders Direct Enrollment banner 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--lock ds-c-usa-banner__inline-lock-icon"
+              height="1.5em"
               viewBox="0 0 52 64"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -350,7 +364,9 @@ exports[`Header renders Direct Enrollment banner 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-u-margin-right--1 ds-c-icon--menu"
+              height="1.5em"
               viewBox="0 0 448 512"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -427,7 +443,9 @@ exports[`Header renders Spanish header 1`] = `
       <svg
         aria-hidden="true"
         class="ds-c-icon ds-c-icon--usa-flag ds-c-usa-banner__header-icon"
+        height="1.5em"
         viewBox="0 0 16 11"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <g
@@ -469,7 +487,9 @@ exports[`Header renders Spanish header 1`] = `
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
           direction="down"
+          height="1.5em"
           viewBox="0 0 320 512"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -492,7 +512,9 @@ exports[`Header renders Spanish header 1`] = `
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
             direction="down"
+            height="1.5em"
             viewBox="0 0 320 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -508,7 +530,9 @@ exports[`Header renders Spanish header 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin ds-c-usa-banner__button-icon"
+            height="1.5em"
             viewBox="-2 -2 18 18"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -536,7 +560,9 @@ exports[`Header renders Spanish header 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--building-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <g>
@@ -576,7 +602,9 @@ exports[`Header renders Spanish header 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--lock-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -607,7 +635,9 @@ exports[`Header renders Spanish header 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--lock ds-c-usa-banner__inline-lock-icon"
+              height="1.5em"
               viewBox="0 0 52 64"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -775,7 +805,9 @@ exports[`Header renders Spanish header 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-u-margin-right--1 ds-c-icon--menu"
+              height="1.5em"
               viewBox="0 0 448 512"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -843,7 +875,9 @@ exports[`Header renders full/homepage header 1`] = `
       <svg
         aria-hidden="true"
         class="ds-c-icon ds-c-icon--usa-flag ds-c-usa-banner__header-icon"
+        height="1.5em"
         viewBox="0 0 16 11"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <g
@@ -885,7 +919,9 @@ exports[`Header renders full/homepage header 1`] = `
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
           direction="down"
+          height="1.5em"
           viewBox="0 0 320 512"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -908,7 +944,9 @@ exports[`Header renders full/homepage header 1`] = `
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
             direction="down"
+            height="1.5em"
             viewBox="0 0 320 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -924,7 +962,9 @@ exports[`Header renders full/homepage header 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin ds-c-usa-banner__button-icon"
+            height="1.5em"
             viewBox="-2 -2 18 18"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -952,7 +992,9 @@ exports[`Header renders full/homepage header 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--building-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <g>
@@ -992,7 +1034,9 @@ exports[`Header renders full/homepage header 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--lock-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -1023,7 +1067,9 @@ exports[`Header renders full/homepage header 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--lock ds-c-usa-banner__inline-lock-icon"
+              height="1.5em"
               viewBox="0 0 52 64"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -1175,7 +1221,9 @@ exports[`Header renders full/homepage header 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-u-margin-right--1 ds-c-icon--menu"
+              height="1.5em"
               viewBox="0 0 448 512"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -1243,7 +1291,9 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
       <svg
         aria-hidden="true"
         class="ds-c-icon ds-c-icon--usa-flag ds-c-usa-banner__header-icon"
+        height="1.5em"
         viewBox="0 0 16 11"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <g
@@ -1285,7 +1335,9 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
           direction="down"
+          height="1.5em"
           viewBox="0 0 320 512"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -1308,7 +1360,9 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
             direction="down"
+            height="1.5em"
             viewBox="0 0 320 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -1324,7 +1378,9 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin ds-c-usa-banner__button-icon"
+            height="1.5em"
             viewBox="-2 -2 18 18"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -1352,7 +1408,9 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--building-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <g>
@@ -1392,7 +1450,9 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--lock-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -1423,7 +1483,9 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--lock ds-c-usa-banner__inline-lock-icon"
+              height="1.5em"
               viewBox="0 0 52 64"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -1575,7 +1637,9 @@ exports[`Header renders links with absolute URLs if provided a primaryDomain pro
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-u-margin-right--1 ds-c-icon--menu"
+              height="1.5em"
               viewBox="0 0 448 512"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -1643,7 +1707,9 @@ exports[`Header renders logged-in header with firstName 1`] = `
       <svg
         aria-hidden="true"
         class="ds-c-icon ds-c-icon--usa-flag ds-c-usa-banner__header-icon"
+        height="1.5em"
         viewBox="0 0 16 11"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <g
@@ -1685,7 +1751,9 @@ exports[`Header renders logged-in header with firstName 1`] = `
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
           direction="down"
+          height="1.5em"
           viewBox="0 0 320 512"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -1708,7 +1776,9 @@ exports[`Header renders logged-in header with firstName 1`] = `
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
             direction="down"
+            height="1.5em"
             viewBox="0 0 320 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -1724,7 +1794,9 @@ exports[`Header renders logged-in header with firstName 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin ds-c-usa-banner__button-icon"
+            height="1.5em"
             viewBox="-2 -2 18 18"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -1752,7 +1824,9 @@ exports[`Header renders logged-in header with firstName 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--building-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <g>
@@ -1792,7 +1866,9 @@ exports[`Header renders logged-in header with firstName 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--lock-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -1823,7 +1899,9 @@ exports[`Header renders logged-in header with firstName 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--lock ds-c-usa-banner__inline-lock-icon"
+              height="1.5em"
               viewBox="0 0 52 64"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -1954,7 +2032,9 @@ exports[`Header renders logged-in header with firstName 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-u-margin-right--1 ds-c-icon--menu"
+              height="1.5em"
               viewBox="0 0 448 512"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -2047,7 +2127,9 @@ exports[`Header renders logged-in header without firstName 1`] = `
       <svg
         aria-hidden="true"
         class="ds-c-icon ds-c-icon--usa-flag ds-c-usa-banner__header-icon"
+        height="1.5em"
         viewBox="0 0 16 11"
+        width="1.5em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <g
@@ -2089,7 +2171,9 @@ exports[`Header renders logged-in header without firstName 1`] = `
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
           direction="down"
+          height="1.5em"
           viewBox="0 0 320 512"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -2112,7 +2196,9 @@ exports[`Header renders logged-in header without firstName 1`] = `
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
             direction="down"
+            height="1.5em"
             viewBox="0 0 320 512"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -2128,7 +2214,9 @@ exports[`Header renders logged-in header without firstName 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin ds-c-usa-banner__button-icon"
+            height="1.5em"
             viewBox="-2 -2 18 18"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -2156,7 +2244,9 @@ exports[`Header renders logged-in header without firstName 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--building-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <g>
@@ -2196,7 +2286,9 @@ exports[`Header renders logged-in header without firstName 1`] = `
           <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--lock-circle ds-c-usa-banner__guidance-icon"
+            height="1.5em"
             viewBox="0 0 54 54"
+            width="1.5em"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
@@ -2227,7 +2319,9 @@ exports[`Header renders logged-in header without firstName 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-c-icon--lock ds-c-usa-banner__inline-lock-icon"
+              height="1.5em"
               viewBox="0 0 52 64"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -2353,7 +2447,9 @@ exports[`Header renders logged-in header without firstName 1`] = `
             <svg
               aria-hidden="true"
               class="ds-c-icon ds-u-margin-right--1 ds-c-icon--menu"
+              height="1.5em"
               viewBox="0 0 448 512"
+              width="1.5em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/packages/ds-healthcare-gov/src/components/HealthcaregovThirdPartyExternalLink/__snapshots__/HealthcaregovThirdPartyExternalLink.test.tsx.snap
+++ b/packages/ds-healthcare-gov/src/components/HealthcaregovThirdPartyExternalLink/__snapshots__/HealthcaregovThirdPartyExternalLink.test.tsx.snap
@@ -30,8 +30,10 @@ exports[`HealthcaregovThirdPartyExternalLink HealthcaregovThirdPartyExternalLink
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           id="dialog--4__close__icon"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -94,9 +96,11 @@ exports[`HealthcaregovThirdPartyExternalLink renders external link 1`] = `
     aria-hidden="false"
     aria-labelledby="icon--1__title"
     class="ds-c-icon ds-c-icon--external-link ds-c-external-link__icon"
+    height="1.5em"
     id="icon--1"
     role="img"
     viewBox="0 0 512 512"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <title

--- a/packages/ds-medicare-gov/src/components/MedicaregovThirdPartyExternalLink/__snapshots__/MedicaregovThirdPartyExternalLink.test.tsx.snap
+++ b/packages/ds-medicare-gov/src/components/MedicaregovThirdPartyExternalLink/__snapshots__/MedicaregovThirdPartyExternalLink.test.tsx.snap
@@ -30,8 +30,10 @@ exports[`MedicaregovThirdPartyExternalLink MedicaregovThirdPartyExternalLink dia
         <svg
           aria-hidden="true"
           class="ds-c-icon ds-c-icon--close ds-c-icon--close-thin "
+          height="1.5em"
           id="dialog--4__close__icon"
           viewBox="-2 -2 18 18"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -94,9 +96,11 @@ exports[`MedicaregovThirdPartyExternalLink renders external link 1`] = `
     aria-hidden="false"
     aria-labelledby="icon--1__title"
     class="ds-c-icon ds-c-icon--external-link ds-c-external-link__icon"
+    height="1.5em"
     id="icon--1"
     role="img"
     viewBox="0 0 512 512"
+    width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
     <title

--- a/packages/ds-medicare-gov/src/components/web-components/ds-simple-footer/__snapshots__/ds-simple-footer.test.tsx.snap
+++ b/packages/ds-medicare-gov/src/components/web-components/ds-simple-footer/__snapshots__/ds-simple-footer.test.tsx.snap
@@ -123,9 +123,11 @@ exports[`SimpleFooter renders without crashing 1`] = `
           aria-hidden="false"
           aria-labelledby="icon--2__title"
           class="ds-c-icon ds-c-icon--hhs-logo m-c-footer__hhs-logo"
+          height="1.5em"
           id="icon--2"
           role="img"
           viewBox="0 0 252 252"
+          width="1.5em"
           xmlns="http://www.w3.org/2000/svg"
         >
           <title


### PR DESCRIPTION
## Summary

- Fixes an issue where SVG icons (such as those used by the USA Banner) could render at unexpectedly large sizes when CSS is disabled or slow to load.
- Adds default `width` and `height` attributes to the `SvgIcon` component that match the dimensions defined by the `ds-c-icon` CSS class, providing a fallback when CSS is unavailable.
- Adds test coverage to verify the default `width` and `height` attributes and confirm that wrapper icon components (such as `AddIcon`) can override them.
- This updates a LOT of snapshots because the rendered icon markup now includes width and height attributes. The main change to inspect is in `SvgIcon.tsx` and the test coverage in `SvgIcon.test.tsx`

For more background, see: [Jira ticket](https://jira.cms.gov/browse/CMSDS-4053)



## How to test

1. `npm run test:unit`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
- [x] Created or updated unit tests to cover any new or modified code
