### PR TITLE
[CMSDS-4174] Replace mocked fetch calls with Promises

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -282,21 +282,14 @@ export const AsyncItems: Story = {
     const hasResults = input.length > 2 && additionalItems.length;
 
     const searchArtwork = () => {
-      // Note: the response is mocked
-      const searchURL = `https://api.artic.edu/api/v1/artworks/search?q=${input}&fields=id,title,artist_title&limit=10`;
-      fetch(searchURL)
-        .then((response) => {
-          if (response.status === 200) {
-            return response.json();
-          }
-        })
-        .then(({ data }: { data: MockedDataResponse[] }) => {
-          const additionalItems = data.map(({ id, title, artist_title }) => ({
-            id: id.toString(),
-            name: `${title} by ${artist_title}`,
-          }));
-          setAdditionalItems(additionalItems);
-        });
+      const searchPromise = Promise.resolve(searchMock.response.body);
+      searchPromise.then(({ data }: { data: MockedDataResponse[] }) => {
+        const additionalItems = data.map(({ id, title, artist_title }) => ({
+          id: id.toString(),
+          name: `${title} by ${artist_title}`,
+        }));
+        setAdditionalItems(additionalItems);
+      });
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -339,9 +332,4 @@ export const AsyncItems: Story = {
       makeItem('Self-Portrait'),
     ],
   } as AutocompleteArgs,
-  parameters: {
-    fetchMock: {
-      mocks: [searchMock],
-    },
-  },
 };

--- a/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.stories.tsx
@@ -441,21 +441,14 @@ export const AsyncItems: Story = {
     const hasResults = input.length > 2 && additionalItems.length;
 
     const searchArtwork = () => {
-      // Note: the response is mocked
-      const searchURL = `https://api.artic.edu/api/v1/artworks/search?q=${input}&fields=id,title,artist_title&limit=10`;
-      fetch(searchURL)
-        .then((response) => {
-          if (response.status === 200) {
-            return response.json();
-          }
-        })
-        .then(({ data }: { data: MockedDataResponse[] }) => {
-          const additionalItems = data.map(({ id, title, artist_title }) => ({
-            id: id.toString(),
-            name: `${title} by ${artist_title}`,
-          }));
-          setAdditionalItems(additionalItems);
-        });
+      const searchPromise = Promise.resolve(searchMock.response.body);
+      searchPromise.then(({ data }: { data: MockedDataResponse[] }) => {
+        const additionalItems = data.map(({ id, title, artist_title }) => ({
+          id: id.toString(),
+          name: `${title} by ${artist_title}`,
+        }));
+        setAdditionalItems(additionalItems);
+      });
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -509,10 +502,5 @@ export const AsyncItems: Story = {
       makeItem('City Landscape'),
       makeItem('Self-Portrait'),
     ],
-  },
-  parameters: {
-    fetchMock: {
-      mocks: [searchMock],
-    },
   },
 };


### PR DESCRIPTION
## Summary

- We currently use `storybook-addon-fetch-mock` to mock fetch requests in Stories for the Autocomplete component and its web components equivalent. This add-on is no longer maintained and is blocking our ability to upgrade Storybook. In order to remove this dependency, we much first replace the mocked responses in these Stories. This PR achieves that using a resolved Promise. This should preserve the functionality of the Story while removing the need for the dependency.
- [CMSDS-4174](https://jira.cms.gov/browse/CMSDS-4174)

## How to test

1. Start up Storybook
2. Navigate to the Autocomplete -> Async Items Story.
3. Focus on the text field and verify the suggested search items are populated.
4. Type at least four letters and verify the suggestions are replaced by a mocked list of results.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to code:

- [x] Verified that running both `npm run test:unit` and `npm run test:browser:all` were each successful
