### PR TITLE
[NO-TICKET] Adjust z index on Mobile Navigation Header

### DIFF
--- a/packages/docs/src/styles/components/navigation.scss
+++ b/packages/docs/src/styles/components/navigation.scss
@@ -136,7 +136,7 @@
   .c-navigation__header {
     position: sticky;
     top: 0;
-    z-index: 1;
+    z-index: 101;
   }
 }
 


### PR DESCRIPTION
## Summary

- Goes from this:
<img width="693" height="433" alt="Screenshot 2026-08-17 at 1 36 01 PM" src="https://github.com/user-attachments/assets/68179dd2-4233-4e65-9217-ae633c543426" />


- To this:
<img width="683" height="481" alt="Screenshot 2026-08-17 at 1 38 33 PM" src="https://github.com/user-attachments/assets/a7ce7cc3-3675-436d-928c-70cfd3fdb57c" />

## How to test

1. `npm run start`
2. Open up dev tools in the browser of your choice
3. Toggle on the device viewport emulation settings. You want to make sure mobile styling is enabled, so viewport width must be less than 768 px. 
4. Open the Using AI and Components sections in the dropdown menu
5. Make sure the Components section is focused (to set focus with dev tools, first select the Components navigation header element using the `Select an element to inspect it tool`, then select the `Styles` tab, then `Toggle Element State` (should be `:hov` in Chrome), then toggle the `:focus` checkbox)
6. Scroll down
7. The Components section should lie behind the CMS Design System header.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone

## AI Usage

- [ ] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [X] NO_AI: I did not use AI.