### PR TITLE
[CMSDS-4567] Enable alwaysStrict and strictBindCallApply

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "alwaysStrict": true,
+    "strictBindCallApply": true
   },
   "include": ["packages/**/src/**/*", ".storybook/**/*"]
 }


### PR DESCRIPTION
## Summary

- Adds `"alwaysStrict": true` and `"strictBindCallApply": true` to the root `tsconfig.json`. Config only — no source changes.
- This is **stage 1 of 10** in a staged rollout toward `"strict": true`. Both flags already pass at zero errors, so this stage is free: it locks them in before the stages that require real fixes. Later stages are stacked on this branch, one ticket per stage.
- Baseline for the rollout: `--strict` currently reports 791 errors across 203 files, dominated by `noImplicitAny` (396) and `strictNullChecks` (425).
- Jira: [CMSDS-4567](https://jira.cms.gov/browse/CMSDS-4567)
- Follows [CMSDS-4564](https://github.com/CMSgov/design-system/pull/4206) (#4206), which modernized the same file.

## How to test

1. `npm run build` — required before type-check so downstream types resolve.
2. `npm run type-check` — expect **0 errors**.
3. Confirm the declaration output is unchanged. The root `tsconfig.json` feeds `ts.createProject` in `gulpfile.js` for `.d.ts` emit, so a config change here can alter published types:
   ```bash
   # stash a baseline built from the previous commit, then:
   diff -r packages/design-system/dist/react-components/types <baseline>
   ```
   Expect byte-identical output across all 302 files.

### Verification results

| Gate | Result |
| --- | --- |
| `npm run type-check` | 0 errors |
| `npm run build` | exit 0 |
| `npm test` (unit + `posttest` lint) | 909 passed, 8 skipped, 195 snapshots passed; eslint/stylelint 0 errors, 93 pre-existing warnings |
| `npm run test:browser:smoke` | 804 passed, 0 failed — **see deviation below** |
| Declaration diff | byte-identical, 302 files |

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

## AI Usage

- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.

#### Type of assistance:

- [x] Other — analysis of the strict-mode error surface, the staging plan, and this config change

#### AI System used:

- [x] Claude

#### Level of modification:

- [x] As-is (AI generated all code in this submission)

### If this is a change to code:

- [ ] Created or updated unit tests to cover any new or modified code — **N/A**, no new or modified code; the change is two compiler flags.
- [ ] Verified that running both `npm run test:unit` and `npm run test:browser:all` were each successful — `test:unit` passed; **`test:browser:all` was not run**, only `test:browser:smoke`, and outside Docker. See the deviation note above.
- [x] If necessary, updated unit-test snapshots and browser-test snapshots — not necessary; no snapshots changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
