### PR TITLE
[CMSDS-4279] Add xl and xxl values

### DIFF
--- a/packages/design-system-tokens/src/css/__snapshots__/css-snapshots.test.ts.snap
+++ b/packages/design-system-tokens/src/css/__snapshots__/css-snapshots.test.ts.snap
@@ -407,6 +407,8 @@ exports[`CSS snapshots variables in cmsgov-theme.css match snapshot 1`] = `
 --radius-medium: 4px;
 --radius-pill: 9999px;
 --radius-small: 2px;
+--radius-xl: 16px;
+--radius-xxl: 24px;
 --review__border-color: var(--color-border);
 --site-margins-mobile: 1.5rem;
 --site-margins: 3rem;
@@ -897,6 +899,8 @@ exports[`CSS snapshots variables in core-theme.css match snapshot 1`] = `
 --radius-medium: 4px;
 --radius-pill: 9999px;
 --radius-small: 2px;
+--radius-xl: 16px;
+--radius-xxl: 24px;
 --review__border-color: var(--color-border);
 --site-margins-mobile: 1.5rem;
 --site-margins: 3rem;
@@ -1386,6 +1390,8 @@ exports[`CSS snapshots variables in healthcare-theme.css match snapshot 1`] = `
 --radius-medium: 4px;
 --radius-pill: 9999px;
 --radius-small: 2px;
+--radius-xl: 16px;
+--radius-xxl: 24px;
 --review__border-color: var(--color-border);
 --site-margins-mobile: 1.5rem;
 --site-margins: 3rem;
@@ -1874,6 +1880,8 @@ exports[`CSS snapshots variables in medicare-theme.css match snapshot 1`] = `
 --radius-medium: 4px;
 --radius-pill: 9999px;
 --radius-small: 2px;
+--radius-xl: 16px;
+--radius-xxl: 24px;
 --review__border-color: var(--color-border);
 --site-margins-mobile: 1.5rem;
 --site-margins: 3rem;

--- a/packages/design-system-tokens/src/tokens/System.Value.json
+++ b/packages/design-system-tokens/src/tokens/System.Value.json
@@ -947,6 +947,14 @@
     "small": {
       "$value": "2px",
       "$type": "dimension"
+    },
+    "xl": {
+      "$value": "16px",
+      "$type": "dimension"
+    },
+    "xxl": {
+      "$value": "24px",
+      "$type": "dimension"
     }
   },
   "site-margins": {

--- a/packages/docs/static/themes/cmsgov-theme.css
+++ b/packages/docs/static/themes/cmsgov-theme.css
@@ -5,6 +5,8 @@
 --radius-medium: 4px;
 --radius-pill: 9999px;
 --radius-small: 2px;
+--radius-xl: 16px;
+--radius-xxl: 24px;
 --site-margins: 3rem;
 --site-margins-mobile: 1.5rem;
 --site-max-width: 1104px;

--- a/packages/docs/static/themes/core-theme.css
+++ b/packages/docs/static/themes/core-theme.css
@@ -5,6 +5,8 @@
 --radius-medium: 4px;
 --radius-pill: 9999px;
 --radius-small: 2px;
+--radius-xl: 16px;
+--radius-xxl: 24px;
 --site-margins: 3rem;
 --site-margins-mobile: 1.5rem;
 --site-max-width: 1104px;

--- a/packages/docs/static/themes/healthcare-theme.css
+++ b/packages/docs/static/themes/healthcare-theme.css
@@ -5,6 +5,8 @@
 --radius-medium: 4px;
 --radius-pill: 9999px;
 --radius-small: 2px;
+--radius-xl: 16px;
+--radius-xxl: 24px;
 --site-margins: 3rem;
 --site-margins-mobile: 1.5rem;
 --site-max-width: 1104px;

--- a/packages/docs/static/themes/medicare-theme.css
+++ b/packages/docs/static/themes/medicare-theme.css
@@ -5,6 +5,8 @@
 --radius-medium: 4px;
 --radius-pill: 9999px;
 --radius-small: 2px;
+--radius-xl: 16px;
+--radius-xxl: 24px;
 --site-margins: 3rem;
 --site-margins-mobile: 1.5rem;
 --site-max-width: 1104px;


### PR DESCRIPTION
## Summary
- Adds two larger radius tokens to System tokens, in order to support the new Medicare styles:
  - `radius.xl`: 16px
  - `radius.xxl`: 24px
- The existing `radius.large` token provides the required 8px default value. So, references to `radius.default` in the Medicare `scss` files will need to be replaced with `radius.large`.

[Jira ticket](https://jira.cms.gov/browse/CMSDS-4279)

## How to test

1. Verify that the new token values are listed in each themed `.css` file.

## Checklist

- [x] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [x] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [x] Selected appropriate `Impacts`, multiple can be selected.
- [x] Selected appropriate release milestone

## AI Usage

- [ ] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [x] NO_AI: I did not use AI.
