### PR TITLE
[CMSDS-4176] Remove Storybook Addon Fetch Mock

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -203,9 +203,6 @@ const preview: Preview = {
         date: /Date$/,
       },
     },
-    fetchMock: {
-      debug: false,
-    },
     viewport: {
       viewports: breakpointViewportSizes,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,6 @@
         "sass": "^1.53.0",
         "sass-loader": "10.2.1",
         "storybook": "^8.6.17",
-        "storybook-addon-fetch-mock": "^2.0.1",
         "stylelint": "16.3.1",
         "stylelint-config-standard-scss": "^13.0.0",
         "stylelint-formatter-pretty": "^4.0.0",
@@ -27884,71 +27883,6 @@
         }
       }
     },
-    "node_modules/fetch-mock": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
-      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.0.0",
-        "@babel/runtime": "^7.0.0",
-        "core-js": "^3.0.0",
-        "debug": "^4.1.1",
-        "glob-to-regexp": "^0.4.0",
-        "is-subset": "^0.1.1",
-        "lodash.isequal": "^4.5.0",
-        "path-to-regexp": "^2.2.1",
-        "querystring": "^0.2.0",
-        "whatwg-url": "^6.5.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      },
-      "funding": {
-        "type": "charity",
-        "url": "https://www.justgiving.com/refugee-support-europe"
-      },
-      "peerDependencies": {
-        "node-fetch": "*"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/fetch-mock/node_modules/path-to-regexp": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
-      "dev": true
-    },
-    "node_modules/fetch-mock/node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/fetch-mock/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "node_modules/fetch-mock/node_modules/whatwg-url": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -35241,12 +35175,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-      "dev": true
-    },
     "node_modules/is-symbol": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
@@ -37218,12 +37146,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ=="
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "dev": true
     },
     "node_modules/lodash.map": {
       "version": "4.6.0",
@@ -45547,16 +45469,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -49581,18 +49493,6 @@
         "prettier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/storybook-addon-fetch-mock": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/storybook-addon-fetch-mock/-/storybook-addon-fetch-mock-2.0.1.tgz",
-      "integrity": "sha512-s9fVg8sv03tHU8jeidruI9fzt8LPYfo27mAYKCEoXsBzVK8KA4XTyHOVLkYXIRs9Y6QGOAvksBfZR3PmAqwvYg==",
-      "dev": true,
-      "dependencies": {
-        "fetch-mock": "^9.11.0"
-      },
-      "peerDependencies": {
-        "@storybook/preview-api": "^7.0.0 || ^8.0.0 || next"
       }
     },
     "node_modules/stream-exhaust": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,6 @@
     "sass": "^1.53.0",
     "sass-loader": "10.2.1",
     "storybook": "^8.6.17",
-    "storybook-addon-fetch-mock": "^2.0.1",
     "stylelint": "16.3.1",
     "stylelint-config-standard-scss": "^13.0.0",
     "stylelint-formatter-pretty": "^4.0.0",


### PR DESCRIPTION
## Summary

- We currently use `storybook-addon-fetch-mock` to mock fetch requests in Stories for the Autocomplete component and its web components equivalent. This add-on is no longer maintained and is blocking our ability to upgrade Storybook. #4152 replaced the mocked fetch requests. We should now be able to remove this dependency with no disruption to Storybook.
- [CMSDS-4176](https://jira.cms.gov/browse/CMSDS-4176)

## How to test

1. Run `npm run freshen`
2. Run Storybook
3. Verify Storybook loads and Stories can be successfully accessed.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
