### PR TITLE
[CMSDS-3959] Generates a list of `llms.txt` urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ bundle-analysis/
 
 # Doc Site ignores
 .cache/
+packages/docs/build-artifacts
 packages/docs/public
 packages/docs/static/storybook
 packages/docs/static/images

--- a/packages/docs/gatsby-node.mjs
+++ b/packages/docs/gatsby-node.mjs
@@ -247,26 +247,36 @@ export const onPostBuild = async ({ graphql, reporter }) => {
   const siteUrl = result.data.site.siteMetadata.siteUrl;
   const mdxNodes = result.data.allMdx.nodes;
   const llmsUrls = [];
+  const failedPages = [];
 
   for (const node of mdxNodes) {
     const pagePath = normalizePagePath(node.fields.slug);
+    try { 
+      const cleanedBody = processMdxForHostedMarkdown(node.body);
 
-    const cleanedBody = processMdxForHostedMarkdown(node.body);
+      const markdown = buildMarkdownPage({
+        title: node.frontmatter?.title,
+        intro: node.frontmatter?.intro,
+        body: cleanedBody,
+      });
 
-    const markdown = buildMarkdownPage({
-      title: node.frontmatter?.title,
-      intro: node.frontmatter?.intro,
-      body: cleanedBody,
-    });
-
-    const relativePath = pagePath.replace(/^\/|\/$/g, '');
-    const outputPath = path.join('public', relativePath, 'llms.txt');
-    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-    fs.writeFileSync(outputPath, markdown, 'utf8');
-    llmsUrls.push(`${siteUrl}${pagePath}/llms.txt`)
+      const relativePath = pagePath.replace(/^\/|\/$/g, '');
+      const outputPath = path.join('public', relativePath, 'llms.txt');
+      fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+      fs.writeFileSync(outputPath, markdown, 'utf8');
+      llmsUrls.push(`${siteUrl}${pagePath}/llms.txt`)     
+    } catch (error) {
+      failedPages.push(pagePath);
+      reporter.warn(`Failed to generate llms.txt for ${pagePath}: ${error.message}`);
+    }
   }
 
-  reporter.success(`Generated page-level llms.txt files for ${mdxNodes.length} documentation pages.`);
+  if (failedPages.length === 0) {
+    reporter.success(`Generated page-level llms.txt files for all ${mdxNodes.length} documentation pages.`);
+  } else {
+    reporter.warn(`Generated ${llmsUrls.length} of ${mdxNodes.length} page-level llms.txt files.`);
+    reporter.warn(`Failed to generate llms.txt for: ${failedPages.join(', ')}`);
+  }
 
   const description = result.data.site.siteMetadata.description;
 
@@ -299,7 +309,5 @@ export const onPostBuild = async ({ graphql, reporter }) => {
     'utf8'
   );
 
-  reporter.success(
-    `Generated llms.txt URL list at ${llmsUrlsOutputPath}`
-  );
+  reporter.success(`Generated llms.txt URL list at ${llmsUrlsOutputPath}.`);
 };

--- a/packages/docs/gatsby-node.mjs
+++ b/packages/docs/gatsby-node.mjs
@@ -244,7 +244,9 @@ export const onPostBuild = async ({ graphql, reporter }) => {
     reporter.panicOnBuild('Error running GraphQL for llms.txt');
     return;
   }
+  const siteUrl = result.data.site.siteMetadata.siteUrl;
   const mdxNodes = result.data.allMdx.nodes;
+  const llmsUrls = [];
 
   for (const node of mdxNodes) {
     const pagePath = normalizePagePath(node.fields.slug);
@@ -261,11 +263,11 @@ export const onPostBuild = async ({ graphql, reporter }) => {
     const outputPath = path.join('public', relativePath, 'llms.txt');
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
     fs.writeFileSync(outputPath, markdown, 'utf8');
+    llmsUrls.push(`${siteUrl}${pagePath}/llms.txt`)
   }
 
   reporter.success(`Generated page-level llms.txt files for ${mdxNodes.length} documentation pages.`);
 
-  const siteUrl = result.data.site.siteMetadata.siteUrl;
   const description = result.data.site.siteMetadata.description;
 
   const normalizedPages = normalizePages(mdxNodes);
@@ -284,4 +286,20 @@ export const onPostBuild = async ({ graphql, reporter }) => {
   fs.writeFileSync(outputPath, markdown, 'utf8');
 
   reporter.success(`Generated root llms.txt at ${outputPath}`);
+
+  llmsUrls.unshift(`${siteUrl}/llms.txt`);
+
+  const llmsUrlsOutputPath = path.join('build-artifacts', 'llms-urls.txt');
+
+  fs.mkdirSync(path.dirname(llmsUrlsOutputPath), { recursive: true });
+
+  fs.writeFileSync(
+    llmsUrlsOutputPath,
+    `${llmsUrls.join('\n')}\n`,
+    'utf8'
+  );
+
+  reporter.success(
+    `Generated llms.txt URL list at ${llmsUrlsOutputPath}`
+  );
 };


### PR DESCRIPTION
## Summary
Generates a list of hosted `llms.txt` URLs as part of the docs build. This provides an easy way to produce an up-to-date list of assets for usage tracking as the documentation IA changes.

The generated list is stored in `packages/docs/build-artifacts/ ` and is not tracked by git.

[Jira ticket](https://jira.cms.gov/browse/CMSDS-3959)

## How to test

- `npm run build:docs`
- Inspect `packages/docs/build-artifacts/llms-urls.txt`

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

## AI Usage

- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

### IF you did use AI please answer these questions:

#### Type of assistance:

- [ ] Code generation
- [ ] Documentation
- [ ] Debugging
- [ ] Testing
- [ ] Refactoring
- [x] Other

#### AI System used:

- [x] ChatGPT
- [ ] Claude
- [ ] Gemini
- [ ] GitHub Copilot

#### Level of modification:

- [ ] As-is (AI generated all code in this submission)
- [ ] Modified (You made some changes to the AI's generation)
- [x] Used as inspiration
