### PR TITLE
[CMSDS-4043] Fix `Drawer` empty footer heading

### DIFF
--- a/packages/design-system/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.stories.tsx
@@ -40,7 +40,7 @@ const meta: Meta<typeof Drawer> = {
   },
   args: {
     footerTitle: 'Footer Title',
-    footerBody: <p className="ds-text-body--md ds-u-margin--0">Footer content</p>,
+    footerBody: 'Footer body content',
     heading: 'Drawer Heading',
   },
   // The Drawer was overlapping the docs page, so customizing the docs page to remove the examples
@@ -98,14 +98,7 @@ export const Default: Story = {
 
     return (
       <>
-        <Drawer
-          {...args}
-          onCloseClick={hideDrawer}
-          footerTitle="Footer Title"
-          footerBody={<p className="ds-text-body--md ds-u-margin--0">Footer content</p>}
-          heading="Drawer Heading"
-          isOpen={drawerOpen}
-        >
+        <Drawer {...args} onCloseClick={hideDrawer} heading="Drawer Heading" isOpen={drawerOpen}>
           {args.children || drawerContent}
         </Drawer>
         <Button className="ds-c-drawer__toggle" variation="ghost" onClick={showDrawer}>
@@ -136,8 +129,6 @@ export const BackdropClickExits: Story = {
           isOpen={drawerOpen}
           onCloseClick={hideDrawer}
           backdropClickExits={true}
-          footerTitle="Footer Title"
-          footerBody={<p className="ds-text-body--md ds-u-margin--0">Footer content</p>}
           heading="Drawer with Backdrop Click Exit"
         >
           {args.children || drawerContent}

--- a/packages/design-system/src/components/Drawer/Drawer.test.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.test.tsx
@@ -44,10 +44,13 @@ describe('Drawer', () => {
 
   describe('footer', () => {
     it('does not render an empty footer title when footerTitle is not provided', () => {
-      renderDrawer({ footerTitle: undefined });
+      const { container } = renderDrawer({ footerTitle: undefined });
 
-      expect(screen.queryByRole('heading', { level: 4 })).not.toBeInTheDocument();
-      expect(screen.getByText(footerBodyContent)).toBeInTheDocument();
+      expect(container.querySelector('.ds-c-drawer__footer')).toBeInTheDocument();
+      expect(container.querySelector('.ds-c-drawer__footer-title')).not.toBeInTheDocument();
+      expect(container.querySelector('.ds-c-drawer__footer-body')).toHaveTextContent(
+        footerBodyContent
+      );
     });
 
     it('renders the footer title and body when both are provided', () => {

--- a/packages/design-system/src/components/Drawer/Drawer.test.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.test.tsx
@@ -51,7 +51,7 @@ describe('Drawer', () => {
     });
 
     it('renders the footer title and body when both are provided', () => {
-      const { container } = renderDrawer({ footerTitle: footerTitle });
+      const { container } = renderDrawer();
 
       expect(container.querySelector('.ds-c-drawer__footer')).toBeInTheDocument();
       expect(container.querySelector('.ds-c-drawer__footer-title')).toHaveTextContent(footerTitle);

--- a/packages/design-system/src/components/Drawer/Drawer.test.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.test.tsx
@@ -61,10 +61,7 @@ describe('Drawer', () => {
     });
 
     it('renders the footer without a body when only footerTitle is provided', () => {
-      const { container } = renderDrawer({
-        footerTitle: footerTitle,
-        footerBody: undefined,
-      });
+      const { container } = renderDrawer({ footerBody: undefined });
 
       expect(container.querySelector('.ds-c-drawer__footer')).toBeInTheDocument();
       expect(container.querySelector('.ds-c-drawer__footer-title')).toHaveTextContent(footerTitle);

--- a/packages/design-system/src/components/Drawer/Drawer.test.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.test.tsx
@@ -9,7 +9,6 @@ const defaultProps = {
       <p>Some footer content</p>
     </div>
   ),
-  footerTitle: 'Footer title',
   isOpen: true,
   onCloseClick: jest.fn(),
   heading: 'Drawer title',
@@ -38,6 +37,31 @@ describe('Drawer', () => {
     expect(screen.queryByRole('dialog')).toBe(null);
     rerenderDrawer({ isOpen: true });
     expect((screen.getByRole('dialog') as HTMLDialogElement).open).toBe(true);
+  });
+
+  describe('footer', () => {
+    it('does not render an empty footer title when footerTitle is not provided', () => {
+      renderDrawer();
+
+      expect(screen.queryByRole('heading', { level: 4 })).not.toBeInTheDocument();
+      expect(screen.getByText('Some footer content')).toBeInTheDocument();
+    });
+
+    it('renders the footer title and body when both are provided', () => {
+      const { container } = renderDrawer({
+        footerTitle: 'Footer title',
+      });
+
+      expect(container.querySelector('.ds-c-drawer__footer')).toBeInTheDocument();
+
+      expect(container.querySelector('.ds-c-drawer__footer-title')).toHaveTextContent(
+        'Footer title'
+      );
+
+      expect(container.querySelector('.ds-c-drawer__footer-body')).toHaveTextContent(
+        'Some footer content'
+      );
+    });
   });
 
   describe('onCloseClick', () => {

--- a/packages/design-system/src/components/Drawer/Drawer.test.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.test.tsx
@@ -11,6 +11,7 @@ const defaultProps = {
       <p>{footerBodyContent}</p>
     </div>
   ),
+  footerTitle: footerTitle,
   isOpen: true,
   onCloseClick: jest.fn(),
   heading: 'Drawer title',
@@ -43,7 +44,7 @@ describe('Drawer', () => {
 
   describe('footer', () => {
     it('does not render an empty footer title when footerTitle is not provided', () => {
-      renderDrawer();
+      renderDrawer({ footerTitle: undefined });
 
       expect(screen.queryByRole('heading', { level: 4 })).not.toBeInTheDocument();
       expect(screen.getByText(footerBodyContent)).toBeInTheDocument();

--- a/packages/design-system/src/components/Drawer/Drawer.test.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.test.tsx
@@ -2,11 +2,13 @@ import Drawer from './Drawer';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+const footerBodyContent = 'Some footer content';
+const footerTitle = 'Footer title';
 const defaultProps = {
   children: <p>content</p>,
   footerBody: (
     <div>
-      <p>Some footer content</p>
+      <p>{footerBodyContent}</p>
     </div>
   ),
   isOpen: true,
@@ -44,23 +46,28 @@ describe('Drawer', () => {
       renderDrawer();
 
       expect(screen.queryByRole('heading', { level: 4 })).not.toBeInTheDocument();
-      expect(screen.getByText('Some footer content')).toBeInTheDocument();
+      expect(screen.getByText(footerBodyContent)).toBeInTheDocument();
     });
 
     it('renders the footer title and body when both are provided', () => {
+      const { container } = renderDrawer({ footerTitle: footerTitle });
+
+      expect(container.querySelector('.ds-c-drawer__footer')).toBeInTheDocument();
+      expect(container.querySelector('.ds-c-drawer__footer-title')).toHaveTextContent(footerTitle);
+      expect(container.querySelector('.ds-c-drawer__footer-body')).toHaveTextContent(
+        footerBodyContent
+      );
+    });
+
+    it('renders the footer without a body when only footerTitle is provided', () => {
       const { container } = renderDrawer({
-        footerTitle: 'Footer title',
+        footerTitle: footerTitle,
+        footerBody: undefined,
       });
 
       expect(container.querySelector('.ds-c-drawer__footer')).toBeInTheDocument();
-
-      expect(container.querySelector('.ds-c-drawer__footer-title')).toHaveTextContent(
-        'Footer title'
-      );
-
-      expect(container.querySelector('.ds-c-drawer__footer-body')).toHaveTextContent(
-        'Some footer content'
-      );
+      expect(container.querySelector('.ds-c-drawer__footer-title')).toHaveTextContent(footerTitle);
+      expect(container.querySelector('.ds-c-drawer__footer-body')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/design-system/src/components/Drawer/Drawer.tsx
+++ b/packages/design-system/src/components/Drawer/Drawer.tsx
@@ -146,8 +146,8 @@ export const Drawer = (props: DrawerProps) => {
         </div>
         {(footerTitle || footerBody) && (
           <div className="ds-c-drawer__footer">
-            <h4 className="ds-c-drawer__footer-title">{footerTitle}</h4>
-            <div className="ds-c-drawer__footer-body">{footerBody}</div>
+            {footerTitle && <h4 className="ds-c-drawer__footer-title">{footerTitle}</h4>}
+            {footerBody && <div className="ds-c-drawer__footer-body">{footerBody}</div>}
           </div>
         )}
       </div>

--- a/packages/design-system/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/design-system/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
@@ -39,11 +39,6 @@ exports[`Drawer renders a dialog 1`] = `
     <div
       class="ds-c-drawer__footer"
     >
-      <h4
-        class="ds-c-drawer__footer-title"
-      >
-        Footer title
-      </h4>
       <div
         class="ds-c-drawer__footer-body"
       >

--- a/packages/design-system/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/design-system/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
@@ -39,6 +39,11 @@ exports[`Drawer renders a dialog 1`] = `
     <div
       class="ds-c-drawer__footer"
     >
+      <h4
+        class="ds-c-drawer__footer-title"
+      >
+        Footer title
+      </h4>
       <div
         class="ds-c-drawer__footer-body"
       >

--- a/packages/design-system/src/components/web-components/ds-drawer/__snapshots__/ds-drawer.test.tsx.snap
+++ b/packages/design-system/src/components/web-components/ds-drawer/__snapshots__/ds-drawer.test.tsx.snap
@@ -37,9 +37,6 @@ exports[`Drawer should render a dialog 1`] = `
     <div
       class="ds-c-drawer__footer"
     >
-      <h4
-        class="ds-c-drawer__footer-title"
-      />
       <div
         class="ds-c-drawer__footer-body"
       >


### PR DESCRIPTION
## Summary

- Fixes an issue where the Drawer footer renders an empty `<h4>` when `footerTitle` is undefined.
- Adds regression tests to verify the expected rendering behavior for the footer.
[Jira ticket](https://jira.cms.gov/browse/CMSDS-4043)


## How to test

1. `npm run test`
2. `npm run test:wc`
3.  Using the Storybook Controls, set `footerTitle` to an empty string. Verify that the `<h4>` does not appear in the markup.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

## AI Usage

- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

### IF you did use AI please answer these questions:

#### Type of assistance:

- [x] Code generation
- [ ] Documentation
- [ ] Debugging
- [ ] Testing
- [ ] Refactoring
- [ ] Other

#### AI System used:

- [x] ChatGPT
- [ ] Claude
- [ ] Gemini
- [ ] GitHub Copilot

#### Level of modification:

- [ ] As-is (AI generated all code in this submission)
- [x] Modified (You made some changes to the AI's generation)
- [ ] Used as inspiration
