### PR TITLE
[NO-TICKET] Prettier should ignore Astro files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+**/*.astro
 **/node_modules/**
 **/dist/**
 tmp/**


### PR DESCRIPTION
## Summary

- If you run npm run apply-example-templates right now, you'll see the following errors:
```shell
[error] No parser could be inferred for file: examples/astro-themes/src/components/WebComponentExamples.astro
[error] No parser could be inferred for file: examples/astro/src/pages/web-components.astro
```
- This is because we don't currently have an Astro plugin for Prettier installed in our repo. I tried installing one to see what would happen, and it wiped the files completely. We probably don't want that.
- The easiest way to get rid of these errors is for Prettier to ignore all Astro files by updating the `.prettierignore` file. This PR does that.

## How to test

1. Run `npm run apply-example-templates`
2. Verify the above errors no longer appear in the output.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

## AI Usage

- [ ] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [x] NO_AI: I did not use AI.