### PR TITLE
[CMSDS-3225] Add docs for styling wrapped `ds-accordion-item`

### DIFF
--- a/packages/docs/content/components/accordion.mdx
+++ b/packages/docs/content/components/accordion.mdx
@@ -105,6 +105,16 @@ From [USWDS’ Accordion accessibility tests](https://designsystem.digital.gov/c
 
 <SeeStorybookForGuidance tech="wc" storyId={'web-components-ds-accordion--docs'} />
 
+#### Spacing when using framework wrappers
+
+Wrapping each `ds-accordion-item` in a framework-specific component changes the items’ sibling relationship and may prevent the default spacing between accordion headings from being applied. When this happens, apply the `ds-u-margin-top--1` utility class to the heading of each item after the first.
+
+```html
+<wrapped-accordion-item headingClassName="ds-u-margin-top--1">
+  ...
+</wrapped-accordion-item>
+```
+
 ### Style customization
 
 The following CSS variables can be overridden to customize Accordion components:


### PR DESCRIPTION
## Summary

* Documents that framework-specific wrappers can prevent the default spacing between `ds-accordion-item` elements from being applied.
* Recommends applying `ds-u-margin-top--1` to the heading of each wrapped accordion item after the first.

[Jira ticket](https://jira.cms.gov/browse/CMSDS-3225)

## How to test

1. `npm run start` and navigate to http://localhost:8000/components/accordion/?theme=core

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

## AI Usage

- [x] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

### IF you did use AI please answer these questions:

#### Type of assistance:

- [ ] Code generation
- [ ] Documentation
- [ ] Debugging
- [ ] Testing
- [ ] Refactoring
- [x] Other — Editing copy

#### AI System used:

- [x] ChatGPT
- [ ] Claude
- [ ] Gemini
- [ ] GitHub Copilot

#### Level of modification:

- [ ] As-is (AI generated all code in this submission)
- [x] Modified (You made some changes to the AI's generation)
- [ ] Used as inspiration
