### PR TITLE
[NO-TICKET] Fix broken Code of Conduct link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,4 +151,4 @@ Please read the [CONTRIBUTING.md](CONTRIBUTING.md) document to learn about contr
 
 To get in touch with the CMS Design System team, please visit [design.cms.gov/contact](https://design.cms.gov/contact) for a list of ways to contact us.
 
-One of our goals is to ensure a welcoming environment for all contributors. Please take a look at our [Code of Conduct](CODE-OF-CONDUCT.md) to learn more.
+One of our goals is to ensure a welcoming environment for all contributors. Please take a look at our [Code of Conduct](CODE_OF_CONDUCT.md) to learn more.


### PR DESCRIPTION
## Summary

- Fixes a broken relative link in the root `README.md`. The link to the Code of
  Conduct pointed to `CODE-OF-CONDUCT.md` (hyphens), but the actual file in the
  repo is `CODE_OF_CONDUCT.md` (underscores). Confirmed the hyphenated path
  404s live on GitHub (`https://github.com/CMSgov/design-system/blob/main/CODE-OF-CONDUCT.md`
  → 404) while the underscored path resolves (200). This PR points the link at
  the real file.
- No Jira ticket for this — it's a one-line doc typo fix, filed as `[NO-TICKET]`.

## How to test

1. Open `README.md` in this branch and click the "Code of Conduct" link near
   the bottom (or view it rendered on GitHub).
2. Confirm it resolves to `CODE_OF_CONDUCT.md` instead of 404ing.

## Checklist

- [x] Prefixed the PR title with `[NO-TICKET]` — this is unticketed, one-line
      doc work.
- [ ] Selected appropriate `Type` label — I don't have label-write access on
      this repo as an external contributor; suggest `Type: Documentation` (or
      equivalent) if promoted upstream.
- [ ] Selected appropriate `Impacts` label — none of the listed impact areas
      apply beyond docs; none selected.
- [ ] Selected appropriate release milestone — no write access; leave to
      maintainers if promoted upstream.

### If this is a change to documentation/content:

- [x] Checked for spelling and grammatical errors — no prose change, only the
      link target.
- [ ] Communicate the assigned milestone/release date with Design — n/a, no
      milestone assigned by an external contributor.

## Evidence

```
$ curl -sS -o /dev/null -w "%{http_code}\n" \
  https://github.com/CMSgov/design-system/blob/main/CODE-OF-CONDUCT.md
404

$ curl -sS -o /dev/null -w "%{http_code}\n" \
  https://github.com/CMSgov/design-system/blob/main/CODE_OF_CONDUCT.md
200
```

`ls` at repo root confirms only `CODE_OF_CONDUCT.md` exists — no
`CODE-OF-CONDUCT.md`. Verified this is the only occurrence of the broken
hyphenated form in any `.md`/`.mdx` file in the repo.