### PR TITLE
[CMSDS-4574] Enable noImplicitThis and useUnknownInCatchVariables

### DIFF
--- a/packages/design-system/src/components/utilities/debounce.ts
+++ b/packages/design-system/src/components/utilities/debounce.ts
@@ -4,7 +4,9 @@ export function debounce<Params extends any[]>(fn: (...args: Params) => any, ms:
     clearTimeout(timer);
     timer = setTimeout(() => {
       timer = null;
-      fn.apply(this, args);
+      // The arrow functions here close over `debounce`'s `this`, which is always
+      // `undefined` in strict-mode module code, so there is no caller `this` to forward.
+      fn(...(args as Params));
     }, ms);
   };
 }

--- a/packages/design-system/src/components/web-components/preactement/globalStyles.ts
+++ b/packages/design-system/src/components/web-components/preactement/globalStyles.ts
@@ -25,9 +25,13 @@ function copyGlobalStyleSheets(): CSSStyleSheet[] {
         .join(' ');
       sheet.replaceSync(css);
     } catch (error) {
-      console.warn(
-        `Could not copy global stylesheets. See following error: \n ${error?.message ?? error}`
-      );
+      // `error` is `unknown`, and the thrown value here is often a `DOMException`, which is
+      // not an `instanceof Error` in browsers, so check for a `message` property instead.
+      const details =
+        typeof error === 'object' && error !== null && 'message' in error
+          ? error.message ?? error
+          : error;
+      console.warn(`Could not copy global stylesheets. See following error: \n ${details}`);
     } finally {
       return sheet;
     }

--- a/packages/design-system/src/components/web-components/preactement/globalStyles.ts
+++ b/packages/design-system/src/components/web-components/preactement/globalStyles.ts
@@ -25,12 +25,7 @@ function copyGlobalStyleSheets(): CSSStyleSheet[] {
         .join(' ');
       sheet.replaceSync(css);
     } catch (error) {
-      // `error` is `unknown`, and the thrown value here is often a `DOMException`, which is
-      // not an `instanceof Error` in browsers, so check for a `message` property instead.
-      const details =
-        typeof error === 'object' && error !== null && 'message' in error
-          ? error.message ?? error
-          : error;
+      const details = error instanceof Error ? error.message : String(error);
       console.warn(`Could not copy global stylesheets. See following error: \n ${details}`);
     } finally {
       return sheet;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "alwaysStrict": true,
-    "strictBindCallApply": true
+    "strictBindCallApply": true,
+    "noImplicitThis": true,
+    "useUnknownInCatchVariables": true
   },
   "include": ["packages/**/src/**/*", ".storybook/**/*"]
 }


### PR DESCRIPTION
## Summary

- Adds `"noImplicitThis": true` and `"useUnknownInCatchVariables": true` to the root `tsconfig.json`, plus the two source fixes required to reach zero errors under them.
- This is **stage 2 of 10** in the staged rollout toward `"strict": true`, following [CMSDS-4567](https://github.com/CMSgov/design-system/pull/4210) (#4210). These two flags accounted for one error each; the remaining stages handle `strictFunctionTypes` (14), `noImplicitAny` (396), and `strictNullChecks` (425).
- Jira: [CMSDS-4574](https://jira.cms.gov/browse/CMSDS-4574)

### The two fixes

**`components/utilities/debounce.ts` (`TS2683`)** — removed the no-op `this` forwarding rather than annotating `this`.

The returned debounced function is an arrow function, so the `this` in `fn.apply(this, args)` was never the caller's `this` — it closed over `debounce`'s own `this`, which is `undefined` in strict-mode module code. `debounce` is only ever called as a plain function (three call sites: `Dropdown`, `Table`, and two stories), so `fn(...args)` is exactly equivalent.

The alternative — annotating `this: void` on `debounce` — was rejected because it would surface in the emitted public `debounce.d.ts` and make `debounce.call(obj, …)` a type error for consumers. This stage should not change published types.

**`components/web-components/preactement/globalStyles.ts` (`TS2339`)** — narrowed the now-`unknown` catch variable with `error instanceof Error ? error.message : String(error)`, matching the pattern already used in `scripts/generate-distributed-docs.ts`.

An earlier revision of this PR used an inline `'message' in error` check instead, on the premise that the `SecurityError` `DOMException` thrown by reading `cssRules` on a cross-origin stylesheet is not an `instanceof Error`. That premise was wrong: WebIDL specifies `DOMException.prototype`'s own prototype as `Error.prototype`, so a `DOMException` *does* satisfy `instanceof Error` and its `message` is reached on the first branch. Logged output is unchanged for every input, and the simpler form matches the rest of the repo.

## How to test

1. `npm run build` — required before type-check so downstream types resolve.
2. `npm run type-check` — expect **0 errors**.
4. `npm run test:unit:wc` — `globalStyles.ts` is web-component code, which the default React-mode suite does not cover.

### Verification results

| Gate | Result |
| --- | --- |
| `npm run type-check` | 0 errors |
| `npm run build` | exit 0 |
| `npm test` (unit + `posttest` lint) | 909 passed, 8 skipped, 195 snapshots passed; eslint/stylelint 0 errors, 93 pre-existing warnings |
| `npm run test:unit:wc` | 407 passed, 6 skipped, 71 snapshots passed |
| Declaration diff | byte-identical, 302 files |

### Deviations

- `test:browser:all` was not run — only `test:browser:smoke`, and outside Docker, so VRT comparison was skipped rather than passed.
- The verification table above was produced before the follow-up commit that simplified the `globalStyles.ts` catch narrowing. That commit changes one expression inside an existing `catch` and is behavior-identical, but the gates have not been re-run against it.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

## AI Usage

- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.

#### Type of assistance:

- [x] Refactoring
- [x] Other — analysis of the strict-mode error surface and the staging plan

#### AI System used:

- [x] Claude

#### Level of modification:

- [x] Modified (You made some changes to the AI's generation)

### If this is a change to code:

- [ ] Created or updated unit tests to cover any new or modified code — **N/A**, both fixes are behavior-preserving and are covered by existing tests (`Dropdown`, `Table`, and the `ds-*` web-component suites).
- [ ] Verified that running both `npm run test:unit` and `npm run test:browser:all` were each successful — `test:unit` passed in React and web-component modes; **`test:browser:all` was not run**, only `test:browser:smoke`, and outside Docker. See the deviation notes above.
- [x] If necessary, updated unit-test snapshots and browser-test snapshots — not necessary; no snapshots changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
