### PR TITLE
[CMSDS-4109] Escape regex search queries

### DIFF
--- a/packages/docs/src/helpers/markQuery.test.ts
+++ b/packages/docs/src/helpers/markQuery.test.ts
@@ -1,0 +1,19 @@
+import markQuery from './markQuery';
+
+describe('markQuery', () => {
+  it('marks the query within the body', () => {
+    const body = 'This is a test body.';
+    const query = 'test';
+    const expectedBody = 'This is a <mark>test</mark> body....';
+
+    expect(markQuery(body, query)).toBe(expectedBody);
+  });
+
+  it('escapes dangerous characters', () => {
+    const body = "return {i18n('account created')};";
+    const dangerousQuery = 'i18n(';
+    const expectedBody = "return {<mark>i18n(</mark>'account created')};...";
+
+    expect(markQuery(body, dangerousQuery)).toBe(expectedBody);
+  });
+});

--- a/packages/docs/src/helpers/markQuery.ts
+++ b/packages/docs/src/helpers/markQuery.ts
@@ -1,0 +1,7 @@
+const markQuery = (body: string, query: string) => {
+  const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(escapedQuery, 'gi');
+  return body.replace(re, '<mark>$&</mark>') + '...';
+};
+
+export default markQuery;

--- a/packages/docs/src/pages/search.tsx
+++ b/packages/docs/src/pages/search.tsx
@@ -65,8 +65,9 @@ const SearchPage = ({ location }: MdxQuery) => {
               let body = result.body;
               const strLoc = body.toLowerCase().indexOf(query.toLowerCase());
               body = body.slice(Math.max(strLoc - 160, 0), strLoc + 160);
-              const re = new RegExp(query, 'gi');
-              body = body.replace(re, `<mark>${query}</mark>`) + '...';
+              const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const re = new RegExp(escapedQuery, 'gi');
+              body = body.replace(re, '<mark>$&</mark>') + '...';
 
               const sendAnalyticsEvent = () => {
                 sendLinkEvent({

--- a/packages/docs/src/pages/search.tsx
+++ b/packages/docs/src/pages/search.tsx
@@ -7,6 +7,7 @@ import Layout from '../components/layout/Layout';
 import SEO from '../components/layout/DocSiteSeo';
 import useTheme from '../helpers/useTheme';
 import { sendSearchInitiatedEvent } from '../helpers/analytics';
+import markQuery from '../helpers/markQuery';
 
 const SearchPage = ({ location }: MdxQuery) => {
   const [query, setQuery] = useState('');
@@ -65,9 +66,7 @@ const SearchPage = ({ location }: MdxQuery) => {
               let body = result.body;
               const strLoc = body.toLowerCase().indexOf(query.toLowerCase());
               body = body.slice(Math.max(strLoc - 160, 0), strLoc + 160);
-              const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-              const re = new RegExp(escapedQuery, 'gi');
-              body = body.replace(re, '<mark>$&</mark>') + '...';
+              body = markQuery(body, query);
 
               const sendAnalyticsEvent = () => {
                 sendLinkEvent({


### PR DESCRIPTION
## Summary

- Escape regex search queries to avoid a local window blanking due to JS eval crashing
- Closes CMSDS-4109

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.

### If this is a change to code:

- [x] Created or updated unit tests to cover any new or modified code
- [x] Verified that running both `npm run test:unit` and `npm run test:browser:all` were each successful
- [ ] If necessary, updated unit-test snapshots (`npm run test:unit:update`) and browser-test snapshots (`npm run test:browser:all:update`)

Need help figuring out a browser test for this.

### If this is a change to documentation/content:

- [ ] Checked for spelling and grammatical errors
- [ ] Communicate the assigned milestone/release date with Design so they can communicate appropriately
