### PR TITLE
[CMSDS-4165] Fix `SingleInputDateField` duplicate date selection with picker.

### DIFF
--- a/packages/design-system/src/components/DateField/CustomDayPicker.tsx
+++ b/packages/design-system/src/components/DateField/CustomDayPicker.tsx
@@ -17,6 +17,7 @@ type CustomDayPickerProps = Pick<
   DayPickerSingleProps,
   | 'selected'
   | 'onSelect'
+  | 'required'
   | 'defaultMonth'
   | 'fromDate'
   | 'fromMonth'

--- a/packages/design-system/src/components/DateField/SingleInputDateField.test.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.test.tsx
@@ -345,28 +345,25 @@ describe('SingleInputDateField', function () {
       expect(onChange).toHaveBeenCalledWith('01/19/2000', '01/19/2000', expectedDate);
     });
 
-    it('does not deselect the date when the selected day is selected again', async () => {
+    it('does not deselect the selected date when it is selected again', async () => {
       const onChange = jest.fn();
-      const { user } = renderPicker({ onChange });
+      const { user } = renderPicker({
+        value: '01/19/2000',
+        onChange,
+      });
 
-      const calendarButton = screen.getByRole('button');
-      const selectedDay = () => screen.getByRole('gridcell', { name: /19th/ });
+      await user.click(screen.getByRole('button'));
 
-      await user.click(calendarButton);
-      await user.click(selectedDay());
+      // Reset the mock so this assertion only covers reselecting the date.
+      onChange.mockClear();
+
+      await user.click(
+        screen.getByRole('gridcell', {
+          name: /19th/,
+        })
+      );
 
       expect(onChange).toHaveBeenCalledWith('01/19/2000', '01/19/2000', new Date(2000, 0, 19));
-
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-
-      await user.click(calendarButton);
-      const callsBeforeReselection = onChange.mock.calls.length;
-
-      await user.click(selectedDay());
-
-      expect(onChange).toHaveBeenCalledTimes(callsBeforeReselection + 1);
-      expect(onChange).toHaveBeenLastCalledWith('01/19/2000', '01/19/2000', new Date(2000, 0, 19));
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/design-system/src/components/DateField/SingleInputDateField.test.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.test.tsx
@@ -344,5 +344,29 @@ describe('SingleInputDateField', function () {
 
       expect(onChange).toHaveBeenCalledWith('01/19/2000', '01/19/2000', expectedDate);
     });
+
+    it('does not deselect the date when the selected day is selected again', async () => {
+      const onChange = jest.fn();
+      const { user } = renderPicker({ onChange });
+
+      const calendarButton = screen.getByRole('button');
+      const selectedDay = () => screen.getByRole('gridcell', { name: /19th/ });
+
+      await user.click(calendarButton);
+      await user.click(selectedDay());
+
+      expect(onChange).toHaveBeenCalledWith('01/19/2000', '01/19/2000', new Date(2000, 0, 19));
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      await user.click(calendarButton);
+      const callsBeforeReselection = onChange.mock.calls.length;
+
+      await user.click(selectedDay());
+
+      expect(onChange).toHaveBeenCalledTimes(callsBeforeReselection + 1);
+      expect(onChange).toHaveBeenLastCalledWith('01/19/2000', '01/19/2000', new Date(2000, 0, 19));
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/design-system/src/components/DateField/SingleInputDateField.tsx
+++ b/packages/design-system/src/components/DateField/SingleInputDateField.tsx
@@ -199,7 +199,12 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
     }
   };
 
-  const handlePickerChange = (date: Date) => {
+  const handlePickerChange = (date?: Date) => {
+    if (!date) {
+      setPickerVisible(false);
+      inputRef.current?.focus();
+      return;
+    }
     const updatedValue = computeDateValue(date, lang);
     const maskedValue = dateMask(updatedValue);
     const validDate = getValidDate(updatedValue);
@@ -302,7 +307,8 @@ const SingleInputDateField = (props: SingleInputDateFieldProps) => {
         <div ref={dayPickerRef} role="dialog" onKeyDown={handleDayPickerKeyDown}>
           <CustomDayPicker
             selected={date}
-            onSelect={(day) => day && handlePickerChange(day)}
+            required
+            onSelect={handlePickerChange}
             defaultMonth={date ?? defaultMonth}
             {...{
               fromDate,


### PR DESCRIPTION
## Summary
**Background**
- When a user selects a date in the calendar picker that is already selected, the `onSelect` handler is invoked with `undefined`. Then,`handlePickerChange` attempts to process this value, resulting in a TypeError when `computeDateValue` calls `getMonth()` on `undefined`. You can see this behavior in our [deployed storybook](https://design.cms.gov/storybook/?path=/story/components-singleinputdatefield--with-picker).
- In [pr-4067](https://github.com/CMSgov/design-system/pull/4067) (targeted for v18.1.0 and not yet released), we updated the `onSelect` handler to guard against undefined values ([link to line](https://github.com/CMSgov/design-system/blob/main/packages/design-system/src/components/DateField/SingleInputDateField.tsx#L305)). This prevents the console error that we see currently in prod, but it also means `handlePickerChange` never runs when the selected date is clicked again. Because `handlePickerChange` is responsible for closing the calendar dialog, the picker remains open after reselecting the same date.

**Fix**
- Enables the `required` prop on `CustomDayPicker`. This is a `react-day-picker` prop (`DayPickerSingleProps`) that makes date selection required, ensuring `onSelect` receives the selected `Date` instead of `undefined`.
- Moves the `undefined` check from the `onSelect` handler into `handlePickerChange`. If `handlePickerChange` is ever invoked with `undefined`, it now exits early after closing the calendar dialog. This shouldn't occur with `required` enabled, but it provides a fallback if `required` is removed in the future.
- Adds test coverage for `SingleInputDateField`

[Jira ticket](https://jira.cms.gov/browse/CMSDS-4165)

- Closes #4141 

## How to test
**Reproduce the bug**
1. Go to [the calendar picker](https://design.cms.gov/storybook/?path=/story/components-singleinputdatefield--with-picker&globals=theme:healthcare)
2. Select any date with the picker
3. Re-open the picker and select the same date
4. Note the picker stays open and an error is logged to the console

**Verify the fix**
- Pull down this branch and start storybook
- Navigate to [SingleInputDateField with picker](http://localhost:6006/?path=/story/components-singleinputdatefield--with-picker)  
- Repeat steps 2 & 3 (above).
- Picker should close and we shouldn't see any console errors.
- Repeat the same verification for the [web component](http://localhost:6006/?path=/story/web-components-ds-date-field--with-picker).
- Run unit tests: `npm run test:unit`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone