### PR TITLE
[CMSDS-4250] Upgrade gulp-sass to 6.0.1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -113,7 +113,7 @@ const compileSass = (cb) => {
   gulp
     .src(sassSourcePaths)
     .pipe(gulpif(envDev, sourcemaps.init()))
-    .pipe(sass({ outputStyle: 'expanded' }))
+    .pipe(sass({ style: 'expanded' }))
     .pipe(gulpif(envDev, sourcemaps.write()))
     .pipe(
       postcss([

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "gulp-filter": "^7.0.0",
         "gulp-if": "^3.0.0",
         "gulp-postcss": "^9.0.1",
-        "gulp-sass": "^5.1.0",
+        "gulp-sass": "^6.0.1",
         "gulp-sourcemaps": "^3.0.0",
         "gulp-svgmin": "^4.1.0",
         "gulp-typescript": "^6.0.0-alpha.1",
@@ -35119,10 +35119,11 @@
       }
     },
     "node_modules/gulp-sass": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-5.1.0.tgz",
-      "integrity": "sha512-7VT0uaF+VZCmkNBglfe1b34bxn/AfcssquLKVDYnCDJ3xNBaW7cUuI3p3BQmoKcoKFrs9jdzUxyb+u+NGfL4OQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-6.0.1.tgz",
+      "integrity": "sha512-4wonidxB8lGPHvahelpGavUBJAuERSl+OIVxPCyQthK4lSJhZ/u3/qjFcyAtnMIXDl6fXTn34H4BXsN7gt54kQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "picocolors": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "gulp-filter": "^7.0.0",
     "gulp-if": "^3.0.0",
     "gulp-postcss": "^9.0.1",
-    "gulp-sass": "^5.1.0",
+    "gulp-sass": "^6.0.1",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-svgmin": "^4.1.0",
     "gulp-typescript": "^6.0.0-alpha.1",


### PR DESCRIPTION
## Summary

- Dart Sass [replaced their API](https://sass-lang.com/documentation/breaking-changes/legacy-js-api/) in 1.45.0 and started yelling at us about it in 1.79.0. We use `gulp-sass` to compile our Sass files through our Gulp build script. Our current version, 5.1.0, uses the legacy API. Version 6+ use the current API. This PR updates `gulp-sass` to version 6 in order to convert over to the modern API and remove that warning.
- [CMSDS-4250](https://jira.cms.gov/browse/CMSDS-4250)

## How to test

1. `npm run clean && npm i && npm run:build:tokens`
2. Run `npm run build:core`
3. Verify the output does not contain a deprecation warning about the legacy JS API. (There will be other Sass deprecation warnings that are out of scope for this ticket.)
4. Verify the build completes successfully.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone
