### PR TITLE
[CMSDS-4573] Enable strictFunctionTypes

### DIFF
--- a/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/design-system/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -275,8 +275,9 @@ export const NoResults: Story = {
 };
 
 export const AsyncItems: Story = {
-  render: function Component(args: AutocompleteArgs) {
-    const { items, textFieldLabel, textFieldHint, label, ...autocompleteArgs } = args;
+  render: function Component(args) {
+    const { items, textFieldLabel, textFieldHint, label, ...autocompleteArgs } =
+      args as AutocompleteArgs;
     const [input, setInput] = useState('');
     const [additionalItems, setAdditionalItems] = useState<AutocompleteItem[]>([]);
     const hasResults = input.length > 2 && additionalItems.length;

--- a/packages/design-system/src/components/Dropdown/utils.tsx
+++ b/packages/design-system/src/components/Dropdown/utils.tsx
@@ -51,7 +51,9 @@ function parseOptGroupElement(optgroup: ReactElement<any, 'optgroup'>): Dropdown
   }
   return {
     label,
-    options: findElementsOfType(['option'], optgroup).map(parseOptionElement),
+    options: findElementsOfType(['option'], optgroup).map((option) =>
+      parseOptionElement(option as ReactElement<any, 'option'>)
+    ),
     ...extraProps,
   };
 }

--- a/packages/design-system/src/components/utilities/usePressEscapeHandler.ts
+++ b/packages/design-system/src/components/utilities/usePressEscapeHandler.ts
@@ -22,9 +22,9 @@ export function usePressEscapeHandler(
     const node = ref ? ref.current : document;
     if (!node) return;
 
-    node.addEventListener('keydown', handleEscapeKey);
+    node.addEventListener('keydown', handleEscapeKey as EventListener);
     return () => {
-      node.removeEventListener('keydown', handleEscapeKey);
+      node.removeEventListener('keydown', handleEscapeKey as EventListener);
     };
   }, [handleEscapeKey]);
 }

--- a/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.stories.tsx
+++ b/packages/design-system/src/components/web-components/ds-autocomplete/ds-autocomplete.stories.tsx
@@ -233,11 +233,14 @@ const Template = (args: DSAutocompleteProps) => {
         action('ds-input-value-change')(event);
         setInput(event.detail.value);
       };
-      element.addEventListener('ds-change', handleOnChange);
-      element.addEventListener('ds-input-value-change', handleOnInputValueChange);
+      element.addEventListener('ds-change', handleOnChange as EventListener);
+      element.addEventListener('ds-input-value-change', handleOnInputValueChange as EventListener);
       return () => {
-        element.removeEventListener('ds-change', handleOnChange);
-        element.removeEventListener('ds-input-value-change', handleOnInputValueChange);
+        element.removeEventListener('ds-change', handleOnChange as EventListener);
+        element.removeEventListener(
+          'ds-input-value-change',
+          handleOnInputValueChange as EventListener
+        );
       };
     }
   }, []);
@@ -473,11 +476,17 @@ export const AsyncItems: Story = {
             debouncedSearch();
           }
         };
-        element.addEventListener('ds-change', handleOnChange);
-        element.addEventListener('ds-input-value-change', handleOnInputValueChange);
+        element.addEventListener('ds-change', handleOnChange as EventListener);
+        element.addEventListener(
+          'ds-input-value-change',
+          handleOnInputValueChange as EventListener
+        );
         return () => {
-          element.removeEventListener('ds-change', handleOnChange);
-          element.removeEventListener('ds-input-value-change', handleOnInputValueChange);
+          element.removeEventListener('ds-change', handleOnChange as EventListener);
+          element.removeEventListener(
+            'ds-input-value-change',
+            handleOnInputValueChange as EventListener
+          );
         };
       }
     }, [debouncedSearch, input]);

--- a/packages/design-system/src/components/web-components/preactement/define.ts
+++ b/packages/design-system/src/components/web-components/preactement/define.ts
@@ -101,7 +101,7 @@ function createCustomElement<T>(
       onConnected.call(this);
     }
 
-    public attributeChangedCallback(...args) {
+    public attributeChangedCallback(...args: Parameters<typeof onAttributeChange>) {
       onAttributeChange.call(this, ...args);
     }
 

--- a/packages/design-system/src/components/web-components/preactement/parse.ts
+++ b/packages/design-system/src/components/web-components/preactement/parse.ts
@@ -109,7 +109,7 @@ function getSlotChildren(children: Array<VNode | string | null>) {
   return h(Fragment, {}, children);
 }
 
-export function createSlotVNode(name?: string): VNode {
+export function createSlotVNode(name?: string): VNode<any> {
   return h('slot', { name });
 }
 

--- a/packages/docs/src/components/content/ResponsiveExample.tsx
+++ b/packages/docs/src/components/content/ResponsiveExample.tsx
@@ -97,7 +97,7 @@ const ResponsiveExample = ({ storyId, title, theme }: ResponsiveExample) => {
     <>
       <div className="c-responsive-example ds-u-border--1" ref={rootRef}>
         <ol className="c-responsive-example__button-list ds-u-border-bottom--1 ds-l-row ds-u-margin--0 ds-u-padding-x--0">
-          {Object.keys(breakpoints).map((breakpointName: keyof typeof breakpoints) => (
+          {(Object.keys(breakpoints) as Array<keyof typeof breakpoints>).map((breakpointName) => (
             <li
               className="c-responsive-example__list-item ds-l-col ds-u-padding-x--0"
               key={`breakpoint-${breakpointName}`}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "alwaysStrict": true,
     "strictBindCallApply": true,
+    "strictFunctionTypes": true,
     "noImplicitThis": true,
     "useUnknownInCatchVariables": true
   },


### PR DESCRIPTION
## Summary

- Adds `"strictFunctionTypes": true` to the root `tsconfig.json`, plus the seven source fixes required to reach zero errors under it.
- This is **stage 3 of 10** in the staged rollout toward `"strict": true`, following [CMSDS-4574](https://github.com/CMSgov/design-system/pull/4214) (#4214). The remaining stages handle `noImplicitAny` (396) and `strictNullChecks` (425).
- Jira: [CMSDS-4573](https://jira.cms.gov/browse/CMSDS-4573)

`strictFunctionTypes` makes function-parameter positions checked contravariantly instead of bivariantly. Every error below is the same shape: a callback that declares a *narrower* parameter than the position it is handed to, which the compiler previously waved through.

### The fixes

| File | n | Fix |
| --- | --- | --- |
| `components/utilities/usePressEscapeHandler.ts` | 2 | `as EventListener` on the add/remove pair |
| `components/Dropdown/utils.tsx` | 1 | `.map(parseOptionElement)` → arrow with an explicit element cast |
| `components/web-components/preactement/define.ts` | 1 | Rest params typed as `Parameters<typeof onAttributeChange>` |
| `components/web-components/preactement/parse.ts` | 1 | `createSlotVNode` return widened to `VNode<any>` |
| `components/web-components/ds-autocomplete/ds-autocomplete.stories.tsx` | 8 | `as EventListener` on four `CustomEvent` handlers, add and remove |
| `components/Autocomplete/Autocomplete.stories.tsx` | 1 | Dropped a contravariant param annotation, cast at the destructure |
| `packages/docs/…/ResponsiveExample.tsx` | 1 | `Object.keys(x) as Array<keyof typeof x>` |

**`usePressEscapeHandler.ts` and `ds-autocomplete.stories.tsx` (10 errors)** — `EventListener` takes `Event`, so a handler declaring `KeyboardEvent` or `CustomEvent<…>` is no longer assignable. In `usePressEscapeHandler` the trigger is that `node` is `HTMLElement | Document`: the union collapses `addEventListener` to its non-generic `EventListenerOrEventListenerObject` overload, so the `keydown`-specific overload that would have supplied `KeyboardEvent` is never reached. In the stories it is that `ds-change` and `ds-input-value-change` aren't in any DOM event map. Both use `as EventListener` at the call site, matching the idiom already in `ds-date-field.stories.tsx:158`. The assertion doesn't create a new function value, so `removeEventListener` still matches by identity and the listeners are still torn down.

**`Dropdown/utils.tsx`** — `findElementsOfType`'s return type isn't parameterized on its filter list, so it returns `ReactElement<any, string | JSXElementConstructor<any>>[]` regardless of what was asked for. `parseOptionElement` declares `ReactElement<any, 'option'>`. Passing it by reference to `.map` is now an error; wrapping it in an arrow that casts uses the exact narrowing `parseChildren` already performs twelve lines down. Teaching `findElementsOfType` to carry its filter through to its return type would fix all three cast sites at once, but that's a signature change to a shared helper and doesn't belong in a flag-enablement PR.

**`preactement/define.ts` (`TS2556`)** — `attributeChangedCallback(...args)` had an implicit `any[]` rest param spread into `onAttributeChange.call(this, ...args)`, which needs a tuple. Typing it `Parameters<typeof onAttributeChange>` derives the tuple from the target and stays correct if that signature changes. `Parameters<T>` drops the `this` param, so the `this: CustomElement` annotation is unaffected. The class is local to `createCustomElement`, which returns `any`, so this does not appear in the emitted declarations.

**`Autocomplete.stories.tsx`** — `render` is typed `ArgsStoryFn<ReactRenderer, AutocompleteProps>`, and the story annotated its parameter as `AutocompleteArgs` (`AutocompleteProps` plus two story-only fields). A function demanding more than its caller promises is precisely what the flag rejects. Removed the annotation — the param is now contextually typed — and cast at the destructure, matching the `as AutocompleteArgs` this file already uses on every `args` object.

**`ResponsiveExample.tsx`** — `Object.keys()` returns `string[]`; annotating the `.map` callback parameter as `keyof typeof breakpoints` asserted a narrowing the array type can't supply. Moved the assertion onto the array, where it's true.

### Declaration change — one line

Stages 1–4 of this rollout are meant to leave `dist/react-components/types` byte-identical. This stage changes exactly one line of 302 files:

```diff
- export declare function createSlotVNode(name?: string): VNode;
+ export declare function createSlotVNode(name?: string): VNode<any>;
```

`h('slot', { name })` produces `VNode<ClassAttributes<HTMLElement> & { name: string }>`. `VNode.type` is `string | ComponentType<P>`, and `ComponentType` is contravariant in its props, so under this flag `VNode<P>` is assignable to `VNode<{}>` only when `P` is `{}` — the declared return type was never accurate.

Widening is the right correction rather than a workaround: it is what the rest of `parse.ts` already declares (`Slots`, `nodeToPreactVNode`), it matches how both call sites in `define.ts` consume the result, and widening a return type cannot break a caller. The alternative — asserting back to `VNode` — would have preserved the byte-identical bar by restating the inaccuracy the flag had just caught. `createSlotVNode` is not re-exported from any package entry point; it is reachable only through the `./dist/*` deep path.

## How to test

1. `npm run build` — required before type-check so downstream types resolve.
2. `npm run type-check` — expect **0 errors**.
3. `npm run test:unit` — covers `Dropdown`, `Autocomplete`, and `usePressEscapeHandler`.
4. `npm run test:unit:wc` — `define.ts` and `parse.ts` are web-component code, which the default React-mode suite does not cover.

### Verification results

| Gate | Result |
| --- | --- |
| `npm run type-check` | 0 errors |
| `npm run build` | exit 0 |
| `npm test` (unit + `posttest` lint) | 909 passed, 8 skipped, 195 snapshots passed; eslint/stylelint 0 errors, 93 pre-existing warnings |
| `npm run test:unit:wc` | 407 passed, 6 skipped, 71 snapshots passed |
| `npm run test:browser:smoke` | 804 passed, 0 failed |
| Declaration diff | 1 line changed across 302 files (see above) |

### Deviations

- **Error count.** 15 errors across 7 files.
- **Declaration output is not byte-identical.** One deliberate return-type widening, detailed above.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

## AI Usage

- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.

#### Type of assistance:

- [x] Refactoring
- [x] Other — analysis of the strict-mode error surface and the staging plan

#### AI System used:

- [x] Claude

#### Level of modification:

- [x] Modified (You made some changes to the AI's generation)

### If this is a change to code:

- [ ] Created or updated unit tests to cover any new or modified code — **N/A**, every fix is type-level and behavior-preserving; all seven files are covered by existing tests.
- [ ] Verified that running both `npm run test:unit` and `npm run test:browser:all` were each successful — `test:unit` passed in React and web-component modes; **`test:browser:all` was not run**, only `test:browser:smoke`, and outside Docker.
- [x] If necessary, updated unit-test snapshots and browser-test snapshots — not necessary; no snapshots changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
