### PR TITLE
[CSMDS-4272] Add aria-haspopup=dialog to DrawerToggle and Drawer stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@figma/code-connect": "^1.4.4",
     "@inquirer/prompts": "^3.0.3",
     "@playwright/test": "1.58.2",
+    "@storybook/addon-docs": "9.1.20",
     "@storybook/addon-links": "9.1.20",
     "@storybook/addon-webpack5-compiler-babel": "^3.0.3",
     "@storybook/react-webpack5": "9.1.20",
@@ -176,7 +177,6 @@
     "webpack": "^5.76.0",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-stream": "^7.0.0",
-    "yargs": "^17.7.2",
-    "@storybook/addon-docs": "9.1.20"
+    "yargs": "^17.7.2"
   }
 }

--- a/packages/design-system/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.stories.tsx
@@ -108,7 +108,12 @@ export const Default: Story = {
         >
           {args.children || drawerContent}
         </Drawer>
-        <Button className="ds-c-drawer__toggle" variation="ghost" onClick={showDrawer}>
+        <Button
+          aria-haspopup="dialog"
+          className="ds-c-drawer__toggle"
+          variation="ghost"
+          onClick={showDrawer}
+        >
           Click to toggle drawer
         </Button>
       </>
@@ -142,7 +147,12 @@ export const BackdropClickExits: Story = {
         >
           {args.children || drawerContent}
         </Drawer>
-        <Button className="ds-c-drawer__toggle" variation="ghost" onClick={showDrawer}>
+        <Button
+          aria-haspopup="dialog"
+          className="ds-c-drawer__toggle"
+          variation="ghost"
+          onClick={showDrawer}
+        >
           Click to open drawer
         </Button>
       </>

--- a/packages/design-system/src/components/Drawer/DrawerManager.stories.tsx
+++ b/packages/design-system/src/components/Drawer/DrawerManager.stories.tsx
@@ -86,6 +86,7 @@ const SingleDrawerWithToggle = (...args) => {
         {children}
       </Drawer>
       <Button
+        aria-haspopup="dialog"
         className="ds-c-drawer__toggle ds-u-margin-bottom--2"
         variation="ghost"
         onClick={toggleDrawer}

--- a/packages/design-system/src/components/Drawer/DrawerToggle.tsx
+++ b/packages/design-system/src/components/Drawer/DrawerToggle.tsx
@@ -26,7 +26,7 @@ export type DrawerToggleProps = ButtonProps & {
    * This function is called with an id that the toggle generates.
    * It can be used in implementing the Drawer for keeping track of which drawer the toggle controls.
    */
-  showDrawer: (string) => any;
+  showDrawer: (id?: string) => any;
 };
 
 /**
@@ -40,7 +40,7 @@ export const DrawerToggle = ({
   drawerOpen,
   ...others
 }: DrawerToggleProps): React.ReactElement<any> => {
-  const buttonRef = useRef(null);
+  const buttonRef = useRef<null | HTMLButtonElement>(null);
   const prevDrawerOpenProp = usePrevious(drawerOpen);
 
   useEffect(() => {
@@ -48,7 +48,7 @@ export const DrawerToggle = ({
     if (prevDrawerOpenProp && !drawerOpen && buttonRef.current) {
       buttonRef.current.focus();
     }
-  }, [drawerOpen]);
+  }, [drawerOpen, prevDrawerOpenProp]);
 
   const classes = classNames(
     'ds-c-drawer__toggle',
@@ -58,6 +58,7 @@ export const DrawerToggle = ({
 
   return (
     <Button
+      aria-haspopup="dialog"
       className={classes}
       inputRef={(el) => (buttonRef.current = el)}
       onClick={showDrawer}

--- a/packages/design-system/src/components/Drawer/__snapshots__/DrawerToggle.test.tsx.snap
+++ b/packages/design-system/src/components/Drawer/__snapshots__/DrawerToggle.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`DrawerToggle renders a button 1`] = `
 <DocumentFragment>
   <button
+    aria-haspopup="dialog"
     class="ds-c-button ds-c-button--ghost ds-c-drawer__toggle"
     type="button"
   >

--- a/packages/design-system/src/components/HelpDrawer/HelpDrawer.stories.tsx
+++ b/packages/design-system/src/components/HelpDrawer/HelpDrawer.stories.tsx
@@ -80,7 +80,12 @@ export const Default: Story = {
         >
           {args.children || drawerContent}
         </HelpDrawer>
-        <Button className="ds-c-drawer__toggle" variation="ghost" onClick={showDrawer}>
+        <Button
+          aria-haspopup="dialog"
+          className="ds-c-drawer__toggle"
+          variation="ghost"
+          onClick={showDrawer}
+        >
           {toggleButtonText}
         </Button>
       </>

--- a/packages/design-system/src/components/HelpDrawer/__snapshots__/HelpDrawerToggle.test.tsx.snap
+++ b/packages/design-system/src/components/HelpDrawer/__snapshots__/HelpDrawerToggle.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`HelpDrawerToggle renders a button 1`] = `
 <button
+  aria-haspopup="dialog"
   class="ds-c-button ds-c-button--ghost ds-c-drawer__toggle ds-c-help-drawer__toggle"
   type="button"
 >

--- a/packages/design-system/src/components/web-components/ds-button/ds-button.test.tsx
+++ b/packages/design-system/src/components/web-components/ds-button/ds-button.test.tsx
@@ -87,10 +87,10 @@ describe('Button', () => {
     const buttonRoot = document.querySelector('ds-button');
     const buttonEl = getByRole(shadowRoot as any as HTMLElement, 'button');
     const mockHandler = jest.fn();
-    buttonRoot.addEventListener('ds-click', mockHandler);
+    buttonRoot?.addEventListener('ds-click', mockHandler);
     fireEvent.click(buttonEl);
     expect(mockHandler).toHaveBeenCalledTimes(1);
-    buttonRoot.removeEventListener('ds-click', mockHandler);
+    buttonRoot?.removeEventListener('ds-click', mockHandler);
   });
 
   it('fires a custom analytics event on click', () => {
@@ -98,10 +98,10 @@ describe('Button', () => {
     const buttonRoot = document.querySelector('ds-button');
     const buttonEl = getByRole(shadowRoot as any as HTMLElement, 'button');
     const mockHandler = jest.fn();
-    buttonRoot.addEventListener('ds-analytics-event', mockHandler);
+    buttonRoot?.addEventListener('ds-analytics-event', mockHandler);
     fireEvent.click(buttonEl);
     expect(mockHandler).toHaveBeenCalledTimes(1);
-    buttonRoot.removeEventListener('ds-analytics-event', mockHandler);
+    buttonRoot?.removeEventListener('ds-analytics-event', mockHandler);
   });
 
   describe('Analytics', () => {
@@ -163,10 +163,12 @@ describe('Button', () => {
       async ({ tealiumMock, waitForAnalytics }) => {
         let analyticsEvent;
         const { shadowRoot } = view();
-        document.querySelector('ds-button').addEventListener('ds-analytics-event', (event: any) => {
-          event.preventDefault();
-          analyticsEvent = event.detail.event;
-        });
+        document
+          .querySelector('ds-button')
+          ?.addEventListener('ds-analytics-event', (event: any) => {
+            event.preventDefault();
+            analyticsEvent = event.detail.event;
+          });
         fireEvent.click(getByRole(shadowRoot as any as HTMLElement, 'button'));
         await waitForAnalytics();
         expect(tealiumMock).not.toHaveBeenCalled();

--- a/packages/design-system/src/components/web-components/ds-button/ds-button.tsx
+++ b/packages/design-system/src/components/web-components/ds-button/ds-button.tsx
@@ -28,9 +28,9 @@ const Wrapper = ({ isAlternate, isOnDark, analytics, ...otherProps }: WrapperPro
   <Button
     {...otherProps}
     {...{
-      isAlternate: isAlternate && Boolean(JSON.parse(isAlternate)),
-      onDark: isOnDark && Boolean(JSON.parse(isOnDark)),
-      analytics: analytics && Boolean(JSON.parse(analytics)),
+      isAlternate: Boolean(isAlternate) && Boolean(JSON.parse(isAlternate as string)),
+      onDark: Boolean(isOnDark) && Boolean(JSON.parse(isOnDark as string)),
+      analytics: Boolean(analytics) && Boolean(JSON.parse(analytics as string)),
     }}
   />
 );
@@ -39,7 +39,7 @@ const Wrapper = ({ isAlternate, isOnDark, analytics, ...otherProps }: WrapperPro
 declare global {
   namespace React.JSX {
     interface IntrinsicElements {
-      'ds-button': React.JSX.IntrinsicElements['div'] & {
+      'ds-button': React.JSX.IntrinsicElements['button'] & {
         'class-name'?: string;
         disabled?: string | boolean;
         href?: string;

--- a/packages/design-system/src/components/web-components/ds-button/ds-button.tsx
+++ b/packages/design-system/src/components/web-components/ds-button/ds-button.tsx
@@ -2,6 +2,7 @@ import { define } from '../preactement/define';
 import Button, { ButtonProps } from '../../Button/Button';
 import { analyticsOverrideAttrs, analyticsParentDataAttrs } from '../shared-attributes/analytics';
 import { onAnalyticsEvent } from '../analytics';
+import { parseBooleanAttr } from '../wrapperUtils';
 
 const attributes = [
   'class-name',
@@ -28,9 +29,9 @@ const Wrapper = ({ isAlternate, isOnDark, analytics, ...otherProps }: WrapperPro
   <Button
     {...otherProps}
     {...{
-      isAlternate: Boolean(isAlternate) && Boolean(JSON.parse(isAlternate as string)),
-      onDark: Boolean(isOnDark) && Boolean(JSON.parse(isOnDark as string)),
-      analytics: Boolean(analytics) && Boolean(JSON.parse(analytics as string)),
+      isAlternate: isAlternate !== undefined ? parseBooleanAttr(isAlternate) : undefined,
+      onDark: isOnDark !== undefined ? parseBooleanAttr(isOnDark) : undefined,
+      analytics: analytics !== undefined ? parseBooleanAttr(analytics) : undefined,
     }}
   />
 );

--- a/packages/design-system/src/components/web-components/ds-button/ds-button.tsx
+++ b/packages/design-system/src/components/web-components/ds-button/ds-button.tsx
@@ -19,7 +19,8 @@ const attributes = [
 ];
 
 // Mapping `onDark` to `isOnDark` because props starting with "on" indicate an event handler and tests fail due to this expectation
-interface WrapperProps extends Omit<ButtonProps, 'isAlternate' | 'onDark' | 'analytics'> {
+interface WrapperProps
+  extends Omit<ButtonProps, 'disabled' | 'isAlternate' | 'onDark' | 'analytics'> {
   analytics?: string;
   isAlternate?: string;
   isOnDark?: string;
@@ -40,7 +41,7 @@ const Wrapper = ({ isAlternate, isOnDark, analytics, ...otherProps }: WrapperPro
 declare global {
   namespace React.JSX {
     interface IntrinsicElements {
-      'ds-button': React.JSX.IntrinsicElements['button'] & {
+      'ds-button': Omit<React.JSX.IntrinsicElements['button'], 'disabled'> & {
         'class-name'?: string;
         disabled?: string | boolean;
         href?: string;

--- a/packages/design-system/src/components/web-components/ds-drawer/ds-drawer.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-drawer/ds-drawer.stories.tsx
@@ -156,7 +156,8 @@ const Template = (args) => {
     'class-name': 'ds-c-drawer__toggle',
     id: 'ds-button',
     variation: 'ghost',
-  };
+    'aria-haspopup': 'dialog',
+  } as const;
 
   return (
     <div>

--- a/packages/docs/content/components/drawer.mdx
+++ b/packages/docs/content/components/drawer.mdx
@@ -126,6 +126,7 @@ What do you do when there are multiple drawers on a page? The simplest behaviorâ
 ### Accessibility
 
 - The `Drawer` should have an `aria-labelledby` attribute that references the `id` of the heading in the `Drawer`.
+- The toggle element should have `aria-haspopup="dialog"` set on it so that assistive technology can appropriately notify users that the button has an associated dialog.
 - The `Drawer` markup should be placed after the toggle element that triggers it in the HTML structure. This keeps the markup semantically sound and improves accessibility for screen readers.
 - The heading level used within the `Drawer` should fit semantically with the heading levels of the rest of the page. For instance, if the heading level before the `Drawer` toggle link is an `<h2>`, the heading level of the `Drawer` would most likely be an `<h3>`.
 
@@ -160,6 +161,7 @@ When `hasFocusTrap` is enabled...
 ##### Screen reader
 
 - The Drawer toggle indicates the purpose of the Drawer and mirrors the first heading inside the Drawer.
+- The Drawer toggle notifies users that there is an associated `dialog popup`.
 - When the Drawer is open:
   - Focus is sent to the Drawer.
   - The Drawer's role of `dialog` is read.
@@ -185,9 +187,7 @@ When `hasFocusTrap` is enabled...
 ### Web Component
 
 <StorybookDocLinks tech="wc">
-  <StorybookDocLink tech="wc" storyId="web-components-ds-drawer--docs">
-    Drawer
-  </StorybookDocLink>
+  <StorybookDocLink tech="wc" storyId="web-components-ds-drawer--docs">Drawer</StorybookDocLink>
 </StorybookDocLinks>
 
 ### Style customization

--- a/packages/docs/content/components/drawer.mdx
+++ b/packages/docs/content/components/drawer.mdx
@@ -161,7 +161,7 @@ When `hasFocusTrap` is enabled...
 ##### Screen reader
 
 - The Drawer toggle indicates the purpose of the Drawer and mirrors the first heading inside the Drawer.
-- The Drawer toggle notifies users that there is an associated `dialog popup`.
+- The Drawer toggle notifies users that there is an associated `dialog pop up`.
 - When the Drawer is open:
   - Focus is sent to the Drawer.
   - The Drawer's role of `dialog` is read.


### PR DESCRIPTION
## Summary

- I added `aria-haspopup="dialog"` to the DrawerToggle component. Since this component is not utilized universally for all Drawers, I updated our Stories to reflect this patter, and I added text to our Drawer guidance to explain that adding this aria property is important and expected. 
- I did not update our mobile accessibility guidance, since we only cover double press guidance at this point in time and this property only presents itself on single press (at least on Android).

## How to test

1. `npm run storybook`
2. Navigate to the [Drawer](http://localhost:6006/?path=/story/components-drawer--default), [Drawer Manager](http://localhost:6006/?path=/story/components-drawermanager--drawer-manager-default), [ds-drawer](http://localhost:6006/?path=/story/web-components-ds-drawer--default) and [Medicare Gov Drawer](http://localhost:6006/?path=/story/medicare-medicaregovhelpdrawer--help-drawer-toggle-with-drawer)
3. Turn on VoiceOver (Cmd + fn + f5)
4. Focus on the toggle 
5. Confirm that `dialog pop up` is read out along with the text within the toggle.
6. NOTE: this does not work on our web component version as far as I can tell. I'm including changes that clean up some of the typing in an attempt to confirm this prop is present in the DOM. It is, and is not respected by VoiceOver.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone

## AI Usage

- [ ] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [X] NO_AI: I did not use AI.
