### PR TITLE
[CMSDS-3712] Create design onboarding space on design.cms.gov

### DIFF
--- a/packages/docs/content/getting-started/for-designers.mdx
+++ b/packages/docs/content/getting-started/for-designers.mdx
@@ -13,7 +13,7 @@ The CMS Design System uses [Figma](https://www.figma.com/design/OYkYP4pC9jwS7j2q
   Sketch access and support ended in 2024. We don't use Sketch. Existing Sketch files may be outdated or cause issues.
 </Alert>
 
-As you review this documentation, keep in mind that the CMS Design System is a family of child themes that vary by product:
+As you review this documentation, keep in mind that the CMS Design System is a [family of child themes](https://design.cms.gov/getting-started/child-design-systems/?theme=core) that vary by product:
 
 - **[Core](https://design.cms.gov/?theme=core)**: The foundation for the entire Design System. Rarely used by CMS project teams as their default theme.
 - **[Healthcare.gov (theme)](https://design.cms.gov/?theme=healthcare)**: For all teams working on [Healthcare.gov](http://healthcare.gov/)
@@ -28,7 +28,7 @@ Find assets through shared Figma libraries. Although the Design System's code is
 
 1. Request CMS Enterprise User Administration (EUA) access and Slack access.
 2. Request access to the CMS Design System libraries through Figma.
-3. Reach out to the Figma Administrator in the [#cms-design-system](https://design.cms.gov/contact/?theme=core) Slack channel to confirm access.
+3. Reach out to the Figma Administrator in the [#cms-design-system](https://design.cms.gov/contact/?theme=core#-slack) Slack channel
 
 Once CMS approves all requests for access, you can access the Figma libraries.
 
@@ -94,7 +94,7 @@ Reference these sections throughout your workflow to ensure consistency and alig
 You can use the CMS Design System documentation site alongside your design work. The documentation helps you:
 
 - Understand how components are intended to be used.
-- [Check accessibility requirements.](https://design.cms.gov/guidelines/accessibility/?query=Third%2BParty%2BExternal%2BLink&theme=core)
+- [Check accessibility requirements.](https://design.cms.gov/guidelines/accessibility/?theme=core)
 - Review component behavior and states.
 
 You may also review live CMS products (such as [CMS.gov](http://cms.gov/), [Healthcare.gov](http://healthcare.gov/), or [Medicare.gov](http://medicare.gov/)) to see how components come together in real-world experiences. This can help you:

--- a/packages/docs/content/getting-started/for-designers.mdx
+++ b/packages/docs/content/getting-started/for-designers.mdx
@@ -13,12 +13,12 @@ The CMS Design System uses [Figma](https://www.figma.com/design/OYkYP4pC9jwS7j2q
   Sketch access and support ended in 2024. We don't use Sketch. Existing Sketch files may be outdated or cause issues.
 </Alert>
 
-As you review this documentation, keep in mind that the CMS Design System is a [family of child themes](https://design.cms.gov/getting-started/child-design-systems/?theme=core) that vary by product:
+As you review this documentation, keep in mind that the CMS Design System is a [family of child themes](/getting-started/child-design-systems/) that vary by product:
 
 - **[Core](https://design.cms.gov/?theme=core)**: The foundation for the entire Design System. Rarely used by CMS project teams as their default theme.
-- **[Healthcare.gov (theme)](https://design.cms.gov/?theme=healthcare)**: For all teams working on [Healthcare.gov](http://healthcare.gov/)
-- **[Medicare.gov (theme)](https://design.cms.gov/?theme=medicare)**: For all teams working on [Medicare.gov](http://medicare.gov/)
-- **[CMS.gov (theme)](https://design.cms.gov/?theme=cmsgov)**: For all teams working on [CMS.gov](http://cms.gov/)
+- **[Healthcare.gov (theme)](https://design.cms.gov/?theme=healthcare)**: For all teams working on [Healthcare.gov](https://healthcare.gov/)
+- **[Medicare.gov (theme)](https://design.cms.gov/?theme=medicare)**: For all teams working on [Medicare.gov](https://medicare.gov/)
+- **[CMS.gov (theme)](https://design.cms.gov/?theme=cmsgov)**: For all teams working on [CMS.gov](https://cms.gov/)
 
 ## Getting design system assets
 
@@ -28,7 +28,7 @@ Find assets through shared Figma libraries. Although the Design System's code is
 
 1. Request CMS Enterprise User Administration (EUA) access and Slack access.
 2. Request access to the CMS Design System libraries through Figma.
-3. Reach out to the Figma Administrator in the [#cms-design-system](https://design.cms.gov/contact/?theme=core#-slack) Slack channel
+3. Reach out to the Figma Administrator in the [#cms-design-system](/contact/#-slack) Slack channel to confirm access.
 
 Once CMS approves all requests for access, you can access the Figma libraries.
 
@@ -67,10 +67,7 @@ When designing in Figma:
 - Keep components set to "auto" whenever possible.
 - Apply the product theme at the page or frame level.
 - Components set to auto will inherit the theme from their parent.
-
-If a component is set to a specific theme:
-
-- It will retain that theme regardless of where it is placed.
+- If a component is set to a specific theme, it will retain that theme regardless of where it is placed.
 
 <Alert heading="Use specific themes sparingly" variation="warn">
   Use specific themes only when necessary, as it can override expected behavior.
@@ -94,10 +91,10 @@ Reference these sections throughout your workflow to ensure consistency and alig
 You can use the CMS Design System documentation site alongside your design work. The documentation helps you:
 
 - Understand how components are intended to be used.
-- [Check accessibility requirements.](https://design.cms.gov/guidelines/accessibility/?theme=core)
+- [Check accessibility requirements.](/guidelines/accessibility/)
 - Review component behavior and states.
 
-You may also review live CMS products (such as [CMS.gov](http://cms.gov/), [Healthcare.gov](http://healthcare.gov/), or [Medicare.gov](http://medicare.gov/)) to see how components come together in real-world experiences. This can help you:
+You may also review live CMS products (such as [CMS.gov](https://cms.gov/), [Healthcare.gov](https://healthcare.gov/), or [Medicare.gov](https://medicare.gov/)) to see how components come together in real-world experiences. This can help you:
 
 - See how multiple components are combined within full pages.
 - Understand layout patterns and content structure.
@@ -117,7 +114,7 @@ Our Design System components are more than a collection of visual styles. They e
 
 ### Components
 
-A [component](https://design.cms.gov/components/overview/?theme=core) is a reusable UI element with a defined function and behavior. These are the building blocks of the Design System. Examples include buttons, checkboxes, and text inputs. Some components have specific usage guidelines that should be followed.
+A [component](/components/overview/) is a reusable UI element with a defined function and behavior. These are the building blocks of the Design System. Examples include buttons, checkboxes, and text inputs. Some components have specific usage guidelines that should be followed.
 
 Each component in the Design System is included in Figma as a reusable, themeable component, often with variants and modes. **CMS expects teams to use Design System components in their designs unless a documented gap exists.**
 
@@ -131,7 +128,7 @@ When designing with components:
 
 ### Patterns
 
-A [pattern](https://design.cms.gov/patterns/overview/?theme=core) is a combination of components used together to solve a common user interaction. Examples include form review or utility actions. Patterns are available in both the CMS Design System documentation and Figma.
+A [pattern](/patterns/overview/) is a combination of components used together to solve a common user interaction. Examples include form review or utility actions. Patterns are available in both the CMS Design System documentation and Figma.
 
 **CMS expects teams to use Design System patterns as outlined.** If a pattern doesn't meet your needs, adapt it only if it remains consistent with the Design System's visual language and accessibility guidelines. If you have significant changes from what's outlined in the Design System, document the use case and coordinate with the Design System team.
 
@@ -145,7 +142,7 @@ If your design requires a solution outside of the Design System, ensure it meets
 
 ### Spacing
 
-Use consistent [spacing](https://design.cms.gov/foundation/spacing/?theme=core) to maintain clear layout and visual rhythm.
+Use consistent [spacing](/foundation/spacing/) to maintain clear layout and visual rhythm.
 
 - Follow the 8px spacing scale used across the Design System.
 - Avoid arbitrary spacing values.
@@ -166,8 +163,8 @@ This helps ensure that designs can be implemented accurately and remain consiste
 
 ## Analytics
 
-[Learn how to enable and configure analytics for design system components.](https://design.cms.gov/components/analytics/)
+[Learn how to enable and configure analytics for design system components.](/components/analytics/)
 
 ## Further resources
 
-If you need help while working with the Design System, [reach out](https://design.cms.gov/contact/?theme=core) in the CMS Design System Slack channel or connect with the Design System team.
+If you need help while working with the Design System, [reach out](/contact/#-slack) in the CMS Design System Slack channel or connect with the Design System team.

--- a/packages/docs/content/getting-started/for-designers.mdx
+++ b/packages/docs/content/getting-started/for-designers.mdx
@@ -9,18 +9,18 @@ Greetings, Designers! The CMS Design System offers flexible and coherent visual 
 
 The CMS Design System uses [Figma](https://www.figma.com/design/OYkYP4pC9jwS7j2qafwmiv/Design-System-Library?m=auto&node-id=718-40190&t=rRYhkftLTZ2TvytT-1) to maintain its visual library.
 
-<Alert variation="warn">
+<Alert heading="Sketch is no longer supported" variation="warn">
   Sketch access and support ended in 2024. We don't use Sketch. Existing Sketch files may be outdated or cause issues.
 </Alert>
 
-As you review this documentation, keep in mind that the CMS Design System is a [family of child themes](/getting-started/child-design-systems/) that vary by product:
+As you review this documentation, keep in mind that the CMS Design System is a family of child themes that vary by product:
 
 - **[Core](https://design.cms.gov/?theme=core)**: The foundation for the entire Design System. Rarely used by CMS project teams as their default theme.
-- **[Healthcare.gov (theme)](https://design.cms.gov/?theme=healthcare)**: For all teams working on [Healthcare.gov](https://healthcare.gov)
-- **[Medicare.gov (theme)](https://design.cms.gov/?theme=medicare)**: For all teams working on [Medicare.gov](https://medicare.gov)
-- **[CMS.gov (theme)](https://design.cms.gov/?theme=cmsgov)**: For all teams working on [CMS.gov](https://cms.gov)
+- **[Healthcare.gov (theme)](https://design.cms.gov/?theme=healthcare)**: For all teams working on [Healthcare.gov](http://healthcare.gov/)
+- **[Medicare.gov (theme)](https://design.cms.gov/?theme=medicare)**: For all teams working on [Medicare.gov](http://medicare.gov/)
+- **[CMS.gov (theme)](https://design.cms.gov/?theme=cmsgov)**: For all teams working on [CMS.gov](http://cms.gov/)
 
-## Getting the design system assets
+## Getting design system assets
 
 Find assets through shared Figma libraries. Although the Design System's code is open source, you need to request access to these libraries to use the CMS Design System.
 
@@ -28,7 +28,7 @@ Find assets through shared Figma libraries. Although the Design System's code is
 
 1. Request CMS Enterprise User Administration (EUA) access and Slack access.
 2. Request access to the CMS Design System libraries through Figma.
-3. Reach out to the Figma Administrator in the [#cms-design-system](/contact/#-slack) Slack channel to confirm access.
+3. Reach out to the Figma Administrator in the [#cms-design-system](https://design.cms.gov/contact/?theme=core) Slack channel to confirm access.
 
 Once CMS approves all requests for access, you can access the Figma libraries.
 
@@ -44,17 +44,17 @@ If the libraries are not visible, you can enable them manually:
 
 You can also view the full Design System in the main [Figma file](https://www.figma.com/design/OYkYP4pC9jwS7j2qafwmiv/Design-System-Library?node-id=718-40190&p=f&t=y9OQHCqVBUoWUyxe-0).
 
-<Alert>
+<Alert heading="Restricted edit access">
   Edit access to the Design System source files is restricted. Most designers will use the published libraries rather than modifying the source files directly.
 </Alert>
 
 ### How to use Figma themes
 
-Figma allows a single file or library to support multiple themes, so you can switch between different product styling. [Get more details from Figma on how to use themes](https://help.figma.com/hc/en-us/articles/5576781786647-Change-themes-in-Figma).
+Figma allows a single file or library to support multiple themes, so you can switch between different product styling. [Get more details from Figma on how to use themes.](https://help.figma.com/hc/en-us/articles/5576781786647-Change-themes-in-Figma)
 
 The CMS Design System Figma file includes a Figma Setup page with configuration guidance for themes and child systems.
 
-<Alert>
+<Alert heading="Can't access Figma Setup?">
   If you access the Figma Setup page, check you have access to the CMS Design System Figma file.
 </Alert>
 
@@ -67,7 +67,14 @@ When designing in Figma:
 - Keep components set to "auto" whenever possible.
 - Apply the product theme at the page or frame level.
 - Components set to auto will inherit the theme from their parent.
-- If a component is set to a specific theme, it will retain that theme regardless of where it is placed.
+
+If a component is set to a specific theme:
+
+- It will retain that theme regardless of where it is placed.
+
+<Alert heading="Use specific themes sparingly" variation="warn">
+  Use specific themes only when necessary, as it can override expected behavior.
+</Alert>
 
 ## Understanding documentation structure
 
@@ -87,32 +94,34 @@ Reference these sections throughout your workflow to ensure consistency and alig
 You can use the CMS Design System documentation site alongside your design work. The documentation helps you:
 
 - Understand how components are intended to be used.
-- [Check accessibility requirements](/guidelines/accessibility/).
+- [Check accessibility requirements.](https://design.cms.gov/guidelines/accessibility/?query=Third%2BParty%2BExternal%2BLink&theme=core)
 - Review component behavior and states.
 
-You may also review live CMS products (such as [CMS.gov](https://cms.gov), [Healthcare.gov](https://healthcare.gov), or [Medicare.gov](https://medicare.gov)) to see how components come together in real-world experiences. This can help you:
+You may also review live CMS products (such as [CMS.gov](http://cms.gov/), [Healthcare.gov](http://healthcare.gov/), or [Medicare.gov](http://medicare.gov/)) to see how components come together in real-world experiences. This can help you:
 
 - See how multiple components are combined within full pages.
 - Understand layout patterns and content structure.
 - Observe how designs adapt across different CMS products.
 
-<Alert>
+<Alert heading="Products may not reflect the latest guidance">
   Existing products may not always reflect the latest Design System guidance. Always use the Figma libraries and documentation as the source of truth.
 </Alert>
 
 ## Designing with components and patterns
 
-CMS sets clear expectations for how to use the Design System. Designers **should follow Design System guidance and use its components and patterns** as defined.
+CMS sets clear expectations for how to use the Design System. Designers **must follow Design System guidance and use its components and patterns** as defined.
 
-If a requirement can't be met using the Design System, document the gap and consider [submitting a contribution proposal](/getting-started/contribution-guidance/) with the Design System team before introducing custom solutions.
+If a requirement can't be met using the Design System, document the gap and coordinate with the Design System team before introducing custom solutions.
 
 Our Design System components are more than a collection of visual styles. They embody guidance, best practices, and interaction patterns that support accessibility and usability.
 
 ### Components
 
-A [component](/components/overview/) is a reusable UI element with a defined function and behavior. These are the building blocks of the Design System. Examples include buttons, checkboxes, and text inputs. Some components have specific usage guidelines that should be followed.
+A [component](https://design.cms.gov/components/overview/?theme=core) is a reusable UI element with a defined function and behavior. These are the building blocks of the Design System. Examples include buttons, checkboxes, and text inputs. Some components have specific usage guidelines that should be followed.
 
-Each component in the Design System is included in Figma as a reusable, themeable component, often with variants and modes. CMS expects teams to use Design System components in their designs unless a documented gap exists.
+Each component in the Design System is included in Figma as a reusable, themeable component, often with variants and modes. **CMS expects teams to use Design System components in their designs unless a documented gap exists.**
+
+If a component doesn't meet your needs, first confirm that a suitable component or pattern doesn't already exist. If a gap exists, document the use case and determine whether it aligns with CMS expectations. Teams should reach out to the Design System team before creating a custom solution.
 
 When designing with components:
 
@@ -122,9 +131,9 @@ When designing with components:
 
 ### Patterns
 
-A [pattern](/patterns/overview/) is a combination of components used together to solve a common user interaction. Examples include form review or utility actions. Patterns are available in both the CMS Design System documentation and Figma.
+A [pattern](https://design.cms.gov/patterns/overview/?theme=core) is a combination of components used together to solve a common user interaction. Examples include form review or utility actions. Patterns are available in both the CMS Design System documentation and Figma.
 
-CMS expects teams to use Design System patterns as outlined. If a pattern doesn't meet your needs, adapt it only if it remains consistent with the Design System's visual language and accessibility guidelines. If you have significant changes from what's outlined in the Design System, document the use case and consider [submitting a contribution proposal](/getting-started/contribution-guidance/).
+**CMS expects teams to use Design System patterns as outlined.** If a pattern doesn't meet your needs, adapt it only if it remains consistent with the Design System's visual language and accessibility guidelines. If you have significant changes from what's outlined in the Design System, document the use case and coordinate with the Design System team.
 
 When designing with patterns:
 
@@ -132,11 +141,11 @@ When designing with patterns:
 - Maintain consistency with established interaction patterns.
 - Adapt patterns carefully while preserving accessibility and usability.
 
-If your design requires a solution outside of the Design System, ensure it meets the same accessibility and interaction standards.
+If your design requires a solution outside of the Design System, ensure it meets the same accessibility and interaction standards and document the deviation.
 
 ### Spacing
 
-Use consistent [spacing](/foundation/spacing/) to maintain clear layout and visual rhythm.
+Use consistent [spacing](https://design.cms.gov/foundation/spacing/?theme=core) to maintain clear layout and visual rhythm.
 
 - Follow the 8px spacing scale used across the Design System.
 - Avoid arbitrary spacing values.
@@ -157,8 +166,8 @@ This helps ensure that designs can be implemented accurately and remain consiste
 
 ## Analytics
 
-[See component-analytics documentation](/components/analytics/) to learn how to enable and configure analytics for design system components.
+[Learn how to enable and configure analytics for design system components.](https://design.cms.gov/components/analytics/)
 
 ## Further resources
 
-If you need help while working with the Design System, [please reach out](/contact/#-slack) in the CMS Design System Slack channel or connect with the Design System team.
+If you need help while working with the Design System, [reach out](https://design.cms.gov/contact/?theme=core) in the CMS Design System Slack channel or connect with the Design System team.


### PR DESCRIPTION
## Summary
- Adds designer onboarding content to the "For Designers" page in the Getting Started section
- Includes new Alert component headings for correct icon alignment because if I don't add the heading the icon alignment looks inconsistent from the developer page. Matching the pattern used on the "For Developers" page
- Related ticket: https://jira.cms.gov/browse/CMSDS-3712

## How to test
1. Pull this branch and run `npm run build`, then `npm run start`
2. Visit `localhost:8000/getting-started/for-designers/`
3. Confirm the page appears in the left nav directly under "For Developers"
4. Confirm all Alert callouts show a heading with the icon properly aligned
5. Click through the page's links (Figma, child themes, contact, components, patterns) to confirm none are broken

## Checklist
- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

### If this is a change to documentation/content:
- [x] Checked for spelling and grammatical errors
- [ ] Communicate the assigned milestone/release date with Design so they can communicate appropriately