### PR TITLE
[CMSDS-4601] Add example font download instructions to our CDN index

### DIFF
--- a/scripts/build-cdn-helpers.ts
+++ b/scripts/build-cdn-helpers.ts
@@ -1,0 +1,93 @@
+import path from 'path';
+import fs from 'node:fs';
+
+export const codeBlock = (lines: string[]) => {
+  const escaped = lines.join('\n').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const stringToCopy = JSON.stringify(lines);
+  return `
+    <pre class="ds-u-fill--gray-lightest ds-u-font-size--sm ds-u-padding--1 ds-u-margin-y--1 ds-u-overflow--auto"><code>${escaped}</code></pre>
+    <ds-button size="small" onclick='navigator.clipboard.writeText(${stringToCopy}.join("\\n"))'>Copy snippet</ds-button>
+  `;
+};
+
+export const renderPageHtml = (
+  system: string,
+  version: string,
+  theme: string,
+  title: string,
+  mainContent: string
+) => {
+  return `<!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+      <title>${title} - CMSDS</title>
+      <link rel="stylesheet" href="https://design.cms.gov/cdn/${system}/${version}/css/index.css" />
+      <link rel="stylesheet" href="https://design.cms.gov/cdn/${system}/${version}/css/${theme}-theme.css" />
+    </head>
+    <body>
+      <ds-usa-banner></ds-usa-banner>
+      <header class="ds-base--inverse ds-u-padding-y--3">
+        <div class="ds-l-container">
+          <h1 class="ds-text-heading--2xl">${title}</h1>
+        </div>
+      </header>
+      <div class="ds-l-container ds-content ds-u-padding-y--4">
+        ${mainContent}
+      </div>
+      <script src="https://design.cms.gov/cdn/${system}/${version}/web-components/bundle/web-components.js"></script>
+    </body>
+  </html>`;
+};
+
+// Take the @font-face code blocks and clean them up.
+const prettyFontFace = (block: string, cdnFontsBase: string): string[] => {
+  const inner = block.replace(/^@font-face\{/, '').replace(/\}$/, '');
+  const declarations = inner
+    .split(';')
+    .map((d) => d.trim())
+    .filter(Boolean)
+    .map((d) => d.replace(/\.\.\/fonts\//g, cdnFontsBase));
+  return ['@font-face {', ...declarations.map((d) => `  ${d};`), '}'];
+};
+
+// Get our @font-face declarations from our distributed CSS files
+// This way we grab only font files that we are actually using.
+const getFontFaceBlocks = (distPath: string): string[] => {
+  // We only define @font-face in the index.css files:
+  const css = fs.readFileSync(path.join(distPath, 'css', 'index.css'), 'utf8');
+  // Blocks are flat, @font-face can in some cases accept {} characters:
+  // See Font property descriptors; https://drafts.csswg.org/css-fonts/#font-prop-desc.
+  // We don't use any currently.
+  return css.match(/@font-face\{[^}]*\}/g) ?? [];
+};
+
+// Create blocks of @font-face declarations with the correct location of the font passed in
+// Our dist CSS assumes a relative location for the font files, here we're replacing with the location
+// of the font files on the CDN.
+export const renderFontFaceExample = (system: string, version: string, distPath: string) => {
+  const cdnFontsBase = `https://design.cms.gov/cdn/${system}/${version}/fonts/`;
+  const blocks = getFontFaceBlocks(distPath);
+  const lines = blocks.flatMap((block, i) => [
+    ...(i > 0 ? [''] : []),
+    ...prettyFontFace(block, cdnFontsBase),
+  ]);
+  return codeBlock(lines);
+};
+
+// Consumers must preload only the faces their above-the-fold content renders,
+// which is page-specific and can't be generated generically.
+export const renderFontPreloadExample = (system: string, version: string, distPath: string) => {
+  const cdnFontsBase = `https://design.cms.gov/cdn/${system}/${version}/fonts/`;
+  const blocks = getFontFaceBlocks(distPath);
+  const firstFile = blocks
+    // Capture and return the second group, which strips the `url(../fonts/` portion of the code block.
+    .flatMap((block) =>
+      [...block.matchAll(/url\(\.\.\/fonts\/([^)]+)\)/g)].map((match) => match[1])
+    )[0];
+  if (!firstFile) return '';
+  return codeBlock([
+    `<link rel="preload" href="${cdnFontsBase}${firstFile}" as="font" type="font/woff2" crossorigin>`,
+  ]);
+};

--- a/scripts/build-cdn-helpers.ts
+++ b/scripts/build-cdn-helpers.ts
@@ -6,7 +6,7 @@ export const codeBlock = (lines: string[]) => {
   const stringToCopy = JSON.stringify(lines);
   return `
     <pre class="ds-u-fill--gray-lightest ds-u-font-size--sm ds-u-padding--1 ds-u-margin-y--1 ds-u-overflow--auto"><code>${escaped}</code></pre>
-    <ds-button size="small" onclick='navigator.clipboard.writeText(${stringToCopy}.join("\\n"))'>Copy snippet</ds-button>
+    <button class="ds-c-button ds-c-button--solid" size="small" onclick='navigator.clipboard.writeText(${stringToCopy}.join("\\n"))'>Copy snippet</button>
   `;
 };
 
@@ -63,17 +63,36 @@ const getFontFaceBlocks = (distPath: string): string[] => {
   return css.match(/@font-face\{[^}]*\}/g) ?? [];
 };
 
+// Get the font-family name declared in a single @font-face block, e.g. "Bitter" or "Open Sans".
+const getFontFamily = (block: string): string => {
+  const match = block.match(/font-family:([^;]+)/);
+  return match ? match[1].trim().replace(/^["']|["']$/g, '') : '';
+};
+
+// The distinct font-family names across all blocks, in first-appearance order.
+const getFontFamilies = (blocks: string[]): string[] => [
+  ...new Set(blocks.map(getFontFamily).filter(Boolean)),
+];
+
 // Create blocks of @font-face declarations with the correct location of the font passed in
 // Our dist CSS assumes a relative location for the font files, here we're replacing with the location
 // of the font files on the CDN.
 export const renderFontFaceExample = (system: string, version: string, distPath: string) => {
   const cdnFontsBase = `https://design.cms.gov/cdn/${system}/${version}/fonts/`;
   const blocks = getFontFaceBlocks(distPath);
-  const lines = blocks.flatMap((block, i) => [
-    ...(i > 0 ? [''] : []),
-    ...prettyFontFace(block, cdnFontsBase),
-  ]);
-  return codeBlock(lines);
+  const fontFamilies = getFontFamilies(blocks);
+
+  // Group each family's faces in a collapsible <details>, with the family name
+  // (an <h3>) as the clickable <summary>, wrapping one code block per face.
+  return fontFamilies
+    .map((fontFamily) => {
+      const familyBlocks = blocks.filter((block) => getFontFamily(block) === fontFamily);
+      const codeBlocks = familyBlocks
+        .map((block) => codeBlock(prettyFontFace(block, cdnFontsBase)))
+        .join('\n');
+      return `<br/><details>\n<summary class="ds-text-body--lg">${fontFamily}</summary>\n${codeBlocks}\n</details>`;
+    })
+    .join('\n');
 };
 
 // Consumers must preload only the faces their above-the-fold content renders,

--- a/scripts/build-cdn-indexes.ts
+++ b/scripts/build-cdn-indexes.ts
@@ -1,46 +1,19 @@
 import path from 'path';
 import themes from '../themes.json';
 import packageVersions from '../versions.json';
+import {
+  codeBlock,
+  renderPageHtml,
+  renderFontFaceExample,
+  renderFontPreloadExample,
+} from './build-cdn-helpers';
 import fs from 'node:fs';
 import c from 'chalk';
 
-function codeBlock(lines: string[]) {
-  const escaped = lines.join('\n').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  const stringToCopy = JSON.stringify(lines);
-  return `
-    <pre class="ds-u-fill--gray-lightest ds-u-font-size--sm ds-u-padding--1 ds-u-margin-y--1 ds-u-overflow--auto"><code>${escaped}</code></pre>
-    <ds-button size="small" onclick='navigator.clipboard.writeText(${stringToCopy}.join("\\n"))'>Copy snippet</ds-button>
-  `;
-}
-function renderPageHtml(theme: keyof typeof themes, title: string, mainContent: string) {
-  const system = themes[theme].packageName;
-  const version = packageVersions[system as keyof typeof packageVersions][0];
-  return `<!DOCTYPE html>
-  <html lang="en">
-    <head>
-      <meta charset="utf-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-      <title>${title} - CMSDS</title>
-      <link rel="stylesheet" href="https://design.cms.gov/cdn/${system}/${version}/css/index.css" />
-      <link rel="stylesheet" href="https://design.cms.gov/cdn/${system}/${version}/css/${theme}-theme.css" />
-    </head>
-    <body>
-      <ds-usa-banner></ds-usa-banner>
-      <header class="ds-base--inverse ds-u-padding-y--3">
-        <div class="ds-l-container">
-          <h1 class="ds-text-heading--2xl">${title}</h1>
-        </div>
-      </header>
-      <div class="ds-l-container ds-content ds-u-padding-y--4">
-        ${mainContent}
-      </div>
-      <script src="https://design.cms.gov/cdn/${system}/${version}/web-components/bundle/web-components.js"></script>
-    </body>
-  </html>`;
-}
-
 function writeCdnIndex() {
   const theme = 'core';
+  const system = themes[theme].packageName;
+  const version = packageVersions[system as keyof typeof packageVersions][0];
 
   const packageSections = Object.keys(themes).map((theme) => {
     const { packageName } = themes[theme as keyof typeof themes];
@@ -65,6 +38,8 @@ function writeCdnIndex() {
   });
 
   const htmlDoc = renderPageHtml(
+    system,
+    version,
     theme,
     'CDN all package versions index',
     `
@@ -97,6 +72,8 @@ function writeThemeIndex(theme: keyof typeof themes) {
     `<link rel="stylesheet" href="https://design.cms.gov/cdn/${system}/${version}/css/index.css" />`,
     `<link rel="stylesheet" href="https://design.cms.gov/cdn/${system}/${version}/css/${theme}-theme.css" />`,
   ]);
+  const fontFaceExample = renderFontFaceExample(system, version, distPath);
+  const fontPreloadExample = renderFontPreloadExample(system, version, distPath);
 
   const webComponentsAllExample = codeBlock([
     `<script src="https://design.cms.gov/cdn/${system}/${version}/web-components/bundle/all.js"></script>`,
@@ -121,6 +98,8 @@ function writeThemeIndex(theme: keyof typeof themes) {
   ]);
 
   const htmlDoc = renderPageHtml(
+    system,
+    version,
     theme,
     'CDN package resource index',
     `
@@ -140,6 +119,21 @@ function writeThemeIndex(theme: keyof typeof themes) {
     <h2>How to load the CSS</h2>
     <p>Place the following HTML in your <strong>head</strong> tag:</p>
     ${cssExample}
+    <h2>How to load the fonts</h2>
+    <p class="ds-u-measure--wide">
+      The fonts load automatically when you include the CSS above — no extra setup
+      needed. If you use your own stylesheet and only want our font files, add these
+      <code>@font-face</code> declarations, which point at the fonts hosted on this CDN:
+    </p>
+    ${fontFaceExample}
+    <h3>Optional: preload for faster text rendering</h3>
+    <p class="ds-u-measure--wide">
+      Preload only the specific font faces you need.
+      <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preload">Learn more about preloading at MDN</a>.
+      Every font preload must also include <code>crossorigin</code>, or the
+      browser downloads the file twice. For example:
+    </p>
+    ${fontPreloadExample}
     <h2>How to load the JavaScript components</h2>
     <h3>Web components</h3>
     <p>To import all web components, place the following code at the end of your <strong>body</strong> tag:</p>


### PR DESCRIPTION
## Summary

- [Ticket](https://jira.cms.gov/browse/CMSDS-4601)
- Added & refactored our CDN index page generation script.
- We now enumerate all of the available fonts on our CDN index page so folks can download the font face from the CDN. 
- The UI could maybe use some help since the list of fonts is quite long.

## How to test

1. Check out the branch
2. run `npx tsx ./scripts/build-cdn-indexes.ts` at the top level
3. Open (`open index.html` in the terminal) each of the new CDN index pages created in the /dist folder for each of our packages
4. Make sure the fonts available in our /dist/fonts folder for that package are captured in the index page html.

## Checklist

- [X] Prefixed the PR title with the [Jira ticket number](https://jira.cms.gov/projects/CMSDS/) as `[CMSDS-####] Title` or [NO-TICKET] if this is unticketed work.
- [X] Selected appropriate `Type` (only one) label for this PR, if it is a breaking change, label should only be `Type: Breaking`
- [X] Selected appropriate `Impacts`, multiple can be selected.
- [X] Selected appropriate release milestone

## AI Usage

- [X] USED_AI: I attest that I have read, understood, and take ownership of all AI-generated code in this PR.
- [ ] NO_AI: I did not use AI.

### IF you did use AI please answer these questions:

#### Type of assistance:

- [X] Code generation
- [ ] Documentation
- [X] Debugging
- [ ] Testing
- [X] Refactoring
- [ ] Other

#### AI System used:

- [ ] ChatGPT
- [X] Claude
- [ ] Gemini
- [ ] GitHub Copilot

#### Level of modification:

- [ ] As-is (AI generated all code in this submission)
- [X] Modified (You made some changes to the AI's generation)
- [ ] Used as inspiration